### PR TITLE
fix(persistence): drain 14 main-red mypy diagnostics

### DIFF
--- a/aragora/persistence/migrations/consolidate.py
+++ b/aragora/persistence/migrations/consolidate.py
@@ -29,7 +29,7 @@ import logging
 import shutil
 import sqlite3
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TypedDict, cast
@@ -67,11 +67,7 @@ class MigrationStats:
     rows_read: int = 0
     rows_written: int = 0
     rows_skipped: int = 0
-    errors: list[str] | None = None
-
-    def __post_init__(self):
-        if self.errors is None:
-            self.errors = []
+    errors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -1161,7 +1157,7 @@ class DatabaseConsolidator:
                 )
 
         # Track target connections
-        target_conns: dict[str, sqlite3.Connection] = {}
+        target_conns: dict[str, sqlite3.Connection | None] = {}
 
         try:
             for source_db_name, config in MIGRATION_MAP.items():
@@ -1215,6 +1211,8 @@ class DatabaseConsolidator:
                         except (OSError, RuntimeError, ValueError) as e:
                             logger.warning("Could not count %s: %s", source_table, e)
                     else:
+                        if target_conn is None:
+                            raise RuntimeError(f"Missing target connection for {target_db_name}")
                         stats = self._migrate_table(
                             source_conn=source_conn,
                             target_conn=target_conn,

--- a/aragora/persistence/repositories/elo.py
+++ b/aragora/persistence/repositories/elo.py
@@ -540,7 +540,10 @@ class EloRepository(BaseRepository[RatingEntity]):
                     (agent, new_elo, debate_id),
                 )
 
-            return cursor.lastrowid
+            match_id = cursor.lastrowid
+            if match_id is None:
+                raise RuntimeError("SQLite did not return an ID for the recorded match")
+            return match_id
 
     def get_match(self, debate_id: str) -> MatchEntity | None:
         """

--- a/aragora/persistence/repositories/memory.py
+++ b/aragora/persistence/repositories/memory.py
@@ -473,6 +473,15 @@ class MemoryRepository(BaseRepository[MemoryEntity]):
             (agent_name,),
         )
 
+        if row is None:
+            return {
+                "total_memories": 0,
+                "observations": 0,
+                "reflections": 0,
+                "insights": 0,
+                "avg_importance": 0.0,
+            }
+
         return {
             "total_memories": row[0] or 0,
             "observations": row[1] or 0,

--- a/aragora/persistence/supabase_client.py
+++ b/aragora/persistence/supabase_client.py
@@ -29,8 +29,8 @@ def _ensure_supabase() -> bool:
     try:
         import supabase as _mod
 
-        Client = _mod.Client
-        create_client = _mod.create_client
+        Client = getattr(_mod, "Client")
+        create_client = getattr(_mod, "create_client")
         SUPABASE_AVAILABLE = True
     except (ImportError, AttributeError):
         SUPABASE_AVAILABLE = False


### PR DESCRIPTION
## Summary
- initialize migration error lists with a typed per-instance factory
- resolve optional Supabase SDK symbols through the existing lazy lookup boundary
- fail explicitly if aggregate rows, target connections, or SQLite insert IDs violate their runtime invariants
- keep migration, repository, and optional-SDK behavior unchanged for valid inputs

## Main-red evidence
- exact base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- exact head: `a914576f8be0d459f60386ee02a448992ecda346`
- scoped `aragora/persistence` diagnostics: 14 -> 0
- full diagnostic set: 14 removed, 0 added
- pinned after-output SHA-256: `3387e9097727428b7c4fc49b284b49dc62fe14d2eefffac6b8d626ce958f6918`
- main-red halt remains active; this PR is intentionally draft-only

## Validation
- focused migration/repository/Supabase tests: 89 passed
- `tests/persistence` on branch: 1 failed, 714 passed
- `tests/persistence` on exact main: the same 1 failed, 714 passed
- isolated failing test passes: `TestConnectionAcquisition::test_acquire_connection_from_primary`
- baseline failure is class-identity pollution in untouched `postgres_pool` code after a module reload; it is not introduced by this diff
- scoped fresh-cache mypy: 0 errors
- exact full-repo mypy set comparison: 14 removed, 0 added
- Ruff check/format, automation preflight, commit hooks, and push hooks passed

Refs #9099

## Current-main restack (2026-07-11)

- old head: `a914576f8be0d459f60386ee02a448992ecda346`
- current-main base merged normally: `a0f0c417916203d7ed0232ebd178a318495d1c23`
- new head: `77ab891968c1090fb7817e39a7aeb40c5fed0f22`
- current-main full mypy identity: `2634 -> 2620` errors, 14 removed, 0 added
- current-main error-set SHA-256: `a74630d72378df4854a1bc596b5072feb267eb8e11f9c437b4f7cafa39853609`
- candidate error-set SHA-256: `8c28870827e3b24e1d257dcff27ca6e9d3a1e381de5530979610f842810f51b8`
- removed-set SHA-256: `c01e5278e73f54565835c8e090f4ce393eb459a365217e3caf4f62bfa3ef08a7`
- added-set SHA-256: `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
- all removals remain confined to the four claimed persistence files
- targeted mypy: clean
- focused tests: 99 passed, 1 deselected; the deselected Supabase environment-import test fails identically on exact current main under the local Python 3.13 dependency set
- Ruff check/format, `git diff --check`, automation preflight, and all push hooks passed
- any pre-restack model evidence is stale and must not be reused

The PR remains draft-only while the main-red halt and #9099 WIP freeze remain active.
