### PR TITLE
[AGT-04] Per-agent rolling Brier scorer for resolved synthetic claims

### DIFF
--- a/aragora/prediction/__init__.py
+++ b/aragora/prediction/__init__.py
@@ -2,9 +2,11 @@
 
 All public symbols are importable regardless of the feature flag.
 The flag (``ARAGORA_PREDICTION_MARKETS_ENABLED``) only gates the runtime
-behaviour of :class:`InMemoryStakeableClaimStore` and the resolution adapter.
+behaviour of :class:`InMemoryStakeableClaimStore`, the resolution adapter,
+and :func:`compute_brier_scores`.
 """
 
+from aragora.prediction.brier import AgentBrierScore, compute_brier_scores
 from aragora.prediction.stakeable_claim import (
     GithubResolutionAdapterStub,
     InMemoryStakeableClaimStore,
@@ -14,9 +16,11 @@ from aragora.prediction.stakeable_claim import (
 )
 
 __all__ = [
+    "AgentBrierScore",
     "GithubResolutionAdapterStub",
     "InMemoryStakeableClaimStore",
     "QuestionType",
     "ResolutionStatus",
     "StakeableClaim",
+    "compute_brier_scores",
 ]

--- a/aragora/prediction/brier.py
+++ b/aragora/prediction/brier.py
@@ -127,9 +127,7 @@ def compute_brier_scores(
         RuntimeError: When *require_enabled* is True and the flag is off.
     """
     if require_enabled and not _flag_enabled():
-        raise RuntimeError(
-            f"Prediction markets are disabled. Set {_ENV_FLAG}=1 to enable."
-        )
+        raise RuntimeError(f"Prediction markets are disabled. Set {_ENV_FLAG}=1 to enable.")
 
     cutoff = (cutoff_dt or datetime.now(tz=UTC)).astimezone(UTC)
     window_start = cutoff - timedelta(days=window_days)

--- a/aragora/prediction/brier.py
+++ b/aragora/prediction/brier.py
@@ -1,0 +1,164 @@
+"""Per-agent rolling Brier scorer for resolved synthetic GitHub prediction claims.
+
+Computes per-agent Brier scores from resolved :class:`StakeableClaim` objects.
+A rolling window (default 90 days) filters by claim *created_at* so only
+recent predictions count toward an agent's calibration measurement.
+
+Brier score formula: B = (1/N) Σ (f_t − o_t)²
+  f_t = agent probability forecast (0–1)
+  o_t = binary outcome (1 for RESOLVED_YES, 0 for RESOLVED_NO)
+  Lower is better; 0 = perfect, 0.25 = no-skill baseline, 1 = worst possible.
+
+Feature flag: ``ARAGORA_PREDICTION_MARKETS_ENABLED`` (default OFF).
+Data classes are always importable; only :func:`compute_brier_scores` checks
+the flag (controllable via *require_enabled*).
+
+Deliberately does NOT:
+- call the GitHub API or any external service
+- touch the live dispatch queue or boss loop
+- import from ``aragora.blockchain`` (reputation wiring is AGT-05)
+
+Advances: issue #6065 (AGT-04), sub-deliverable 4 — per-agent rolling Brier score.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aragora.prediction.stakeable_claim import ResolutionStatus, StakeableClaim
+
+_ENV_FLAG = "ARAGORA_PREDICTION_MARKETS_ENABLED"
+
+
+def _flag_enabled() -> bool:
+    return os.environ.get(_ENV_FLAG, "").lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentBrierScore:
+    """Per-agent Brier score over resolved claims in the rolling window.
+
+    Attributes:
+        agent_id: Agent identifier.
+        score: Brier score (lower is better; 0 = perfect, 0.25 = no-skill baseline).
+        n_predictions: Number of resolved claims scored.
+        window_days: Rolling window width used for filtering.
+        computed_at: ISO-8601 UTC timestamp of this computation.
+    """
+
+    agent_id: str
+    score: float
+    n_predictions: int
+    window_days: int
+    computed_at: str
+
+    @property
+    def has_skill(self) -> bool:
+        """True when score is strictly better than the 0.25 no-skill baseline."""
+        return self.score < 0.25
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "score": self.score,
+            "n_predictions": self.n_predictions,
+            "window_days": self.window_days,
+            "computed_at": self.computed_at,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _binary_outcome(claim: StakeableClaim) -> float | None:
+    """Return 1.0 for YES, 0.0 for NO, None for anything else."""
+    if claim.resolution_status == ResolutionStatus.RESOLVED_YES:
+        return 1.0
+    if claim.resolution_status == ResolutionStatus.RESOLVED_NO:
+        return 0.0
+    return None
+
+
+def _parse_utc(ts: str) -> datetime:
+    dt = datetime.fromisoformat(ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_brier_scores(
+    claims: list[StakeableClaim],
+    *,
+    window_days: int = 90,
+    cutoff_dt: datetime | None = None,
+    require_enabled: bool = True,
+) -> dict[str, AgentBrierScore]:
+    """Compute per-agent Brier scores over resolved claims in the rolling window.
+
+    Only claims that are RESOLVED_YES or RESOLVED_NO and whose *created_at*
+    falls within [cutoff − window_days, cutoff] are included.  Agents with no
+    qualifying predictions are omitted from the result.
+
+    Args:
+        claims: All claims to consider; unresolved ones are silently skipped.
+        window_days: Rolling window width in days (default 90).
+        cutoff_dt: Upper bound of the window (default: ``datetime.now(UTC)``).
+        require_enabled: When True (default), raises if the feature flag is off.
+
+    Returns:
+        ``{agent_id: AgentBrierScore}`` for every agent with ≥1 scored prediction.
+
+    Raises:
+        RuntimeError: When *require_enabled* is True and the flag is off.
+    """
+    if require_enabled and not _flag_enabled():
+        raise RuntimeError(
+            f"Prediction markets are disabled. Set {_ENV_FLAG}=1 to enable."
+        )
+
+    cutoff = (cutoff_dt or datetime.now(tz=UTC)).astimezone(UTC)
+    window_start = cutoff - timedelta(days=window_days)
+    computed_at = cutoff.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    # {agent_id: [squared_errors]}
+    squared_errors: dict[str, list[float]] = {}
+
+    for claim in claims:
+        outcome = _binary_outcome(claim)
+        if outcome is None:
+            continue
+        try:
+            created = _parse_utc(claim.created_at)
+        except (ValueError, AttributeError):
+            continue
+        if not (window_start <= created <= cutoff):
+            continue
+
+        for agent_id, prob in claim.positions.items():
+            squared_errors.setdefault(agent_id, []).append((prob - outcome) ** 2)
+
+    return {
+        agent_id: AgentBrierScore(
+            agent_id=agent_id,
+            score=sum(errs) / len(errs),
+            n_predictions=len(errs),
+            window_days=window_days,
+            computed_at=computed_at,
+        )
+        for agent_id, errs in squared_errors.items()
+    }

--- a/tests/prediction/test_brier.py
+++ b/tests/prediction/test_brier.py
@@ -1,0 +1,192 @@
+"""Tests for aragora.prediction.brier — per-agent rolling Brier scorer (AGT-04 / #6065)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.prediction.brier import AgentBrierScore, compute_brier_scores
+from aragora.prediction.stakeable_claim import (
+    QuestionType,
+    ResolutionStatus,
+    StakeableClaim,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _claim(
+    claim_id: str,
+    *,
+    status: ResolutionStatus = ResolutionStatus.RESOLVED_YES,
+    positions: dict[str, float] | None = None,
+    created_at: datetime | None = None,
+) -> StakeableClaim:
+    ts = (created_at or datetime.now(tz=UTC))
+    return StakeableClaim(
+        claim_id=claim_id,
+        question=f"Will PR #{claim_id} merge?",
+        question_type=QuestionType.PR_MERGE,
+        target_ref=f"synaptent/aragora#{claim_id}",
+        expiry=(ts + timedelta(days=30)).isoformat(),
+        resolution_status=status,
+        resolution_value=(status == ResolutionStatus.RESOLVED_YES),
+        positions=positions or {},
+        created_at=ts.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag tests
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlag:
+    def test_raises_when_flag_off(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PREDICTION_MARKETS_ENABLED", raising=False)
+        with pytest.raises(RuntimeError, match="disabled"):
+            compute_brier_scores([])
+
+    def test_require_enabled_false_bypasses_flag(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PREDICTION_MARKETS_ENABLED", raising=False)
+        result = compute_brier_scores([], require_enabled=False)
+        assert result == {}
+
+    def test_flag_on_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_PREDICTION_MARKETS_ENABLED", "1")
+        result = compute_brier_scores([])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Score arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestScoreArithmetic:
+    def test_perfect_score_yes(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0})
+        result = compute_brier_scores([c], require_enabled=False)
+        assert result["a"].score == pytest.approx(0.0)
+
+    def test_perfect_score_no(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_NO, positions={"a": 0.0})
+        result = compute_brier_scores([c], require_enabled=False)
+        assert result["a"].score == pytest.approx(0.0)
+
+    def test_no_skill_baseline_half(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 0.5})
+        result = compute_brier_scores([c], require_enabled=False)
+        assert result["a"].score == pytest.approx(0.25)
+
+    def test_average_over_multiple_claims(self):
+        # Perfect on YES (0), worst on NO (1) → average 0.5
+        c1 = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0})
+        c2 = _claim("c2", status=ResolutionStatus.RESOLVED_NO, positions={"a": 1.0})
+        result = compute_brier_scores([c1, c2], require_enabled=False)
+        assert result["a"].score == pytest.approx(0.5)
+        assert result["a"].n_predictions == 2
+
+    def test_multiple_agents_scored_independently(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
+                   positions={"a": 1.0, "b": 0.0})
+        result = compute_brier_scores([c], require_enabled=False)
+        assert result["a"].score == pytest.approx(0.0)
+        assert result["b"].score == pytest.approx(1.0)
+
+    def test_four_predictions_known_average(self):
+        # (0.8-1)^2=0.04, (0.6-1)^2=0.16, (0.4-0)^2=0.16, (0.2-0)^2=0.04 → mean=0.10
+        now = datetime.now(tz=UTC)
+        claims = [
+            _claim("c1", status=ResolutionStatus.RESOLVED_YES,
+                   positions={"a": 0.8}, created_at=now),
+            _claim("c2", status=ResolutionStatus.RESOLVED_YES,
+                   positions={"a": 0.6}, created_at=now),
+            _claim("c3", status=ResolutionStatus.RESOLVED_NO,
+                   positions={"a": 0.4}, created_at=now),
+            _claim("c4", status=ResolutionStatus.RESOLVED_NO,
+                   positions={"a": 0.2}, created_at=now),
+        ]
+        result = compute_brier_scores(claims, require_enabled=False)
+        assert result["a"].score == pytest.approx(0.10)
+        assert result["a"].n_predictions == 4
+
+
+# ---------------------------------------------------------------------------
+# Claim filtering
+# ---------------------------------------------------------------------------
+
+
+class TestClaimFiltering:
+    def test_open_claims_excluded(self):
+        c = _claim("c1", status=ResolutionStatus.OPEN, positions={"a": 0.8})
+        assert compute_brier_scores([c], require_enabled=False) == {}
+
+    def test_expired_claims_excluded(self):
+        c = _claim("c1", status=ResolutionStatus.EXPIRED, positions={"a": 0.8})
+        assert compute_brier_scores([c], require_enabled=False) == {}
+
+    def test_inconclusive_claims_excluded(self):
+        c = _claim("c1", status=ResolutionStatus.INCONCLUSIVE, positions={"a": 0.8})
+        assert compute_brier_scores([c], require_enabled=False) == {}
+
+    def test_no_positions_agent_absent_from_result(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={})
+        assert compute_brier_scores([c], require_enabled=False) == {}
+
+    def test_old_claim_outside_window_excluded(self):
+        old = datetime(2020, 1, 1, tzinfo=UTC)
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
+                   positions={"a": 1.0}, created_at=old)
+        assert compute_brier_scores([c], window_days=90, require_enabled=False) == {}
+
+    def test_recent_claim_inside_window_included(self):
+        recent = datetime.now(tz=UTC) - timedelta(days=10)
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
+                   positions={"a": 1.0}, created_at=recent)
+        result = compute_brier_scores([c], window_days=90, require_enabled=False)
+        assert "a" in result
+
+    def test_future_claim_above_cutoff_excluded(self):
+        cutoff = datetime.now(tz=UTC)
+        future = cutoff + timedelta(days=5)
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
+                   positions={"a": 1.0}, created_at=future)
+        result = compute_brier_scores([c], cutoff_dt=cutoff, require_enabled=False)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# AgentBrierScore dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestAgentBrierScore:
+    def test_has_skill_below_025(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 0.9})
+        score = compute_brier_scores([c], require_enabled=False)["a"]
+        assert score.score == pytest.approx(0.01)
+        assert score.has_skill is True
+
+    def test_no_skill_at_025(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 0.5})
+        score = compute_brier_scores([c], require_enabled=False)["a"]
+        assert score.has_skill is False
+
+    def test_to_dict_keys(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0})
+        d = compute_brier_scores([c], require_enabled=False)["a"].to_dict()
+        assert set(d.keys()) == {"agent_id", "score", "n_predictions", "window_days", "computed_at"}
+
+    def test_to_dict_values(self):
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0})
+        d = compute_brier_scores([c], window_days=45, require_enabled=False)["a"].to_dict()
+        assert d["agent_id"] == "a"
+        assert d["score"] == pytest.approx(0.0)
+        assert d["n_predictions"] == 1
+        assert d["window_days"] == 45
+

--- a/tests/prediction/test_brier.py
+++ b/tests/prediction/test_brier.py
@@ -26,7 +26,7 @@ def _claim(
     positions: dict[str, float] | None = None,
     created_at: datetime | None = None,
 ) -> StakeableClaim:
-    ts = (created_at or datetime.now(tz=UTC))
+    ts = created_at or datetime.now(tz=UTC)
     return StakeableClaim(
         claim_id=claim_id,
         question=f"Will PR #{claim_id} merge?",
@@ -92,8 +92,7 @@ class TestScoreArithmetic:
         assert result["a"].n_predictions == 2
 
     def test_multiple_agents_scored_independently(self):
-        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
-                   positions={"a": 1.0, "b": 0.0})
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0, "b": 0.0})
         result = compute_brier_scores([c], require_enabled=False)
         assert result["a"].score == pytest.approx(0.0)
         assert result["b"].score == pytest.approx(1.0)
@@ -102,14 +101,14 @@ class TestScoreArithmetic:
         # (0.8-1)^2=0.04, (0.6-1)^2=0.16, (0.4-0)^2=0.16, (0.2-0)^2=0.04 → mean=0.10
         now = datetime.now(tz=UTC)
         claims = [
-            _claim("c1", status=ResolutionStatus.RESOLVED_YES,
-                   positions={"a": 0.8}, created_at=now),
-            _claim("c2", status=ResolutionStatus.RESOLVED_YES,
-                   positions={"a": 0.6}, created_at=now),
-            _claim("c3", status=ResolutionStatus.RESOLVED_NO,
-                   positions={"a": 0.4}, created_at=now),
-            _claim("c4", status=ResolutionStatus.RESOLVED_NO,
-                   positions={"a": 0.2}, created_at=now),
+            _claim(
+                "c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 0.8}, created_at=now
+            ),
+            _claim(
+                "c2", status=ResolutionStatus.RESOLVED_YES, positions={"a": 0.6}, created_at=now
+            ),
+            _claim("c3", status=ResolutionStatus.RESOLVED_NO, positions={"a": 0.4}, created_at=now),
+            _claim("c4", status=ResolutionStatus.RESOLVED_NO, positions={"a": 0.2}, created_at=now),
         ]
         result = compute_brier_scores(claims, require_enabled=False)
         assert result["a"].score == pytest.approx(0.10)
@@ -140,22 +139,23 @@ class TestClaimFiltering:
 
     def test_old_claim_outside_window_excluded(self):
         old = datetime(2020, 1, 1, tzinfo=UTC)
-        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
-                   positions={"a": 1.0}, created_at=old)
+        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0}, created_at=old)
         assert compute_brier_scores([c], window_days=90, require_enabled=False) == {}
 
     def test_recent_claim_inside_window_included(self):
         recent = datetime.now(tz=UTC) - timedelta(days=10)
-        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
-                   positions={"a": 1.0}, created_at=recent)
+        c = _claim(
+            "c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0}, created_at=recent
+        )
         result = compute_brier_scores([c], window_days=90, require_enabled=False)
         assert "a" in result
 
     def test_future_claim_above_cutoff_excluded(self):
         cutoff = datetime.now(tz=UTC)
         future = cutoff + timedelta(days=5)
-        c = _claim("c1", status=ResolutionStatus.RESOLVED_YES,
-                   positions={"a": 1.0}, created_at=future)
+        c = _claim(
+            "c1", status=ResolutionStatus.RESOLVED_YES, positions={"a": 1.0}, created_at=future
+        )
         result = compute_brier_scores([c], cutoff_dt=cutoff, require_enabled=False)
         assert result == {}
 
@@ -189,4 +189,3 @@ class TestAgentBrierScore:
         assert d["score"] == pytest.approx(0.0)
         assert d["n_predictions"] == 1
         assert d["window_days"] == 45
-


### PR DESCRIPTION
## Slice

Adds `aragora/prediction/brier.py` — a `compute_brier_scores()` function and `AgentBrierScore` frozen dataclass that compute per-agent Brier scores over resolved `StakeableClaim` objects, filtered to a configurable rolling window (default 90 days). Sub-deliverable 4 of AGT-04: per-agent prediction storage and rolling Brier score.

## Summary

- Adds `AgentBrierScore` frozen dataclass: `score`, `n_predictions`, `window_days`, `computed_at`, `has_skill` property, `to_dict()`
- Adds `compute_brier_scores(claims, *, window_days=90, cutoff_dt=None, require_enabled=True)` — filters to resolved claims in rolling window, computes per-agent Brier score (B = (1/N) Σ (f_t − o_t)²)
- Extends `aragora/prediction/__init__.py` to export both new symbols

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Related to #6065 (AGT-04 — Synthetic GitHub prediction markets)

## Gating

- Default: OFF (flag: `ARAGORA_PREDICTION_MARKETS_ENABLED` — same gate as existing store)
- Live queue effect: none
- Advances issue: #6065 (AGT-04 sub-deliverable 4)

## Tests

- `TestFeatureFlag` (3 tests) — flag off raises, `require_enabled=False` bypasses, flag on succeeds
- `TestScoreArithmetic` (6 tests) — perfect score YES/NO, no-skill baseline 0.25, average over multiple claims, multiple agents scored independently, four-prediction known-average (0.10)
- `TestClaimFiltering` (7 tests) — OPEN/EXPIRED/INCONCLUSIVE excluded, no-positions agent absent, old claim outside window excluded, recent included, future above cutoff excluded
- `TestAgentBrierScore` (4 tests) — `has_skill` below/at 0.25, `to_dict` keys and values

## Validation

- `pytest tests/prediction/test_brier.py --noconftest` — **20 passed**
- `ruff check aragora/prediction/brier.py aragora/prediction/__init__.py tests/prediction/test_brier.py` — clean
- `mypy aragora/prediction/brier.py --ignore-missing-imports` — clean

## Out of scope

- Credit bookkeeping / stake forfeit-refund (AGT-04 sub-deliverable 3 — future slice)
- Durable JSONL/PostgreSQL persistence (already tracked by `agt-04-jsonl-claim-store` branch)
- Reputation wiring (AGT-05 — depends on this output as an input signal)
- Manifold Brier scoring (AGT-03 — separate module; this scorer is for internal GitHub synthetic claims only)

## Checklist

### Before Submitting

- [x] My code follows the project's code style (ruff clean)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`pytest tests/prediction/test_brier.py --noconftest` — 20 passed)
- [x] My commit messages follow conventional commit format

### Code Quality

- [x] No new `# type: ignore` comments without justification
- [x] No hardcoded secrets or credentials
- [x] New code has type hints

### For New Features

- [x] Feature is tested with unit tests
- [x] Feature integrates with existing systems appropriately (same flag, same `StakeableClaim` schema)

## Additional Notes

Gate per `NEXT_STEPS_CANONICAL.md`: AGT-01..06 must not carry `boss-ready` until the proof-first Foreman gate explicitly permits the upper-layer tranche. This PR is `vision-layer` only — keep as DRAFT until the gate opens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbnaQMYWhfiLWczsrLrbMh)_