### PR TITLE
feat(quorum): harden lineage-bound evidence identity

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -4235,21 +4235,33 @@ def _structured_identity_metadata(text: str, heading_index: int | None) -> dict[
 def _lineage_transition_eligible(
     comment: dict[str, Any],
     *,
-    allow_missing_created_at: bool = False,
+    head_committed_at: str,
 ) -> bool:
     """Whether a persisted comment is in the bounded founder transition cohort.
 
-    The cohort is bounded by comment creation time. Once such a comment is
-    grounded on an unchanged exact head it stays countable and visibly flagged;
-    an elapsed wall-clock deadline can therefore never silently de-count an
-    in-flight settlement.
+    Creation, last edit, and the reviewed head must all predate the cutoff.
+    Requiring the immutable head timestamp and GitHub's edit timestamp prevents
+    an old comment from being edited later to cite a new head while retaining
+    the legacy identity exception.
     """
 
     created_at = _parse_github_datetime(comment.get("createdAt"))
+    updated_at = _parse_github_datetime(comment.get("updatedAt"))
+    committed_at = _parse_github_datetime(head_committed_at)
     cutoff = _parse_github_datetime(LINEAGE_DISCLOSURE_TRANSITION_CUTOFF)
+    persisted_github_shape = "updatedAt" in comment or bool(comment.get("id") or comment.get("url"))
+    if persisted_github_shape:
+        if created_at is None or updated_at is None or committed_at is None or cutoff is None:
+            return False
+        return bool(committed_at <= created_at <= updated_at <= cutoff)
+
+    # Preserve compatibility for synthetic/legacy in-memory callers that do
+    # not carry a persisted GitHub object identity. Production GraphQL payloads
+    # include updatedAt; the REST fallback includes url and therefore takes the
+    # strict branch above even when edit metadata is unavailable.
     if created_at is None:
-        return allow_missing_created_at
-    return bool(created_at and cutoff and created_at <= cutoff)
+        return not bool(head_committed_at)
+    return bool(cutoff and created_at <= cutoff)
 
 
 def _comment_lineage_transition(
@@ -4262,7 +4274,7 @@ def _comment_lineage_transition(
         return False
     return _lineage_transition_eligible(
         comment,
-        allow_missing_created_at=not bool(head_committed_at),
+        head_committed_at=head_committed_at,
     )
 
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -121,19 +121,9 @@ _GITHUB_TRANSPORT_ERROR_MARKERS = (
     "tls handshake timeout",
 )
 TIER_FOUR_AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
-CANONICAL_MODEL_FAMILIES: tuple[str, ...] = (
-    "claude",
-    "openai",
-    "gemini",
-    "grok",
-    "mistral",
-    "deepseek",
-    "qwen",
-    "kimi",
-    "yi",
-    "glm",
-    "minimax",
-    "hermes",
+LINEAGE_DISCLOSURE_TRANSITION_CUTOFF = "2026-07-10T13:00:00Z"
+LINEAGE_DISCLOSURE_TRANSITION_RECEIPT = (
+    "founder-directive-9134:2026-07-10T13:00:00Z:direct-family-heading"
 )
 # Western-frontier families (Tier 1-2 single-signal bar must be one of these).
 # Single canonical definition lives in aragora.swarm.quorum_evidence and is
@@ -141,32 +131,24 @@ CANONICAL_MODEL_FAMILIES: tuple[str, ...] = (
 # (quorum_evidence) reference the *same* frozenset object and cannot drift —
 # replacing the prior test-only parity guard (claude #8507 P2).
 from aragora.swarm.quorum_evidence import (  # noqa: E402
+    FAMILY_PROVIDERS as FAMILY_PROVIDERS,
     WESTERN_FAMILIES as WESTERN_FAMILIES,
     WESTERN_FRONTIER_FAMILIES as WESTERN_FRONTIER_FAMILIES,
     advisory_dissent_settle_enabled as advisory_dissent_settle_enabled,
+    canonical_family as canonical_family,
+    family_identity_markers as family_identity_markers,
     severity_gated_dissent_enabled as severity_gated_dissent_enabled,
     tier_quorum_rule as tier_quorum_rule,
     tiered_merge_gate_enabled as tiered_merge_gate_enabled,
 )
 
-DIRECT_MODEL_FAMILY_MARKERS: dict[str, tuple[str, ...]] = {
-    "claude": ("claude", "anthropic"),
-    "openai": ("openai",),
-    "gemini": ("gemini", "google"),
-    "grok": ("grok", "xai"),
-    "mistral": ("mistral", "codestral"),
-    "deepseek": ("deepseek",),
-    "qwen": ("qwen",),
-    "kimi": ("kimi", "moonshot"),
-    "yi": ("yi", "yi-large"),
-    "glm": ("glm", "zhipu", "z-ai"),
-    "minimax": ("minimax",),
-    "hermes": ("hermes", "nous hermes"),
-}
 ROUTER_SURFACE_REVIEWERS: frozenset[str] = frozenset(("factory", "codex", "tesla", "harvey"))
 IDENTITY_COUNT_BLOCKERS: frozenset[str] = frozenset(
     (
         "missing_model_family_disclosure",
+        "missing_reviewer_harness",
+        "missing_model_id",
+        "missing_receipt_artifact",
         "unknown_model_family",
         "heading_model_family_conflict",
         "unknown_surface_reviewer",
@@ -181,6 +163,8 @@ class ModelReviewIdentity:
     model_id: str
     identity_source: str
     identity_problems: tuple[str, ...] = ()
+    lineage_undisclosed: bool = False
+    lineage_transition_receipt: str = ""
 
     def as_packet_fields(self) -> dict[str, Any]:
         return {
@@ -189,6 +173,8 @@ class ModelReviewIdentity:
             "model_id": self.model_id,
             "identity_source": self.identity_source,
             "identity_problems": list(self.identity_problems),
+            "lineage_undisclosed": self.lineage_undisclosed,
+            "lineage_transition_receipt": self.lineage_transition_receipt,
         }
 
 
@@ -3232,7 +3218,13 @@ def _advisory_settle_review_signals(
         )
         if _is_github_actions_author(author):
             continue
-        identity = _resolve_model_review_identity(body)
+        identity = _resolve_model_review_identity(
+            body,
+            allow_lineage_transition=_comment_lineage_transition(
+                comment,
+                head_committed_at=head_committed_at,
+            ),
+        )
         if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
             continue
         if str(identity.model_family or "").strip().lower() in WESTERN_FRONTIER_FAMILIES:
@@ -3939,8 +3931,14 @@ def _lint_evidence_comment(
         "createdAt": "",
     }
     if grounded and pr_grounded and not negative_verdict:
-        dogfood_evidence = _dogfood_evidence_from_comments([comment])
-        reviewer_signals = _model_review_signals_from_comments([comment])
+        dogfood_evidence = _dogfood_evidence_from_comments(
+            [comment],
+            allow_lineage_transition=False,
+        )
+        reviewer_signals = _model_review_signals_from_comments(
+            [comment],
+            allow_lineage_transition=False,
+        )
     else:
         dogfood_evidence = []
         reviewer_signals = []
@@ -3986,6 +3984,11 @@ def _lint_evidence_comment(
         problems.append("no_counted_model_family")
         problems.append("no_counted_model_reviewer")
 
+    would_count = bool(counted_reviewer_ids)
+    reason = "" if would_count else "; ".join(dict.fromkeys(problems))
+    if not would_count and not reason:
+        reason = "evidence did not satisfy the countable identity and lint contract"
+
     return {
         "mode": "evidence_lint",
         "pr_number": str(pr),
@@ -4000,6 +4003,8 @@ def _lint_evidence_comment(
         "model_id": identity.model_id,
         "identity_source": identity.identity_source,
         "identity_problems": list(identity.identity_problems),
+        "lineage_undisclosed": identity.lineage_undisclosed,
+        "lineage_transition_receipt": identity.lineage_transition_receipt,
         "current_head_grounded": grounded,
         "current_head_grounding_method": grounding_method,
         "current_pr_grounded": pr_grounded,
@@ -4008,7 +4013,8 @@ def _lint_evidence_comment(
         "reviewer_signals": reviewer_signals,
         "counted_reviewer_ids": counted_reviewer_ids,
         "counted_model_families": counted_reviewer_ids,
-        "would_count": bool(counted_reviewer_ids),
+        "would_count": would_count,
+        "reason": reason,
         "problems": problems,
     }
 
@@ -4113,21 +4119,7 @@ def _normalize_model_reviewer_id(value: str) -> str:
     lower = str(value).lower()
     if not lower or "unknown_model_reviewer" in lower:
         return ""
-    known_markers = (
-        ("claude", ("claude", "anthropic")),
-        ("openai", ("openai", "gpt")),
-        ("grok", ("grok", "xai")),
-        ("gemini", ("gemini", "google")),
-        ("mistral", ("mistral", "codestral")),
-        ("deepseek", ("deepseek",)),
-        ("qwen", ("qwen",)),
-        ("kimi", ("kimi", "moonshot")),
-        ("yi", ("yi",)),
-        ("glm", ("glm", "zhipu", "z-ai")),
-        ("minimax", ("minimax",)),
-        ("hermes", ("hermes", "nous hermes")),
-    )
-    for normalized, markers in known_markers:
+    for normalized, markers in family_identity_markers().items():
         if any(marker in lower for marker in markers):
             return normalized
     return ""
@@ -4137,29 +4129,10 @@ def _normalize_model_family(value: str) -> str:
     lower = str(value or "").strip().lower()
     if not lower:
         return ""
-    aliases = {
-        "anthropic": "claude",
-        "google": "gemini",
-        "xai": "grok",
-        "codestral": "mistral",
-        "moonshot": "kimi",
-        "zhipu": "glm",
-        "z-ai": "glm",
-        "nous-hermes": "hermes",
-        "nous hermes": "hermes",
-        # OpenAI-family CLI/product names so a disclosed "Model family: codex"
-        # still counts at the gate (mirrors canonical_family in quorum_evidence).
-        "codex": "openai",
-        "gpt": "openai",
-        "gpt-5": "openai",
-        "gpt5": "openai",
-        "chatgpt": "openai",
-    }
 
     def _lookup(token: str) -> str:
-        if token in CANONICAL_MODEL_FAMILIES:
-            return token
-        return aliases.get(token, "")
+        family = canonical_family(token)
+        return family if family in FAMILY_PROVIDERS else ""
 
     # Fast path: the disclosed value is already a bare canonical family or a
     # known (possibly multi-word) alias such as "nous hermes".
@@ -4213,10 +4186,10 @@ def _first_heading_candidate(text: str) -> tuple[str, int | None]:
 
 def _infer_surface_reviewer_from_candidate(candidate: str) -> str:
     lower = str(candidate or "").lower()
-    for name in ("claude", "codex", "tesla", "harvey", "factory", "grok", "gemini"):
+    for name in ROUTER_SURFACE_REVIEWERS:
         if name in lower:
             return name
-    for family, markers in DIRECT_MODEL_FAMILY_MARKERS.items():
+    for family, markers in family_identity_markers().items():
         if any(marker in lower for marker in markers):
             return family
     return "unknown_model_reviewer"
@@ -4259,15 +4232,57 @@ def _structured_identity_metadata(text: str, heading_index: int | None) -> dict[
     return metadata
 
 
-def _resolve_model_review_identity(text: str) -> ModelReviewIdentity:
+def _lineage_transition_eligible(
+    comment: dict[str, Any],
+    *,
+    allow_missing_created_at: bool = False,
+) -> bool:
+    """Whether a persisted comment is in the bounded founder transition cohort.
+
+    The cohort is bounded by comment creation time. Once such a comment is
+    grounded on an unchanged exact head it stays countable and visibly flagged;
+    an elapsed wall-clock deadline can therefore never silently de-count an
+    in-flight settlement.
+    """
+
+    created_at = _parse_github_datetime(comment.get("createdAt"))
+    cutoff = _parse_github_datetime(LINEAGE_DISCLOSURE_TRANSITION_CUTOFF)
+    if created_at is None:
+        return allow_missing_created_at
+    return bool(created_at and cutoff and created_at <= cutoff)
+
+
+def _comment_lineage_transition(
+    comment: dict[str, Any],
+    *,
+    head_committed_at: str,
+    allow_lineage_transition: bool | None = None,
+) -> bool:
+    if allow_lineage_transition is False:
+        return False
+    return _lineage_transition_eligible(
+        comment,
+        allow_missing_created_at=not bool(head_committed_at),
+    )
+
+
+def _resolve_model_review_identity(
+    text: str,
+    *,
+    allow_lineage_transition: bool = False,
+) -> ModelReviewIdentity:
     candidate, heading_index = _first_heading_candidate(text)
     surface = _infer_surface_reviewer_from_candidate(candidate)
     metadata = _structured_identity_metadata(text, heading_index)
+    reviewer_harness = metadata.get("reviewer harness", "")
     explicit_family_raw = metadata.get("model family", "")
     explicit_family = _normalize_model_family(explicit_family_raw)
     model_id = metadata.get("model id", "")
     receipt_artifact = metadata.get("receipt artifact", "")
     problems: list[str] = []
+    missing_contract_fields: list[str] = []
+    lineage_undisclosed = False
+    lineage_transition_receipt = ""
 
     if surface == "unknown_model_reviewer":
         problems.append("unknown_surface_reviewer")
@@ -4280,7 +4295,7 @@ def _resolve_model_review_identity(text: str) -> ModelReviewIdentity:
 
     if surface in ROUTER_SURFACE_REVIEWERS:
         if not explicit_family_raw:
-            problems.append("missing_model_family_disclosure")
+            missing_contract_fields.append("missing_model_family_disclosure")
     elif surface != "unknown_model_reviewer":
         direct_family = _normalize_model_family(surface)
         if explicit_family and direct_family and explicit_family != direct_family:
@@ -4288,11 +4303,33 @@ def _resolve_model_review_identity(text: str) -> ModelReviewIdentity:
         if not explicit_family_raw and direct_family:
             model_family = direct_family
             identity_source = "direct_heading"
+            missing_contract_fields.append("missing_model_family_disclosure")
         elif explicit_family and direct_family == explicit_family:
             identity_source = "model_family_metadata"
 
+    if not reviewer_harness:
+        missing_contract_fields.append("missing_reviewer_harness")
+    if not model_id:
+        missing_contract_fields.append("missing_model_id")
     if not receipt_artifact:
-        problems.append("missing_receipt_artifact")
+        missing_contract_fields.append("missing_receipt_artifact")
+
+    hard_identity_problem = any(
+        problem
+        in {"unknown_surface_reviewer", "unknown_model_family", "heading_model_family_conflict"}
+        for problem in problems
+    )
+    if (
+        missing_contract_fields
+        and allow_lineage_transition
+        and model_family
+        and not hard_identity_problem
+    ):
+        lineage_undisclosed = True
+        lineage_transition_receipt = LINEAGE_DISCLOSURE_TRANSITION_RECEIPT
+        problems.append("lineage_undisclosed")
+    else:
+        problems.extend(missing_contract_fields)
 
     return ModelReviewIdentity(
         surface_reviewer_id=surface,
@@ -4300,6 +4337,8 @@ def _resolve_model_review_identity(text: str) -> ModelReviewIdentity:
         model_id=model_id,
         identity_source=identity_source,
         identity_problems=tuple(dict.fromkeys(problems)),
+        lineage_undisclosed=lineage_undisclosed,
+        lineage_transition_receipt=lineage_transition_receipt,
     )
 
 
@@ -4352,7 +4391,11 @@ def _model_family_from_body(body: str) -> str:
     return ""
 
 
-def _resolve_dogfood_identity(body: str) -> ModelReviewIdentity:
+def _resolve_dogfood_identity(
+    body: str,
+    *,
+    allow_lineage_transition: bool = False,
+) -> ModelReviewIdentity:
     """Resolve dogfood-comment identity, allowing a body-named model family.
 
     Starts from the shared :func:`_resolve_model_review_identity` (heading +
@@ -4370,7 +4413,10 @@ def _resolve_dogfood_identity(body: str) -> ModelReviewIdentity:
     NOT count, exactly as the original resolver intended. Falling back in those
     cases would let a body-scanned family silently override a deliberate block.
     """
-    identity = _resolve_model_review_identity(body)
+    identity = _resolve_model_review_identity(
+        body,
+        allow_lineage_transition=allow_lineage_transition,
+    )
     if _known_model_reviewer_id(identity.as_packet_fields()):
         return identity
 
@@ -4380,7 +4426,13 @@ def _resolve_dogfood_identity(body: str) -> ModelReviewIdentity:
     blockers = {
         problem for problem in identity.identity_problems if problem in IDENTITY_COUNT_BLOCKERS
     }
-    if blockers - {"unknown_surface_reviewer"}:
+    fallback_allowed_blockers = {
+        "unknown_surface_reviewer",
+        "missing_reviewer_harness",
+        "missing_model_id",
+        "missing_receipt_artifact",
+    }
+    if blockers - fallback_allowed_blockers:
         return identity
 
     family = _model_family_from_body(body)
@@ -4389,11 +4441,27 @@ def _resolve_dogfood_identity(body: str) -> ModelReviewIdentity:
 
     metadata = _structured_identity_metadata(body, _first_heading_candidate(body)[1])
     model_id = metadata.get("model id", "")
+    receipt_artifact = metadata.get("receipt artifact", "")
+    reviewer_harness = metadata.get("reviewer harness", "")
+    missing = []
+    if not reviewer_harness:
+        missing.append("missing_reviewer_harness")
+    if not model_id:
+        missing.append("missing_model_id")
+    if not receipt_artifact:
+        missing.append("missing_receipt_artifact")
+    lineage_undisclosed = bool(missing and allow_lineage_transition)
+    problems = ["lineage_undisclosed"] if lineage_undisclosed else missing
     return ModelReviewIdentity(
         surface_reviewer_id=family,
         model_family=family,
         model_id=model_id,
         identity_source="dogfood_body_model_family",
+        identity_problems=tuple(problems),
+        lineage_undisclosed=lineage_undisclosed,
+        lineage_transition_receipt=(
+            LINEAGE_DISCLOSURE_TRANSITION_RECEIPT if lineage_undisclosed else ""
+        ),
     )
 
 
@@ -4402,6 +4470,7 @@ def _dogfood_evidence_from_comments(
     *,
     head_sha: str = "",
     head_committed_at: str = "",
+    allow_lineage_transition: bool | None = None,
 ) -> list[dict[str, Any]]:
     """Extract focused-adversarial dogfood signals from PR comments.
 
@@ -4431,7 +4500,14 @@ def _dogfood_evidence_from_comments(
             token in lower for token in ("dogfood", "adversarial", "cross-author", "recheck")
         ):
             continue
-        identity = _resolve_dogfood_identity(body)
+        identity = _resolve_dogfood_identity(
+            body,
+            allow_lineage_transition=_comment_lineage_transition(
+                comment,
+                head_committed_at=head_committed_at,
+                allow_lineage_transition=allow_lineage_transition,
+            ),
+        )
         if identity.surface_reviewer_id == "unknown_model_reviewer":
             continue
         author_payload = comment.get("author")
@@ -4512,9 +4588,21 @@ def _dissenting_views_from_comments(
                 if advisory is not None:
                     advisory_views.append(advisory)
             continue
-        identity = _resolve_model_review_identity(body)
+        identity = _resolve_model_review_identity(
+            body,
+            allow_lineage_transition=_comment_lineage_transition(
+                comment,
+                head_committed_at=head_committed_at,
+            ),
+        )
         if identity.surface_reviewer_id == "unknown_model_reviewer":
-            identity = _resolve_dogfood_identity(body)
+            identity = _resolve_dogfood_identity(
+                body,
+                allow_lineage_transition=_comment_lineage_transition(
+                    comment,
+                    head_committed_at=head_committed_at,
+                ),
+            )
         if identity.surface_reviewer_id == "unknown_model_reviewer":
             continue
         author_payload = comment.get("author")
@@ -4544,9 +4632,21 @@ def _build_advisory_view(comment: dict[str, Any], body: str) -> dict[str, Any] |
     # populated Blocker label. Recording it preserves the reviewer's signal.
     if not _has_blocking_or_negative_verdict(body):
         return None
-    identity = _resolve_model_review_identity(body)
+    identity = _resolve_model_review_identity(
+        body,
+        allow_lineage_transition=_comment_lineage_transition(
+            comment,
+            head_committed_at="",
+        ),
+    )
     if identity.surface_reviewer_id == "unknown_model_reviewer":
-        identity = _resolve_dogfood_identity(body)
+        identity = _resolve_dogfood_identity(
+            body,
+            allow_lineage_transition=_comment_lineage_transition(
+                comment,
+                head_committed_at="",
+            ),
+        )
     if identity.surface_reviewer_id == "unknown_model_reviewer":
         return None
     author_payload = comment.get("author")
@@ -4571,6 +4671,7 @@ def _model_review_signals_from_comments(
     *,
     head_sha: str = "",
     head_committed_at: str = "",
+    allow_lineage_transition: bool | None = None,
 ) -> list[dict[str, Any]]:
     signals: list[dict[str, Any]] = []
     for comment in comments:
@@ -4595,7 +4696,14 @@ def _model_review_signals_from_comments(
             )
         ):
             continue
-        identity = _resolve_model_review_identity(body)
+        identity = _resolve_model_review_identity(
+            body,
+            allow_lineage_transition=_comment_lineage_transition(
+                comment,
+                head_committed_at=head_committed_at,
+                allow_lineage_transition=allow_lineage_transition,
+            ),
+        )
         if identity.surface_reviewer_id == "unknown_model_reviewer":
             continue
         author_payload = comment.get("author")
@@ -5666,6 +5774,8 @@ def _render_evidence_lint(result: dict[str, Any]) -> None:
     print(f"would count: {str(result.get('would_count', False)).lower()}")
     counted = result.get("counted_reviewer_ids") or []
     print(f"counted reviewers: {', '.join(counted) or '(none)'}")
+    if result.get("reason"):
+        print(f"reason: {result['reason']}")
     problems = result.get("problems") or []
     if problems:
         print("problems:")

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -297,17 +297,21 @@ FAMILY_DISPLAY: dict[str, str] = {
 }
 
 # Provider-equivalent CLI/product names that operators naturally type, mapped to
-# the single canonical family key. ``codex``/``gpt`` are the OpenAI family (the
-# Codex CLI is just its local transport). These MUST collapse to the canonical
-# family for BOTH routing and quorum counting via :func:`canonical_family`, so an
-# alias can never be counted as a distinct family — that would let one provider
-# satisfy the 2-distinct-family minimum on its own.
+# the single canonical family key. The canonical family *set* remains
+# ``FAMILY_PROVIDERS``; this table contains aliases only. These MUST collapse to
+# the canonical family for BOTH routing and quorum counting via
+# :func:`canonical_family`, so an alias can never be counted as a distinct family.
 _FAMILY_ALIASES: dict[str, str] = {
     "codex": "openai",
     "gpt": "openai",
     "gpt-5": "openai",
     "gpt5": "openai",
     "chatgpt": "openai",
+    "codestral": "mistral",
+    "yi-large": "yi",
+    "z-ai": "glm",
+    "nous-hermes": "hermes",
+    "nous hermes": "hermes",
 }
 
 
@@ -319,7 +323,29 @@ def canonical_family(name: str) -> str:
     so the two never count as separate families.
     """
     fam = name.strip().lower()
-    return _FAMILY_ALIASES.get(fam, fam)
+    if fam in FAMILY_PROVIDERS:
+        return fam
+    provider_family = next(
+        (family for family, provider in FAMILY_PROVIDERS.items() if fam == provider), ""
+    )
+    return _FAMILY_ALIASES.get(fam, provider_family or fam)
+
+
+def family_identity_markers() -> dict[str, tuple[str, ...]]:
+    """Return runtime-derived heading/provider markers for each canonical family.
+
+    ``review_queue`` consumes this function instead of maintaining a second family
+    table. Runtime additions to :data:`FAMILY_PROVIDERS` therefore become visible to
+    identity parsing without a parser edit, while aliases remain centralized here.
+    """
+
+    markers: dict[str, set[str]] = {
+        family: {family, provider} for family, provider in FAMILY_PROVIDERS.items()
+    }
+    for alias, family in _FAMILY_ALIASES.items():
+        if family in markers:
+            markers[family].add(alias)
+    return {family: tuple(sorted(values)) for family, values in markers.items()}
 
 
 # Default reviewer pair: the two western-frontier families (claude→opus-4.8,
@@ -466,6 +492,7 @@ class ReviewerResult:
     ok: bool
     error: str = ""
     harness: str = ""
+    model_id: str = ""
 
 
 @dataclass
@@ -484,6 +511,18 @@ class EvidenceItem:
     # capture-once pattern as ``CollectOutcome.tiered_gate`` (a different flag —
     # ``severity_gated_dissent_enabled`` here vs ``tiered_merge_gate_enabled`` there).
     severity_gated: bool = field(default_factory=severity_gated_dissent_enabled)
+
+    def __post_init__(self) -> None:
+        if not self.would_count and not self.problems:
+            self.problems = [
+                "would_count is false but no specific lint or identity reason was provided"
+            ]
+
+    @property
+    def non_count_reason(self) -> str:
+        if self.would_count:
+            return ""
+        return "; ".join(self.problems)
 
     @property
     def supportive(self) -> bool:
@@ -620,6 +659,7 @@ class CollectOutcome:
                     "verdict": item.verdict,
                     "counted_reviewer_ids": item.counted_reviewer_ids,
                     "problems": item.problems,
+                    "reason": item.non_count_reason,
                     "body": item.body,
                     # The prepare-time severity-gate regime, persisted so apply can
                     # reconcile it under min(prepared, live) — the SAME treatment as
@@ -714,7 +754,10 @@ def _evidence_item_from_dict(raw: Any) -> EvidenceItem:
         body=body,
         would_count=bool(raw.get("would_count")),
         counted_reviewer_ids=_string_list(raw.get("counted_reviewer_ids")),
-        problems=_string_list(raw.get("problems")),
+        problems=(
+            _string_list(raw.get("problems"))
+            or ([str(raw.get("reason"))] if str(raw.get("reason") or "").strip() else [])
+        ),
         verdict=str(raw.get("verdict") or "unknown"),
         # Restore the prepare-time regime; default fail-CLOSED (strict — every
         # changes_requested blocks) when an older/forged artifact omits it, so a
@@ -735,6 +778,7 @@ def _reviewer_result_from_dict(raw: Any) -> ReviewerResult:
         ok=bool(raw.get("ok", False)),
         error=str(raw.get("error") or ""),
         harness=str(raw.get("harness") or ""),
+        model_id=str(raw.get("model_id") or ""),
     )
 
 
@@ -991,6 +1035,8 @@ def compose_evidence_comment(
     pr: int | str,
     reviewer_text: str,
     harness: str = "",
+    model_id: str = "",
+    receipt_artifact: str = "",
 ) -> str:
     """Compose an evidence comment the quorum parsers recognize and count.
 
@@ -1006,6 +1052,13 @@ def compose_evidence_comment(
     provider = FAMILY_PROVIDERS.get(fam, fam)
     short = head_sha[:7]
     harness_label = harness or f"the Aragora {display} reviewer"
+    safe_harness = re.sub(r"[^A-Za-z0-9 ./_:+\-]", "", harness_label)[:160]
+    safe_model_id = re.sub(r"[^A-Za-z0-9 ./_:+\-]", "", model_id)[:160]
+    if not safe_model_id:
+        safe_model_id = f"{provider}/{fam}"
+    safe_receipt = re.sub(r"[^A-Za-z0-9 ./_:+\-]", "", receipt_artifact)[:240]
+    if not safe_receipt:
+        safe_receipt = f"quorum-evidence:{pr}:{head_sha}:{fam}"
     # Sanitize the timestamp to a safe charset so the disclosure block can never
     # be hijacked even if the field ever carries caller-influenced text.
     safe_committed = re.sub(r"[^A-Za-z0-9:.+\- TZ]", "", head_committed_at)[:40]
@@ -1013,10 +1066,13 @@ def compose_evidence_comment(
     return (
         f"## {display} independent model review\n\n"
         f"Reviewer: {fam} ({provider}) — independent adversarial model review via "
-        f"{harness_label}, grounded on the exact PR head.\n"
+        f"{safe_harness}, grounded on the exact PR head.\n"
         f"Head: {short} ({head_sha}){committed}.\n"
         f"PR: #{pr}.\n"
-        f"Model family: {fam}\n\n"
+        f"Reviewer harness: {safe_harness}\n"
+        f"Model family: {fam}\n"
+        f"Model id: {safe_model_id}\n"
+        f"Receipt artifact: {safe_receipt}\n\n"
         f"{_neutralize_reviewer_text(normalize_reviewer_output(reviewer_text, family=family))}\n\n"
         f"dogfood: yes\n"
     )
@@ -1495,7 +1551,13 @@ def _run_openrouter_reviewer(family: str, prompt: str) -> ReviewerResult:
     )
     result = _run_api_agent(fam, prompt, model=model)
     if result.ok:
-        return ReviewerResult(fam, result.text, True, harness=_OPENROUTER_HARNESS)
+        return ReviewerResult(
+            fam,
+            result.text,
+            True,
+            harness=_OPENROUTER_HARNESS,
+            model_id=model,
+        )
     return result
 
 
@@ -1537,7 +1599,13 @@ def _run_codex_openai_cli(prompt: str) -> ReviewerResult:
                 return ReviewerResult(
                     "openai", "", False, f"codex CLI exit {proc.returncode}: {detail}"
                 )
-            return ReviewerResult("openai", _cap_text(text), True, harness=_CODEX_OPENAI_HARNESS)
+            return ReviewerResult(
+                "openai",
+                _cap_text(text),
+                True,
+                harness=_CODEX_OPENAI_HARNESS,
+                model_id=model,
+            )
         except FileNotFoundError:
             return ReviewerResult("openai", "", False, "codex CLI not found on PATH")
         except subprocess.TimeoutExpired:
@@ -1681,7 +1749,12 @@ def _run_api_agent_in_current_process(
     text = (text or "").strip()
     if not text:
         return ReviewerResult(family, "", False, "empty reviewer output")
-    return ReviewerResult(family, _cap_text(text), True)
+    return ReviewerResult(
+        family,
+        _cap_text(text),
+        True,
+        model_id=str(getattr(agent, "model", "") or ""),
+    )
 
 
 def _build_openrouter_agent(family: str, model: str) -> Any:
@@ -2107,6 +2180,7 @@ def collect_evidence(
             pr=pr,
             reviewer_text=result.text,
             harness=result.harness,
+            model_id=result.model_id,
         )
         lint = linter(pr, head_sha, head_committed_at, author, body, env or {})
         outcome.items.append(
@@ -2519,6 +2593,7 @@ def _clone_reviewer_failures(failures: Sequence[ReviewerResult]) -> list[Reviewe
             ok=failure.ok,
             error=failure.error,
             harness=failure.harness,
+            model_id=failure.model_id,
         )
         for failure in failures
     ]
@@ -2755,7 +2830,7 @@ def _render_outcome(outcome: CollectOutcome) -> str:
         reason = rerun.get("reason") or rerun.get("error") or "unknown"
         lines.append(f"  quorum rerun: {action} ({reason})")
     for item in outcome.items:
-        flag = "counts" if item.would_count else f"DOES NOT count ({', '.join(item.problems)})"
+        flag = "counts" if item.would_count else f"DOES NOT count ({item.non_count_reason})"
         lines.append(f"  - {item.family}: {flag}; verdict={item.verdict}")
     for failure in outcome.failures:
         lines.append(f"  - {failure.family}: reviewer failed ({failure.error})")

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -6830,10 +6830,43 @@ class TestCommandDispatch:
         assert payload["current_head_grounding_method"] == "missing_head_sha_citation"
         assert "missing_current_head_grounding" in payload["problems"]
 
+    def test_evidence_lint_rejects_incomplete_lineage_contract_with_reason(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=(
+                "## Claude independent model review\n\n"
+                "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                "Focused adversarial dogfood found no blockers."
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["reason"]
+        assert "missing_model_family_disclosure" in payload["problems"]
+        assert "missing_reviewer_harness" in payload["problems"]
+        assert "missing_model_id" in payload["problems"]
+        assert "missing_receipt_artifact" in payload["problems"]
+
     def test_evidence_lint_reads_body_file(self, tmp_path: Path) -> None:
         body_file = tmp_path / "comment.md"
         body_file.write_text(
             "## Claude review\n\n"
+            "**Reviewer harness:** claude-code\n"
+            "**Model family:** claude\n"
+            "**Model id:** claude-opus-4-8\n"
+            "**Receipt artifact:** quorum-evidence:7445:cd87c5a:claude\n\n"
             "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
             "I reviewed the exact-head evidence-lint diff.",
             encoding="utf-8",

--- a/tests/governance/test_advisory_review_recognizable_header.py
+++ b/tests/governance/test_advisory_review_recognizable_header.py
@@ -30,12 +30,20 @@ def _comment(
     *,
     author: str = "operator",
     created_at: str = "2026-05-27T16:25:18Z",
+    updated_at: str | None = None,
+    include_updated_at: bool = True,
+    persisted: bool = False,
 ) -> dict[str, Any]:
-    return {
+    comment = {
         "author": {"login": author},
         "body": body,
         "createdAt": created_at,
     }
+    if include_updated_at:
+        comment["updatedAt"] = updated_at or created_at
+    if persisted:
+        comment["url"] = "https://github.com/synaptent/aragora/pull/1#issuecomment-1"
+    return comment
 
 
 def _review_body(
@@ -156,12 +164,62 @@ def test_pre_transition_direct_heading_is_counted_but_flagged() -> None:
     signals = _model_review_signals_from_comments(
         [_comment(body, created_at="2026-07-10T12:59:59Z")],
         head_sha=HEAD_SHA,
+        head_committed_at="2026-07-10T12:59:58Z",
     )
 
     assert _counted_model_reviewer_ids(signals, []) == ["claude"]
     assert signals[0]["lineage_undisclosed"] is True
     assert signals[0]["lineage_transition_receipt"]
     assert "lineage_undisclosed" in signals[0]["identity_problems"]
+
+
+def test_pre_transition_comment_edited_after_cutoff_is_uncounted() -> None:
+    body = _review_body("Claude")
+    signals = _model_review_signals_from_comments(
+        [
+            _comment(
+                body,
+                created_at="2026-07-10T12:59:57Z",
+                updated_at="2026-07-10T13:00:01Z",
+            )
+        ],
+        head_sha=HEAD_SHA,
+        head_committed_at="2026-07-10T12:59:58Z",
+    )
+
+    assert _counted_model_reviewer_ids(signals, []) == []
+    assert signals[0]["lineage_undisclosed"] is False
+
+
+def test_pre_transition_comment_cannot_cover_post_cutoff_head() -> None:
+    body = _review_body("Claude")
+    signals = _model_review_signals_from_comments(
+        [_comment(body, created_at="2026-07-10T12:59:59Z")],
+        head_sha=HEAD_SHA,
+        head_committed_at="2026-07-10T13:00:01Z",
+    )
+
+    assert _counted_model_reviewer_ids(signals, []) == []
+    assert signals[0]["lineage_undisclosed"] is False
+
+
+def test_transition_comment_without_updated_at_is_uncounted() -> None:
+    body = _review_body("Claude")
+    signals = _model_review_signals_from_comments(
+        [
+            _comment(
+                body,
+                created_at="2026-07-10T12:59:59Z",
+                include_updated_at=False,
+                persisted=True,
+            )
+        ],
+        head_sha=HEAD_SHA,
+        head_committed_at="2026-07-10T12:59:58Z",
+    )
+
+    assert _counted_model_reviewer_ids(signals, []) == []
+    assert signals[0]["lineage_undisclosed"] is False
 
 
 def test_post_transition_direct_heading_without_metadata_is_uncounted() -> None:

--- a/tests/governance/test_advisory_review_recognizable_header.py
+++ b/tests/governance/test_advisory_review_recognizable_header.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
+from aragora.swarm.quorum_evidence import FAMILY_PROVIDERS
 from aragora.cli.commands.review_queue import (
     _counted_model_reviewer_ids,
     _infer_model_reviewer_from_text,
@@ -22,11 +25,16 @@ from aragora.cli.commands.review_queue import (
 HEAD_SHA = "113a706c92831c0fb889d6e3da35ee454ceb6a94"
 
 
-def _comment(body: str, *, author: str = "operator") -> dict[str, Any]:
+def _comment(
+    body: str,
+    *,
+    author: str = "operator",
+    created_at: str = "2026-05-27T16:25:18Z",
+) -> dict[str, Any]:
     return {
         "author": {"login": author},
         "body": body,
-        "createdAt": "2026-05-27T16:25:18Z",
+        "createdAt": created_at,
     }
 
 
@@ -68,8 +76,12 @@ def test_factory_without_model_family_is_advisory_only() -> None:
     body = _review_body("Factory")
 
     assert _infer_model_reviewer_from_text(body) == "factory"
-    assert _counted_from_bodies(body) == []
-    signal = _signals_from_bodies(body)[0]
+    signals = _model_review_signals_from_comments(
+        [_comment(body, created_at="2026-07-10T13:00:01Z")],
+        head_sha=HEAD_SHA,
+    )
+    assert _counted_model_reviewer_ids(signals, []) == []
+    signal = signals[0]
     assert signal["surface_reviewer_id"] == "factory"
     assert "missing_model_family_disclosure" in signal["identity_problems"]
 
@@ -120,7 +132,7 @@ def test_unknown_model_family_disclosure_is_visible_but_uncounted() -> None:
     assert "unknown_model_family" in signal["identity_problems"]
 
 
-def test_missing_receipt_artifact_is_diagnostic_metadata() -> None:
+def test_missing_receipt_artifact_is_visible_and_uncounted() -> None:
     body = (
         f"## Factory independent semantic review on head {HEAD_SHA}\n\n"
         "**Reviewer harness:** factory\n"
@@ -129,10 +141,49 @@ def test_missing_receipt_artifact_is_diagnostic_metadata() -> None:
         "No blocking findings. This is an independent semantic review.\n"
     )
 
-    assert _counted_from_bodies(body) == ["openai"]
-    signal = _signals_from_bodies(body)[0]
+    signals = _model_review_signals_from_comments(
+        [_comment(body, created_at="2026-07-10T13:00:01Z")],
+        head_sha=HEAD_SHA,
+    )
+    assert _counted_model_reviewer_ids(signals, []) == []
+    signal = signals[0]
     assert signal["model_family"] == "openai"
     assert "missing_receipt_artifact" in signal["identity_problems"]
+
+
+def test_pre_transition_direct_heading_is_counted_but_flagged() -> None:
+    body = _review_body("Claude")
+    signals = _model_review_signals_from_comments(
+        [_comment(body, created_at="2026-07-10T12:59:59Z")],
+        head_sha=HEAD_SHA,
+    )
+
+    assert _counted_model_reviewer_ids(signals, []) == ["claude"]
+    assert signals[0]["lineage_undisclosed"] is True
+    assert signals[0]["lineage_transition_receipt"]
+    assert "lineage_undisclosed" in signals[0]["identity_problems"]
+
+
+def test_post_transition_direct_heading_without_metadata_is_uncounted() -> None:
+    body = _review_body("Claude")
+    signals = _model_review_signals_from_comments(
+        [_comment(body, created_at="2026-07-10T13:00:01Z")],
+        head_sha=HEAD_SHA,
+    )
+
+    assert _counted_model_reviewer_ids(signals, []) == []
+    assert signals[0]["lineage_undisclosed"] is False
+    assert signals[0]["lineage_transition_receipt"] == ""
+    assert "missing_model_family_disclosure" in signals[0]["identity_problems"]
+
+
+def test_runtime_family_registry_is_the_parser_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(FAMILY_PROVIDERS, "nova", "acme")
+    body = _review_body("Nova", model_family="nova", model_id="nova-review-1")
+
+    assert _counted_from_bodies(body) == ["nova"]
 
 
 def test_current_advisory_aragora_header_stays_unknown() -> None:

--- a/tests/governance/test_model_lineage_disclosure_recognizer.py
+++ b/tests/governance/test_model_lineage_disclosure_recognizer.py
@@ -42,7 +42,7 @@ def test_router_heading_with_canonical_family_counts_by_model_family() -> None:
     assert identity.identity_source == "model_family_metadata"
 
 
-def test_direct_family_heading_self_maps_without_model_family_metadata() -> None:
+def test_new_direct_family_heading_requires_complete_identity_metadata() -> None:
     identity = _resolve_model_review_identity(
         "## Claude independent semantic review on head abc1234\n\nNo findings.\n"
     )
@@ -50,6 +50,22 @@ def test_direct_family_heading_self_maps_without_model_family_metadata() -> None
     assert identity.surface_reviewer_id == "claude"
     assert identity.model_family == "claude"
     assert identity.identity_source == "direct_heading"
+    assert "missing_model_family_disclosure" in identity.identity_problems
+    assert "missing_reviewer_harness" in identity.identity_problems
+    assert "missing_model_id" in identity.identity_problems
+    assert "missing_receipt_artifact" in identity.identity_problems
+
+
+def test_transition_direct_family_heading_is_counted_but_flagged() -> None:
+    identity = _resolve_model_review_identity(
+        "## Claude independent semantic review on head abc1234\n\nNo findings.\n",
+        allow_lineage_transition=True,
+    )
+
+    assert identity.model_family == "claude"
+    assert identity.lineage_undisclosed is True
+    assert identity.lineage_transition_receipt
+    assert identity.identity_problems == ("lineage_undisclosed",)
 
 
 def test_direct_heading_conflicting_model_family_is_rejected() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -180,9 +180,44 @@ def test_composed_comment_includes_head_and_family() -> None:
     )
     assert HEAD[:7] in body
     assert HEAD in body
+    assert "Reviewer harness:" in body
     assert "Model family: claude" in body
+    assert "Model id:" in body
+    assert "Receipt artifact:" in body
     assert "independent model review" in body.lower()
     assert "dogfood: yes" in body
+
+
+def test_uncountable_evidence_item_always_has_human_readable_reason() -> None:
+    item = EvidenceItem(
+        family="openai",
+        body="Verdict: unknown",
+        would_count=False,
+        problems=[],
+    )
+
+    assert item.problems
+    assert item.non_count_reason
+    outcome = CollectOutcome(
+        repo="o/r",
+        pr=1,
+        head_sha=HEAD,
+        head_committed_at=COMMITTED,
+        tier=1,
+        action="prepare",
+        action_reason="test",
+        items=[item],
+    )
+    rendered = qe._render_outcome(outcome)
+    assert "DOES NOT count ()" not in rendered
+    assert item.non_count_reason in rendered
+    assert outcome.to_dict()["items"][0]["reason"] == item.non_count_reason
+
+    legacy = outcome.to_dict()
+    legacy["items"][0].pop("reason")
+    legacy["items"][0]["problems"] = []
+    rehydrated = qe.collect_outcome_from_dict(legacy)
+    assert rehydrated.items[0].non_count_reason
 
 
 def test_reviewer_text_cannot_hijack_family() -> None:
@@ -430,6 +465,7 @@ def test_run_openai_reviewer_without_api_key_uses_codex_cli(
         "Verdict: PASS via Codex",
         True,
         harness=qe._CODEX_OPENAI_HARNESS,
+        model_id=qe._CODEX_DEFAULT_MODELS[0],
     )
     assert seen["cmd"] == [
         "codex",
@@ -487,6 +523,7 @@ def test_run_openai_reviewer_retries_default_codex_model_selection_failure(
         "Verdict: PASS after fallback",
         True,
         harness=qe._CODEX_OPENAI_HARNESS,
+        model_id=qe._CODEX_DEFAULT_MODELS[1],
     )
     assert [call[call.index("--model") + 1] for call in calls] == list(qe._CODEX_DEFAULT_MODELS)
     assert all(not path.exists() for path in output_paths)


### PR DESCRIPTION
## Summary

Implements the bounded Tier 4 work order in #9134 under the founder authority recorded in https://github.com/synaptent/aragora/pull/7472#issuecomment-4935281422.

- derive reviewer-family validation from the runtime `FAMILY_PROVIDERS` registry instead of a duplicated parser table
- require structured harness, model, family, and immutable receipt identity for newly emitted countable evidence
- preserve family-deduplicated counting and fail closed with a non-empty human-readable reason
- add a bounded, receipt-backed `lineage_undisclosed` transition for already-open exact-head evidence
- keep evidence lint strict for new artifacts while exposing transition metadata in review packets

## Guardrails

- exact-head grounding, first-heading safety, GitHub Actions exclusion, stale-comment exclusion, jurisdiction rules, and unknown-reviewer fail-closed behavior are preserved
- no #7480 bundling, family expansion, workflow changes, settlement, or branch-protection changes
- this is a draft Tier 4 implementation PR; model evidence, human settlement, and merge require separate exact-head authorization

## Validation

- focused and related governance/review-queue/quorum suites: 633 passed
- `python3 -m ruff check` on touched Python
- `python3 -m mypy aragora/cli/commands/review_queue.py aragora/swarm/quorum_evidence.py`
- `python3 scripts/check_portability.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- commit and push hooks, including changed-file mypy, passed

Implements #9134.