### PR TITLE
[DIC-15] CruxVerifierCatalog — candidate-verifier enrichment for CruxSets

### DIFF
--- a/aragora/epistemic/crux_verifier_catalog.py
+++ b/aragora/epistemic/crux_verifier_catalog.py
@@ -102,7 +102,7 @@ def enrich_cruxset(cruxset: CruxSet, catalog: CruxVerifierCatalog) -> CruxSet:
     updated: list[Crux] = []
     changed = False
     for crux in cruxset.cruxes:
-        if crux.candidate_verifier:
+        if (crux.candidate_verifier or "").strip():
             updated.append(crux)
             continue
         verifier = catalog.lookup(crux)
@@ -125,6 +125,10 @@ def enrich_cruxset(cruxset: CruxSet, catalog: CruxVerifierCatalog) -> CruxSet:
         receipt_id=cruxset.receipt_id,
         provenance=dict(cruxset.provenance),
         created_at=cruxset.created_at,
+        # Enrichment only sets candidate_verifier. Without this, CruxSet.build
+        # restamps a deserialized set with the current CRUXSET_SCHEMA_VERSION,
+        # silently changing metadata this function does not own.
+        schema_version=cruxset.schema_version,
     )
 
 

--- a/aragora/epistemic/crux_verifier_catalog.py
+++ b/aragora/epistemic/crux_verifier_catalog.py
@@ -72,9 +72,7 @@ class CruxVerifierCatalog:
         Entries are inserted in iteration order (Python 3.7+ dict order is
         insertion order), so the caller controls priority.
         """
-        return cls(
-            entries=[VerifierEntry(pattern=p, verifier=v) for p, v in mapping.items()]
-        )
+        return cls(entries=[VerifierEntry(pattern=p, verifier=v) for p, v in mapping.items()])
 
     @classmethod
     def from_entries(cls, entries: Sequence[VerifierEntry]) -> "CruxVerifierCatalog":

--- a/aragora/epistemic/crux_verifier_catalog.py
+++ b/aragora/epistemic/crux_verifier_catalog.py
@@ -1,0 +1,137 @@
+"""CruxVerifierCatalog — candidate-verifier enrichment for CruxSets (DIC-15 / #6025).
+
+Fills the ``Crux.candidate_verifier`` field that ``build_cruxset_from_analysis``
+always leaves empty.  Matching: ``pattern`` is a crux_id prefix OR a
+case-insensitive statement substring; first matching entry wins.
+
+:func:`enrich_cruxset` requires ``ARAGORA_CRUXSET_EMISSION_ENABLED=1`` and is
+idempotent — cruxes that already have a ``candidate_verifier`` are left unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field, replace
+from typing import Sequence
+
+from aragora.reasoning.cruxset import Crux, CruxSet
+
+_EMISSION_ENV_VAR = "ARAGORA_CRUXSET_EMISSION_ENABLED"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _cruxset_emission_enabled() -> bool:
+    return str(os.environ.get(_EMISSION_ENV_VAR) or "").strip().lower() in _TRUTHY
+
+
+def _require_enabled() -> None:
+    if not _cruxset_emission_enabled():
+        raise RuntimeError(
+            f"enrich_cruxset requires {_EMISSION_ENV_VAR}=1; "
+            "set the flag before enriching CruxSets."
+        )
+
+
+@dataclass(frozen=True)
+class VerifierEntry:
+    """One (pattern, verifier) mapping in the catalog.
+
+    Matching semantics:
+    - If ``pattern`` is a prefix of ``crux.crux_id`` → match.
+    - Else if ``pattern`` (case-insensitive) is a substring of
+      ``crux.statement`` → match.
+
+    The first matching entry wins.
+    """
+
+    pattern: str
+    verifier: str
+
+    def __post_init__(self) -> None:
+        if not self.pattern.strip():
+            raise ValueError("VerifierEntry.pattern must be non-empty")
+        if not self.verifier.strip():
+            raise ValueError("VerifierEntry.verifier must be non-empty")
+
+    def matches(self, crux: Crux) -> bool:
+        if crux.crux_id.startswith(self.pattern):
+            return True
+        return self.pattern.lower() in crux.statement.lower()
+
+
+@dataclass
+class CruxVerifierCatalog:
+    """Ordered list of :class:`VerifierEntry` objects; first match wins."""
+
+    entries: list[VerifierEntry] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, mapping: dict[str, str]) -> "CruxVerifierCatalog":
+        """Build a catalog from a ``{pattern: verifier}`` dict.
+
+        Entries are inserted in iteration order (Python 3.7+ dict order is
+        insertion order), so the caller controls priority.
+        """
+        return cls(
+            entries=[VerifierEntry(pattern=p, verifier=v) for p, v in mapping.items()]
+        )
+
+    @classmethod
+    def from_entries(cls, entries: Sequence[VerifierEntry]) -> "CruxVerifierCatalog":
+        return cls(entries=list(entries))
+
+    def lookup(self, crux: Crux) -> str:
+        """Return the first matching verifier string, or ``""`` if none match."""
+        for entry in self.entries:
+            if entry.matches(crux):
+                return entry.verifier
+        return ""
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+
+def enrich_cruxset(cruxset: CruxSet, catalog: CruxVerifierCatalog) -> CruxSet:
+    """Return a new CruxSet with ``candidate_verifier`` populated from *catalog*.
+
+    Requires ``ARAGORA_CRUXSET_EMISSION_ENABLED=1``.  Cruxes that already have
+    a non-empty ``candidate_verifier`` are left unchanged.  If nothing changes,
+    the original object is returned (no rebuild overhead).  ``cruxset_id`` is
+    stable across enrichment; ``checksum`` reflects the new payload.
+    """
+    _require_enabled()
+
+    updated: list[Crux] = []
+    changed = False
+    for crux in cruxset.cruxes:
+        if crux.candidate_verifier:
+            updated.append(crux)
+            continue
+        verifier = catalog.lookup(crux)
+        if verifier:
+            updated.append(replace(crux, candidate_verifier=verifier))
+            changed = True
+        else:
+            updated.append(crux)
+
+    if not changed:
+        return cruxset
+
+    return CruxSet.build(
+        question=cruxset.question,
+        cruxes=updated,
+        decision=cruxset.decision,
+        evidence_gaps=cruxset.evidence_gaps,
+        counterfactual_notes=cruxset.counterfactual_notes,
+        verifier_candidates=cruxset.verifier_candidates,
+        receipt_id=cruxset.receipt_id,
+        provenance=dict(cruxset.provenance),
+        created_at=cruxset.created_at,
+    )
+
+
+__all__ = [
+    "CruxVerifierCatalog",
+    "VerifierEntry",
+    "enrich_cruxset",
+]

--- a/aragora/reasoning/cruxset.py
+++ b/aragora/reasoning/cruxset.py
@@ -165,7 +165,16 @@ class CruxSet:
         receipt_id: str = "",
         provenance: dict[str, Any] | None = None,
         created_at: str | None = None,
+        schema_version: str | None = None,
     ) -> "CruxSet":
+        """Build a CruxSet, computing ``cruxset_id`` and ``checksum``.
+
+        ``schema_version`` defaults to :data:`CRUXSET_SCHEMA_VERSION`. Pass the
+        original value when *rebuilding* an existing set (e.g. enrichment) so a
+        deserialized older- or future-version set is not silently restamped with
+        the current version — ``from_dict`` preserves what it read, and a rebuild
+        must not quietly disagree with it.
+        """
         question_str = (question or "").strip()
         if not question_str:
             raise ValueError("question must be non-empty")
@@ -188,7 +197,7 @@ class CruxSet:
         # Build a draft and then compute the checksum over its canonical form.
         draft = cls(
             cruxset_id=cruxset_id,
-            schema_version=CRUXSET_SCHEMA_VERSION,
+            schema_version=schema_version or CRUXSET_SCHEMA_VERSION,
             question=question_str,
             decision=decision,
             cruxes=cruxes_sorted,
@@ -329,7 +338,9 @@ def build_cruxset_from_analysis(
     for entry in raw_cruxes[:max_cruxes]:
         if not isinstance(entry, dict):
             continue
-        positions = (
+        # Annotated variable-length: mypy otherwise infers tuple[CruxPosition]
+        # from this single-element literal and rejects the append below.
+        positions: tuple[CruxPosition, ...] = (
             CruxPosition(
                 side="for",
                 agents=(str(entry.get("author") or ""),),

--- a/tests/epistemic/test_crux_verifier_catalog.py
+++ b/tests/epistemic/test_crux_verifier_catalog.py
@@ -198,7 +198,9 @@ def test_enriches_by_statement_substring(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_existing_candidate_verifier_not_overwritten(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(_ENV_VAR, "1")
     catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/catalog.md"})
-    cs = _cruxset(_crux("bc12.green_shift", "Soaks required.", candidate_verifier="docs/original.md"))
+    cs = _cruxset(
+        _crux("bc12.green_shift", "Soaks required.", candidate_verifier="docs/original.md")
+    )
     enriched = enrich_cruxset(cs, catalog)
     # The crux already had a verifier; it must not be overwritten
     assert enriched.cruxes[0].candidate_verifier == "docs/original.md"

--- a/tests/epistemic/test_crux_verifier_catalog.py
+++ b/tests/epistemic/test_crux_verifier_catalog.py
@@ -1,0 +1,258 @@
+"""Unit tests for CruxVerifierCatalog (DIC-15 / #6025).
+
+Covers: VerifierEntry validation, CruxVerifierCatalog.lookup, enrich_cruxset
+flag-gate, idempotency, checksum validity, and cruxset_id stability.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from aragora.epistemic.crux_verifier_catalog import (
+    CruxVerifierCatalog,
+    VerifierEntry,
+    enrich_cruxset,
+)
+from aragora.reasoning.cruxset import Crux, CruxPosition, CruxSet
+
+_ENV_VAR = "ARAGORA_CRUXSET_EMISSION_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pos(side: str) -> CruxPosition:
+    return CruxPosition(side=side, agents=("agent_a",))
+
+
+def _crux(
+    crux_id: str,
+    statement: str,
+    score: float = 0.8,
+    candidate_verifier: str = "",
+) -> Crux:
+    return Crux(
+        crux_id=crux_id,
+        statement=statement,
+        positions=(_pos("yes"), _pos("no")),
+        load_bearing_score=score,
+        candidate_verifier=candidate_verifier,
+    )
+
+
+def _cruxset(*cruxes: Crux, question: str = "Should we expand now?") -> CruxSet:
+    return CruxSet.build(question=question, cruxes=cruxes)
+
+
+# ---------------------------------------------------------------------------
+# VerifierEntry validation
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_entry_empty_pattern_raises() -> None:
+    with pytest.raises(ValueError, match="pattern"):
+        VerifierEntry(pattern="", verifier="docs/status/foo.md")
+
+
+def test_verifier_entry_empty_verifier_raises() -> None:
+    with pytest.raises(ValueError, match="verifier"):
+        VerifierEntry(pattern="bc12.green_shift", verifier="")
+
+
+# ---------------------------------------------------------------------------
+# VerifierEntry.matches
+# ---------------------------------------------------------------------------
+
+
+def test_entry_matches_crux_id_prefix() -> None:
+    entry = VerifierEntry(pattern="bc12.", verifier="docs/foo.md")
+    assert entry.matches(_crux("bc12.green_shift", "Some statement"))
+
+
+def test_entry_matches_crux_id_exact() -> None:
+    entry = VerifierEntry(pattern="queue.boss_ready", verifier="cmd.sh")
+    assert entry.matches(_crux("queue.boss_ready", "Queue state"))
+
+
+def test_entry_matches_statement_when_not_crux_id_prefix() -> None:
+    # "green" is not a prefix of "bc12.green_shift" but IS a substring of the statement
+    entry = VerifierEntry(pattern="green", verifier="docs/foo.md")
+    crux = _crux("bc12.green_shift", "Three consecutive green soak days required.")
+    assert entry.matches(crux)
+
+
+def test_entry_matches_statement_case_insensitive() -> None:
+    entry = VerifierEntry(pattern="GREEN SOAK", verifier="docs/soak.md")
+    assert entry.matches(_crux("bc12.x", "Three consecutive green soak days required."))
+
+
+def test_entry_no_match() -> None:
+    entry = VerifierEntry(pattern="unrelated.topic", verifier="docs/bar.md")
+    assert not entry.matches(_crux("bc12.green_shift", "Soaks are required."))
+
+
+# ---------------------------------------------------------------------------
+# CruxVerifierCatalog.lookup and from_dict
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_from_dict_insertion_order() -> None:
+    catalog = CruxVerifierCatalog.from_dict(
+        {
+            "bc12.": "docs/first.md",
+            "bc12.green": "docs/second.md",
+        }
+    )
+    # First entry should win for a crux_id that matches both prefixes
+    crux = _crux("bc12.green_shift", "irrelevant")
+    assert catalog.lookup(crux) == "docs/first.md"
+
+
+def test_catalog_first_matching_entry_wins() -> None:
+    catalog = CruxVerifierCatalog.from_dict(
+        {
+            "soaks are": "docs/soak_policy.md",
+            "soaks": "docs/broader.md",
+        }
+    )
+    crux = _crux("crux.x", "Soaks are required before widening.")
+    assert catalog.lookup(crux) == "docs/soak_policy.md"
+
+
+def test_catalog_no_match_returns_empty() -> None:
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/first.md"})
+    crux = _crux("queue.boss_ready", "Queue must be empty.")
+    assert catalog.lookup(crux) == ""
+
+
+def test_catalog_from_entries() -> None:
+    entries = [
+        VerifierEntry("bc12.", "docs/a.md"),
+        VerifierEntry("queue.", "docs/b.md"),
+    ]
+    catalog = CruxVerifierCatalog.from_entries(entries)
+    assert len(catalog) == 2
+    assert catalog.lookup(_crux("queue.boss_ready", "Queue state")) == "docs/b.md"
+
+
+# ---------------------------------------------------------------------------
+# enrich_cruxset — flag gate
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/foo.md"})
+    cs = _cruxset(_crux("bc12.x", "Something"))
+    with pytest.raises(RuntimeError, match=_ENV_VAR):
+        enrich_cruxset(cs, catalog)
+
+
+def test_flag_on_allows_enrich(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/foo.md"})
+    cs = _cruxset(_crux("bc12.x", "Something"))
+    result = enrich_cruxset(cs, catalog)
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# enrich_cruxset — behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_empty_catalog_returns_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog()
+    cs = _cruxset(_crux("bc12.x", "Something"))
+    assert enrich_cruxset(cs, catalog) is cs
+
+
+def test_no_match_returns_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"queue.": "docs/queue.md"})
+    cs = _cruxset(_crux("bc12.x", "Something unrelated"))
+    assert enrich_cruxset(cs, catalog) is cs
+
+
+def test_enriches_by_crux_id_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/bc12.md"})
+    cs = _cruxset(_crux("bc12.green_shift", "Soaks required."))
+    enriched = enrich_cruxset(cs, catalog)
+    assert enriched.cruxes[0].candidate_verifier == "docs/bc12.md"
+
+
+def test_enriches_by_statement_substring(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"soak equivalence": "docs/soak.md"})
+    cs = _cruxset(_crux("crux.x", "The soak equivalence question is unresolved."))
+    enriched = enrich_cruxset(cs, catalog)
+    assert enriched.cruxes[0].candidate_verifier == "docs/soak.md"
+
+
+def test_existing_candidate_verifier_not_overwritten(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/catalog.md"})
+    cs = _cruxset(_crux("bc12.green_shift", "Soaks required.", candidate_verifier="docs/original.md"))
+    enriched = enrich_cruxset(cs, catalog)
+    # The crux already had a verifier; it must not be overwritten
+    assert enriched.cruxes[0].candidate_verifier == "docs/original.md"
+
+
+def test_partial_enrichment_mixed_cruxes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/bc12.md"})
+    matched = _crux("bc12.green_shift", "Matched.", score=0.9)
+    unmatched = _crux("queue.boss_ready", "Queue must be idle.", score=0.7)
+    cs = _cruxset(matched, unmatched)
+    enriched = enrich_cruxset(cs, catalog)
+    # cruxes are sorted by load_bearing_score desc: matched first
+    verifiers = {c.crux_id: c.candidate_verifier for c in enriched.cruxes}
+    assert verifiers["bc12.green_shift"] == "docs/bc12.md"
+    assert verifiers["queue.boss_ready"] == ""
+
+
+# ---------------------------------------------------------------------------
+# enrich_cruxset — checksum and cruxset_id stability
+# ---------------------------------------------------------------------------
+
+
+def test_enriched_checksum_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/bc12.md"})
+    cs = _cruxset(_crux("bc12.green_shift", "Soaks required."))
+    enriched = enrich_cruxset(cs, catalog)
+    assert enriched.verify_checksum()
+
+
+def test_cruxset_id_unchanged_after_enrichment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/bc12.md"})
+    cs = _cruxset(_crux("bc12.green_shift", "Soaks required."))
+    enriched = enrich_cruxset(cs, catalog)
+    # cruxset_id is content-addressed from question + crux IDs only
+    assert enriched.cruxset_id == cs.cruxset_id
+
+
+def test_checksum_changes_after_enrichment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/bc12.md"})
+    cs = _cruxset(_crux("bc12.green_shift", "Soaks required."))
+    enriched = enrich_cruxset(cs, catalog)
+    # candidate_verifier is included in the checksum payload, so it must change
+    assert enriched.checksum != cs.checksum
+
+
+def test_enrich_idempotent_second_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/bc12.md"})
+    cs = _cruxset(_crux("bc12.green_shift", "Soaks required."))
+    enriched = enrich_cruxset(cs, catalog)
+    # Second call: all cruxes already have candidate_verifier → original returned
+    enriched_again = enrich_cruxset(enriched, catalog)
+    assert enriched_again is enriched

--- a/tests/epistemic/test_crux_verifier_catalog.py
+++ b/tests/epistemic/test_crux_verifier_catalog.py
@@ -6,8 +6,6 @@ flag-gate, idempotency, checksum validity, and cruxset_id stability.
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from aragora.epistemic.crux_verifier_catalog import (

--- a/tests/epistemic/test_crux_verifier_catalog.py
+++ b/tests/epistemic/test_crux_verifier_catalog.py
@@ -256,3 +256,43 @@ def test_enrich_idempotent_second_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     # Second call: all cruxes already have candidate_verifier → original returned
     enriched_again = enrich_cruxset(enriched, catalog)
     assert enriched_again is enriched
+
+
+# ---------------------------------------------------------------------------
+# enrich_cruxset — metadata it must NOT touch (openai review, PR #9565)
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_preserves_deserialized_schema_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enrichment must not restamp schema_version.
+
+    ``CruxSet.build`` defaults schema_version to CRUXSET_SCHEMA_VERSION, so
+    rebuilding a set deserialized at an older/future version silently rewrote
+    metadata unrelated to candidate_verifier — while ``from_json`` deliberately
+    preserves what it read.
+    """
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/foo.md"})
+
+    payload = _cruxset(_crux("bc12.x", "Something")).to_json()
+    payload["schema_version"] = "0.9-legacy"
+    legacy = CruxSet.from_json(payload)
+    assert legacy.schema_version == "0.9-legacy"
+
+    result = enrich_cruxset(legacy, catalog)
+
+    assert result is not legacy, "expected enrichment to produce a new set"
+    assert result.cruxes[0].candidate_verifier == "docs/foo.md"
+    assert result.schema_version == "0.9-legacy"
+    assert result.verify_checksum(), "checksum must cover the preserved version"
+
+
+def test_whitespace_only_verifier_is_treated_as_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blank candidate_verifier is not "already populated"."""
+    monkeypatch.setenv(_ENV_VAR, "1")
+    catalog = CruxVerifierCatalog.from_dict({"bc12.": "docs/foo.md"})
+    cs = _cruxset(_crux("bc12.x", "Something", candidate_verifier="   "))
+
+    result = enrich_cruxset(cs, catalog)
+
+    assert result.cruxes[0].candidate_verifier == "docs/foo.md"


### PR DESCRIPTION
## Summary

- Adds `aragora/epistemic/crux_verifier_catalog.py` with `VerifierEntry`, `CruxVerifierCatalog`, and `enrich_cruxset()` to fill the `Crux.candidate_verifier` field that `build_cruxset_from_analysis` always leaves empty (DIC-15 / #6025 acceptance criterion).
- Catalog maps patterns (crux_id prefix **or** case-insensitive statement substring) to verifier strings (doc paths, CLI commands, URLs); first entry wins.
- `enrich_cruxset()` is idempotent (existing verifiers not overwritten), flag-gated on `ARAGORA_CRUXSET_EMISSION_ENABLED=1`, and returns the original object unchanged when nothing changes. `cruxset_id` is stable across enrichment; `checksum` is correctly recomputed.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Related to #6025 (DIC-15: CruxSet contract and consensus mode)

## Checklist

### Before Submitting

- [x] My code follows the project's code style (ruff clean, mypy clean)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commit messages follow conventional commit format

### Code Quality

- [x] New code has type hints
- [x] No hardcoded secrets or credentials
- [x] Error handling is appropriate

### For New Features

- [x] Feature is tested with unit tests
- [x] Feature integrates with existing systems appropriately (uses same flag as `cruxset_emission.py`, same `CruxSet.build()` path)

## Test Plan

```bash
python -m pytest tests/epistemic/test_crux_verifier_catalog.py -v --noconftest
# 23 passed
```

Tests cover: flag-gate enforcement, crux_id prefix matching, statement substring matching (case-insensitive), first-entry-wins priority, idempotency, checksum validity on enriched CruxSet, cruxset_id stability, and partial enrichment of mixed crux lists.

## Additional Notes

This is a **vision-layer incubator slice** for DIC-15. The flag `ARAGORA_CRUXSET_EMISSION_ENABLED` must be set to `1` to call `enrich_cruxset()`; catalog construction is gate-free. Net diff: 137 LOC implementation + 258 LOC tests. No live queue effects; default OFF.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y48uya5mgJpK1zFxwMLvj9)_