### PR TITLE
feat(scripts): settlement gate-preflight classifier + runbook

### DIFF
--- a/docs/runbooks/SETTLEMENT_PREFLIGHT.md
+++ b/docs/runbooks/SETTLEMENT_PREFLIGHT.md
@@ -1,0 +1,73 @@
+# Settlement Gate Preflight
+
+`scripts/settle_preflight.py` is a read-only classifier for conductor queue
+selection. It answers one question before a lane spends review or settlement
+effort: what is the next legal action for this PR under
+`docs/AGENT_OPERATING_CONTRACT.md` §Conductor?
+
+The classifier does not post comments, rerun checks, collect evidence, mark PRs
+ready, merge, edit labels, or change branch protection.
+
+## Usage
+
+Classify one PR:
+
+```bash
+python3 scripts/settle_preflight.py --pr 8990 --repo synaptent/aragora --json
+```
+
+Classify the open queue:
+
+```bash
+python3 scripts/settle_preflight.py --queue --repo synaptent/aragora --json
+```
+
+Callers must run the main-health check first. If any material required context
+on `origin/main` is red or missing, pass `--main-red` only to produce a
+`MAIN_RED_HALT` report; do not keep advancing PRs.
+
+Every verdict carries this recheck rule:
+
+> recheck on next origin/main push; never poll in a loop.
+
+## Verdicts
+
+| Verdict | Meaning | Conductor action |
+| --- | --- | --- |
+| `MAIN_RED_HALT` | `origin/main` required checks are not green. | Stop queue work and enter main-red incident mode. |
+| `DRAFT_SKIP` | The PR is draft. | Skip until the PR is explicitly ready for review. |
+| `HUMAN_GATED` | Tier is above 2, or the merge packet requires human risk settlement without recorded preapproval. | Stop and request exact-head human settlement before evidence or merge. |
+| `HEAD_BLOCKED` | The head is conflicting, behind, dirty, missing a satisfied packet, or has current-head blockers. | Park this head until the blocker clears or a repair head lands. |
+| `GITHUB_UNSTABLE` | The model packet is authorized, but GitHub reports an unstable or non-mergeable state. | Do not merge; wait for settlement-stable GitHub state on a future main push. |
+| `READY` | The PR is model-authorized and settlement-stable. | Run one final live check, then use normal exact-head protected squash merge. |
+
+## Park vs. Wait
+
+Park when the blocker is about the PR head: human gate, draft state, missing
+model quorum, current-head dissent, dirty/conflicting state, or an unresolved
+repair finding.
+
+Wait when the blocker is GitHub's transient merge-state calculation after the
+packet is already authorized. Do not poll continuously. Record the exact head,
+merge packet status, check state, and next recheck trigger.
+
+This composes with
+`docs/plans/2026-07-07-repeat-blocker-park-policy.md`: a current-head park
+record remains the source of truth for avoiding repeated evidence attempts, and
+the preflight classifier provides the cheap first-pass skip signal before a
+conductor spends a cycle.
+
+## Worked Example: #8990
+
+#8990 added `docs/plans/2026-07-07-repeat-blocker-park-policy.md`. The exact
+head `427aacc893a1f508690296405e0bbcf233b17c56` first failed
+`aragora-merge-quorum` because no countable Tier 0 model signal existed. After
+an exact-head OpenAI PASS landed, the merge packet became satisfied and
+required checks were green, but GitHub still reported `mergeStateStatus` as
+`UNSTABLE`.
+
+Under §Conductor, `UNSTABLE` is not settlement-stable, so the correct
+preflight verdict during that interval was `GITHUB_UNSTABLE`: wait for the next
+main-push recheck, do not run another evidence cycle, and do not merge by
+conductor automation. The PR later merged normally at merge commit
+`196bf38d540df5bd37a5a0918d8b8dd54604c2f6` once the unstable state cleared.

--- a/docs/runbooks/SETTLEMENT_PREFLIGHT.md
+++ b/docs/runbooks/SETTLEMENT_PREFLIGHT.md
@@ -22,6 +22,12 @@ Classify the open queue:
 python3 scripts/settle_preflight.py --queue --repo synaptent/aragora --json
 ```
 
+`--queue` is intentionally a thin enumerator. It lists open PR numbers, then
+classifies each PR through the same single-PR loader used by `--pr`: live PR
+metadata, non-empty policy file metadata, required-check state, active-owner
+state, and the merge packet all flow through one classification path. Queue mode
+must not carry a separate policy or readiness implementation.
+
 Callers must run the main-health check first. If any material required context
 on `origin/main` is red or missing, pass `--main-red` only to produce a
 `MAIN_RED_HALT` report; do not keep advancing PRs.
@@ -40,6 +46,17 @@ Every verdict carries this recheck rule:
 | `HEAD_BLOCKED` | The packet head does not match the live head, the head is conflicting, behind, dirty, missing a satisfied packet, or has current-head blockers. | Park this head until the blocker clears or a repair head lands. |
 | `GITHUB_UNSTABLE` | The model packet is authorized, but GitHub reports an unstable, unknown, or non-mergeable state. | Do not merge; wait for settlement-stable GitHub state on a future main push. |
 | `READY` | The PR is model-authorized and settlement-stable: `MERGEABLE` plus `CLEAN`, or `MERGEABLE` plus `BLOCKED` when packet/check blockers are clear and the only remaining gate is quorum/human-settlement. | Run one final live check, then use normal exact-head protected squash merge. |
+
+## READY Invariant
+
+`READY` is fail-closed. A PR with `mergeStateStatus=BLOCKED` is only
+settlement-stable when the live required-check surface proves the block is
+quorum-only: `lint`, `typecheck`, `sdk-parity`, `Generate & Validate`, and
+`TypeScript SDK Type Check` are successful, `aragora-merge-quorum` is the only
+non-success required context, `reviewDecision` is not `CHANGES_REQUESTED`, and
+policy metadata includes at least one changed file. Missing live metadata,
+missing or empty file scope, missing required-check metadata, unknown required
+contexts, or active-owner uncertainty parks the PR as `HEAD_BLOCKED`.
 
 ## Park vs. Wait
 

--- a/docs/runbooks/SETTLEMENT_PREFLIGHT.md
+++ b/docs/runbooks/SETTLEMENT_PREFLIGHT.md
@@ -36,10 +36,10 @@ Every verdict carries this recheck rule:
 | --- | --- | --- |
 | `MAIN_RED_HALT` | `origin/main` required checks are not green. | Stop queue work and enter main-red incident mode. |
 | `DRAFT_SKIP` | The PR is draft. | Skip until the PR is explicitly ready for review. |
-| `HUMAN_GATED` | Tier is above 2, or the merge packet requires human risk settlement without recorded preapproval. | Stop and request exact-head human settlement before evidence or merge. |
-| `HEAD_BLOCKED` | The head is conflicting, behind, dirty, missing a satisfied packet, or has current-head blockers. | Park this head until the blocker clears or a repair head lands. |
-| `GITHUB_UNSTABLE` | The model packet is authorized, but GitHub reports an unstable or non-mergeable state. | Do not merge; wait for settlement-stable GitHub state on a future main push. |
-| `READY` | The PR is model-authorized and settlement-stable. | Run one final live check, then use normal exact-head protected squash merge. |
+| `HUMAN_GATED` | Tier is above 2, the packet requires unsettled human risk settlement or preapproval, or repo policy excludes autonomous settlement. | Stop and request exact-head human/operator settlement before evidence or merge. |
+| `HEAD_BLOCKED` | The packet head does not match the live head, the head is conflicting, behind, dirty, missing a satisfied packet, or has current-head blockers. | Park this head until the blocker clears or a repair head lands. |
+| `GITHUB_UNSTABLE` | The model packet is authorized, but GitHub reports an unstable, unknown, or non-mergeable state. | Do not merge; wait for settlement-stable GitHub state on a future main push. |
+| `READY` | The PR is model-authorized and settlement-stable: `MERGEABLE` plus `CLEAN`, or `MERGEABLE` plus `BLOCKED` when packet/check blockers are clear and the only remaining gate is quorum/human-settlement. | Run one final live check, then use normal exact-head protected squash merge. |
 
 ## Park vs. Wait
 
@@ -48,8 +48,13 @@ model quorum, current-head dissent, dirty/conflicting state, or an unresolved
 repair finding.
 
 Wait when the blocker is GitHub's transient merge-state calculation after the
-packet is already authorized. Do not poll continuously. Record the exact head,
-merge packet status, check state, and next recheck trigger.
+packet is already authorized. `UNSTABLE`, missing/unknown merge state, and
+non-`MERGEABLE` live state are not settlement-stable. `BLOCKED` is
+settlement-stable only after policy exclusions, packet blockers, and
+current-head blockers are clear, because in that case the remaining blocker is
+the exact quorum or human-settlement context the packet is meant to satisfy. Do
+not poll continuously. Record the exact head, merge packet status, check state,
+and next recheck trigger.
 
 This composes with
 `docs/plans/2026-07-07-repeat-blocker-park-policy.md`: a current-head park

--- a/scripts/settle_preflight.py
+++ b/scripts/settle_preflight.py
@@ -81,10 +81,19 @@ def _human_preapproval_recorded(entry: dict[str, Any]) -> bool:
 
 
 def _model_authorized(entry: dict[str, Any]) -> bool:
-    return bool(entry.get("admin_squash_allowed")) or (
-        str(entry.get("status") or "") == "satisfied"
+    return (
+        bool(entry.get("admin_squash_allowed"))
+        and str(entry.get("status") or "") == "satisfied"
         and str(entry.get("verdict") or "") == "admin_squash_allowed"
     )
+
+
+def _head_drift_reason(entry: dict[str, Any], metadata: dict[str, Any]) -> str | None:
+    packet_head = str(entry.get("head_sha") or "")
+    live_head = str(metadata.get("headRefOid") or "")
+    if packet_head and live_head and packet_head != live_head:
+        return f"head drift: packet {packet_head} live {live_head}"
+    return None
 
 
 def classify_pr(
@@ -131,31 +140,21 @@ def classify_pr(
             ("PR is draft",),
         )
 
-    human_reasons = settle_one_pr.policy_exclusion_reasons(
+    head_drift = _head_drift_reason(entry, metadata)
+    if head_drift:
+        return result(
+            HEAD_BLOCKED,
+            "park this head until the merge packet is regenerated for the live head",
+            (head_drift,),
+        )
+
+    policy_reasons = settle_one_pr.policy_exclusion_reasons(
         entry, policy_metadata={pr_number: metadata}
     )
     tier_human = tier is not None and tier > 2
-    requires_human = bool(
+    requires_human_risk = bool(
         entry.get("requires_human_risk_settlement")
     ) and not _human_preapproval_recorded(entry)
-    if tier_human or requires_human:
-        reasons = []
-        if tier_human:
-            reasons.append(f"Tier {tier}")
-        if requires_human:
-            reasons.append("requires_human_risk_settlement=true without recorded preapproval")
-        for reason in human_reasons:
-            if reason not in reasons and (
-                reason.startswith("Tier ")
-                or reason == "requires_human_risk_settlement=true"
-                or reason == settle_one_pr.SURFACE_EXCLUDE_REASON
-            ):
-                reasons.append(reason)
-        return result(
-            HUMAN_GATED,
-            "stop and request exact-head human settlement before evidence or merge",
-            tuple(reasons),
-        )
 
     if merge_state in {"DIRTY", "BEHIND"} or mergeable == "CONFLICTING":
         return result(
@@ -164,9 +163,49 @@ def classify_pr(
             (f"mergeable={mergeable or 'unknown'} mergeStateStatus={merge_state or 'unknown'}",),
         )
 
-    if _model_authorized(entry) and (
-        merge_state in {"UNSTABLE", "BLOCKED", "BEHIND"} or mergeable != "MERGEABLE"
-    ):
+    requires_human_preapproval = bool(
+        entry.get("requires_human_preapproval")
+    ) and not _human_preapproval_recorded(entry)
+    recorded_human_settlement = _human_preapproval_recorded(entry)
+    policy_gate_reasons = [
+        reason
+        for reason in policy_reasons
+        if reason != "dirty/conflicting PR"
+        and not (recorded_human_settlement and reason == "requires_human_risk_settlement=true")
+    ]
+    if tier_human or requires_human_risk or requires_human_preapproval or policy_gate_reasons:
+        reasons = []
+        if tier_human:
+            reasons.append(f"Tier {tier}")
+        if requires_human_risk:
+            reasons.append("requires_human_risk_settlement=true without recorded preapproval")
+        if requires_human_preapproval:
+            reasons.append("requires_human_preapproval=true without recorded preapproval")
+        for reason in policy_gate_reasons:
+            if reason not in reasons:
+                reasons.append(reason)
+        return result(
+            HUMAN_GATED,
+            "stop and request exact-head human settlement or operator decision before evidence or merge",
+            tuple(reasons),
+        )
+
+    entry_blockers = settle_one_pr.entry_blockers(entry) if entry else []
+    if recorded_human_settlement:
+        entry_blockers = [
+            blocker
+            for blocker in entry_blockers
+            if blocker != "requires_human_risk_settlement=true"
+        ]
+    if entry_blockers:
+        return result(
+            HEAD_BLOCKED,
+            "park this head until the merge-packet blockers are resolved",
+            tuple(entry_blockers),
+        )
+
+    model_authorized = _model_authorized(entry)
+    if model_authorized and (merge_state not in {"CLEAN", "BLOCKED"} or mergeable != "MERGEABLE"):
         return result(
             GITHUB_UNSTABLE,
             "do not merge; wait for GitHub merge state to become settlement-stable",
@@ -175,15 +214,7 @@ def classify_pr(
             ),
         )
 
-    entry_blockers = settle_one_pr.entry_blockers(entry) if entry else []
-    if entry_blockers:
-        return result(
-            HEAD_BLOCKED,
-            "park this head until the merge-packet blockers are resolved",
-            tuple(entry_blockers),
-        )
-
-    if mergeable == "MERGEABLE" and merge_state in {"CLEAN", ""} and _model_authorized(entry):
+    if mergeable == "MERGEABLE" and merge_state in {"CLEAN", "BLOCKED"} and model_authorized:
         return result(
             READY,
             "run exact-head normal protected squash merge after one final live-state check",

--- a/scripts/settle_preflight.py
+++ b/scripts/settle_preflight.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Read-only settlement gate preflight for conductor queue selection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.settle_one_pr as settle_one_pr
+
+RECHECK_RULE = "recheck on next origin/main push; never poll in a loop."
+
+MAIN_RED_HALT = "MAIN_RED_HALT"
+DRAFT_SKIP = "DRAFT_SKIP"
+HUMAN_GATED = "HUMAN_GATED"
+HEAD_BLOCKED = "HEAD_BLOCKED"
+GITHUB_UNSTABLE = "GITHUB_UNSTABLE"
+READY = "READY"
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    pr_number: int
+    verdict: str
+    action: str
+    recheck_rule: str
+    title: str = ""
+    head_sha: str = ""
+    tier: int | None = None
+    mergeable: str = ""
+    merge_state: str = ""
+    reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _pr_number(*payloads: dict[str, Any]) -> int:
+    for payload in payloads:
+        value = settle_one_pr._coerce_int(payload.get("pr_number") or payload.get("number"))
+        if value is not None:
+            return value
+    return 0
+
+
+def _title(entry: dict[str, Any], metadata: dict[str, Any]) -> str:
+    return str(metadata.get("title") or entry.get("title") or "")
+
+
+def _head_sha(entry: dict[str, Any], metadata: dict[str, Any]) -> str:
+    return str(metadata.get("headRefOid") or entry.get("head_sha") or "")
+
+
+def _mergeable(metadata: dict[str, Any], entry: dict[str, Any]) -> str:
+    return str(metadata.get("mergeable") or entry.get("mergeable") or "").upper()
+
+
+def _merge_state(metadata: dict[str, Any], entry: dict[str, Any]) -> str:
+    return str(metadata.get("mergeStateStatus") or entry.get("mergeStateStatus") or "").upper()
+
+
+def _tier(entry: dict[str, Any]) -> int | None:
+    return settle_one_pr._coerce_int(entry.get("tier"))
+
+
+def _human_preapproval_recorded(entry: dict[str, Any]) -> bool:
+    if bool(entry.get("human_preapproval_recorded")):
+        return True
+    settlement = entry.get("settlement_creator_pin")
+    if isinstance(settlement, dict):
+        return bool(settlement.get("verified") and settlement.get("trusted_creator"))
+    return False
+
+
+def _model_authorized(entry: dict[str, Any]) -> bool:
+    return bool(entry.get("admin_squash_allowed")) or (
+        str(entry.get("status") or "") == "satisfied"
+        and str(entry.get("verdict") or "") == "admin_squash_allowed"
+    )
+
+
+def classify_pr(
+    *,
+    entry: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    main_red: bool = False,
+) -> PreflightResult:
+    """Classify one PR using read-only metadata and merge-packet fields."""
+    entry = dict(entry or {})
+    metadata = dict(metadata or {})
+    pr_number = _pr_number(entry, metadata)
+    tier = _tier(entry)
+    mergeable = _mergeable(metadata, entry)
+    merge_state = _merge_state(metadata, entry)
+    title = _title(entry, metadata)
+    head_sha = _head_sha(entry, metadata)
+
+    def result(verdict: str, action: str, reasons: tuple[str, ...]) -> PreflightResult:
+        return PreflightResult(
+            pr_number=pr_number,
+            verdict=verdict,
+            action=action,
+            recheck_rule=RECHECK_RULE,
+            title=title,
+            head_sha=head_sha,
+            tier=tier,
+            mergeable=mergeable,
+            merge_state=merge_state,
+            reasons=reasons,
+        )
+
+    if main_red:
+        return result(
+            MAIN_RED_HALT,
+            "halt conductor work and enter main-red incident mode",
+            ("origin/main required checks are not green",),
+        )
+
+    if bool(metadata.get("isDraft") or entry.get("isDraft")):
+        return result(
+            DRAFT_SKIP,
+            "skip this PR until it is marked ready for review",
+            ("PR is draft",),
+        )
+
+    human_reasons = settle_one_pr.policy_exclusion_reasons(
+        entry, policy_metadata={pr_number: metadata}
+    )
+    tier_human = tier is not None and tier > 2
+    requires_human = bool(
+        entry.get("requires_human_risk_settlement")
+    ) and not _human_preapproval_recorded(entry)
+    if tier_human or requires_human:
+        reasons = []
+        if tier_human:
+            reasons.append(f"Tier {tier}")
+        if requires_human:
+            reasons.append("requires_human_risk_settlement=true without recorded preapproval")
+        for reason in human_reasons:
+            if reason not in reasons and (
+                reason.startswith("Tier ")
+                or reason == "requires_human_risk_settlement=true"
+                or reason == settle_one_pr.SURFACE_EXCLUDE_REASON
+            ):
+                reasons.append(reason)
+        return result(
+            HUMAN_GATED,
+            "stop and request exact-head human settlement before evidence or merge",
+            tuple(reasons),
+        )
+
+    if merge_state in {"DIRTY", "BEHIND"} or mergeable == "CONFLICTING":
+        return result(
+            HEAD_BLOCKED,
+            "park this head until conflicts, behind-base state, or current-head blocker clears",
+            (f"mergeable={mergeable or 'unknown'} mergeStateStatus={merge_state or 'unknown'}",),
+        )
+
+    if _model_authorized(entry) and (
+        merge_state in {"UNSTABLE", "BLOCKED", "BEHIND"} or mergeable != "MERGEABLE"
+    ):
+        return result(
+            GITHUB_UNSTABLE,
+            "do not merge; wait for GitHub merge state to become settlement-stable",
+            (
+                f"model-authorized but mergeable={mergeable or 'unknown'} mergeStateStatus={merge_state or 'unknown'}",
+            ),
+        )
+
+    entry_blockers = settle_one_pr.entry_blockers(entry) if entry else []
+    if entry_blockers:
+        return result(
+            HEAD_BLOCKED,
+            "park this head until the merge-packet blockers are resolved",
+            tuple(entry_blockers),
+        )
+
+    if mergeable == "MERGEABLE" and merge_state in {"CLEAN", ""} and _model_authorized(entry):
+        return result(
+            READY,
+            "run exact-head normal protected squash merge after one final live-state check",
+            ("model-authorized and settlement-stable",),
+        )
+
+    return result(
+        HEAD_BLOCKED,
+        "park this head until it has a satisfied model packet and stable GitHub merge state",
+        (f"status={entry.get('status') or 'unknown'} verdict={entry.get('verdict') or 'unknown'}",),
+    )
+
+
+def _packet_entry(packet: dict[str, Any], pr_number: int) -> dict[str, Any]:
+    entries = packet.get("entries")
+    if not isinstance(entries, list):
+        return {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if _pr_number(entry) == pr_number:
+            return entry
+    return {}
+
+
+def _load_single(
+    cwd: Path, pr_number: int, repo: str | None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
+    entry = _packet_entry(packet, pr_number)
+    metadata, _command = settle_one_pr.load_pr_policy_metadata(cwd, pr_number, repo=repo)
+    live_payload, _live_command = settle_one_pr._run_json(
+        settle_one_pr._with_repo(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                "number,title,headRefName,headRefOid,isDraft,mergeable,mergeStateStatus,files",
+            ],
+            repo,
+        ),
+        cwd=cwd,
+        timeout=settle_one_pr.GH_METADATA_TIMEOUT_SECONDS,
+    )
+    if isinstance(live_payload, dict):
+        metadata.update(live_payload)
+    return entry, metadata
+
+
+def _classify_queue(cwd: Path, repo: str | None, limit: int) -> list[PreflightResult]:
+    metadata_by_pr, _command = settle_one_pr.load_open_pr_metadata(cwd, limit=limit, repo=repo)
+    results: list[PreflightResult] = []
+    for pr_number, metadata in sorted(metadata_by_pr.items()):
+        entry: dict[str, Any] = {}
+        if not metadata.get("isDraft"):
+            try:
+                packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
+                entry = _packet_entry(packet, pr_number)
+            except RuntimeError as exc:
+                entry = {
+                    "pr_number": pr_number,
+                    "title": metadata.get("title"),
+                    "head_sha": metadata.get("headRefOid"),
+                    "status": "packet_unavailable",
+                    "verdict": "packet_unavailable",
+                    "reasons": [str(exc)],
+                }
+        results.append(classify_pr(entry=entry, metadata=metadata))
+    return results
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--pr", type=int, help="Classify one pull request")
+    target.add_argument("--queue", action="store_true", help="Classify open pull requests")
+    parser.add_argument("--repo", default=None, help="GitHub repo owner/name")
+    parser.add_argument("--limit", type=int, default=50, help="Open-PR limit for --queue")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument(
+        "--main-red",
+        action="store_true",
+        help="Classify all targets as MAIN_RED_HALT after an external main-health check",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    cwd = Path.cwd()
+    if args.pr is not None:
+        entry, metadata = _load_single(cwd, args.pr, args.repo)
+        results = [classify_pr(entry=entry, metadata=metadata, main_red=args.main_red)]
+    else:
+        results = _classify_queue(cwd, args.repo, args.limit)
+        if args.main_red:
+            results = [
+                classify_pr(
+                    entry={
+                        "pr_number": item.pr_number,
+                        "title": item.title,
+                        "head_sha": item.head_sha,
+                    },
+                    metadata={},
+                    main_red=True,
+                )
+                for item in results
+            ]
+
+    payload = {"results": [result.to_dict() for result in results]}
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for result in results:
+            print(f"#{result.pr_number} {result.verdict}: {result.action} ({result.recheck_rule})")
+            for reason in result.reasons:
+                print(f"  - {reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/settle_preflight.py
+++ b/scripts/settle_preflight.py
@@ -17,7 +17,31 @@ if str(REPO_ROOT) not in sys.path:
 import scripts.settle_one_pr as settle_one_pr
 
 RECHECK_RULE = "recheck on next origin/main push; never poll in a loop."
-QUEUE_POLICY_METADATA_REASON = "missing queue policy metadata with files"
+POLICY_METADATA_REASON = "missing PR policy metadata with non-empty files"
+QUEUE_POLICY_METADATA_REASON = POLICY_METADATA_REASON
+LIVE_METADATA_REASON = "live PR metadata unavailable"
+REQUIRED_CHECK_METADATA_REASON = "required check metadata unavailable"
+OPEN_QUEUE_METADATA_REASON = "open PR queue metadata unavailable"
+ACTIVE_OWNER_METADATA_REASON = (
+    "operator-snapshot unavailable; active-owned exclusions cannot be trusted"
+)
+ACTIVE_OWNER_REASON = "active-owned lane"
+MERGE_QUORUM = "aragora-merge-quorum"
+REQUIRED_GREEN_CONTEXTS = (
+    "lint",
+    "typecheck",
+    "sdk-parity",
+    "Generate & Validate",
+    "TypeScript SDK Type Check",
+)
+EXPECTED_REQUIRED_CONTEXTS = {*REQUIRED_GREEN_CONTEXTS, MERGE_QUORUM}
+TRANSPORT_FAILURE_PREFIXES = (
+    POLICY_METADATA_REASON,
+    LIVE_METADATA_REASON,
+    REQUIRED_CHECK_METADATA_REASON,
+    OPEN_QUEUE_METADATA_REASON,
+    ACTIVE_OWNER_METADATA_REASON,
+)
 
 MAIN_RED_HALT = "MAIN_RED_HALT"
 DRAFT_SKIP = "DRAFT_SKIP"
@@ -97,16 +121,89 @@ def _head_drift_reason(entry: dict[str, Any], metadata: dict[str, Any]) -> str |
     return None
 
 
+def _has_nonempty_policy_file_scope(metadata: dict[str, Any]) -> bool:
+    files = metadata.get("files")
+    return isinstance(files, list) and bool(files)
+
+
+def _check_name(check: dict[str, Any]) -> str:
+    return str(check.get("name") or check.get("context") or "")
+
+
+def _check_state(check: dict[str, Any]) -> str:
+    return str(check.get("state") or check.get("status") or check.get("conclusion") or "").upper()
+
+
+def _check_success(check: dict[str, Any]) -> bool:
+    return _check_state(check) in {"SUCCESS", "SKIPPED", "NEUTRAL", "PASS"}
+
+
+def _blocked_ready_reasons(metadata: dict[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    review_decision = str(metadata.get("reviewDecision") or "").upper()
+    if review_decision == "CHANGES_REQUESTED":
+        reasons.append("reviewDecision=CHANGES_REQUESTED")
+
+    if not _has_nonempty_policy_file_scope(metadata):
+        reasons.append(POLICY_METADATA_REASON)
+
+    if metadata.get("required_checks_error"):
+        reasons.append(f"{REQUIRED_CHECK_METADATA_REASON}: {metadata['required_checks_error']}")
+        return tuple(reasons)
+
+    required_checks = metadata.get("required_checks")
+    if not isinstance(required_checks, list):
+        reasons.append(REQUIRED_CHECK_METADATA_REASON)
+        return tuple(reasons)
+
+    by_name: dict[str, dict[str, Any]] = {}
+    for check in required_checks:
+        if not isinstance(check, dict):
+            continue
+        name = _check_name(check)
+        if name:
+            by_name[name] = check
+
+    unexpected = sorted(name for name in by_name if name not in EXPECTED_REQUIRED_CONTEXTS)
+    for name in unexpected:
+        reasons.append(f"unexpected required context {name}")
+
+    for context in REQUIRED_GREEN_CONTEXTS:
+        check = by_name.get(context)
+        if check is None:
+            reasons.append(f"required context {context} missing")
+        elif not _check_success(check):
+            reasons.append(f"required context {context} is {_check_state(check) or 'unknown'}")
+
+    quorum_check = by_name.get(MERGE_QUORUM)
+    if quorum_check is None:
+        reasons.append(f"required context {MERGE_QUORUM} missing")
+    elif _check_success(quorum_check):
+        reasons.append(f"{MERGE_QUORUM} is not the remaining BLOCKED gate")
+
+    non_success = [
+        name
+        for name, check in by_name.items()
+        if not _check_success(check) and name != MERGE_QUORUM
+    ]
+    for name in sorted(non_success):
+        reasons.append(f"non-quorum required context {name} is {_check_state(by_name[name])}")
+    return tuple(dict.fromkeys(reasons))
+
+
 def classify_pr(
     *,
     entry: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     main_red: bool = False,
+    active_owned_prs: set[int] | None = None,
+    active_owner_error: str | None = None,
 ) -> PreflightResult:
     """Classify one PR using read-only metadata and merge-packet fields."""
     entry = dict(entry or {})
     metadata = dict(metadata or {})
     pr_number = _pr_number(entry, metadata)
+    active_owned = set(active_owned_prs or set())
     tier = _tier(entry)
     mergeable = _mergeable(metadata, entry)
     merge_state = _merge_state(metadata, entry)
@@ -149,14 +246,35 @@ def classify_pr(
             (head_drift,),
         )
 
-    if bool(entry.get("policy_metadata_unavailable")):
+    if active_owner_error:
+        return result(
+            HEAD_BLOCKED,
+            "park this head until active-owner state can be trusted",
+            (active_owner_error,),
+        )
+
+    if pr_number in active_owned:
+        return result(
+            HEAD_BLOCKED,
+            "park this head because another active lane owns it",
+            (ACTIVE_OWNER_REASON,),
+        )
+
+    if bool(entry.get("metadata_unavailable") or entry.get("policy_metadata_unavailable")):
         metadata_reasons = tuple(
-            str(reason) for reason in entry.get("reasons") or [QUEUE_POLICY_METADATA_REASON]
+            str(reason) for reason in entry.get("reasons") or [POLICY_METADATA_REASON]
         )
         return result(
             HEAD_BLOCKED,
-            "park this head until queue-mode policy metadata with files can be loaded",
+            "park this head until fail-closed preflight metadata can be loaded",
             metadata_reasons,
+        )
+
+    if not _has_nonempty_policy_file_scope(metadata):
+        return result(
+            HEAD_BLOCKED,
+            "park this head until PR policy metadata includes changed files",
+            (POLICY_METADATA_REASON,),
         )
 
     policy_reasons = settle_one_pr.policy_exclusion_reasons(
@@ -225,7 +343,21 @@ def classify_pr(
             ),
         )
 
-    if mergeable == "MERGEABLE" and merge_state in {"CLEAN", "BLOCKED"} and model_authorized:
+    if model_authorized and mergeable == "MERGEABLE" and merge_state == "BLOCKED":
+        blocked_reasons = _blocked_ready_reasons(metadata)
+        if blocked_reasons:
+            return result(
+                HEAD_BLOCKED,
+                "park this head until BLOCKED is proven to be quorum-only",
+                blocked_reasons,
+            )
+        return result(
+            READY,
+            "run exact-head normal protected squash merge after one final live-state check",
+            ("model-authorized and BLOCKED only by aragora-merge-quorum",),
+        )
+
+    if mergeable == "MERGEABLE" and merge_state == "CLEAN" and model_authorized:
         return result(
             READY,
             "run exact-head normal protected squash merge after one final live-state check",
@@ -266,19 +398,20 @@ def _packet_unavailable_entry(
     }
 
 
-def _policy_metadata_unavailable_entry(
+def _metadata_unavailable_entry(
     pr_number: int,
     metadata: dict[str, Any],
+    prefix: str,
     reason: str,
 ) -> dict[str, Any]:
     return {
         "pr_number": pr_number,
         "title": metadata.get("title"),
         "head_sha": metadata.get("headRefOid"),
-        "status": "policy_metadata_unavailable",
-        "verdict": "policy_metadata_unavailable",
-        "policy_metadata_unavailable": True,
-        "reasons": [f"{QUEUE_POLICY_METADATA_REASON}: {reason}"],
+        "status": "metadata_unavailable",
+        "verdict": "metadata_unavailable",
+        "metadata_unavailable": True,
+        "reasons": [f"{prefix}: {reason}"],
     }
 
 
@@ -290,19 +423,10 @@ def _command_failure_reason(command: dict[str, Any]) -> str:
     return "files field missing from PR policy metadata"
 
 
-def _load_queue_policy_metadata(
-    cwd: Path,
-    repo: str | None,
-    pr_number: int,
-) -> tuple[dict[str, Any] | None, str | None]:
-    metadata, command = settle_one_pr.load_pr_policy_metadata(cwd, pr_number, repo=repo)
-    if settle_one_pr._has_policy_file_scope(metadata):
-        return metadata, None
-    return None, _command_failure_reason(command)
-
-
-def _load_live_file_metadata(cwd: Path, repo: str | None, pr_number: int) -> dict[str, Any]:
-    live_payload, _command = settle_one_pr._run_json(
+def _load_live_metadata(
+    cwd: Path, repo: str | None, pr_number: int
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    live_payload, command = settle_one_pr._run_json(
         settle_one_pr._with_repo(
             [
                 "gh",
@@ -310,47 +434,161 @@ def _load_live_file_metadata(cwd: Path, repo: str | None, pr_number: int) -> dic
                 "view",
                 str(pr_number),
                 "--json",
-                "number,title,headRefName,headRefOid,isDraft,mergeable,mergeStateStatus,files",
+                (
+                    "number,title,headRefName,headRefOid,isDraft,mergeable,"
+                    "mergeStateStatus,reviewDecision,statusCheckRollup"
+                ),
             ],
             repo,
         ),
         cwd=cwd,
         timeout=settle_one_pr.GH_METADATA_TIMEOUT_SECONDS,
     )
-    return live_payload if isinstance(live_payload, dict) else {}
+    return (live_payload if isinstance(live_payload, dict) else {}), command
+
+
+def _load_required_checks(
+    cwd: Path, repo: str | None, pr_number: int
+) -> tuple[list[dict[str, Any]] | None, dict[str, Any]]:
+    payload, command = settle_one_pr._run_json(
+        settle_one_pr._with_repo(
+            [
+                "gh",
+                "pr",
+                "checks",
+                str(pr_number),
+                "--required",
+                "--json",
+                "name,state,bucket,workflow,link",
+            ],
+            repo,
+        ),
+        cwd=cwd,
+        timeout=settle_one_pr.GH_METADATA_TIMEOUT_SECONDS,
+    )
+    return (payload if isinstance(payload, list) else None), command
+
+
+def _load_active_owner_scope(cwd: Path) -> tuple[set[int], str | None]:
+    active_owned_prs, command = settle_one_pr.load_active_owned_prs(cwd)
+    blocker = settle_one_pr.active_owned_snapshot_blocker(command)
+    return active_owned_prs, blocker
 
 
 def _load_single(
-    cwd: Path, pr_number: int, repo: str | None
+    cwd: Path,
+    pr_number: int,
+    repo: str | None,
+    *,
+    seed_metadata: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    metadata, _command = settle_one_pr.load_pr_policy_metadata(cwd, pr_number, repo=repo)
+    metadata = dict(seed_metadata or {})
+    live_metadata, live_command = _load_live_metadata(cwd, repo, pr_number)
+    metadata.update(live_metadata)
+    live_required_fields = {"headRefOid", "isDraft", "mergeable", "mergeStateStatus"}
+    if not live_required_fields.issubset(live_metadata):
+        return _metadata_unavailable_entry(
+            pr_number,
+            metadata,
+            LIVE_METADATA_REASON,
+            _command_failure_reason(live_command),
+        ), metadata
+
+    if bool(metadata.get("isDraft")):
+        return {}, metadata
+
+    policy_metadata, policy_command = settle_one_pr.load_pr_policy_metadata(
+        cwd, pr_number, repo=repo
+    )
+    metadata.update(policy_metadata)
+    if not _has_nonempty_policy_file_scope(policy_metadata):
+        return _metadata_unavailable_entry(
+            pr_number,
+            metadata,
+            POLICY_METADATA_REASON,
+            _command_failure_reason(policy_command),
+        ), metadata
+
+    required_checks, required_command = _load_required_checks(cwd, repo, pr_number)
+    if required_checks is None:
+        metadata["required_checks_error"] = _command_failure_reason(required_command)
+    else:
+        metadata["required_checks"] = required_checks
+
     try:
         packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
         entry = _packet_entry(packet, pr_number)
     except RuntimeError as exc:
         entry = _packet_unavailable_entry(pr_number, metadata, exc)
-    metadata.update(_load_live_file_metadata(cwd, repo, pr_number))
     return entry, metadata
 
 
-def _classify_queue(cwd: Path, repo: str | None, limit: int) -> list[PreflightResult]:
+def _classify_single(
+    cwd: Path,
+    pr_number: int,
+    repo: str | None,
+    *,
+    main_red: bool = False,
+    active_owned_prs: set[int] | None = None,
+    active_owner_error: str | None = None,
+    seed_metadata: dict[str, Any] | None = None,
+) -> PreflightResult:
+    if main_red:
+        return classify_pr(
+            entry={"pr_number": pr_number},
+            metadata=seed_metadata or {},
+            main_red=True,
+        )
+    entry, metadata = _load_single(cwd, pr_number, repo, seed_metadata=seed_metadata)
+    return classify_pr(
+        entry=entry,
+        metadata=metadata,
+        active_owned_prs=active_owned_prs,
+        active_owner_error=active_owner_error,
+    )
+
+
+def _open_queue_unavailable_result(command: dict[str, Any]) -> PreflightResult:
+    reason = _command_failure_reason(command)
+    entry = _metadata_unavailable_entry(0, {}, OPEN_QUEUE_METADATA_REASON, reason)
+    return classify_pr(entry=entry, metadata={})
+
+
+def _has_transport_failure(result: PreflightResult) -> bool:
+    return any(
+        reason.startswith(prefix)
+        for reason in result.reasons
+        for prefix in TRANSPORT_FAILURE_PREFIXES
+    )
+
+
+def _exit_code(results: list[PreflightResult]) -> int:
+    return 2 if any(_has_transport_failure(result) for result in results) else 0
+
+
+def _classify_queue(
+    cwd: Path,
+    repo: str | None,
+    limit: int,
+    *,
+    active_owned_prs: set[int] | None = None,
+    active_owner_error: str | None = None,
+) -> list[PreflightResult]:
     metadata_by_pr, _command = settle_one_pr.load_open_pr_metadata(cwd, limit=limit, repo=repo)
+    if _command.get("returncode") not in (0, None) or _command.get("json_error"):
+        return [_open_queue_unavailable_result(_command)]
     results: list[PreflightResult] = []
     for pr_number, metadata in sorted(metadata_by_pr.items()):
-        entry: dict[str, Any] = {}
-        if not metadata.get("isDraft"):
-            policy_metadata, policy_error = _load_queue_policy_metadata(cwd, repo, pr_number)
-            if policy_error:
-                entry = _policy_metadata_unavailable_entry(pr_number, metadata, policy_error)
-                results.append(classify_pr(entry=entry, metadata=metadata))
-                continue
-            metadata = {**metadata, **dict(policy_metadata or {})}
-            try:
-                packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
-                entry = _packet_entry(packet, pr_number)
-            except RuntimeError as exc:
-                entry = _packet_unavailable_entry(pr_number, metadata, exc)
-        results.append(classify_pr(entry=entry, metadata=metadata))
+        results.append(
+            _classify_single(
+                cwd,
+                pr_number,
+                repo,
+                active_owned_prs=active_owned_prs,
+                active_owner_error=active_owner_error,
+                seed_metadata=metadata,
+            )
+        )
     return results
 
 
@@ -373,6 +611,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     cwd = Path.cwd()
+    active_owned_prs: set[int] = set()
+    active_owner_error: str | None = None
+    if not args.main_red:
+        active_owned_prs, active_owner_error = _load_active_owner_scope(cwd)
 
     if args.main_red:
         if args.pr is not None:
@@ -402,10 +644,23 @@ def main(argv: list[str] | None = None) -> int:
             if not results:
                 results = [classify_pr(entry={}, metadata={}, main_red=True)]
     elif args.pr is not None:
-        entry, metadata = _load_single(cwd, args.pr, args.repo)
-        results = [classify_pr(entry=entry, metadata=metadata, main_red=args.main_red)]
+        results = [
+            _classify_single(
+                cwd,
+                args.pr,
+                args.repo,
+                active_owned_prs=active_owned_prs,
+                active_owner_error=active_owner_error,
+            )
+        ]
     else:
-        results = _classify_queue(cwd, args.repo, args.limit)
+        results = _classify_queue(
+            cwd,
+            args.repo,
+            args.limit,
+            active_owned_prs=active_owned_prs,
+            active_owner_error=active_owner_error,
+        )
 
     payload = {"results": [result.to_dict() for result in results]}
     if args.json:
@@ -415,7 +670,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"#{result.pr_number} {result.verdict}: {result.action} ({result.recheck_rule})")
             for reason in result.reasons:
                 print(f"  - {reason}")
-    return 0
+    return _exit_code(results)
 
 
 if __name__ == "__main__":

--- a/scripts/settle_preflight.py
+++ b/scripts/settle_preflight.py
@@ -240,13 +240,23 @@ def _packet_entry(packet: dict[str, Any], pr_number: int) -> dict[str, Any]:
     return {}
 
 
-def _load_single(
-    cwd: Path, pr_number: int, repo: str | None
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
-    entry = _packet_entry(packet, pr_number)
-    metadata, _command = settle_one_pr.load_pr_policy_metadata(cwd, pr_number, repo=repo)
-    live_payload, _live_command = settle_one_pr._run_json(
+def _packet_unavailable_entry(
+    pr_number: int,
+    metadata: dict[str, Any],
+    exc: RuntimeError,
+) -> dict[str, Any]:
+    return {
+        "pr_number": pr_number,
+        "title": metadata.get("title"),
+        "head_sha": metadata.get("headRefOid"),
+        "status": "packet_unavailable",
+        "verdict": "packet_unavailable",
+        "reasons": [str(exc)],
+    }
+
+
+def _load_live_file_metadata(cwd: Path, repo: str | None, pr_number: int) -> dict[str, Any]:
+    live_payload, _command = settle_one_pr._run_json(
         settle_one_pr._with_repo(
             [
                 "gh",
@@ -261,8 +271,19 @@ def _load_single(
         cwd=cwd,
         timeout=settle_one_pr.GH_METADATA_TIMEOUT_SECONDS,
     )
-    if isinstance(live_payload, dict):
-        metadata.update(live_payload)
+    return live_payload if isinstance(live_payload, dict) else {}
+
+
+def _load_single(
+    cwd: Path, pr_number: int, repo: str | None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    metadata, _command = settle_one_pr.load_pr_policy_metadata(cwd, pr_number, repo=repo)
+    try:
+        packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
+        entry = _packet_entry(packet, pr_number)
+    except RuntimeError as exc:
+        entry = _packet_unavailable_entry(pr_number, metadata, exc)
+    metadata.update(_load_live_file_metadata(cwd, repo, pr_number))
     return entry, metadata
 
 
@@ -272,18 +293,13 @@ def _classify_queue(cwd: Path, repo: str | None, limit: int) -> list[PreflightRe
     for pr_number, metadata in sorted(metadata_by_pr.items()):
         entry: dict[str, Any] = {}
         if not metadata.get("isDraft"):
+            if not metadata.get("files"):
+                metadata = {**metadata, **_load_live_file_metadata(cwd, repo, pr_number)}
             try:
                 packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
                 entry = _packet_entry(packet, pr_number)
             except RuntimeError as exc:
-                entry = {
-                    "pr_number": pr_number,
-                    "title": metadata.get("title"),
-                    "head_sha": metadata.get("headRefOid"),
-                    "status": "packet_unavailable",
-                    "verdict": "packet_unavailable",
-                    "reasons": [str(exc)],
-                }
+                entry = _packet_unavailable_entry(pr_number, metadata, exc)
         results.append(classify_pr(entry=entry, metadata=metadata))
     return results
 
@@ -307,24 +323,39 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     cwd = Path.cwd()
-    if args.pr is not None:
+
+    if args.main_red:
+        if args.pr is not None:
+            results = [
+                classify_pr(
+                    entry={"pr_number": args.pr},
+                    metadata={},
+                    main_red=True,
+                )
+            ]
+        else:
+            metadata_by_pr, _command = settle_one_pr.load_open_pr_metadata(
+                cwd, limit=args.limit, repo=args.repo
+            )
+            results = [
+                classify_pr(
+                    entry={
+                        "pr_number": pr_number,
+                        "title": metadata.get("title"),
+                        "head_sha": metadata.get("headRefOid"),
+                    },
+                    metadata=metadata,
+                    main_red=True,
+                )
+                for pr_number, metadata in sorted(metadata_by_pr.items())
+            ]
+            if not results:
+                results = [classify_pr(entry={}, metadata={}, main_red=True)]
+    elif args.pr is not None:
         entry, metadata = _load_single(cwd, args.pr, args.repo)
         results = [classify_pr(entry=entry, metadata=metadata, main_red=args.main_red)]
     else:
         results = _classify_queue(cwd, args.repo, args.limit)
-        if args.main_red:
-            results = [
-                classify_pr(
-                    entry={
-                        "pr_number": item.pr_number,
-                        "title": item.title,
-                        "head_sha": item.head_sha,
-                    },
-                    metadata={},
-                    main_red=True,
-                )
-                for item in results
-            ]
 
     payload = {"results": [result.to_dict() for result in results]}
     if args.json:

--- a/scripts/settle_preflight.py
+++ b/scripts/settle_preflight.py
@@ -17,6 +17,7 @@ if str(REPO_ROOT) not in sys.path:
 import scripts.settle_one_pr as settle_one_pr
 
 RECHECK_RULE = "recheck on next origin/main push; never poll in a loop."
+QUEUE_POLICY_METADATA_REASON = "missing queue policy metadata with files"
 
 MAIN_RED_HALT = "MAIN_RED_HALT"
 DRAFT_SKIP = "DRAFT_SKIP"
@@ -148,6 +149,16 @@ def classify_pr(
             (head_drift,),
         )
 
+    if bool(entry.get("policy_metadata_unavailable")):
+        metadata_reasons = tuple(
+            str(reason) for reason in entry.get("reasons") or [QUEUE_POLICY_METADATA_REASON]
+        )
+        return result(
+            HEAD_BLOCKED,
+            "park this head until queue-mode policy metadata with files can be loaded",
+            metadata_reasons,
+        )
+
     policy_reasons = settle_one_pr.policy_exclusion_reasons(
         entry, policy_metadata={pr_number: metadata}
     )
@@ -255,6 +266,41 @@ def _packet_unavailable_entry(
     }
 
 
+def _policy_metadata_unavailable_entry(
+    pr_number: int,
+    metadata: dict[str, Any],
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "pr_number": pr_number,
+        "title": metadata.get("title"),
+        "head_sha": metadata.get("headRefOid"),
+        "status": "policy_metadata_unavailable",
+        "verdict": "policy_metadata_unavailable",
+        "policy_metadata_unavailable": True,
+        "reasons": [f"{QUEUE_POLICY_METADATA_REASON}: {reason}"],
+    }
+
+
+def _command_failure_reason(command: dict[str, Any]) -> str:
+    for key in ("stderr", "json_error", "stdout"):
+        value = str(command.get(key) or "").strip()
+        if value:
+            return value
+    return "files field missing from PR policy metadata"
+
+
+def _load_queue_policy_metadata(
+    cwd: Path,
+    repo: str | None,
+    pr_number: int,
+) -> tuple[dict[str, Any] | None, str | None]:
+    metadata, command = settle_one_pr.load_pr_policy_metadata(cwd, pr_number, repo=repo)
+    if settle_one_pr._has_policy_file_scope(metadata):
+        return metadata, None
+    return None, _command_failure_reason(command)
+
+
 def _load_live_file_metadata(cwd: Path, repo: str | None, pr_number: int) -> dict[str, Any]:
     live_payload, _command = settle_one_pr._run_json(
         settle_one_pr._with_repo(
@@ -293,8 +339,12 @@ def _classify_queue(cwd: Path, repo: str | None, limit: int) -> list[PreflightRe
     for pr_number, metadata in sorted(metadata_by_pr.items()):
         entry: dict[str, Any] = {}
         if not metadata.get("isDraft"):
-            if not metadata.get("files"):
-                metadata = {**metadata, **_load_live_file_metadata(cwd, repo, pr_number)}
+            policy_metadata, policy_error = _load_queue_policy_metadata(cwd, repo, pr_number)
+            if policy_error:
+                entry = _policy_metadata_unavailable_entry(pr_number, metadata, policy_error)
+                results.append(classify_pr(entry=entry, metadata=metadata))
+                continue
+            metadata = {**metadata, **dict(policy_metadata or {})}
             try:
                 packet = settle_one_pr._load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo)
                 entry = _packet_entry(packet, pr_number)

--- a/tests/scripts/test_settle_preflight.py
+++ b/tests/scripts/test_settle_preflight.py
@@ -31,10 +31,34 @@ def _metadata(**overrides):
         "isDraft": False,
         "mergeable": "MERGEABLE",
         "mergeStateStatus": "CLEAN",
+        "reviewDecision": "",
         "files": [{"path": "docs/example.md"}],
     }
     base.update(overrides)
     return base
+
+
+def _check(name, state="SUCCESS"):
+    return {"name": name, "state": state, "workflow": name, "link": ""}
+
+
+def _required_checks(**overrides):
+    states = {
+        "lint": "SUCCESS",
+        "typecheck": "SUCCESS",
+        "sdk-parity": "SUCCESS",
+        "Generate & Validate": "SUCCESS",
+        "TypeScript SDK Type Check": "SUCCESS",
+        "aragora-merge-quorum": "FAILURE",
+    }
+    states.update(overrides)
+    return [_check(name, state) for name, state in states.items()]
+
+
+def _blocked_metadata(**overrides):
+    base = {"mergeStateStatus": "BLOCKED", "required_checks": _required_checks()}
+    base.update(overrides)
+    return _metadata(**base)
 
 
 def _light_metadata(**overrides):
@@ -177,11 +201,49 @@ def test_ready_for_model_authorized_clean_state() -> None:
 def test_ready_for_model_authorized_blocked_quorum_state() -> None:
     result = settle_preflight.classify_pr(
         entry=_entry(),
-        metadata=_metadata(mergeStateStatus="BLOCKED"),
+        metadata=_blocked_metadata(),
     )
 
     assert result.verdict == settle_preflight.READY
-    assert any("settlement-stable" in reason for reason in result.reasons)
+    assert any("aragora-merge-quorum" in reason for reason in result.reasons)
+
+
+def test_blocked_required_red_context_does_not_become_ready() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(),
+        metadata=_blocked_metadata(required_checks=_required_checks(typecheck="FAILURE")),
+    )
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert any("typecheck" in reason for reason in result.reasons)
+
+
+def test_blocked_review_changes_requested_does_not_become_ready() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(),
+        metadata=_blocked_metadata(reviewDecision="CHANGES_REQUESTED"),
+    )
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert "reviewDecision=CHANGES_REQUESTED" in result.reasons
+
+
+def test_empty_file_scope_does_not_become_ready() -> None:
+    result = settle_preflight.classify_pr(entry=_entry(), metadata=_metadata(files=[]))
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert settle_preflight.POLICY_METADATA_REASON in result.reasons
+
+
+def test_active_owner_signal_parks_head() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(),
+        metadata=_metadata(),
+        active_owned_prs={9001},
+    )
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert settle_preflight.ACTIVE_OWNER_REASON in result.reasons
 
 
 def test_status_and_verdict_do_not_authorize_without_boolean() -> None:
@@ -256,12 +318,21 @@ def test_load_single_degrades_packet_failure(monkeypatch) -> None:
         "load_pr_policy_metadata",
         lambda *_args, **_kwargs: (_metadata(), {}),
     )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_live_metadata",
+        lambda *_args, **_kwargs: (_metadata(), {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_required_checks",
+        lambda *_args, **_kwargs: (_required_checks(), {}),
+    )
 
     def fail_packet(*_args, **_kwargs):
         raise RuntimeError("packet unavailable")
 
     monkeypatch.setattr(settle_preflight.settle_one_pr, "_load_single_pr_packet", fail_packet)
-    monkeypatch.setattr(settle_preflight, "_load_live_file_metadata", lambda *_args: {})
 
     entry, metadata = settle_preflight._load_single(Path.cwd(), 9001, None)
 
@@ -278,6 +349,11 @@ def test_queue_mode_uses_policy_files_for_unsafe_surface(monkeypatch) -> None:
         lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
     )
     monkeypatch.setattr(
+        settle_preflight,
+        "_load_live_metadata",
+        lambda *_args, **_kwargs: (_metadata(), {}),
+    )
+    monkeypatch.setattr(
         settle_preflight.settle_one_pr,
         "load_pr_policy_metadata",
         lambda *_args, **_kwargs: (
@@ -289,6 +365,11 @@ def test_queue_mode_uses_policy_files_for_unsafe_surface(monkeypatch) -> None:
             ),
             {},
         ),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_required_checks",
+        lambda *_args, **_kwargs: (_required_checks(), {}),
     )
     monkeypatch.setattr(
         settle_preflight.settle_one_pr,
@@ -308,6 +389,11 @@ def test_queue_mode_policy_metadata_failure_does_not_classify_ready(monkeypatch)
         settle_preflight.settle_one_pr,
         "load_open_pr_metadata",
         lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_live_metadata",
+        lambda *_args, **_kwargs: (_metadata(), {}),
     )
     monkeypatch.setattr(
         settle_preflight.settle_one_pr,
@@ -340,12 +426,22 @@ def test_queue_policy_exclusion_uses_policy_file_metadata(monkeypatch) -> None:
         lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
     )
     monkeypatch.setattr(
+        settle_preflight,
+        "_load_live_metadata",
+        lambda *_args, **_kwargs: (_metadata(), {}),
+    )
+    monkeypatch.setattr(
         settle_preflight.settle_one_pr,
         "load_pr_policy_metadata",
         lambda *_args, **_kwargs: (
             _metadata(files=[{"path": ".github/workflows/build.yml"}]),
             {},
         ),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_required_checks",
+        lambda *_args, **_kwargs: (_required_checks(), {}),
     )
     monkeypatch.setattr(
         settle_preflight.settle_one_pr,
@@ -358,3 +454,95 @@ def test_queue_policy_exclusion_uses_policy_file_metadata(monkeypatch) -> None:
     assert len(results) == 1
     assert results[0].verdict == settle_preflight.HUMAN_GATED
     assert settle_preflight.settle_one_pr.SURFACE_EXCLUDE_REASON in results[0].reasons
+
+
+def test_policy_metadata_failure_exits_nonzero_and_parks(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(settle_preflight, "_load_active_owner_scope", lambda *_args: (set(), None))
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_open_pr_metadata",
+        lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_live_metadata",
+        lambda *_args, **_kwargs: (_metadata(), {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_pr_policy_metadata",
+        lambda *_args, **_kwargs: (
+            {},
+            {"returncode": 1, "stderr": "gh pr view failed"},
+        ),
+    )
+
+    def fail_packet(*_args, **_kwargs):
+        raise AssertionError("preflight should not load packet without policy files")
+
+    monkeypatch.setattr(settle_preflight.settle_one_pr, "_load_single_pr_packet", fail_packet)
+
+    rc = settle_preflight.main(["--queue", "--json"])
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["verdict"] == settle_preflight.HEAD_BLOCKED
+    assert any(
+        settle_preflight.POLICY_METADATA_REASON in reason
+        for reason in payload["results"][0]["reasons"]
+    )
+
+
+def test_open_queue_metadata_failure_exits_nonzero(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(settle_preflight, "_load_active_owner_scope", lambda *_args: (set(), None))
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_open_pr_metadata",
+        lambda *_args, **_kwargs: (
+            {},
+            {"returncode": 1, "stderr": "gh pr list failed"},
+        ),
+    )
+
+    rc = settle_preflight.main(["--queue", "--json"])
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["verdict"] == settle_preflight.HEAD_BLOCKED
+    assert any(
+        settle_preflight.OPEN_QUEUE_METADATA_REASON in reason
+        for reason in payload["results"][0]["reasons"]
+    )
+
+
+def test_queue_and_single_pr_modes_share_classification_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_open_pr_metadata",
+        lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_live_metadata",
+        lambda *_args, **_kwargs: (_blocked_metadata(), {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_pr_policy_metadata",
+        lambda *_args, **_kwargs: (_metadata(), {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_required_checks",
+        lambda *_args, **_kwargs: (_required_checks(), {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "_load_single_pr_packet",
+        lambda *_args, **_kwargs: _packet(),
+    )
+
+    single = settle_preflight._classify_single(Path.cwd(), 9001, None)
+    queue = settle_preflight._classify_queue(Path.cwd(), None, 50)[0]
+
+    assert queue.to_dict() == single.to_dict()

--- a/tests/scripts/test_settle_preflight.py
+++ b/tests/scripts/test_settle_preflight.py
@@ -37,6 +37,16 @@ def _metadata(**overrides):
     return base
 
 
+def _light_metadata(**overrides):
+    metadata = _metadata(**overrides)
+    metadata.pop("files", None)
+    return metadata
+
+
+def _packet(entry=None):
+    return {"entries": [entry or _entry()]}
+
+
 def test_main_red_halt_verdict() -> None:
     result = settle_preflight.classify_pr(entry=_entry(), metadata=_metadata(), main_red=True)
 
@@ -261,21 +271,86 @@ def test_load_single_degrades_packet_failure(monkeypatch) -> None:
     assert metadata["number"] == 9001
 
 
-def test_queue_policy_exclusion_uses_live_file_metadata(monkeypatch) -> None:
+def test_queue_mode_uses_policy_files_for_unsafe_surface(monkeypatch) -> None:
     monkeypatch.setattr(
         settle_preflight.settle_one_pr,
         "load_open_pr_metadata",
-        lambda *_args, **_kwargs: ({9001: _metadata(files=[])}, {}),
+        lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
     )
     monkeypatch.setattr(
-        settle_preflight,
-        "_load_live_file_metadata",
-        lambda *_args: {"files": [{"path": ".github/workflows/build.yml"}]},
+        settle_preflight.settle_one_pr,
+        "load_pr_policy_metadata",
+        lambda *_args, **_kwargs: (
+            _metadata(
+                files=[
+                    {"path": ".github/workflows/build.yml"},
+                    {"path": "aragora/server/auth/session.py"},
+                ]
+            ),
+            {},
+        ),
     )
     monkeypatch.setattr(
         settle_preflight.settle_one_pr,
         "_load_single_pr_packet",
-        lambda **_kwargs: {"entries": [_entry()]},
+        lambda *_args, **_kwargs: _packet(),
+    )
+
+    results = settle_preflight._classify_queue(Path.cwd(), "synaptent/aragora", 10)
+
+    assert len(results) == 1
+    assert results[0].verdict == settle_preflight.HUMAN_GATED
+    assert settle_preflight.settle_one_pr.SURFACE_EXCLUDE_REASON in results[0].reasons
+
+
+def test_queue_mode_policy_metadata_failure_does_not_classify_ready(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_open_pr_metadata",
+        lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_pr_policy_metadata",
+        lambda *_args, **_kwargs: (
+            {},
+            {"returncode": 1, "stderr": "gh pr view failed"},
+        ),
+    )
+
+    def fail_packet(*_args, **_kwargs):
+        raise AssertionError("queue mode should not load packet without policy files")
+
+    monkeypatch.setattr(settle_preflight.settle_one_pr, "_load_single_pr_packet", fail_packet)
+
+    results = settle_preflight._classify_queue(Path.cwd(), "synaptent/aragora", 10)
+
+    assert len(results) == 1
+    assert results[0].verdict == settle_preflight.HEAD_BLOCKED
+    assert results[0].verdict != settle_preflight.READY
+    assert any(
+        settle_preflight.QUEUE_POLICY_METADATA_REASON in reason for reason in results[0].reasons
+    )
+
+
+def test_queue_policy_exclusion_uses_policy_file_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_open_pr_metadata",
+        lambda *_args, **_kwargs: ({9001: _light_metadata()}, {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_pr_policy_metadata",
+        lambda *_args, **_kwargs: (
+            _metadata(files=[{"path": ".github/workflows/build.yml"}]),
+            {},
+        ),
+    )
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "_load_single_pr_packet",
+        lambda **_kwargs: _packet(),
     )
 
     results = settle_preflight._classify_queue(Path.cwd(), None, 50)

--- a/tests/scripts/test_settle_preflight.py
+++ b/tests/scripts/test_settle_preflight.py
@@ -67,6 +67,39 @@ def test_human_gated_for_unsettled_human_risk() -> None:
     assert any("requires_human_risk_settlement" in reason for reason in result.reasons)
 
 
+def test_recorded_human_settlement_clears_human_risk_reason() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(
+            tier=2,
+            requires_human_risk_settlement=True,
+            human_preapproval_recorded=True,
+        ),
+        metadata=_metadata(),
+    )
+
+    assert result.verdict == settle_preflight.READY
+
+
+def test_human_gated_for_unsettled_human_preapproval() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(tier=2, requires_human_preapproval=True),
+        metadata=_metadata(),
+    )
+
+    assert result.verdict == settle_preflight.HUMAN_GATED
+    assert any("requires_human_preapproval" in reason for reason in result.reasons)
+
+
+def test_policy_exclusions_do_not_become_ready() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(),
+        metadata=_metadata(files=[{"path": ".github/workflows/build.yml"}]),
+    )
+
+    assert result.verdict == settle_preflight.HUMAN_GATED
+    assert settle_preflight.settle_one_pr.SURFACE_EXCLUDE_REASON in result.reasons
+
+
 def test_head_blocked_for_conflicting_or_behind_state() -> None:
     dirty = settle_preflight.classify_pr(
         entry=_entry(admin_squash_allowed=False),
@@ -81,6 +114,26 @@ def test_head_blocked_for_conflicting_or_behind_state() -> None:
     assert behind.verdict == settle_preflight.HEAD_BLOCKED
 
 
+def test_head_blocked_for_packet_head_drift() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(head_sha="b" * 40),
+        metadata=_metadata(headRefOid="a" * 40),
+    )
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert any("head drift" in reason for reason in result.reasons)
+
+
+def test_head_blockers_take_precedence_over_github_unstable() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(checks_summary="5/6 green, 1 failing"),
+        metadata=_metadata(mergeStateStatus="UNSTABLE"),
+    )
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert any("checks failing" in reason for reason in result.reasons)
+
+
 def test_github_unstable_for_model_authorized_unstable_state() -> None:
     result = settle_preflight.classify_pr(
         entry=_entry(),
@@ -91,11 +144,41 @@ def test_github_unstable_for_model_authorized_unstable_state() -> None:
     assert "do not merge" in result.action
 
 
+def test_github_unstable_for_unknown_merge_state() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(),
+        metadata=_metadata(mergeStateStatus=""),
+    )
+
+    assert result.verdict == settle_preflight.GITHUB_UNSTABLE
+    assert any("mergeStateStatus=unknown" in reason for reason in result.reasons)
+
+
 def test_ready_for_model_authorized_clean_state() -> None:
     result = settle_preflight.classify_pr(entry=_entry(), metadata=_metadata())
 
     assert result.verdict == settle_preflight.READY
     assert "normal protected squash merge" in result.action
+
+
+def test_ready_for_model_authorized_blocked_quorum_state() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(),
+        metadata=_metadata(mergeStateStatus="BLOCKED"),
+    )
+
+    assert result.verdict == settle_preflight.READY
+    assert any("settlement-stable" in reason for reason in result.reasons)
+
+
+def test_status_and_verdict_do_not_authorize_without_boolean() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(admin_squash_allowed=False),
+        metadata=_metadata(),
+    )
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert "satisfied model packet" in result.action
 
 
 def test_head_blocked_when_packet_not_authorized() -> None:

--- a/tests/scripts/test_settle_preflight.py
+++ b/tests/scripts/test_settle_preflight.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import scripts.settle_preflight as settle_preflight
+
+
+def _entry(**overrides):
+    base = {
+        "pr_number": 9001,
+        "title": "test pr",
+        "head_sha": "a" * 40,
+        "tier": 0,
+        "status": "satisfied",
+        "verdict": "admin_squash_allowed",
+        "admin_squash_allowed": True,
+        "requires_human_risk_settlement": False,
+        "checks_summary": "6/6 green",
+        "reasons": ["docs/tests/status-only"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _metadata(**overrides):
+    base = {
+        "number": 9001,
+        "title": "test pr",
+        "headRefOid": "a" * 40,
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "files": [{"path": "docs/example.md"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_main_red_halt_verdict() -> None:
+    result = settle_preflight.classify_pr(entry=_entry(), metadata=_metadata(), main_red=True)
+
+    assert result.verdict == settle_preflight.MAIN_RED_HALT
+    assert "main-red" in result.action
+    assert result.recheck_rule == settle_preflight.RECHECK_RULE
+
+
+def test_draft_skip_verdict() -> None:
+    result = settle_preflight.classify_pr(entry=_entry(), metadata=_metadata(isDraft=True))
+
+    assert result.verdict == settle_preflight.DRAFT_SKIP
+    assert "marked ready" in result.action
+
+
+def test_human_gated_for_tier_above_two() -> None:
+    result = settle_preflight.classify_pr(entry=_entry(tier=4), metadata=_metadata())
+
+    assert result.verdict == settle_preflight.HUMAN_GATED
+    assert "Tier 4" in result.reasons
+    assert "human settlement" in result.action
+
+
+def test_human_gated_for_unsettled_human_risk() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(tier=2, requires_human_risk_settlement=True),
+        metadata=_metadata(),
+    )
+
+    assert result.verdict == settle_preflight.HUMAN_GATED
+    assert any("requires_human_risk_settlement" in reason for reason in result.reasons)
+
+
+def test_head_blocked_for_conflicting_or_behind_state() -> None:
+    dirty = settle_preflight.classify_pr(
+        entry=_entry(admin_squash_allowed=False),
+        metadata=_metadata(mergeable="CONFLICTING", mergeStateStatus="DIRTY"),
+    )
+    behind = settle_preflight.classify_pr(
+        entry=_entry(admin_squash_allowed=False),
+        metadata=_metadata(mergeStateStatus="BEHIND"),
+    )
+
+    assert dirty.verdict == settle_preflight.HEAD_BLOCKED
+    assert behind.verdict == settle_preflight.HEAD_BLOCKED
+
+
+def test_github_unstable_for_model_authorized_unstable_state() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(),
+        metadata=_metadata(mergeStateStatus="UNSTABLE"),
+    )
+
+    assert result.verdict == settle_preflight.GITHUB_UNSTABLE
+    assert "do not merge" in result.action
+
+
+def test_ready_for_model_authorized_clean_state() -> None:
+    result = settle_preflight.classify_pr(entry=_entry(), metadata=_metadata())
+
+    assert result.verdict == settle_preflight.READY
+    assert "normal protected squash merge" in result.action
+
+
+def test_head_blocked_when_packet_not_authorized() -> None:
+    result = settle_preflight.classify_pr(
+        entry=_entry(
+            status="needs_model_review_quorum",
+            verdict="collect_model_quorum_before_merge",
+            admin_squash_allowed=False,
+        ),
+        metadata=_metadata(),
+    )
+
+    assert result.verdict == settle_preflight.HEAD_BLOCKED
+    assert "satisfied model packet" in result.action

--- a/tests/scripts/test_settle_preflight.py
+++ b/tests/scripts/test_settle_preflight.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import scripts.settle_preflight as settle_preflight
 
 
@@ -193,3 +196,90 @@ def test_head_blocked_when_packet_not_authorized() -> None:
 
     assert result.verdict == settle_preflight.HEAD_BLOCKED
     assert "satisfied model packet" in result.action
+
+
+def test_main_red_pr_short_circuits_packet_loading(monkeypatch, capsys) -> None:
+    def fail_load_single(*_args, **_kwargs):
+        raise AssertionError("main-red should not load PR packets")
+
+    monkeypatch.setattr(settle_preflight, "_load_single", fail_load_single)
+
+    rc = settle_preflight.main(["--pr", "9001", "--main-red", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["pr_number"] == 9001
+    assert payload["results"][0]["verdict"] == settle_preflight.MAIN_RED_HALT
+
+
+def test_main_red_queue_short_circuits_packet_loading(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_open_pr_metadata",
+        lambda *_args, **_kwargs: (
+            {
+                9001: _metadata(number=9001, files=[]),
+                9002: _metadata(number=9002, title="other", headRefOid="b" * 40, files=[]),
+            },
+            {},
+        ),
+    )
+
+    def fail_packet(*_args, **_kwargs):
+        raise AssertionError("main-red queue should not load merge packets")
+
+    monkeypatch.setattr(settle_preflight.settle_one_pr, "_load_single_pr_packet", fail_packet)
+
+    rc = settle_preflight.main(["--queue", "--main-red", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["verdict"] for item in payload["results"]] == [
+        settle_preflight.MAIN_RED_HALT,
+        settle_preflight.MAIN_RED_HALT,
+    ]
+
+
+def test_load_single_degrades_packet_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_pr_policy_metadata",
+        lambda *_args, **_kwargs: (_metadata(), {}),
+    )
+
+    def fail_packet(*_args, **_kwargs):
+        raise RuntimeError("packet unavailable")
+
+    monkeypatch.setattr(settle_preflight.settle_one_pr, "_load_single_pr_packet", fail_packet)
+    monkeypatch.setattr(settle_preflight, "_load_live_file_metadata", lambda *_args: {})
+
+    entry, metadata = settle_preflight._load_single(Path.cwd(), 9001, None)
+
+    assert entry["status"] == "packet_unavailable"
+    assert entry["verdict"] == "packet_unavailable"
+    assert entry["reasons"] == ["packet unavailable"]
+    assert metadata["number"] == 9001
+
+
+def test_queue_policy_exclusion_uses_live_file_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "load_open_pr_metadata",
+        lambda *_args, **_kwargs: ({9001: _metadata(files=[])}, {}),
+    )
+    monkeypatch.setattr(
+        settle_preflight,
+        "_load_live_file_metadata",
+        lambda *_args: {"files": [{"path": ".github/workflows/build.yml"}]},
+    )
+    monkeypatch.setattr(
+        settle_preflight.settle_one_pr,
+        "_load_single_pr_packet",
+        lambda **_kwargs: {"entries": [_entry()]},
+    )
+
+    results = settle_preflight._classify_queue(Path.cwd(), None, 50)
+
+    assert len(results) == 1
+    assert results[0].verdict == settle_preflight.HUMAN_GATED
+    assert settle_preflight.settle_one_pr.SURFACE_EXCLUDE_REASON in results[0].reasons


### PR DESCRIPTION
## Summary

Adds a read-only settlement gate-preflight classifier and runbook so conductor cycles can cheaply distinguish routine settlement candidates from draft, human-gated, head-blocked, and GitHub-unstable PRs before spending review/settlement cycles.

New artifacts:
- `scripts/settle_preflight.py`
- `tests/scripts/test_settle_preflight.py`
- `docs/runbooks/SETTLEMENT_PREFLIGHT.md`

The script supports:
- `--pr N` for one PR
- `--queue` for open PR classification
- `--json`

Verdicts are exactly one of:
- `MAIN_RED_HALT`
- `DRAFT_SKIP`
- `HUMAN_GATED`
- `HEAD_BLOCKED`
- `GITHUB_UNSTABLE`
- `READY`

Each verdict includes a recommended conductor action and the recheck rule: `recheck on next origin/main push; never poll in a loop.`

## Context

This follows the #8990 episode: the repeat-blocker policy PR became model-authorized and green, but GitHub stayed `UNSTABLE` long enough that §Conductor correctly blocked conductor merge. #8990 later merged normally at `196bf38d540df5bd37a5a0918d8b8dd54604c2f6`, showing the useful classifier state was `GITHUB_UNSTABLE`, not another evidence run.

## Live validation

#8987:

```json
{
  "results": [
    {
      "action": "stop and request exact-head human settlement before evidence or merge",
      "head_sha": "0d30c5114c5dbf5a011f53225581cc41d1b6f1bf",
      "merge_state": "BLOCKED",
      "mergeable": "MERGEABLE",
      "pr_number": 8987,
      "reasons": [
        "Tier 4",
        "requires_human_risk_settlement=true without recorded preapproval",
        "requires_human_risk_settlement=true"
      ],
      "recheck_rule": "recheck on next origin/main push; never poll in a loop.",
      "tier": 4,
      "title": "fix(steward): skip draft PRs during broad settlement selection",
      "verdict": "HUMAN_GATED"
    }
  ]
}
```

#8989:

```json
{
  "results": [
    {
      "action": "do not merge; wait for GitHub merge state to become settlement-stable",
      "head_sha": "e576ec092f7929139e63b4107a3c1c9e8aa3a479",
      "merge_state": "UNSTABLE",
      "mergeable": "MERGEABLE",
      "pr_number": 8989,
      "reasons": [
        "model-authorized but mergeable=MERGEABLE mergeStateStatus=UNSTABLE"
      ],
      "recheck_rule": "recheck on next origin/main push; never poll in a loop.",
      "tier": 0,
      "title": "docs(runbooks): worktree fleet audit rubric + 2026-07-07 snapshot",
      "verdict": "GITHUB_UNSTABLE"
    }
  ]
}
```

Draft #8960:

```json
{
  "results": [
    {
      "action": "skip this PR until it is marked ready for review",
      "head_sha": "ba54b1f87b52de4718cb57ff920e9a45c54b5933",
      "merge_state": "CLEAN",
      "mergeable": "MERGEABLE",
      "pr_number": 8960,
      "reasons": [
        "PR is draft"
      ],
      "recheck_rule": "recheck on next origin/main push; never poll in a loop.",
      "tier": 2,
      "title": "fix(conductor): gate drafts with pending ready tokens",
      "verdict": "DRAFT_SKIP"
    }
  ]
}
```

## Validation

Passed:

- `python3 -m pytest tests/scripts/test_settle_preflight.py -q`
- `python3 -m pytest tests/scripts/test_settle_one_pr.py tests/scripts/test_settle_preflight.py -q`
- `python3 -m ruff check scripts/settle_preflight.py tests/scripts/test_settle_preflight.py`
- `python3 -m mypy scripts/settle_preflight.py --ignore-missing-imports`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Full required local gate:

- `make ci-required` failed at broad repo `mypy aragora/ --ignore-missing-imports` after `ruff check aragora/ tests/ scripts/` passed.
- Observed summary: `Found 2646 errors in 648 files (checked 4248 source files)`.
- The failures are broad existing mypy debt outside this diff; the changed script has targeted mypy pass listed above.

## Scope

No workflow, branch-protection, merge, evidence, or label changes. This PR is opened as draft only.

Tracking: #8761. Related: #8990, #8987, #8989, #8960.
