### PR TITLE
fix(governance): align optional-check merge authorization

### DIFF
--- a/aragora/cli/commands/review_queue_unstable.py
+++ b/aragora/cli/commands/review_queue_unstable.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 from aragora.cli.commands import review_queue_rest_fallback as rest_fallback
 from aragora.cli.commands.review_queue_transport import _GhError
+from aragora.swarm.auto_merge_green import required_check_surface_proves_optional_only_unstable
 
 UNSTABLE_CANCELLATION_POLICY_PATH = "docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md"
 UNSTABLE_ALLOWLISTED_WORKFLOW_PATHS: dict[str, str] = {
@@ -445,12 +446,19 @@ def admin_squash_live_gate_blockers(packet: Any) -> list[str]:
 
     merge_state_status = str(packet.merge_state_status or "").strip().upper()
     if not merge_state_status:
-        blockers.append("mergeStateStatus unavailable; admin squash requires CLEAN or BLOCKED")
-    elif merge_state_status == "UNSTABLE" and _verified_unstable_cancellation_override(packet):
+        blockers.append(
+            "mergeStateStatus unavailable; admin squash requires CLEAN/BLOCKED or "
+            "authoritative optional-only UNSTABLE proof"
+        )
+    elif merge_state_status == "UNSTABLE" and (
+        _verified_unstable_cancellation_override(packet)
+        or required_check_surface_proves_optional_only_unstable(packet.check_surfaces)
+    ):
         pass
     elif merge_state_status not in {"CLEAN", "BLOCKED"}:
         blockers.append(
-            f"mergeStateStatus={merge_state_status}; admin squash requires CLEAN or BLOCKED"
+            f"mergeStateStatus={merge_state_status}; admin squash requires CLEAN/BLOCKED or "
+            "authoritative optional-only UNSTABLE proof"
         )
     return blockers
 

--- a/aragora/swarm/auto_merge_green.py
+++ b/aragora/swarm/auto_merge_green.py
@@ -20,7 +20,7 @@ to flow through ``scripts/settle_tier4_pr.py`` unchanged.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 # The branch-protection required checks (mirrors boss_drain_pass._REQUIRED).
@@ -34,10 +34,10 @@ QUORUM_CHECK = "aragora-merge-quorum"
 # Tiers 0-2 settle without human risk acceptance; 3-4 always need a human.
 MAX_AUTO_MERGE_TIER = 2
 
-# Merge states from which an authorized admin squash is safe. BLOCKED is allowed
-# only because a satisfied merge-packet is what substitutes for the missing
-# review approval under branch protection; every other non-CLEAN state (DIRTY,
-# BEHIND, UNSTABLE, UNKNOWN) is refused.
+# Merge states from which an authorized admin squash is ordinarily safe. BLOCKED
+# is allowed only because a satisfied merge-packet substitutes for the missing
+# review approval under branch protection. UNSTABLE requires the separate,
+# authoritative required-check proof below; all other states are refused.
 _SAFE_MERGE_STATES = frozenset({"CLEAN", "BLOCKED"})
 
 # Any check ending in one of these conclusions blocks the merge -- even a
@@ -69,6 +69,7 @@ class PRMergeContext:
     mergeable: str
     merge_state_status: str
     check_states: dict[str, str]
+    check_surfaces: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,63 @@ class MergeDecision:
     head_sha: str
     should_merge: bool
     blockers: tuple[str, ...]
+
+
+def required_check_surface_proves_optional_only_unstable(check_surfaces: Any) -> bool:
+    """Return whether an authoritative surface proves every non-green row optional.
+
+    This is deliberately stricter than merely observing ``UNSTABLE``. The
+    required-check query must be available and selected with at least one
+    effective required check, no required failures or pending rows, and the
+    complete rollup diagnostics must classify every non-green row as
+    non-required. Missing or malformed diagnostics fail closed.
+    """
+    if not isinstance(check_surfaces, dict):
+        return False
+    required = check_surfaces.get("required_pr_checks")
+    rollup = check_surfaces.get("pr_rollup")
+    effective_gate = check_surfaces.get("effective_gate")
+    if not isinstance(required, dict) or not isinstance(rollup, dict):
+        return False
+    if not isinstance(effective_gate, dict):
+        return False
+    if required.get("available") is not True or required.get("gate_selected") is not True:
+        return False
+    if effective_gate.get("source") != "required_pr_checks":
+        return False
+    effective_total = required.get("effective_total")
+    if (
+        not isinstance(effective_total, int)
+        or isinstance(effective_total, bool)
+        or effective_total <= 0
+    ):
+        return False
+    gate_blocked_reason = required.get("gate_blocked_reason")
+    if gate_blocked_reason is not None and gate_blocked_reason != "":
+        return False
+    if required.get("failing_or_cancelled") != [] or required.get("pending") != []:
+        return False
+    if rollup.get("available") is not True:
+        return False
+
+    count_keys = (
+        "non_green_count",
+        "non_required_non_green_count",
+        "failing_or_cancelled_count",
+        "pending_count",
+    )
+    counts: dict[str, int] = {}
+    for key in count_keys:
+        value = rollup.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            return False
+        counts[key] = value
+    non_green = counts["non_green_count"]
+    return (
+        non_green > 0
+        and counts["non_required_non_green_count"] == non_green
+        and counts["failing_or_cancelled_count"] + counts["pending_count"] == non_green
+    )
 
 
 def decide_auto_merge(
@@ -142,7 +200,11 @@ def decide_auto_merge(
     if ctx.mergeable != "MERGEABLE":
         blockers.append(f"not mergeable (mergeable={ctx.mergeable or 'unknown'})")
 
-    if ctx.merge_state_status not in _SAFE_MERGE_STATES:
+    optional_only_unstable = (
+        ctx.merge_state_status == "UNSTABLE"
+        and required_check_surface_proves_optional_only_unstable(ctx.check_surfaces)
+    )
+    if ctx.merge_state_status not in _SAFE_MERGE_STATES and not optional_only_unstable:
         blockers.append(
             f"merge state not safe (mergeStateStatus={ctx.merge_state_status or 'unknown'})"
         )
@@ -157,7 +219,7 @@ def decide_auto_merge(
             blockers.append(f"required check not green: {name}={state or 'absent'}")
 
     failing = sorted(n for n, s in ctx.check_states.items() if s in _FAILING_CHECK_STATES)
-    if failing:
+    if failing and not optional_only_unstable:
         shown = ", ".join(failing[:3])
         blockers.append(
             f"failing checks present (incl. non-required): {shown}{', …' if len(failing) > 3 else ''}"
@@ -232,6 +294,11 @@ def context_from_gh(view: dict[str, Any], packet_entry: dict[str, Any] | None) -
         mergeable=str(view.get("mergeable") or ""),
         merge_state_status=str(view.get("mergeStateStatus") or ""),
         check_states=check_states,
+        check_surfaces=(
+            dict(packet.get("check_surfaces") or {})
+            if isinstance(packet.get("check_surfaces"), dict)
+            else {}
+        ),
     )
 
 

--- a/docs/AGENT_OPERATING_CONTRACT.md
+++ b/docs/AGENT_OPERATING_CONTRACT.md
@@ -129,10 +129,13 @@ reviewed; (3) every branch-protection required check **other than** the exact qu
 human-settlement context being satisfied by this evidence/settlement step is green, with no
 non-quorum required check pending, failing, or cancelled; AND (4) the PR is mergeable — not
 behind base and free of conflicts — with the PR non-draft and GitHub reporting `mergeable` as
-`MERGEABLE` and `mergeStateStatus` as `CLEAN` or `BLOCKED`. Required-check gating comes from
-`gh pr checks --required` / merge-packet's required-check surface, not the raw
-`statusCheckRollup`: non-required rollup failures remain advisory, but any failing non-quorum
-required check makes the head not settlement-stable. Do not add a "base unchanged" condition
+`MERGEABLE` and `mergeStateStatus` as `CLEAN` or `BLOCKED`; `UNSTABLE` is also permitted only
+when merge-packet has an available, selected required-check surface with at least one effective
+required check, every required check green, and complete rollup diagnostics proving every
+non-green context is non-required. Required-check gating comes from `gh pr checks --required` /
+merge-packet's required-check surface, not the raw `statusCheckRollup`: non-required rollup
+failures remain advisory, but any failing non-quorum required check makes the head not
+settlement-stable. Do not add a "base unchanged" condition
 that depends on a `baseRefOid` / base-OID freeze the helper does not record (the `BEHIND` /
 `DIRTY` exclusion below already rejects a head that drifted behind or conflicts with its base).
 "Clean" is a
@@ -141,8 +144,8 @@ semantic/body-marker requirement, not only the helper's `verdict`, `would_count`
 `[P0]`, `[P1]`, or `[P2]` finding is not clean and must become a repair packet, not countable
 support. `BLOCKED` is allowed only when the blocker is the quorum / exact-head human-settlement
 context this step is designed to satisfy; `BLOCKED` from any other required check failure is
-not settlement-stable. `DIRTY`, `BEHIND`, `DRAFT`, `UNKNOWN`, `UNSTABLE`, and missing/unknown
-mergeability or `mergeStateStatus` are not settlement-stable. The
+not settlement-stable. `DIRTY`, `BEHIND`, `DRAFT`, `UNKNOWN`, unproven `UNSTABLE`, and
+missing/unknown mergeability or `mergeStateStatus` are not settlement-stable. The
 counted-family set comes from
 [`docs/REVIEW_AUTHORITY_PRINCIPLES.md`](REVIEW_AUTHORITY_PRINCIPLES.md), especially the
 Tier-eligibility table; do not invent a smaller family set inside a recursive prompt.

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4167,7 +4167,10 @@ class TestBuildQueueAndPacket:
             (
                 "UNSTABLE",
                 [],
-                "mergeStateStatus=UNSTABLE; admin squash requires CLEAN or BLOCKED",
+                (
+                    "mergeStateStatus=UNSTABLE; admin squash requires CLEAN/BLOCKED or "
+                    "authoritative optional-only UNSTABLE proof"
+                ),
             ),
             (
                 "CLEAN",
@@ -4177,7 +4180,10 @@ class TestBuildQueueAndPacket:
             (
                 "",
                 [],
-                "mergeStateStatus unavailable; admin squash requires CLEAN or BLOCKED",
+                (
+                    "mergeStateStatus unavailable; admin squash requires CLEAN/BLOCKED or "
+                    "authoritative optional-only UNSTABLE proof"
+                ),
             ),
         ],
     )
@@ -4336,6 +4342,89 @@ class TestBuildQueueAndPacket:
         assert entry["admin_squash_gate_blockers"] == []
         assert entry["unstable_non_required_contexts_ignored"] == [ignored_context]
         assert packet["admin_squash_order"] == [9034]
+
+    def test_merge_packet_allows_unstable_with_authoritative_required_checks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_build_packet(ref: str, **_kwargs: Any) -> ReviewPacket:
+            return ReviewPacket(
+                pr_number=int(ref),
+                title=f"PR {ref}",
+                url=f"https://github.com/synaptent/aragora/pull/{ref}",
+                head_sha="abc123",
+                base_sha="def456",
+                author="codex",
+                is_draft=False,
+                additions=1,
+                deletions=1,
+                changed_files=1,
+                queue_bucket="ready_now",
+                touched_subsystems=["scripts"],
+                high_risk_paths_touched=[],
+                validation=[],
+                checks_summary="6/6 required green",
+                risk_flags=[],
+                machine_recommendation="approve_candidate",
+                machine_recommendation_reason="required checks authoritative",
+                packet_sha="sha256:test",
+                generated_at="2026-07-22T00:00:00+00:00",
+                check_surfaces={
+                    "effective_gate": {
+                        "source": "required_pr_checks",
+                        "summary": "6/6 required green",
+                    },
+                    "required_pr_checks": {
+                        "available": True,
+                        "effective_total": 6,
+                        "gate_selected": True,
+                        "gate_blocked_reason": "",
+                        "failing_or_cancelled": [],
+                        "pending": [],
+                    },
+                    "pr_rollup": {
+                        "available": True,
+                        "non_green_count": 2,
+                        "non_required_non_green_count": 2,
+                        "failing_or_cancelled_count": 2,
+                        "pending_count": 0,
+                        "non_required_non_green_sample": [
+                            "Security Gate / npm Security Scan",
+                            "Security Gate / Security Gate Summary",
+                        ],
+                    },
+                },
+                merge_state_status="UNSTABLE",
+                model_review_quorum={
+                    "tier": 2,
+                    "tier_name": "Tier 2",
+                    "status": "satisfied",
+                    "verdict": "admin_squash_allowed",
+                    "admin_squash_allowed": True,
+                    "requires_human_risk_settlement": False,
+                    "unresolved_dissent": False,
+                    "reviewer_signals": [],
+                    "dogfood_evidence": [],
+                    "counted_reviewer_ids": ["claude", "openai"],
+                    "reasons": ["clean exact-head quorum"],
+                },
+            )
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._build_packet", fake_build_packet)
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._explicit_merged_pr_merge_packet_entry",
+            lambda ref, repo_override: None,
+        )
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["9453"],
+            limit=30,
+            repo_override="synaptent/aragora",
+        )
+
+        entry = packet["entries"][0]
+        assert entry["admin_squash_allowed"] is True
+        assert entry["admin_squash_gate_blockers"] == []
+        assert packet["admin_squash_order"] == [9453]
 
     def test_merge_packet_text_renderer_prints_live_gate_blockers(
         self,

--- a/tests/scripts/test_merge_executor.py
+++ b/tests/scripts/test_merge_executor.py
@@ -69,6 +69,27 @@ def _packet(number: int = 100, head: str = HEAD, tier: int = 1, **overrides) -> 
     return base
 
 
+def _optional_only_unstable_surface() -> dict:
+    return {
+        "effective_gate": {"source": "required_pr_checks", "summary": "6/6 required green"},
+        "required_pr_checks": {
+            "available": True,
+            "effective_total": 6,
+            "gate_selected": True,
+            "gate_blocked_reason": "",
+            "failing_or_cancelled": [],
+            "pending": [],
+        },
+        "pr_rollup": {
+            "available": True,
+            "non_green_count": 2,
+            "non_required_non_green_count": 2,
+            "failing_or_cancelled_count": 2,
+            "pending_count": 0,
+        },
+    }
+
+
 def _main_runs_green() -> list[dict]:
     return [
         {"id": i, "name": name, "status": "completed", "conclusion": "success"}
@@ -195,6 +216,24 @@ def test_dry_run_never_calls_merge_fn(tmp_path):
     summary = me.run_pass(**_kwargs(h, tmp_path))
     assert h.merge_calls == []
     assert summary["mode"] == "dry-run"
+    assert _actions(summary)[100] == "would-merge"
+
+
+def test_9453_optional_security_failures_reach_would_merge(tmp_path):
+    rollup = _rollup_all_green()
+    rollup.extend(
+        [
+            {"name": "npm Security Scan", "conclusion": "FAILURE"},
+            {"name": "Security Gate Summary", "conclusion": "FAILURE"},
+        ]
+    )
+    view = _view(mergeStateStatus="UNSTABLE", statusCheckRollup=rollup)
+    packet = _packet(check_surfaces=_optional_only_unstable_surface())
+    h = _Harness({100: view}, {100: packet})
+
+    summary = me.run_pass(**_kwargs(h, tmp_path))
+
+    assert h.merge_calls == []
     assert _actions(summary)[100] == "would-merge"
 
 

--- a/tests/swarm/test_auto_merge_green.py
+++ b/tests/swarm/test_auto_merge_green.py
@@ -21,8 +21,10 @@ from aragora.swarm.auto_merge_green import (
     MAX_AUTO_MERGE_TIER,
     REQUIRED_CHECKS,
     PRMergeContext,
+    context_from_gh,
     decide_auto_merge,
     first_error_line,
+    required_check_surface_proves_optional_only_unstable,
 )
 
 
@@ -49,6 +51,7 @@ def _authorized_context(**overrides) -> PRMergeContext:
         mergeable="MERGEABLE",
         merge_state_status="BLOCKED",
         check_states=_green_checks(),
+        check_surfaces={},
     )
     base.update(overrides)
     return PRMergeContext(**base)
@@ -181,10 +184,99 @@ def test_dirty_merge_state_is_blocked():
 
 
 def test_unstable_merge_state_is_blocked():
-    # UNSTABLE = a non-required check is failing; skip rather than risk it.
+    # UNSTABLE alone is not evidence that only optional checks are non-green.
     decision = decide_auto_merge(_authorized_context(merge_state_status="UNSTABLE"))
     assert decision.should_merge is False
     assert any("merge state" in b.lower() for b in decision.blockers)
+
+
+def _optional_only_unstable_surface(**required_overrides) -> dict:
+    required = {
+        "available": True,
+        "effective_total": 6,
+        "gate_selected": True,
+        "gate_blocked_reason": "",
+        "failing_or_cancelled": [],
+        "pending": [],
+    }
+    required.update(required_overrides)
+    return {
+        "effective_gate": {"source": "required_pr_checks", "summary": "6/6 required green"},
+        "required_pr_checks": required,
+        "pr_rollup": {
+            "available": True,
+            "non_green_count": 2,
+            "non_required_non_green_count": 2,
+            "failing_or_cancelled_count": 2,
+            "pending_count": 0,
+        },
+    }
+
+
+def test_unstable_with_authoritative_required_green_surface_is_mergeable():
+    states = _green_checks()
+    states["npm Security Scan"] = "FAILURE"
+    states["Security Gate Summary"] = "FAILURE"
+    decision = decide_auto_merge(
+        _authorized_context(
+            merge_state_status="UNSTABLE",
+            check_states=states,
+            check_surfaces=_optional_only_unstable_surface(),
+        )
+    )
+    assert decision.should_merge is True
+    assert decision.blockers == ()
+
+
+@pytest.mark.parametrize(
+    "required_overrides",
+    [
+        {"available": False},
+        {"failing_or_cancelled": ["lint"]},
+        {"pending": ["typecheck"]},
+        {"gate_blocked_reason": ["malformed"]},
+    ],
+)
+def test_unstable_required_surface_failures_remain_blocked(required_overrides):
+    surface = _optional_only_unstable_surface(**required_overrides)
+    assert required_check_surface_proves_optional_only_unstable(surface) is False
+    decision = decide_auto_merge(
+        _authorized_context(merge_state_status="UNSTABLE", check_surfaces=surface)
+    )
+    assert decision.should_merge is False
+    assert any("merge state" in blocker.lower() for blocker in decision.blockers)
+
+
+def test_context_from_gh_preserves_packet_required_check_surface():
+    view = {
+        "number": 9453,
+        "headRefOid": "a" * 40,
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "UNSTABLE",
+        "statusCheckRollup": [
+            *[
+                {"name": name, "conclusion": "SUCCESS"}
+                for name in sorted(REQUIRED_CHECKS | {"aragora-merge-quorum"})
+            ],
+            {"name": "npm Security Scan", "conclusion": "FAILURE"},
+            {"name": "Security Gate Summary", "conclusion": "FAILURE"},
+        ],
+    }
+    packet = {
+        "pr_number": 9453,
+        "head_sha": "a" * 40,
+        "tier": 2,
+        "status": "satisfied",
+        "verdict": "admin_squash_allowed",
+        "admin_squash_allowed": True,
+        "requires_human_risk_settlement": False,
+        "unresolved_dissent": False,
+        "check_surfaces": _optional_only_unstable_surface(),
+    }
+    decision = decide_auto_merge(context_from_gh(view, packet))
+    assert decision.should_merge is True
+    assert decision.blockers == ()
 
 
 def test_quorum_not_green_is_blocked():


### PR DESCRIPTION
## Summary

- add one strict, shared proof that GitHub's required-check surface is available, selected, non-empty, and fully green while every non-green rollup context is proven non-required
- use that proof consistently in merge-packet live-gate authorization and `auto_merge_green` / `merge_executor` decisions
- preserve fail-closed behavior for missing or malformed required-check data, required failures or pending rows, conflicts, head drift, unresolved dissent, and Tier 3/4 restrictions
- clarify the operating contract for the narrowly proven `MERGEABLE/UNSTABLE` case exposed by #9453

## Safety

`UNSTABLE` alone never authorizes a merge. The exception requires a positive effective required-check count, an explicitly selected required-check gate, no required failures or pending rows, and complete rollup counts proving every non-green context is non-required. Existing verified cancellation-receipt handling remains unchanged.

This is a Tier 4 merge-authority self-modification. Keep this PR draft until separate exact-head human preapproval/settlement is recorded; this PR does not change workflows, branch protection, evidence, settlement, or security dependencies.

## Validation

- `python3 -m pytest tests/swarm/test_auto_merge_green.py tests/scripts/test_merge_executor.py tests/cli/commands/test_review_queue.py -q` (412 passed)
- `python3 -m ruff check` on touched Python files
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- pre-commit and pre-push hooks, including changed-file mypy

## Follow-up

After this PR lands, recheck #9453 at exact head `ac3924716e4eb74496954e36305c7d83215d1e05` without recollecting evidence or rerunning quorum. Only a clean merge-packet plus merge-executor dry-run may authorize its normal protected squash merge with `--match-head-commit` and without `--admin`.