### PR TITLE
feat(governance): enforce Boundary 2 module edges

### DIFF
--- a/.github/actions/pr-scope-classifier/action.yml
+++ b/.github/actions/pr-scope-classifier/action.yml
@@ -58,6 +58,7 @@ runs:
             - 'scripts/**'
           lint_python:
             - 'aragora/**'
+            - 'aragora-verify/**'
             - 'tests/**'
             - 'scripts/**'
             - 'pyproject.toml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -155,6 +155,9 @@ jobs:
       - name: Validate Prometheus rule syntax with promtool
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_prometheus_rules.py
 
+      - name: Enforce Boundary 2 receipts+verifier edges
+        run: ${{ steps.lint_python.outputs.python_bin }} scripts/ci/check_boundary_edges.py
+
       - name: Enforce code quality ratchet
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/report_code_quality.py --check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,6 +180,18 @@ repos:
         language: system
         types: [text]
 
+  # Boundary 2 quarantine: reject new receipts+verifier imports that escape the
+  # machine-readable map, new standalone-verifier dependencies, or schema drift.
+  - repo: local
+    hooks:
+      - id: boundary2-edges
+        name: Boundary 2 receipts+verifier fail-on-new edges
+        entry: python3 scripts/ci/check_boundary_edges.py
+        language: system
+        pass_filenames: false
+        files: ^(?:\.pre\-commit\-config\.yaml|aragora/.*|aragora/gauntlet/odr_export\.py|aragora/gauntlet/odr_schema\.json|aragora/gauntlet/odr_signing\.py|aragora/gauntlet/odr_verify\.py|aragora/gauntlet/receipt\.py|aragora/gauntlet/receipt_models\.py|aragora/receipts/.*|aragora\-verify/.*|aragora\-verify/pyproject\.toml|aragora\-verify/src/aragora_verify/.*|aragora\-verify/src/aragora_verify/odr_schema\.json|docs/specs/OPEN_DECISION_RECEIPT\.md|docs/specs/RECEIPT_LINEAGE_RECONCILIATION\.md|docs/specs/examples/.*|docs/specs/odr\-native\-mapping\.md|scripts/baselines/boundary2_edges_baseline\.json|scripts/ci/boundary_maps/receipts_verifier\.json|scripts/ci/check_boundary_edges\.py)$
+        stages: [pre-commit, pre-push]
+
   # Security checks
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.8

--- a/scripts/baselines/boundary2_edges_baseline.json
+++ b/scripts/baselines/boundary2_edges_baseline.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "_comment": "Shrink-only Boundary 2 receipts+verifier violations. New entries fail scripts/ci/check_boundary_edges.py; baseline growth requires the explicit --freeze --adopt command and review.",
+  "boundary": {
+    "id": 2,
+    "name": "receipts+verifier"
+  },
+  "map": "scripts/ci/boundary_maps/receipts_verifier.json",
+  "frozen_from_ref": "8b97a31d1f81ec74d63e30409b867971999bb2aa",
+  "frozen_at": "2026-07-24T23:54:05Z",
+  "violations": [
+    "import aragora.gauntlet.odr_export -> aragora.ranking.calibration_report",
+    "import aragora.gauntlet.receipt -> aragora.gauntlet.receipt_exporters",
+    "import aragora.gauntlet.receipt_models -> aragora.compliance.artifact_generator",
+    "import aragora.gauntlet.receipt_models -> aragora.debate.crux_mode",
+    "import aragora.gauntlet.receipt_models -> aragora.debate.provider_diversity",
+    "import aragora.gauntlet.receipt_models -> aragora.gauntlet.receipt_exporters",
+    "import aragora.gauntlet.receipt_models -> aragora.gauntlet.result",
+    "import aragora.gauntlet.receipt_models -> aragora.gauntlet.signing",
+    "import aragora.receipts -> aragora.export.decision_receipt",
+    "import aragora.receipts.provenance -> aragora.gauntlet.signing",
+    "import aragora.receipts.provenance -> aragora.pipeline.receipt_store_facade",
+    "offline aragora_verify.schema -> jsonschema"
+  ]
+}

--- a/scripts/baselines/boundary2_edges_baseline.json
+++ b/scripts/baselines/boundary2_edges_baseline.json
@@ -6,8 +6,8 @@
     "name": "receipts+verifier"
   },
   "map": "scripts/ci/boundary_maps/receipts_verifier.json",
-  "frozen_from_ref": "8b97a31d1f81ec74d63e30409b867971999bb2aa",
-  "frozen_at": "2026-07-24T23:54:05Z",
+  "frozen_from_ref": "ab5914da28fc789eae16f006674afc002fb531a2",
+  "frozen_at": "2026-07-27T17:38:10Z",
   "violations": [
     "import aragora.gauntlet.odr_export -> aragora.ranking.calibration_report",
     "import aragora.gauntlet.receipt -> aragora.gauntlet.receipt_exporters",
@@ -20,6 +20,8 @@
     "import aragora.receipts -> aragora.export.decision_receipt",
     "import aragora.receipts.provenance -> aragora.gauntlet.signing",
     "import aragora.receipts.provenance -> aragora.pipeline.receipt_store_facade",
-    "offline aragora_verify.schema -> jsonschema"
+    "offline aragora_verify.schema -> jsonschema",
+    "offline dependency aragora-verify -> jsonschema",
+    "offline dependency aragora-verify -> pytest"
   ]
 }

--- a/scripts/ci/boundary_maps/receipts_verifier.json
+++ b/scripts/ci/boundary_maps/receipts_verifier.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "boundary": {
+    "id": 2,
+    "name": "receipts+verifier",
+    "provenance": "docs/architecture/MODULE_QUARANTINE_PROPOSAL.md#boundary-2--receiptsverifier"
+  },
+  "members": [
+    "aragora/gauntlet/receipt_models.py",
+    "aragora/gauntlet/receipt.py",
+    "aragora/receipts",
+    "aragora/gauntlet/odr_export.py",
+    "aragora/gauntlet/odr_signing.py",
+    "aragora/gauntlet/odr_verify.py",
+    "aragora/gauntlet/odr_schema.json",
+    "aragora-verify",
+    "docs/specs/OPEN_DECISION_RECEIPT.md",
+    "docs/specs/odr-native-mapping.md",
+    "docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md",
+    "docs/specs/examples"
+  ],
+  "python_import_policy": {
+    "sources": [
+      "aragora/gauntlet/receipt_models.py",
+      "aragora/gauntlet/receipt.py",
+      "aragora/receipts",
+      "aragora/gauntlet/odr_export.py",
+      "aragora/gauntlet/odr_signing.py",
+      "aragora/gauntlet/odr_verify.py",
+      "aragora-verify/src/aragora_verify"
+    ],
+    "allowed_internal_prefixes": [
+      "aragora.core",
+      "aragora.core_types",
+      "aragora.errors",
+      "aragora.exceptions",
+      "aragora.agents",
+      "aragora.memory",
+      "aragora.knowledge",
+      "aragora.config",
+      "aragora.storage",
+      "aragora.db",
+      "aragora.persistence",
+      "aragora.observability",
+      "aragora.telemetry",
+      "aragora.gauntlet.receipt_models",
+      "aragora.gauntlet.receipt",
+      "aragora.receipts",
+      "aragora.gauntlet.odr_export",
+      "aragora.gauntlet.odr_signing",
+      "aragora.gauntlet.odr_verify"
+    ],
+    "standalone": {
+      "source": "aragora-verify/src/aragora_verify",
+      "project_file": "aragora-verify/pyproject.toml",
+      "package_root": "aragora_verify",
+      "allowed_external_roots": [
+        "cryptography"
+      ]
+    }
+  },
+  "mirror_pairs": [
+    {
+      "left": "aragora/gauntlet/odr_schema.json",
+      "right": "aragora-verify/src/aragora_verify/odr_schema.json"
+    }
+  ]
+}

--- a/scripts/ci/check_boundary_edges.py
+++ b/scripts/ci/check_boundary_edges.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+"""Fail on new Boundary 2 receipts+verifier dependency violations.
+
+Exit codes:
+    0 -- no new violations
+    1 -- one or more new forbidden edges or mirror mismatches
+    2 -- invalid usage, map, baseline, or source input
+
+Default mode is non-mutating. ``--freeze`` may shrink the baseline; initial
+adoption or later growth additionally requires ``--adopt``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MAP = REPO_ROOT / "scripts" / "ci" / "boundary_maps" / "receipts_verifier.json"
+DEFAULT_BASELINE = REPO_ROOT / "scripts" / "baselines" / "boundary2_edges_baseline.json"
+
+
+class CheckerError(RuntimeError):
+    """A usage or configuration error that maps to exit code 2."""
+
+
+@dataclass(frozen=True)
+class BoundaryConfig:
+    boundary_id: int
+    boundary_name: str
+    map_path: Path
+    members: tuple[Path, ...]
+    sources: tuple[Path, ...]
+    allowed_internal_prefixes: tuple[str, ...]
+    standalone_source: Path
+    standalone_project_file: Path
+    standalone_package_root: str
+    allowed_external_roots: frozenset[str]
+    mirror_pairs: tuple[tuple[Path, Path], ...]
+
+
+def _load_json_object(path: Path, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise CheckerError(f"{label} does not exist: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CheckerError(f"Cannot read {label} {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise CheckerError(f"{label} must contain a JSON object: {path}")
+    return data
+
+
+def _relative_path(root: Path, raw: object, label: str) -> Path:
+    if not isinstance(raw, str) or not raw.strip():
+        raise CheckerError(f"{label} must be a non-empty relative path")
+    relative = Path(raw)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise CheckerError(f"{label} must stay within the repository: {raw}")
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as exc:
+        raise CheckerError(f"{label} resolves outside the repository: {raw}") from exc
+    return resolved
+
+
+def _string_list(value: object, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise CheckerError(f"{label} must be a non-empty JSON array")
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        raise CheckerError(f"{label} entries must be non-empty strings")
+    items = tuple(value)
+    if len(items) != len(set(items)):
+        raise CheckerError(f"{label} must not contain duplicate entries")
+    return items
+
+
+def load_boundary_map(repo_root: Path, map_path: Path) -> BoundaryConfig:
+    root = repo_root.resolve()
+    data = _load_json_object(map_path, "Boundary map")
+    if data.get("schema_version") != 1:
+        raise CheckerError("Boundary map schema_version must be 1")
+
+    boundary = data.get("boundary")
+    if not isinstance(boundary, dict):
+        raise CheckerError("Boundary map must define a boundary object")
+    if boundary.get("id") != 2 or boundary.get("name") != "receipts+verifier":
+        raise CheckerError("This checker accepts only Boundary 2 receipts+verifier")
+    if not isinstance(boundary.get("provenance"), str) or not boundary["provenance"]:
+        raise CheckerError("Boundary map must record non-empty provenance")
+
+    members = tuple(
+        _relative_path(root, raw, f"members[{index}]")
+        for index, raw in enumerate(_string_list(data.get("members"), "members"))
+    )
+
+    import_policy = data.get("python_import_policy")
+    if not isinstance(import_policy, dict):
+        raise CheckerError("Boundary map must define python_import_policy")
+    sources = tuple(
+        _relative_path(root, raw, f"python_import_policy.sources[{index}]")
+        for index, raw in enumerate(
+            _string_list(import_policy.get("sources"), "python_import_policy.sources")
+        )
+    )
+    allowed_internal = _string_list(
+        import_policy.get("allowed_internal_prefixes"),
+        "python_import_policy.allowed_internal_prefixes",
+    )
+    if any(not prefix.startswith("aragora.") for prefix in allowed_internal):
+        raise CheckerError("allowed_internal_prefixes entries must start with 'aragora.'")
+
+    standalone = import_policy.get("standalone")
+    if not isinstance(standalone, dict):
+        raise CheckerError("python_import_policy must define standalone")
+    standalone_source = _relative_path(
+        root, standalone.get("source"), "python_import_policy.standalone.source"
+    )
+    standalone_project_file = _relative_path(
+        root,
+        standalone.get("project_file"),
+        "python_import_policy.standalone.project_file",
+    )
+    package_root = standalone.get("package_root")
+    if not isinstance(package_root, str) or not package_root.isidentifier():
+        raise CheckerError("standalone.package_root must be a Python identifier")
+    allowed_external = frozenset(
+        _string_list(
+            standalone.get("allowed_external_roots"),
+            "python_import_policy.standalone.allowed_external_roots",
+        )
+    )
+    if standalone_source not in sources:
+        raise CheckerError("standalone.source must also appear in python_import_policy.sources")
+    if not standalone_project_file.is_file():
+        raise CheckerError(
+            f"Standalone project file does not exist: {standalone_project_file.relative_to(root)}"
+        )
+
+    raw_pairs = data.get("mirror_pairs")
+    if not isinstance(raw_pairs, list) or not raw_pairs:
+        raise CheckerError("mirror_pairs must be a non-empty JSON array")
+    mirror_pairs: list[tuple[Path, Path]] = []
+    for index, pair in enumerate(raw_pairs):
+        if not isinstance(pair, dict):
+            raise CheckerError(f"mirror_pairs[{index}] must be a JSON object")
+        left = _relative_path(root, pair.get("left"), f"mirror_pairs[{index}].left")
+        right = _relative_path(root, pair.get("right"), f"mirror_pairs[{index}].right")
+        mirror_pairs.append((left, right))
+
+    for label, paths in (("member", members), ("source", sources)):
+        for path in paths:
+            if not path.exists():
+                raise CheckerError(f"Boundary {label} does not exist: {path.relative_to(root)}")
+    for left, right in mirror_pairs:
+        if not left.is_file() or not right.is_file():
+            raise CheckerError(
+                "Mirror inputs must be files: "
+                f"{left.relative_to(root)} and {right.relative_to(root)}"
+            )
+
+    return BoundaryConfig(
+        boundary_id=2,
+        boundary_name="receipts+verifier",
+        map_path=map_path.resolve(),
+        members=members,
+        sources=sources,
+        allowed_internal_prefixes=allowed_internal,
+        standalone_source=standalone_source,
+        standalone_project_file=standalone_project_file,
+        standalone_package_root=package_root,
+        allowed_external_roots=allowed_external,
+        mirror_pairs=tuple(mirror_pairs),
+    )
+
+
+def _python_files(source: Path) -> list[Path]:
+    if source.is_file():
+        if source.suffix != ".py":
+            raise CheckerError(f"Python source entry is not a .py file: {source}")
+        return [source]
+    if not source.is_dir():
+        raise CheckerError(f"Python source entry is neither a file nor directory: {source}")
+    return sorted(path for path in source.rglob("*.py") if "__pycache__" not in path.parts)
+
+
+def _module_name(path: Path, repo_root: Path, config: BoundaryConfig) -> tuple[str, bool]:
+    is_package = path.name == "__init__.py"
+    if path.is_relative_to(config.standalone_source):
+        relative = path.relative_to(config.standalone_source.parent).with_suffix("")
+    else:
+        relative = path.relative_to(repo_root).with_suffix("")
+    parts = list(relative.parts)
+    if is_package:
+        parts.pop()
+    return ".".join(parts), is_package
+
+
+def _module_search_roots(repo_root: Path, config: BoundaryConfig) -> set[Path]:
+    roots = {config.standalone_source}
+    for source in config.sources:
+        if source.is_relative_to(config.standalone_source):
+            continue
+        relative = source.relative_to(repo_root)
+        roots.add(repo_root / relative.parts[0])
+    return roots
+
+
+def _known_module_names(repo_root: Path, config: BoundaryConfig) -> set[str]:
+    modules: set[str] = set()
+    for source_root in _module_search_roots(repo_root, config):
+        for path in _python_files(source_root):
+            module_name, _ = _module_name(path, repo_root, config)
+            if module_name:
+                modules.add(module_name)
+    return modules
+
+
+def _relative_import_base(
+    module_name: str,
+    is_package: bool,
+    level: int,
+    imported_module: str | None,
+) -> str | None:
+    package_parts = module_name.split(".") if is_package else module_name.split(".")[:-1]
+    keep = len(package_parts) - (level - 1)
+    if keep < 1:
+        return None
+    base = package_parts[:keep]
+    if imported_module:
+        base.extend(imported_module.split("."))
+    return ".".join(base)
+
+
+def _resolve_imported_names(
+    base_module: str,
+    imported_names: list[str],
+    known_modules: set[str],
+) -> set[str]:
+    targets: set[str] = set()
+    for imported_name in imported_names:
+        if imported_name == "*":
+            targets.add(base_module)
+            continue
+        candidate = f"{base_module}.{imported_name}"
+        targets.add(candidate if candidate in known_modules else base_module)
+    return targets
+
+
+def _import_targets(
+    tree: ast.AST,
+    module_name: str,
+    is_package: bool,
+    known_modules: set[str],
+) -> set[str]:
+    targets: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            targets.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            base_module: str | None
+            if node.level:
+                base_module = _relative_import_base(
+                    module_name,
+                    is_package,
+                    node.level,
+                    node.module,
+                )
+            else:
+                base_module = node.module
+            if base_module:
+                targets.update(
+                    _resolve_imported_names(
+                        base_module,
+                        [alias.name for alias in node.names],
+                        known_modules,
+                    )
+                )
+    return targets
+
+
+def _prefix_allowed(target: str, prefixes: tuple[str, ...]) -> bool:
+    return any(target == prefix or target.startswith(f"{prefix}.") for prefix in prefixes)
+
+
+def expected_hook_files_pattern(
+    repo_root: Path,
+    config: BoundaryConfig,
+    baseline_path: Path = DEFAULT_BASELINE,
+) -> str:
+    root = repo_root.resolve()
+    trigger_paths = {
+        root / ".pre-commit-config.yaml",
+        root / "scripts" / "ci" / "check_boundary_edges.py",
+        baseline_path.resolve(),
+        config.map_path,
+        config.standalone_project_file,
+        *config.members,
+        *config.sources,
+        *_module_search_roots(root, config),
+    }
+    for left, right in config.mirror_pairs:
+        trigger_paths.update((left, right))
+
+    fragments: set[str] = set()
+    for path in trigger_paths:
+        try:
+            relative = path.resolve().relative_to(root).as_posix()
+        except ValueError as exc:
+            raise CheckerError(
+                f"Hook trigger path must stay within the repository: {path}"
+            ) from exc
+        escaped = re.escape(relative)
+        fragments.add(f"{escaped}/.*" if path.is_dir() else escaped)
+    return f"^(?:{'|'.join(sorted(fragments))})$"
+
+
+_REQUIREMENT_NAME = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def _normalize_distribution_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _parse_toml_object(content: str, label: str) -> dict[str, Any]:
+    try:
+        import tomllib as tomllib_module
+    except ModuleNotFoundError:
+        try:
+            import tomli as tomllib_module  # type: ignore[import-not-found,no-redef]
+        except ModuleNotFoundError as exc:
+            raise CheckerError(
+                f"Reading {label} requires Python 3.11+ or the tomli package"
+            ) from exc
+    try:
+        data = tomllib_module.loads(content)
+    except ValueError as exc:
+        raise CheckerError(f"Cannot parse {label}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise CheckerError(f"{label} must contain a TOML object")
+    return data
+
+
+def _load_toml_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise CheckerError(f"Cannot read {label} {path}: {exc}") from exc
+    return _parse_toml_object(content, f"{label} {path}")
+
+
+def _requirement_names(raw_dependencies: object, label: str) -> set[str]:
+    if not isinstance(raw_dependencies, list) or any(
+        not isinstance(item, str) or not item.strip() for item in raw_dependencies
+    ):
+        raise CheckerError(f"{label} must be a TOML string array")
+
+    dependencies: set[str] = set()
+    for requirement in raw_dependencies:
+        match = _REQUIREMENT_NAME.match(requirement)
+        if not match:
+            raise CheckerError(f"Cannot parse {label} requirement: {requirement!r}")
+        dependencies.add(_normalize_distribution_name(match.group(1)))
+    return dependencies
+
+
+def _declared_project_dependencies_from_data(
+    data: dict[str, Any],
+    label: str,
+) -> set[str]:
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise CheckerError(f"{label} must define a [project] table")
+
+    dependencies = _requirement_names(
+        project.get("dependencies", []),
+        f"{label} [project].dependencies",
+    )
+    optional_dependencies = project.get("optional-dependencies", {})
+    if not isinstance(optional_dependencies, dict):
+        raise CheckerError(f"{label} [project.optional-dependencies] must be a TOML table")
+    for extra, requirements in optional_dependencies.items():
+        if not isinstance(extra, str) or not extra:
+            raise CheckerError(
+                f"{label} [project.optional-dependencies] keys must be non-empty strings"
+            )
+        dependencies.update(
+            _requirement_names(
+                requirements,
+                f"{label} [project.optional-dependencies].{extra}",
+            )
+        )
+    return dependencies
+
+
+def _declared_project_dependencies(path: Path) -> set[str]:
+    return _declared_project_dependencies_from_data(
+        _load_toml_object(path, "Standalone project file"),
+        "Standalone project file",
+    )
+
+
+def _frozen_project_dependencies(
+    repo_root: Path,
+    config: BoundaryConfig,
+    baseline_path: Path,
+) -> set[str]:
+    if not baseline_path.is_file():
+        return set()
+    baseline = _load_json_object(baseline_path, "Boundary baseline")
+    frozen_ref = baseline.get("frozen_from_ref")
+    if not isinstance(frozen_ref, str) or not frozen_ref:
+        return set()
+    try:
+        project_path = config.standalone_project_file.relative_to(repo_root)
+    except ValueError as exc:
+        raise CheckerError("Standalone project file must stay within the repository") from exc
+    result = subprocess.run(
+        ["git", "show", f"{frozen_ref}:{project_path.as_posix()}"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise CheckerError(
+            "Cannot read frozen standalone project file "
+            f"{project_path} at {frozen_ref}: {result.stderr.strip()}"
+        )
+    data = _parse_toml_object(
+        result.stdout,
+        f"Frozen standalone project file {project_path} at {frozen_ref}",
+    )
+    return _declared_project_dependencies_from_data(
+        data,
+        f"Frozen standalone project file {project_path} at {frozen_ref}",
+    )
+
+
+def _scan_python_imports(repo_root: Path, config: BoundaryConfig) -> set[str]:
+    violations: set[str] = set()
+    seen: set[Path] = set()
+    known_modules = _known_module_names(repo_root, config)
+    for source in config.sources:
+        for path in _python_files(source):
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            module_name, is_package = _module_name(path, repo_root, config)
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except (OSError, SyntaxError, UnicodeError) as exc:
+                raise CheckerError(f"Cannot parse Python source {path}: {exc}") from exc
+
+            standalone = path.is_relative_to(config.standalone_source)
+            for target in _import_targets(tree, module_name, is_package, known_modules):
+                if standalone:
+                    root = target.split(".", 1)[0]
+                    allowed = (
+                        root == config.standalone_package_root
+                        or root in sys.stdlib_module_names
+                        or root in config.allowed_external_roots
+                    )
+                    if not allowed:
+                        violations.add(f"offline {module_name} -> {target}")
+                elif target == "aragora" or (
+                    target.startswith("aragora.")
+                    and not _prefix_allowed(target, config.allowed_internal_prefixes)
+                ):
+                    violations.add(f"import {module_name} -> {target}")
+    return violations
+
+
+def compute_violations(
+    repo_root: Path,
+    config: BoundaryConfig,
+    *,
+    grandfathered_dependencies: set[str] | None = None,
+    baseline_violations: set[str] | None = None,
+) -> set[str]:
+    root = repo_root.resolve()
+    violations = _scan_python_imports(root, config)
+    allowed_dependencies = {
+        _normalize_distribution_name(name) for name in config.allowed_external_roots
+    }
+    grandfathered = grandfathered_dependencies or set()
+    existing_violations = baseline_violations or set()
+    project_name = config.standalone_project_file.parent.name
+    for dependency in _declared_project_dependencies(config.standalone_project_file):
+        violation = f"offline dependency {project_name} -> {dependency}"
+        if dependency not in allowed_dependencies and (
+            dependency not in grandfathered or violation in existing_violations
+        ):
+            violations.add(violation)
+    for left, right in config.mirror_pairs:
+        try:
+            matches = left.read_bytes() == right.read_bytes()
+        except OSError as exc:
+            raise CheckerError(f"Cannot compare schema mirrors: {exc}") from exc
+        if not matches:
+            violations.add(f"mirror {left.relative_to(root)} != {right.relative_to(root)}")
+    return violations
+
+
+def load_baseline(path: Path, config: BoundaryConfig, repo_root: Path) -> set[str]:
+    data = _load_json_object(path, "Boundary baseline")
+    if data.get("schema_version") != 1:
+        raise CheckerError("Boundary baseline schema_version must be 1")
+    boundary = data.get("boundary")
+    if boundary != {
+        "id": config.boundary_id,
+        "name": config.boundary_name,
+    }:
+        raise CheckerError("Boundary baseline identity does not match the boundary map")
+    map_value = data.get("map")
+    try:
+        expected_map = str(config.map_path.relative_to(repo_root.resolve()))
+    except ValueError:
+        expected_map = str(config.map_path)
+    if map_value != expected_map:
+        raise CheckerError(f"Boundary baseline map is {map_value!r}; expected {expected_map!r}")
+    raw_violations = data.get("violations")
+    if not isinstance(raw_violations, list) or any(
+        not isinstance(item, str) or not item for item in raw_violations
+    ):
+        raise CheckerError("Boundary baseline violations must be a JSON string array")
+    if len(raw_violations) != len(set(raw_violations)):
+        raise CheckerError("Boundary baseline contains duplicate violations")
+    return set(raw_violations)
+
+
+def _git_ref(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def write_baseline(
+    path: Path,
+    violations: set[str],
+    config: BoundaryConfig,
+    repo_root: Path,
+) -> None:
+    root = repo_root.resolve()
+    try:
+        map_value = str(config.map_path.relative_to(root))
+    except ValueError:
+        map_value = str(config.map_path)
+    data = {
+        "schema_version": 1,
+        "_comment": (
+            "Shrink-only Boundary 2 receipts+verifier violations. New entries fail "
+            "scripts/ci/check_boundary_edges.py; baseline growth requires the explicit "
+            "--freeze --adopt command and review."
+        ),
+        "boundary": {
+            "id": config.boundary_id,
+            "name": config.boundary_name,
+        },
+        "map": map_value,
+        "frozen_from_ref": _git_ref(root),
+        "frozen_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "violations": sorted(violations),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check Boundary 2 edges against a shrink-only baseline."
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--map", type=Path, default=DEFAULT_MAP)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument(
+        "--freeze",
+        action="store_true",
+        help="Write the current set; growth also requires --adopt.",
+    )
+    parser.add_argument(
+        "--adopt",
+        action="store_true",
+        help="With --freeze, explicitly permit initial creation or baseline growth.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON result.")
+    return parser
+
+
+def _run_freeze(
+    args: argparse.Namespace,
+    config: BoundaryConfig,
+    current: set[str],
+) -> int:
+    if args.baseline.exists():
+        existing = load_baseline(args.baseline, config, args.repo_root)
+        added = current - existing
+        if added and not args.adopt:
+            for item in sorted(added):
+                print(f"REFUSED (would grow baseline): {item}", file=sys.stderr)
+            raise CheckerError(
+                "--freeze would add violations to the shrink-only baseline; "
+                "resolve them or use --freeze --adopt for an explicit re-adoption"
+            )
+    elif not args.adopt:
+        raise CheckerError(
+            "Initial baseline creation requires the explicit --freeze --adopt command"
+        )
+    write_baseline(args.baseline, current, config, args.repo_root)
+    print(f"Froze {len(current)} Boundary 2 violation(s) -> {args.baseline}")
+    return 0
+
+
+def _emit_result(
+    *,
+    current: set[str],
+    baseline: set[str],
+    new: set[str],
+    resolved: set[str],
+    as_json: bool,
+) -> None:
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "ok": not new,
+                    "current_violations": sorted(current),
+                    "baseline_violations": sorted(baseline),
+                    "new_violations": sorted(new),
+                    "resolved_violations": sorted(resolved),
+                },
+                indent=2,
+            )
+        )
+        return
+    if new:
+        print("FAIL: new Boundary 2 receipts+verifier violation(s) detected:")
+        for item in sorted(new):
+            print(f"  NEW {item}")
+    else:
+        print("OK: no new Boundary 2 receipts+verifier violations.")
+        print(f"    baseline holds {len(baseline)} grandfathered violation(s).")
+    if resolved:
+        print(
+            f"    {len(resolved)} baselined violation(s) are resolved; "
+            "run --freeze to shrink the baseline."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.adopt and not args.freeze:
+        print("ERROR: --adopt is valid only with --freeze", file=sys.stderr)
+        return 2
+    try:
+        repo_root = args.repo_root.resolve()
+        map_path = args.map if args.map.is_absolute() else repo_root / args.map
+        baseline_path = args.baseline if args.baseline.is_absolute() else repo_root / args.baseline
+        args.map = map_path
+        args.baseline = baseline_path
+        args.repo_root = repo_root
+        config = load_boundary_map(repo_root, map_path)
+        baseline = (
+            load_baseline(baseline_path, config, repo_root) if baseline_path.exists() else set()
+        )
+        current = compute_violations(
+            repo_root,
+            config,
+            grandfathered_dependencies=_frozen_project_dependencies(
+                repo_root,
+                config,
+                baseline_path,
+            ),
+            baseline_violations=baseline,
+        )
+        if args.freeze:
+            return _run_freeze(args, config, current)
+        if not baseline_path.exists():
+            raise CheckerError(f"Boundary baseline does not exist: {baseline_path}")
+    except CheckerError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    new = current - baseline
+    resolved = baseline - current
+    _emit_result(
+        current=current,
+        baseline=baseline,
+        new=new,
+        resolved=resolved,
+        as_json=args.json,
+    )
+    return 1 if new else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_boundary_edges.py
+++ b/scripts/ci/check_boundary_edges.py
@@ -409,43 +409,6 @@ def _declared_project_dependencies(path: Path) -> set[str]:
     )
 
 
-def _frozen_project_dependencies(
-    repo_root: Path,
-    config: BoundaryConfig,
-    baseline_path: Path,
-) -> set[str]:
-    if not baseline_path.is_file():
-        return set()
-    baseline = _load_json_object(baseline_path, "Boundary baseline")
-    frozen_ref = baseline.get("frozen_from_ref")
-    if not isinstance(frozen_ref, str) or not frozen_ref:
-        return set()
-    try:
-        project_path = config.standalone_project_file.relative_to(repo_root)
-    except ValueError as exc:
-        raise CheckerError("Standalone project file must stay within the repository") from exc
-    result = subprocess.run(
-        ["git", "show", f"{frozen_ref}:{project_path.as_posix()}"],
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise CheckerError(
-            "Cannot read frozen standalone project file "
-            f"{project_path} at {frozen_ref}: {result.stderr.strip()}"
-        )
-    data = _parse_toml_object(
-        result.stdout,
-        f"Frozen standalone project file {project_path} at {frozen_ref}",
-    )
-    return _declared_project_dependencies_from_data(
-        data,
-        f"Frozen standalone project file {project_path} at {frozen_ref}",
-    )
-
-
 def _scan_python_imports(repo_root: Path, config: BoundaryConfig) -> set[str]:
     violations: set[str] = set()
     seen: set[Path] = set()
@@ -484,23 +447,16 @@ def _scan_python_imports(repo_root: Path, config: BoundaryConfig) -> set[str]:
 def compute_violations(
     repo_root: Path,
     config: BoundaryConfig,
-    *,
-    grandfathered_dependencies: set[str] | None = None,
-    baseline_violations: set[str] | None = None,
 ) -> set[str]:
     root = repo_root.resolve()
     violations = _scan_python_imports(root, config)
     allowed_dependencies = {
         _normalize_distribution_name(name) for name in config.allowed_external_roots
     }
-    grandfathered = grandfathered_dependencies or set()
-    existing_violations = baseline_violations or set()
     project_name = config.standalone_project_file.parent.name
     for dependency in _declared_project_dependencies(config.standalone_project_file):
         violation = f"offline dependency {project_name} -> {dependency}"
-        if dependency not in allowed_dependencies and (
-            dependency not in grandfathered or violation in existing_violations
-        ):
+        if dependency not in allowed_dependencies:
             violations.add(violation)
     for left, right in config.mirror_pairs:
         try:
@@ -684,12 +640,6 @@ def main(argv: list[str] | None = None) -> int:
         current = compute_violations(
             repo_root,
             config,
-            grandfathered_dependencies=_frozen_project_dependencies(
-                repo_root,
-                config,
-                baseline_path,
-            ),
-            baseline_violations=baseline,
         )
         if args.freeze:
             return _run_freeze(args, config, current)

--- a/tests/ci/test_check_boundary_edges.py
+++ b/tests/ci/test_check_boundary_edges.py
@@ -1,0 +1,364 @@
+"""Focused tests for the Boundary 2 fail-on-new checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER_PATH = REPO_ROOT / "scripts" / "ci" / "check_boundary_edges.py"
+
+_spec = importlib.util.spec_from_file_location("check_boundary_edges", CHECKER_PATH)
+assert _spec and _spec.loader
+cbe = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cbe
+_spec.loader.exec_module(cbe)
+
+
+def _write_file(root: Path, relative: str, content: str = "") -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _write_map(root: Path) -> Path:
+    paths = [
+        "aragora/gauntlet/receipt.py",
+        "aragora/gauntlet/odr_export.py",
+        "aragora/receipts",
+        "aragora/gauntlet/odr_schema.json",
+        "aragora-verify",
+        "docs/specs/OPEN_DECISION_RECEIPT.md",
+    ]
+    for relative in paths:
+        path = root / relative
+        if Path(relative).suffix:
+            _write_file(root, relative, "{}\n" if relative.endswith(".json") else "")
+        else:
+            path.mkdir(parents=True, exist_ok=True)
+    _write_file(root, "aragora/receipts/__init__.py")
+    _write_file(root, "aragora/core/__init__.py")
+    _write_file(root, "aragora/server/__init__.py")
+    _write_file(root, "aragora/server/handlers.py")
+    _write_file(root, "aragora-verify/src/aragora_verify/__init__.py")
+    _write_file(root, "aragora-verify/src/aragora_verify/odr_schema.json", "{}\n")
+    _write_file(
+        root,
+        "aragora-verify/pyproject.toml",
+        '[project]\nname = "aragora-verify"\ndependencies = ["cryptography>=48.0.1"]\n',
+    )
+
+    data = {
+        "schema_version": 1,
+        "boundary": {
+            "id": 2,
+            "name": "receipts+verifier",
+            "provenance": "docs/architecture/MODULE_QUARANTINE_PROPOSAL.md#boundary-2",
+        },
+        "members": paths,
+        "python_import_policy": {
+            "sources": [
+                "aragora/gauntlet/receipt.py",
+                "aragora/gauntlet/odr_export.py",
+                "aragora/receipts",
+                "aragora-verify/src/aragora_verify",
+            ],
+            "allowed_internal_prefixes": [
+                "aragora.core",
+                "aragora.gauntlet.receipt",
+                "aragora.receipts",
+            ],
+            "standalone": {
+                "source": "aragora-verify/src/aragora_verify",
+                "project_file": "aragora-verify/pyproject.toml",
+                "package_root": "aragora_verify",
+                "allowed_external_roots": ["cryptography"],
+            },
+        },
+        "mirror_pairs": [
+            {
+                "left": "aragora/gauntlet/odr_schema.json",
+                "right": "aragora-verify/src/aragora_verify/odr_schema.json",
+            }
+        ],
+    }
+    path = _write_file(root, "boundary.json", json.dumps(data))
+    return path
+
+
+def _write_baseline(root: Path, map_path: Path, violations: set[str]) -> Path:
+    path = root / "baseline.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "boundary": {"id": 2, "name": "receipts+verifier"},
+                "map": str(map_path.relative_to(root)),
+                "violations": sorted(violations),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _args(root: Path, map_path: Path, baseline: Path) -> list[str]:
+    return [
+        "--repo-root",
+        str(root),
+        "--map",
+        str(map_path),
+        "--baseline",
+        str(baseline),
+    ]
+
+
+def test_new_forbidden_edge_exits_one_and_names_offender(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(
+        tmp_path,
+        "aragora/gauntlet/receipt.py",
+        "from aragora.server import handlers\n",
+    )
+
+    rc = cbe.main(_args(tmp_path, map_path, baseline))
+
+    assert rc == 1
+    assert "import aragora.gauntlet.receipt -> aragora.server.handlers" in capsys.readouterr().out
+
+
+def test_allowed_package_importfrom_resolves_submodule(tmp_path):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(
+        tmp_path,
+        "aragora/gauntlet/receipt.py",
+        "from aragora import core\n",
+    )
+
+    assert cbe.main(_args(tmp_path, map_path, baseline)) == 0
+
+
+def test_forbidden_package_importfrom_names_submodule(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(
+        tmp_path,
+        "aragora/gauntlet/receipt.py",
+        "from aragora import server\n",
+    )
+
+    assert cbe.main(_args(tmp_path, map_path, baseline)) == 1
+    assert "import aragora.gauntlet.receipt -> aragora.server" in capsys.readouterr().out
+
+
+def test_dotted_importfrom_is_not_absorbed_by_parent_baseline(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(
+        tmp_path,
+        map_path,
+        {"import aragora.gauntlet.odr_export -> aragora.gauntlet"},
+    )
+    _write_file(tmp_path, "aragora/gauntlet/runner.py")
+    _write_file(
+        tmp_path,
+        "aragora/gauntlet/odr_export.py",
+        "from aragora.gauntlet import runner\n",
+    )
+
+    assert cbe.main(_args(tmp_path, map_path, baseline)) == 1
+    output = capsys.readouterr().out
+    assert "import aragora.gauntlet.odr_export -> aragora.gauntlet.runner" in output
+
+
+def test_relative_importfrom_uses_known_submodule(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(tmp_path, "aragora/gauntlet/runner.py")
+    _write_file(
+        tmp_path,
+        "aragora/gauntlet/receipt.py",
+        "from . import runner\n",
+    )
+
+    assert cbe.main(_args(tmp_path, map_path, baseline)) == 1
+    assert "import aragora.gauntlet.receipt -> aragora.gauntlet.runner" in capsys.readouterr().out
+
+
+def test_baselined_edge_and_resolved_subset_exit_zero(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(
+        tmp_path,
+        map_path,
+        {
+            "import aragora.gauntlet.receipt -> aragora.server.handlers",
+            "offline aragora_verify -> jsonschema",
+        },
+    )
+    _write_file(
+        tmp_path,
+        "aragora/gauntlet/receipt.py",
+        "from aragora.server import handlers\n",
+    )
+
+    rc = cbe.main(_args(tmp_path, map_path, baseline))
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "no new" in output.lower()
+    assert "1 baselined violation(s) are resolved" in output
+
+
+def test_standalone_dependency_is_offline_violation(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(
+        tmp_path,
+        "aragora-verify/src/aragora_verify/schema.py",
+        "import jsonschema\n",
+    )
+
+    rc = cbe.main(_args(tmp_path, map_path, baseline))
+
+    assert rc == 1
+    assert "offline aragora_verify.schema -> jsonschema" in capsys.readouterr().out
+
+
+def test_declared_standalone_dependency_is_offline_violation(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(
+        tmp_path,
+        "aragora-verify/pyproject.toml",
+        '[project]\nname = "aragora-verify"\ndependencies = ["httpx[socks]>=0.28"]\n',
+    )
+
+    rc = cbe.main(_args(tmp_path, map_path, baseline))
+
+    assert rc == 1
+    assert "offline dependency aragora-verify -> httpx" in capsys.readouterr().out
+
+
+def test_optional_standalone_dependency_is_offline_violation(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(
+        tmp_path,
+        "aragora-verify/pyproject.toml",
+        (
+            '[project]\nname = "aragora-verify"\ndependencies = []\n'
+            '[project.optional-dependencies]\nschema = ["httpx[socks]>=0.28"]\n'
+        ),
+    )
+
+    assert cbe.main(_args(tmp_path, map_path, baseline)) == 1
+    assert "offline dependency aragora-verify -> httpx" in capsys.readouterr().out
+
+
+def test_grandfathered_optional_dependency_is_not_new_violation(tmp_path):
+    map_path = _write_map(tmp_path)
+    _write_file(
+        tmp_path,
+        "aragora-verify/pyproject.toml",
+        (
+            '[project]\nname = "aragora-verify"\ndependencies = []\n'
+            '[project.optional-dependencies]\nschema = ["jsonschema>=4.0"]\n'
+        ),
+    )
+    config = cbe.load_boundary_map(tmp_path, map_path)
+
+    violations = cbe.compute_violations(
+        tmp_path,
+        config,
+        grandfathered_dependencies={"jsonschema"},
+    )
+
+    assert "offline dependency aragora-verify -> jsonschema" not in violations
+
+
+def test_boundary_hook_covers_default_install_and_nested_sources():
+    precommit = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    hook = next(
+        hook
+        for repository in precommit["repos"]
+        for hook in repository["hooks"]
+        if hook["id"] == "boundary2-edges"
+    )
+    boundary = cbe.load_boundary_map(REPO_ROOT, cbe.DEFAULT_MAP)
+    pattern = re.compile(hook["files"])
+
+    assert set(hook["stages"]) == {"pre-commit", "pre-push"}
+    assert hook["files"] == cbe.expected_hook_files_pattern(REPO_ROOT, boundary)
+    assert pattern.search("aragora/receipts/__init__.py")
+    assert pattern.search("aragora-verify/src/aragora_verify/verifier.py")
+    assert pattern.search("aragora-verify/pyproject.toml")
+    assert pattern.search("aragora-verify/src/aragora_verify/odr_schema.json")
+    assert pattern.search("docs/specs/OPEN_DECISION_RECEIPT.md")
+    assert pattern.search("aragora/new_module.py")
+    assert not pattern.search("frontend/src/unrelated.ts")
+
+
+def test_schema_mirror_drift_exits_one(tmp_path, capsys):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    _write_file(
+        tmp_path,
+        "aragora-verify/src/aragora_verify/odr_schema.json",
+        '{"changed": true}\n',
+    )
+
+    rc = cbe.main(_args(tmp_path, map_path, baseline))
+
+    assert rc == 1
+    assert (
+        "mirror aragora/gauntlet/odr_schema.json != "
+        "aragora-verify/src/aragora_verify/odr_schema.json"
+    ) in capsys.readouterr().out
+
+
+def test_freeze_refuses_growth_and_preserves_baseline(tmp_path):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(tmp_path, map_path, set())
+    original = baseline.read_text(encoding="utf-8")
+    _write_file(
+        tmp_path,
+        "aragora/gauntlet/receipt.py",
+        "from aragora.server import handlers\n",
+    )
+
+    rc = cbe.main([*_args(tmp_path, map_path, baseline), "--freeze"])
+
+    assert rc == 2
+    assert baseline.read_text(encoding="utf-8") == original
+
+
+def test_freeze_shrinks_without_adopt(tmp_path):
+    map_path = _write_map(tmp_path)
+    baseline = _write_baseline(
+        tmp_path,
+        map_path,
+        {"import aragora.gauntlet.receipt -> aragora.server"},
+    )
+
+    rc = cbe.main([*_args(tmp_path, map_path, baseline), "--freeze"])
+
+    assert rc == 0
+    config = cbe.load_boundary_map(tmp_path, map_path)
+    assert cbe.load_baseline(baseline, config, tmp_path) == set()
+
+
+def test_initial_freeze_requires_explicit_adopt(tmp_path):
+    map_path = _write_map(tmp_path)
+    baseline = tmp_path / "missing.json"
+
+    assert cbe.main([*_args(tmp_path, map_path, baseline), "--freeze"]) == 2
+    assert not baseline.exists()
+    assert cbe.main([*_args(tmp_path, map_path, baseline), "--freeze", "--adopt"]) == 0
+    assert baseline.exists()

--- a/tests/ci/test_check_boundary_edges.py
+++ b/tests/ci/test_check_boundary_edges.py
@@ -340,6 +340,28 @@ def test_boundary_hook_covers_default_install_and_nested_sources():
     assert not pattern.search("frontend/src/unrelated.ts")
 
 
+def test_boundary_checker_runs_in_required_lint_job():
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/lint.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["lint-run"]["steps"]
+
+    assert {
+        "name": "Enforce Boundary 2 receipts+verifier edges",
+        "run": "${{ steps.lint_python.outputs.python_bin }} scripts/ci/check_boundary_edges.py",
+    } in steps
+
+
+def test_lint_scope_includes_standalone_verifier():
+    classifier = yaml.safe_load(
+        (REPO_ROOT / ".github/actions/pr-scope-classifier/action.yml").read_text(encoding="utf-8")
+    )
+    filter_step = next(step for step in classifier["runs"]["steps"] if step.get("id") == "filter")
+    filters = yaml.safe_load(filter_step["with"]["filters"])
+
+    assert "aragora-verify/**" in filters["lint_python"]
+
+
 def test_schema_mirror_drift_exits_one(tmp_path, capsys):
     map_path = _write_map(tmp_path)
     baseline = _write_baseline(tmp_path, map_path, set())

--- a/tests/ci/test_check_boundary_edges.py
+++ b/tests/ci/test_check_boundary_edges.py
@@ -8,6 +8,7 @@ import re
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -92,17 +93,24 @@ def _write_map(root: Path) -> Path:
     return path
 
 
-def _write_baseline(root: Path, map_path: Path, violations: set[str]) -> Path:
+def _write_baseline(
+    root: Path,
+    map_path: Path,
+    violations: set[str],
+    *,
+    frozen_from_ref: str | None = None,
+) -> Path:
     path = root / "baseline.json"
+    data = {
+        "schema_version": 1,
+        "boundary": {"id": 2, "name": "receipts+verifier"},
+        "map": str(map_path.relative_to(root)),
+        "violations": sorted(violations),
+    }
+    if frozen_from_ref is not None:
+        data["frozen_from_ref"] = frozen_from_ref
     path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "boundary": {"id": 2, "name": "receipts+verifier"},
-                "map": str(map_path.relative_to(root)),
-                "violations": sorted(violations),
-            }
-        ),
+        json.dumps(data),
         encoding="utf-8",
     )
     return path
@@ -262,7 +270,7 @@ def test_optional_standalone_dependency_is_offline_violation(tmp_path, capsys):
     assert "offline dependency aragora-verify -> httpx" in capsys.readouterr().out
 
 
-def test_grandfathered_optional_dependency_is_not_new_violation(tmp_path):
+def test_unreachable_frozen_ref_is_informational_only(tmp_path):
     map_path = _write_map(tmp_path)
     _write_file(
         tmp_path,
@@ -272,15 +280,42 @@ def test_grandfathered_optional_dependency_is_not_new_violation(tmp_path):
             '[project.optional-dependencies]\nschema = ["jsonschema>=4.0"]\n'
         ),
     )
-    config = cbe.load_boundary_map(tmp_path, map_path)
-
-    violations = cbe.compute_violations(
+    baseline = _write_baseline(
         tmp_path,
-        config,
-        grandfathered_dependencies={"jsonschema"},
+        map_path,
+        {"offline dependency aragora-verify -> jsonschema"},
+        frozen_from_ref="0000000000000000000000000000000000000000",
     )
 
-    assert "offline dependency aragora-verify -> jsonschema" not in violations
+    assert cbe.main(_args(tmp_path, map_path, baseline)) == 0
+
+
+@pytest.mark.parametrize("dependency", ["jsonschema", "pytest"])
+def test_removing_dependency_from_baseline_makes_it_new(tmp_path, capsys, dependency):
+    map_path = _write_map(tmp_path)
+    _write_file(
+        tmp_path,
+        "aragora-verify/pyproject.toml",
+        (
+            '[project]\nname = "aragora-verify"\ndependencies = []\n'
+            "[project.optional-dependencies]\n"
+            'schema = ["jsonschema>=4.0"]\n'
+            'dev = ["pytest>=8.0"]\n'
+        ),
+    )
+    all_dependency_edges = {
+        "offline dependency aragora-verify -> jsonschema",
+        "offline dependency aragora-verify -> pytest",
+    }
+    missing_edge = f"offline dependency aragora-verify -> {dependency}"
+    baseline = _write_baseline(
+        tmp_path,
+        map_path,
+        all_dependency_edges - {missing_edge},
+    )
+
+    assert cbe.main(_args(tmp_path, map_path, baseline)) == 1
+    assert missing_edge in capsys.readouterr().out
 
 
 def test_boundary_hook_covers_default_install_and_nested_sources():


### PR DESCRIPTION
## Summary

Replacement for #9543 from current main. The parked branch and its review history remain preserved as design rationale.

- add the machine-readable Boundary 2 receipts+verifier map and shrink-only fail-on-new baseline
- resolve absolute and relative `ImportFrom` targets against real modules enumerated from the scanned source roots
- enforce every PEP 621 dependency source, including `[project.optional-dependencies]`, for the standalone verifier
- fail on map/schema mirror drift and preserve exit 1 semantics for new forbidden edges
- run the checker at pre-commit and pre-push, with a canonical map-derived trigger and an exact synchronization regression

## Baseline

Frozen from current main `8b97a31d1f81ec74d63e30409b867971999bb2aa`: **12 violations**.

This is intentionally not the prior 13-entry baseline. Precise module resolution removes one old false positive: `from aragora.gauntlet import odr_signing` now resolves to the real, explicitly allowlisted `aragora.gauntlet.odr_signing` module instead of the coarse `aragora.gauntlet` parent. The focused regression creates a real `aragora.gauntlet.runner` module beneath that already-baselined parent and proves the new child edge is reported and exits 1 rather than being absorbed.

## Validation

- `python -m pytest -q tests/ci/test_check_boundary_edges.py` (15 passed)
- `ruff check` and `ruff format --check` on the checker and focused tests
- `mypy` on the checker and focused tests
- Boundary 2 hook at `pre-commit` and `pre-push` stages
- `pre-commit validate-config .pre-commit-config.yaml`
- `python scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

No model evidence or settlement action has been performed. This draft stops for fresh exact-head Tier-2 review authorization.