### PR TITLE
feat(scripts): fresh active-lane ownership table in Fable goal-cycle packet

### DIFF
--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -19,8 +19,9 @@ recorded in the packet as gaps rather than aborting the cycle, so Fable knows
 what it is *not* seeing. The consult itself is hard-bounded (default 900s).
 
 Fresh lane ownership is per-object, never a global lock. The packet includes
-``active`` and ``working`` lanes whose latest heartbeat or activity timestamp
-is at most 15 minutes old, matching the canonical owner-tool heartbeat window.
+lanes in the canonical active lifecycle states whose latest heartbeat or
+activity timestamp is at most 15 minutes old, matching the canonical owner-tool
+heartbeat window.
 
 The response is strategy input, not authority: executing agents remain bound
 by the operating contract (tier gates, quorum, anti-treadmill rules).
@@ -63,7 +64,19 @@ MAX_ACTIVE_PROCESS_LINES = 40
 MAX_ACTIVE_LANE_LINES = 40
 MAX_ACTIVE_LANE_FIELD_CHARS = 240
 ACTIVE_LANE_FRESH_SECONDS = 15 * 60
-ACTIVE_LANE_STATUSES = frozenset({"active", "working"})
+ACTIVE_LANE_STATUSES = frozenset(
+    {
+        "active",
+        "running",
+        "pending",
+        "queued",
+        "claimed",
+        "waiting_for_steering",
+        "acknowledged",
+        "working",
+        "blocked",
+    }
+)
 ACTIVE_PROCESS_SCRIPT_NAMES = frozenset(
     {
         "agent_bridge.py",
@@ -352,28 +365,133 @@ def _lane_packet_value(value: object) -> object:
     return rendered[: MAX_ACTIVE_LANE_FIELD_CHARS - 3] + "..."
 
 
+def _lane_registry_paths(root: Path, *, home: Path | None = None) -> list[Path]:
+    """Return canonical user and repo/state-root lane registry locations."""
+
+    user_root = home or Path.home()
+    configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    if configured:
+        state_root = Path(configured).expanduser()
+        state_dir = state_root if state_root.name == ".aragora" else state_root / ".aragora"
+    else:
+        state_dir = root / ".aragora"
+
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for path in (
+        user_root / ".aragora" / "agent-bridge" / "lanes.json",
+        state_dir / "agent-bridge" / "lanes.json",
+    ):
+        try:
+            identity = path.resolve()
+        except OSError:
+            identity = path
+        if identity in seen:
+            continue
+        seen.add(identity)
+        paths.append(path)
+    return paths
+
+
+def _prefer_lane_record(
+    candidate: dict[str, object],
+    candidate_source: int,
+    current: tuple[dict[str, object], int],
+) -> bool:
+    """Match agent_bridge precedence: newest update, then repo/state-root."""
+
+    current_record, current_source = current
+    candidate_time = _parse_lane_timestamp(candidate.get("updated_at"))
+    current_time = _parse_lane_timestamp(current_record.get("updated_at"))
+    if candidate_time is not None and current_time is not None and candidate_time != current_time:
+        return candidate_time > current_time
+    return candidate_source >= current_source
+
+
+def _fill_sparse_lane_identity(
+    preferred: dict[str, object], fallback: dict[str, object]
+) -> dict[str, object]:
+    merged = dict(preferred)
+    for key in (
+        "lane_id",
+        "owner_session",
+        "pr_number",
+        "branch",
+        "worktree",
+        "next_action",
+    ):
+        if merged.get(key) in (None, "") and fallback.get(key) not in (None, ""):
+            merged[key] = fallback[key]
+    return merged
+
+
 def _fresh_active_lanes(
     root: Path,
     *,
     now: _dt.datetime | None = None,
+    home: Path | None = None,
 ) -> tuple[str | None, list[str]]:
     """Render fresh per-object lane ownership; malformed state becomes a gap."""
 
-    lanes_path = root / ".aragora" / "agent-bridge" / "lanes.json"
-    if not lanes_path.exists():
-        return None, [
-            f"fresh active lanes (object ownership): lanes registry missing: {lanes_path}"
-        ]
-    try:
-        raw_lanes = json.loads(lanes_path.read_text(encoding="utf-8"))
-    except OSError as exc:
-        return None, [f"fresh active lanes (object ownership): lanes registry unreadable: {exc}"]
-    except json.JSONDecodeError as exc:
-        return None, [f"fresh active lanes (object ownership): lanes registry malformed: {exc}"]
-    if not isinstance(raw_lanes, list):
-        return None, [
-            "fresh active lanes (object ownership): lanes registry malformed: expected JSON array"
-        ]
+    registry_paths = _lane_registry_paths(root, home=home)
+    existing_paths = [path for path in registry_paths if path.exists()]
+    if not existing_paths:
+        rendered = ", ".join(str(path) for path in registry_paths)
+        return None, [f"fresh active lanes (object ownership): lane registries missing: {rendered}"]
+
+    gaps: list[str] = []
+    merged: dict[str, tuple[dict[str, object], int]] = {}
+    anonymous: list[dict[str, object]] = []
+    valid_registry_count = 0
+    malformed_entries = 0
+    for source_index, lanes_path in enumerate(existing_paths):
+        try:
+            raw_lanes = json.loads(lanes_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError) as exc:
+            gaps.append(
+                "fresh active lanes (object ownership): "
+                f"lanes registry unreadable ({lanes_path}): {exc}"
+            )
+            continue
+        except json.JSONDecodeError as exc:
+            gaps.append(
+                "fresh active lanes (object ownership): "
+                f"lanes registry malformed ({lanes_path}): {exc}"
+            )
+            continue
+        if not isinstance(raw_lanes, list):
+            gaps.append(
+                "fresh active lanes (object ownership): "
+                f"lanes registry malformed ({lanes_path}): expected JSON array"
+            )
+            continue
+        valid_registry_count += 1
+        for raw_lane in raw_lanes:
+            if not isinstance(raw_lane, dict):
+                malformed_entries += 1
+                continue
+            lane = {str(key): value for key, value in raw_lane.items()}
+            lane_id = str(lane.get("lane_id") or "").strip()
+            if not lane_id:
+                anonymous.append(lane)
+                continue
+            current = merged.get(lane_id)
+            if current is None:
+                merged[lane_id] = (lane, source_index)
+                continue
+            if _prefer_lane_record(lane, source_index, current):
+                merged[lane_id] = (
+                    _fill_sparse_lane_identity(lane, current[0]),
+                    source_index,
+                )
+            else:
+                merged[lane_id] = (
+                    _fill_sparse_lane_identity(current[0], lane),
+                    current[1],
+                )
+
+    if valid_registry_count == 0:
+        return None, gaps
 
     current = now or _dt.datetime.now(_dt.timezone.utc)
     if current.tzinfo is None:
@@ -381,17 +499,17 @@ def _fresh_active_lanes(
     else:
         current = current.astimezone(_dt.timezone.utc)
 
-    malformed_entries = 0
     fresh: list[tuple[_dt.datetime, dict[str, object]]] = []
+    raw_lanes = anonymous + [record for record, _source in merged.values()]
     for raw_lane in raw_lanes:
-        if not isinstance(raw_lane, dict):
-            malformed_entries += 1
-            continue
         status = str(raw_lane.get("status") or "").strip().lower()
         if status not in ACTIVE_LANE_STATUSES:
             continue
-        heartbeat_raw = raw_lane.get("last_heartbeat_at") or raw_lane.get("updated_at")
+        heartbeat_raw = raw_lane.get("last_heartbeat_at")
         heartbeat = _parse_lane_timestamp(heartbeat_raw)
+        if heartbeat is None:
+            heartbeat_raw = raw_lane.get("updated_at")
+            heartbeat = _parse_lane_timestamp(heartbeat_raw)
         if heartbeat is None:
             malformed_entries += 1
             continue
@@ -415,7 +533,6 @@ def _fresh_active_lanes(
     if omitted > 0:
         lines.append(f"[truncated {omitted} additional fresh active lane(s)]")
 
-    gaps: list[str] = []
     if malformed_entries:
         gaps.append(
             "fresh active lanes (object ownership): "

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -18,6 +18,10 @@ Every context source is best-effort with its own short timeout; failures are
 recorded in the packet as gaps rather than aborting the cycle, so Fable knows
 what it is *not* seeing. The consult itself is hard-bounded (default 900s).
 
+Fresh lane ownership is per-object, never a global lock. The packet includes
+``active`` and ``working`` lanes whose latest heartbeat or activity timestamp
+is at most 15 minutes old, matching the canonical owner-tool heartbeat window.
+
 The response is strategy input, not authority: executing agents remain bound
 by the operating contract (tier gates, quorum, anti-treadmill rules).
 
@@ -56,6 +60,10 @@ SAFE_CONTEXT_SUBDIRS = (
 DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 DEFAULT_MODEL = "claude-fable-5"
 MAX_ACTIVE_PROCESS_LINES = 40
+MAX_ACTIVE_LANE_LINES = 40
+MAX_ACTIVE_LANE_FIELD_CHARS = 240
+ACTIVE_LANE_FRESH_SECONDS = 15 * 60
+ACTIVE_LANE_STATUSES = frozenset({"active", "working"})
 ACTIVE_PROCESS_SCRIPT_NAMES = frozenset(
     {
         "agent_bridge.py",
@@ -144,6 +152,9 @@ Constraints on your recommendations:
 - One bounded progress unit per cycle; if a blocker repeats, switch progress
   class rather than retrying.
 - Prefer finishing and settling in-flight work over starting new work.
+- Treat the "fresh active lanes (object ownership)" section as collision
+  authority: do not recommend a PR, branch, or worktree listed there. Ownership
+  is per-object, not a global lock; unrelated work remains eligible.
 - Your output is strategy input, not authority: nothing you write authorizes
   merging, settlement, or evidence posting outside normal gates.
 """
@@ -315,6 +326,104 @@ def _active_conductor_processes() -> tuple[bool, str]:
     return False, "; ".join(error for error in errors if error) or "ps unavailable"
 
 
+def _parse_lane_timestamp(value: object) -> _dt.datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = _dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(_dt.timezone.utc)
+
+
+def _lane_packet_value(value: object) -> object:
+    if value is None or value == "":
+        return "-"
+    if isinstance(value, (bool, int, float)):
+        return value
+    rendered = " ".join(str(value).split())
+    if len(rendered) <= MAX_ACTIVE_LANE_FIELD_CHARS:
+        return rendered
+    return rendered[: MAX_ACTIVE_LANE_FIELD_CHARS - 3] + "..."
+
+
+def _fresh_active_lanes(
+    root: Path,
+    *,
+    now: _dt.datetime | None = None,
+) -> tuple[str | None, list[str]]:
+    """Render fresh per-object lane ownership; malformed state becomes a gap."""
+
+    lanes_path = root / ".aragora" / "agent-bridge" / "lanes.json"
+    if not lanes_path.exists():
+        return None, [
+            f"fresh active lanes (object ownership): lanes registry missing: {lanes_path}"
+        ]
+    try:
+        raw_lanes = json.loads(lanes_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return None, [f"fresh active lanes (object ownership): lanes registry unreadable: {exc}"]
+    except json.JSONDecodeError as exc:
+        return None, [f"fresh active lanes (object ownership): lanes registry malformed: {exc}"]
+    if not isinstance(raw_lanes, list):
+        return None, [
+            "fresh active lanes (object ownership): lanes registry malformed: expected JSON array"
+        ]
+
+    current = now or _dt.datetime.now(_dt.timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=_dt.timezone.utc)
+    else:
+        current = current.astimezone(_dt.timezone.utc)
+
+    malformed_entries = 0
+    fresh: list[tuple[_dt.datetime, dict[str, object]]] = []
+    for raw_lane in raw_lanes:
+        if not isinstance(raw_lane, dict):
+            malformed_entries += 1
+            continue
+        status = str(raw_lane.get("status") or "").strip().lower()
+        if status not in ACTIVE_LANE_STATUSES:
+            continue
+        heartbeat_raw = raw_lane.get("last_heartbeat_at") or raw_lane.get("updated_at")
+        heartbeat = _parse_lane_timestamp(heartbeat_raw)
+        if heartbeat is None:
+            malformed_entries += 1
+            continue
+        age_seconds = max(0.0, (current - heartbeat).total_seconds())
+        if age_seconds > ACTIVE_LANE_FRESH_SECONDS:
+            continue
+        rendered = {
+            "lane_id": _lane_packet_value(raw_lane.get("lane_id")),
+            "owner_session": _lane_packet_value(raw_lane.get("owner_session")),
+            "pr_number": _lane_packet_value(raw_lane.get("pr_number")),
+            "branch": _lane_packet_value(raw_lane.get("branch")),
+            "worktree": _lane_packet_value(raw_lane.get("worktree")),
+            "heartbeat_at": _lane_packet_value(heartbeat_raw),
+            "next_action": _lane_packet_value(raw_lane.get("next_action")),
+        }
+        fresh.append((heartbeat, rendered))
+
+    fresh.sort(key=lambda item: item[0], reverse=True)
+    lines = [json.dumps(item[1], ensure_ascii=True) for item in fresh[:MAX_ACTIVE_LANE_LINES]]
+    omitted = len(fresh) - MAX_ACTIVE_LANE_LINES
+    if omitted > 0:
+        lines.append(f"[truncated {omitted} additional fresh active lane(s)]")
+
+    gaps: list[str] = []
+    if malformed_entries:
+        gaps.append(
+            "fresh active lanes (object ownership): "
+            f"skipped {malformed_entries} malformed lane entries"
+        )
+    return "\n".join(lines) if lines else "none observed", gaps
+
+
 def _is_relative_to(path: Path, parent: Path) -> bool:
     try:
         path.relative_to(parent)
@@ -400,6 +509,10 @@ def gather_context(root: Path, since_hours: float, max_prs: int, skip_digest: bo
         sections["active conductor/evidence processes"] = active_processes
     else:
         gaps.append(f"active conductor/evidence processes: {active_processes}")
+    active_lanes, lane_gaps = _fresh_active_lanes(root)
+    if active_lanes is not None:
+        sections["fresh active lanes (object ownership)"] = active_lanes
+    gaps.extend(lane_gaps)
     if shutil.which("gh"):
         section(
             f"open non-draft PRs (up to {max_prs})",

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -376,7 +376,7 @@ def test_fresh_active_lanes_reports_object_identity(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now)
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now, home=tmp_path / "home")
 
     assert gaps == []
     assert body is not None
@@ -414,7 +414,7 @@ def test_fresh_active_lanes_excludes_stale_and_terminal_lanes(tmp_path: Path) ->
         encoding="utf-8",
     )
 
-    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now)
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now, home=tmp_path / "home")
 
     assert body == "none observed"
     assert gaps == []
@@ -429,7 +429,7 @@ def test_fresh_active_lanes_surfaces_bad_entries_as_gap(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now)
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now, home=tmp_path / "home")
 
     assert body == "none observed"
     assert len(gaps) == 1
@@ -437,17 +437,17 @@ def test_fresh_active_lanes_surfaces_bad_entries_as_gap(tmp_path: Path) -> None:
 
 
 def test_fresh_active_lanes_surfaces_missing_and_malformed_registry(tmp_path: Path) -> None:
-    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path)
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, home=tmp_path / "home")
 
     assert body is None
     assert len(gaps) == 1
-    assert "lanes registry missing" in gaps[0]
+    assert "lane registries missing" in gaps[0]
 
     lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
     lanes_path.parent.mkdir(parents=True)
     lanes_path.write_text("{not-json", encoding="utf-8")
 
-    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path)
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, home=tmp_path / "home")
 
     assert body is None
     assert len(gaps) == 1
@@ -484,6 +484,114 @@ def test_gather_context_includes_fresh_active_lane_section(monkeypatch, tmp_path
     body = context["sections"]["fresh active lanes (object ownership)"]
     assert '"lane_id": "lane-owned-branch"' in body
     assert '"branch": "codex/owned-branch"' in body
+
+
+def test_fresh_active_lanes_merges_canonical_registries_and_statuses(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 10, 4, 15, tzinfo=timezone.utc)
+    home = tmp_path / "home"
+    home_path = home / ".aragora" / "agent-bridge" / "lanes.json"
+    repo_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    home_path.parent.mkdir(parents=True)
+    repo_path.parent.mkdir(parents=True)
+    home_path.write_text(
+        json.dumps(
+            [
+                {
+                    "status": "running",
+                    "lane_id": "shared-lane",
+                    "owner_session": "home-owner",
+                    "branch": "codex/from-home",
+                    "updated_at": (now - timedelta(minutes=5)).isoformat(),
+                },
+                {
+                    "status": "queued",
+                    "lane_id": "home-only",
+                    "updated_at": (now - timedelta(minutes=3)).isoformat(),
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    repo_path.write_text(
+        json.dumps(
+            [
+                {
+                    "status": "blocked",
+                    "lane_id": "shared-lane",
+                    "owner_session": "repo-owner",
+                    "updated_at": (now - timedelta(minutes=1)).isoformat(),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now, home=home)
+
+    assert gaps == []
+    assert body is not None
+    assert body.count('"lane_id": "shared-lane"') == 1
+    assert '"owner_session": "repo-owner"' in body
+    assert '"branch": "codex/from-home"' in body
+    assert '"lane_id": "home-only"' in body
+
+
+def test_fresh_active_lanes_surfaces_partial_utf8_degradation(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 10, 4, 15, tzinfo=timezone.utc)
+    home = tmp_path / "home"
+    home_path = home / ".aragora" / "agent-bridge" / "lanes.json"
+    repo_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    home_path.parent.mkdir(parents=True)
+    repo_path.parent.mkdir(parents=True)
+    home_path.write_bytes(b"\xff\xfe")
+    repo_path.write_text(
+        json.dumps(
+            [
+                {
+                    "status": "claimed",
+                    "lane_id": "repo-lane",
+                    "updated_at": (now - timedelta(minutes=1)).isoformat(),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now, home=home)
+
+    assert body is not None
+    assert '"lane_id": "repo-lane"' in body
+    assert len(gaps) == 1
+    assert "lanes registry unreadable" in gaps[0]
+    assert str(home_path) in gaps[0]
+
+
+def test_fresh_active_lanes_falls_back_from_bad_heartbeat_to_updated_at(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 7, 10, 4, 15, tzinfo=timezone.utc)
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "status": "acknowledged",
+                    "lane_id": "fallback-lane",
+                    "last_heartbeat_at": "not-a-time",
+                    "updated_at": (now - timedelta(minutes=2)).isoformat(),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now, home=tmp_path / "home")
+
+    assert gaps == []
+    assert body is not None
+    assert '"lane_id": "fallback-lane"' in body
+    assert '"heartbeat_at": "2026-07-10T04:13:00+00:00"' in body
 
 
 def test_response_instructions_make_fresh_lane_ownership_per_object() -> None:

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -351,6 +352,147 @@ def test_active_conductor_processes_falls_back_to_portable_ps(monkeypatch) -> No
         ["ps", "-eo", "pid,ppid,etime,command"],
     ]
     assert "pid=200 elapsed=01:00 command=python3 settle_pr.py" in body
+
+
+def test_fresh_active_lanes_reports_object_identity(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 10, 4, 15, tzinfo=timezone.utc)
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "status": "active",
+                    "lane_id": "lane-pr-9083",
+                    "owner_session": "session-1",
+                    "pr_number": 9083,
+                    "branch": "codex/main-red-slice",
+                    "worktree": "/private/tmp/aragora-main-red-slice",
+                    "last_heartbeat_at": (now - timedelta(minutes=4)).isoformat(),
+                    "next_action": "measure current main",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now)
+
+    assert gaps == []
+    assert body is not None
+    assert '"lane_id": "lane-pr-9083"' in body
+    assert '"pr_number": 9083' in body
+    assert '"branch": "codex/main-red-slice"' in body
+    assert '"heartbeat_at": "2026-07-10T04:11:00+00:00"' in body
+    assert '"next_action": "measure current main"' in body
+
+
+def test_fresh_active_lanes_excludes_stale_and_terminal_lanes(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 10, 4, 15, tzinfo=timezone.utc)
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "status": "working",
+                    "lane_id": "stale-working",
+                    "updated_at": (now - timedelta(minutes=16)).isoformat(),
+                },
+                {
+                    "status": "released",
+                    "lane_id": "fresh-released",
+                    "updated_at": (now - timedelta(minutes=1)).isoformat(),
+                },
+                {
+                    "status": "completed",
+                    "lane_id": "fresh-completed",
+                    "updated_at": (now - timedelta(minutes=1)).isoformat(),
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now)
+
+    assert body == "none observed"
+    assert gaps == []
+
+
+def test_fresh_active_lanes_surfaces_bad_entries_as_gap(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 10, 4, 15, tzinfo=timezone.utc)
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True)
+    lanes_path.write_text(
+        json.dumps([42, {"status": "active", "lane_id": "bad-time", "updated_at": "nope"}]),
+        encoding="utf-8",
+    )
+
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path, now=now)
+
+    assert body == "none observed"
+    assert len(gaps) == 1
+    assert "skipped 2 malformed lane entries" in gaps[0]
+
+
+def test_fresh_active_lanes_surfaces_missing_and_malformed_registry(tmp_path: Path) -> None:
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path)
+
+    assert body is None
+    assert len(gaps) == 1
+    assert "lanes registry missing" in gaps[0]
+
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True)
+    lanes_path.write_text("{not-json", encoding="utf-8")
+
+    body, gaps = fable_goal_cycle._fresh_active_lanes(tmp_path)
+
+    assert body is None
+    assert len(gaps) == 1
+    assert "lanes registry malformed" in gaps[0]
+
+
+def test_gather_context_includes_fresh_active_lane_section(monkeypatch, tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "status": "active",
+                    "lane_id": "lane-owned-branch",
+                    "branch": "codex/owned-branch",
+                    "updated_at": now.isoformat(),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(fable_goal_cycle, "_run", lambda *args, **kwargs: (False, "offline"))
+    monkeypatch.setattr(
+        fable_goal_cycle, "_active_conductor_processes", lambda: (True, "none observed")
+    )
+    monkeypatch.setattr(fable_goal_cycle.shutil, "which", lambda _name: None)
+
+    context = fable_goal_cycle.gather_context(
+        tmp_path, since_hours=24, max_prs=30, skip_digest=True
+    )
+
+    body = context["sections"]["fresh active lanes (object ownership)"]
+    assert '"lane_id": "lane-owned-branch"' in body
+    assert '"branch": "codex/owned-branch"' in body
+
+
+def test_response_instructions_make_fresh_lane_ownership_per_object() -> None:
+    instructions = fable_goal_cycle.RESPONSE_FORMAT_INSTRUCTIONS
+
+    assert "fresh active lane" in instructions
+    assert "PR, branch, or worktree" in instructions
+    assert "per-object" in instructions
+    assert "not a global lock" in instructions
 
 
 def test_run_consult_sets_overall_timeout_and_bounded_outer_timeout(


### PR DESCRIPTION
## Summary

- add a bounded `fresh active lanes (object ownership)` packet section sourced from `.aragora/agent-bridge/lanes.json`
- include active/working lanes with heartbeat or activity no older than 15 minutes, matching the canonical owner-tool freshness window
- carry lane, owner, PR/branch/worktree, heartbeat, and next-action identity while keeping locking per-object rather than global
- surface missing, unreadable, malformed registry data and malformed active entries as context gaps
- instruct Fable not to recommend objects held by fresh active lanes

## Validation

- `ARAGORA_USE_SECRETS_MANAGER=0 python -m pytest tests/scripts/test_fable_goal_cycle.py -v` (26 passed)
- `python -m ruff check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py`
- `python -m ruff format --check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- live render against the shared lane registry: 2 fresh active lanes, 0 context gaps

## Safety

Draft only. No evidence, settlement, merge, workflow, branch-protection, main-health, or merge-executor-halt mutation.