### PR TITLE
fix(ci): commit sdk-parity debt ceilings instead of deriving them from the clock (#9086)

### DIFF
--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -21,8 +21,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](https://g
 | Python files under `aragora/` | 4,303 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
 | Lines of code under `aragora/` | 1,989,764 | `docs/METRICS.md` |
-| Automated tests | 225,004 test functions | `docs/METRICS.md` |
-| Test files | 5,517 | `docs/METRICS.md` |
+| Automated tests | 225,022 test functions | `docs/METRICS.md` |
+| Test files | 5,519 | `docs/METRICS.md` |
 | API operations | 3,084 across 2,876 paths | `docs/METRICS.md` |
 | API paths | 2,876 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,303 tracked Python files | 145 top-level modules | 225,004 test functions across 5,517 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
+**Scale:** 4,303 tracked Python files | 145 top-level modules | 225,022 test functions across 5,519 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,303 Python files | 225,004 tests | 3,084 API operations across 2,876 paths
+**Total**: 230+ features | 4,303 Python files | 225,022 tests | 3,084 API operations across 2,876 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -159,7 +159,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,303
-- **Tests**: 225,004 across 5,517 test files
+- **Tests**: 225,022 across 5,519 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,084 across 2,876 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,7 +766,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 225,004 tests across 5,517 test files
+- **Test coverage**: 225,022 tests across 5,519 test files
 - **Source files**: 4,303 Python files under `aragora/`
 - **API surface**: 3,084 API operations across 2,876 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -16,8 +16,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Python files under `aragora/` | 4,303 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
 | Lines of code under `aragora/` | 1,989,764 | `docs/METRICS.md` |
-| Automated tests | 225,004 test functions | `docs/METRICS.md` |
-| Test files | 5,517 | `docs/METRICS.md` |
+| Automated tests | 225,022 test functions | `docs/METRICS.md` |
+| Test files | 5,519 | `docs/METRICS.md` |
 | API operations | 3,084 across 2,876 paths | `docs/METRICS.md` |
 | API paths | 2,876 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,303 tracked Python files | 145 top-level modules | 225,004 test functions across 5,517 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,303 tracked Python files | 145 top-level modules | 225,022 test functions across 5,519 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -15,8 +15,8 @@
 | Python files under aragora/ | `4303` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
 | Python lines of code under aragora/ | `1989764` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5517` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `225004` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5519` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `225022` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `953` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2876` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -154,7 +154,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,303
-- **Tests**: 225,004 across 5,517 test files
+- **Tests**: 225,022 across 5,519 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,084 across 2,876 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,7 +761,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 225,004 tests across 5,517 test files
+- **Test coverage**: 225,022 tests across 5,519 test files
 - **Source files**: 4,303 Python files under `aragora/`
 - **API surface**: 3,084 API operations across 2,876 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,303 Python files | 225,004 tests | 3,084 API operations across 2,876 paths
+**Total**: 230+ features | 4,303 Python files | 225,022 tests | 3,084 API operations across 2,876 paths
 <!-- metrics:end -->
 
 ---

--- a/scripts/baselines/check_sdk_parity_budget.json
+++ b/scripts/baselines/check_sdk_parity_budget.json
@@ -1,5 +1,7 @@
 {
   "start_date": "2026-04-24",
+  "max_missing_from_both_sdks": 0,
+  "max_stale_python_sdk_paths": 44,
   "initial_missing_from_both_sdks": 32,
   "weekly_reduction_missing_from_both_sdks": 3,
   "initial_stale_python_sdk_paths": 87,

--- a/scripts/check_sdk_parity.py
+++ b/scripts/check_sdk_parity.py
@@ -636,11 +636,117 @@ def _expected_budget_max(
     start_date: dt.date,
     today: dt.date,
 ) -> int:
-    """Compute expected maximum debt after weekly reduction cadence."""
+    """Compute the *advisory* debt-reduction target for a date.
+
+    This is reported, never enforced. Enforcement reads the committed ceiling —
+    see ``_committed_ceilings``. Deriving the enforced ceiling from elapsed time
+    is what let the required ``sdk-parity`` check go red with no code change
+    (#9086): the 54 -> 51 roll landed at a week boundary while actual debt was 53.
+    """
     if weekly_reduction <= 0 or today <= start_date:
         return initial
     weeks_elapsed = (today - start_date).days // 7
     return max(0, initial - (weeks_elapsed * weekly_reduction))
+
+
+def _resolve_today(value: str | None) -> dt.date:
+    """Resolve the effective date, pinned to UTC.
+
+    ``dt.date.today()`` is local-time, so the same commit passed under
+    TZ=America/Chicago and failed under TZ=UTC — CI and a laptop disagreed about
+    whether the tree was green (#9086). UTC is the one clock both share.
+    """
+    if value:
+        return dt.date.fromisoformat(value)
+    return dt.datetime.now(dt.timezone.utc).date()
+
+
+CEILING_FIELDS = {
+    "max_missing_from_both_sdks": "missing_from_both_sdks",
+    "max_stale_python_sdk_paths": "stale_python_sdk_paths",
+}
+
+
+def _committed_ceilings(budget_data: dict) -> dict[str, int]:
+    """Read the explicitly committed debt ceilings.
+
+    These change only when a human commits a new number (``--tighten`` writes
+    them), so the gate cannot tighten on a timer.
+    """
+    missing_fields = [field for field in CEILING_FIELDS if field not in budget_data]
+    if missing_fields:
+        raise ValueError(
+            f"budget file must declare {', '.join(sorted(missing_fields))}. "
+            "Time-derived ceilings were removed in #9086 because they reddened the "
+            "required check with no code change. Run with --tighten to write the "
+            "current debt as the committed ceiling, then commit the file."
+        )
+    return {field: int(budget_data[field]) for field in CEILING_FIELDS}
+
+
+def _print_advisory_target(
+    *,
+    budget_data: dict,
+    start_date: dt.date,
+    today: dt.date,
+    ceilings: dict[str, int],
+) -> None:
+    """Report the debt-reduction cadence as guidance, never as a gate.
+
+    The cadence fields survive #9086 so the original reduction intent stays
+    visible; what changed is that missing the target prints a nudge instead of
+    failing a required check.
+    """
+    for ceiling_field, label in (
+        ("max_missing_from_both_sdks", "missing_from_both_sdks"),
+        ("max_stale_python_sdk_paths", "stale_python_sdk_paths"),
+    ):
+        weekly = int(budget_data.get(f"weekly_reduction_{label}", 0))
+        if weekly <= 0:
+            continue
+        initial = int(budget_data.get(f"initial_{label}", ceilings[ceiling_field]))
+        target = _expected_budget_max(
+            initial=initial, weekly_reduction=weekly, start_date=start_date, today=today
+        )
+        committed = ceilings[ceiling_field]
+        if committed > target:
+            print(
+                f"  advisory: {label} cadence target for {today.isoformat()} is {target}; "
+                f"committed ceiling is {committed}. Pay down debt and run --tighten."
+            )
+
+
+def _tighten_budget(
+    *,
+    path: Path,
+    budget_data: dict,
+    current: dict[str, int],
+    ceilings: dict[str, int],
+) -> int:
+    """Commit current debt as the new ceiling. Ratchets down only."""
+    regressions = [
+        f"{field}: current {current[field]} > committed ceiling {ceilings[field]}"
+        for field in CEILING_FIELDS
+        if current[field] > ceilings[field]
+    ]
+    if regressions:
+        print("\nFAIL: refusing to tighten — that would raise the ceiling and hide a regression:")
+        for line in regressions:
+            print(f"  {line}")
+        return 1
+
+    changes = {f: (ceilings[f], current[f]) for f in CEILING_FIELDS if current[f] < ceilings[f]}
+    if not changes:
+        print("\nBudget already tight; nothing to lower.")
+        return 0
+
+    budget_data.update(current)
+    path.write_text(json.dumps(budget_data, indent=2) + "\n", encoding="utf-8")
+    print(f"\nTightened {path}:")
+    for field, (was, now) in sorted(changes.items()):
+        print(f"  {field}: {was} -> {now}")
+    print("Commit this file — the roll is only real once it is committed.")
+    return 0
 
 
 def main() -> int:
@@ -680,6 +786,15 @@ def main() -> int:
         type=str,
         default=None,
         help="Override current date (YYYY-MM-DD) for deterministic budget checks",
+    )
+    parser.add_argument(
+        "--tighten",
+        action="store_true",
+        help=(
+            "Write current debt back as the committed ceiling in the budget file. "
+            "This is the explicit budget roll — it only ever lowers the ceiling, and "
+            "exits 1 without writing if current debt is above it."
+        ),
     )
     args = parser.parse_args()
 
@@ -728,43 +843,44 @@ def main() -> int:
             if not start_date_str:
                 raise ValueError("budget.start_date is required")
             start_date = dt.date.fromisoformat(start_date_str)
-            today = dt.date.fromisoformat(args.today) if args.today else dt.date.today()
+            today = _resolve_today(args.today)
 
-            initial_missing = int(
-                budget_data.get(
-                    "initial_missing_from_both_sdks",
-                    report["summary"]["routes_missing_from_both_sdks"],
-                )
-            )
-            weekly_missing = int(budget_data.get("weekly_reduction_missing_from_both_sdks", 0))
-            expected_missing = _expected_budget_max(
-                initial=initial_missing,
-                weekly_reduction=weekly_missing,
-                start_date=start_date,
-                today=today,
-            )
+            ceilings = _committed_ceilings(budget_data)
+            expected_missing = ceilings["max_missing_from_both_sdks"]
+            expected_stale = ceilings["max_stale_python_sdk_paths"]
 
             stale_current = len(report["gaps"]["stale_python_sdk_paths"])
-            initial_stale = int(budget_data.get("initial_stale_python_sdk_paths", stale_current))
-            weekly_stale = int(budget_data.get("weekly_reduction_stale_python_sdk_paths", 0))
-            expected_stale = _expected_budget_max(
-                initial=initial_stale,
-                weekly_reduction=weekly_stale,
-                start_date=start_date,
-                today=today,
-            )
+            current_missing = report["summary"]["routes_missing_from_both_sdks"]
 
             budget_status = {
                 "expected_missing_max": expected_missing,
-                "current_missing": report["summary"]["routes_missing_from_both_sdks"],
+                "current_missing": current_missing,
                 "expected_stale_python_max": expected_stale,
                 "current_stale_python": stale_current,
             }
+
+            if args.tighten:
+                return _tighten_budget(
+                    path=args.budget,
+                    budget_data=budget_data,
+                    current={
+                        "max_missing_from_both_sdks": current_missing,
+                        "max_stale_python_sdk_paths": stale_current,
+                    },
+                    ceilings=ceilings,
+                )
+
             if not args.json:
                 print(
                     "\nBudget status: "
-                    f"missing_from_both {budget_status['current_missing']}/{budget_status['expected_missing_max']} "
-                    f"| stale_python {budget_status['current_stale_python']}/{budget_status['expected_stale_python_max']}"
+                    f"missing_from_both {current_missing}/{expected_missing} "
+                    f"| stale_python {stale_current}/{expected_stale}"
+                )
+                _print_advisory_target(
+                    budget_data=budget_data,
+                    start_date=start_date,
+                    today=today,
+                    ceilings=ceilings,
                 )
         except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
             print(f"\nFAIL: Invalid SDK parity budget file ({args.budget}): {exc}")

--- a/tests/scripts/test_check_sdk_parity.py
+++ b/tests/scripts/test_check_sdk_parity.py
@@ -103,10 +103,8 @@ def test_strict_budget_fails_when_missing_exceeds_budget(monkeypatch, tmp_path):
         """
 {
   "start_date": "2026-01-01",
-  "initial_missing_from_both_sdks": 2,
-  "weekly_reduction_missing_from_both_sdks": 0,
-  "initial_stale_python_sdk_paths": 1,
-  "weekly_reduction_stale_python_sdk_paths": 0
+  "max_missing_from_both_sdks": 2,
+  "max_stale_python_sdk_paths": 1
 }
 """.strip()
         + "\n",
@@ -135,10 +133,8 @@ def test_strict_budget_fails_when_stale_exceeds_budget(monkeypatch, tmp_path):
         """
 {
   "start_date": "2026-01-01",
-  "initial_missing_from_both_sdks": 0,
-  "weekly_reduction_missing_from_both_sdks": 0,
-  "initial_stale_python_sdk_paths": 4,
-  "weekly_reduction_stale_python_sdk_paths": 0
+  "max_missing_from_both_sdks": 0,
+  "max_stale_python_sdk_paths": 4
 }
 """.strip()
         + "\n",
@@ -172,6 +168,8 @@ def test_strict_budget_passes_when_within_budget(monkeypatch, tmp_path):
         """
 {
   "start_date": "2026-02-13",
+  "max_missing_from_both_sdks": 2,
+  "max_stale_python_sdk_paths": 10,
   "initial_missing_from_both_sdks": 2,
   "weekly_reduction_missing_from_both_sdks": 1,
   "initial_stale_python_sdk_paths": 10,
@@ -359,3 +357,137 @@ def test_handler_coverage_excludes_internal_route_families():
     assert report["gaps"]["missing_from_python_sdk"] == []
     assert report["gaps"]["missing_from_typescript_sdk"] == []
     assert report["gaps"]["missing_from_both_sdks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Budget semantics (#9086)
+#
+# The progressive budget used to be derived from wall-clock: an `initial` debt
+# minus `weekly_reduction` per elapsed week. Two consequences, both real:
+#
+#   1. The required `sdk-parity` check could go red with NO code change, simply
+#      because a week boundary passed. #9086 records the 54 -> 51 roll doing
+#      exactly that while actual debt sat at 53.
+#   2. `dt.date.today()` is local-time, so the same commit passed under
+#      TZ=America/Chicago and failed under TZ=UTC — CI and a developer's laptop
+#      disagreed about whether the tree was green.
+#
+# The enforced ceiling is now an explicit committed number (`max_*`). It changes
+# when a human commits a change to it, never when the clock advances.
+# ---------------------------------------------------------------------------
+
+import datetime as dt  # noqa: E402
+import json  # noqa: E402
+
+
+def _budget(tmp_path, *, max_missing: int, max_stale: int, extra: str = "") -> Path:
+    path = tmp_path / "budget.json"
+    payload = {
+        "start_date": "2026-01-01",
+        "max_missing_from_both_sdks": max_missing,
+        "max_stale_python_sdk_paths": max_stale,
+    }
+    if extra:
+        payload.update(json.loads(extra))
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _run(monkeypatch, budget: Path, *, today: str | None = None) -> int:
+    argv = ["check_sdk_parity.py", "--strict", "--allow-missing", "--budget", str(budget)]
+    if today:
+        argv += ["--today", today]
+    monkeypatch.setattr(sys, "argv", argv)
+    return check_sdk_parity.main()
+
+
+def test_budget_verdict_is_stable_across_dates(monkeypatch, tmp_path):
+    """The #9086 invariant: the calendar alone must never flip the verdict.
+
+    Same tree, same budget file, dates a year apart — identical result. Under the
+    old date-derived ceiling the later date went red with no code change.
+    """
+    budget = _budget(tmp_path, max_missing=0, max_stale=44)
+    verdicts = []
+    for today in ("2026-01-01", "2026-08-07", "2027-06-01"):
+        _patch_report(monkeypatch, missing=0, stale_python=44)
+        verdicts.append(_run(monkeypatch, budget, today=today))
+    assert verdicts == [0, 0, 0], (
+        f"verdict changed with the calendar alone: {verdicts}. A gate that reddens "
+        "without a code change is untruthful (#9086)."
+    )
+
+
+def test_default_today_is_utc_not_local_time(monkeypatch):
+    """CI and a laptop must agree on the date.
+
+    `dt.date.today()` is local-time, which is why the same commit passed under
+    TZ=America/Chicago and failed under TZ=UTC.
+    """
+    resolved = check_sdk_parity._resolve_today(None)
+    assert resolved == dt.datetime.now(dt.timezone.utc).date(), (
+        "default 'today' is not UTC-pinned; local timezone can shift it by a day"
+    )
+
+
+def test_budget_fails_when_actual_exceeds_committed_ceiling(monkeypatch, tmp_path):
+    """A real regression — debt rose above the committed number — still fails."""
+    _patch_report(monkeypatch, missing=0, stale_python=45)
+    budget = _budget(tmp_path, max_missing=0, max_stale=44)
+    assert _run(monkeypatch, budget, today="2026-08-07") == 1
+
+
+def test_budget_passes_when_actual_within_committed_ceiling(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=44)
+    budget = _budget(tmp_path, max_missing=0, max_stale=44)
+    assert _run(monkeypatch, budget, today="2026-08-07") == 0
+
+
+def test_budget_file_without_committed_ceiling_fails_closed(monkeypatch, tmp_path):
+    """A legacy time-derived budget file must not silently resurrect the bug.
+
+    Failing closed with an actionable message beats quietly re-enabling a ceiling
+    that tightens on a timer.
+    """
+    _patch_report(monkeypatch, missing=0, stale_python=44)
+    legacy = tmp_path / "budget.json"
+    legacy.write_text(
+        json.dumps(
+            {
+                "start_date": "2026-04-24",
+                "initial_stale_python_sdk_paths": 87,
+                "weekly_reduction_stale_python_sdk_paths": 3,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert _run(monkeypatch, legacy, today="2026-08-07") == 2
+
+
+def test_tighten_lowers_ceiling_to_current_actuals(monkeypatch, tmp_path):
+    """`--tighten` is the explicit roll: debt paid down, ceiling committed lower."""
+    _patch_report(monkeypatch, missing=0, stale_python=40)
+    budget = _budget(tmp_path, max_missing=0, max_stale=44)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_sdk_parity.py", "--budget", str(budget), "--tighten", "--today", "2026-08-07"],
+    )
+    assert check_sdk_parity.main() == 0
+    written = json.loads(budget.read_text(encoding="utf-8"))
+    assert written["max_stale_python_sdk_paths"] == 40
+
+
+def test_tighten_never_raises_the_ceiling(monkeypatch, tmp_path):
+    """A ratchet only turns one way — `--tighten` must not launder a regression."""
+    _patch_report(monkeypatch, missing=0, stale_python=60)
+    budget = _budget(tmp_path, max_missing=0, max_stale=44)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_sdk_parity.py", "--budget", str(budget), "--tighten", "--today", "2026-08-07"],
+    )
+    assert check_sdk_parity.main() == 1
+    written = json.loads(budget.read_text(encoding="utf-8"))
+    assert written["max_stale_python_sdk_paths"] == 44, "ceiling was raised to hide a regression"


### PR DESCRIPTION
Closes #9086.

## Problem

The progressive parity budget derived its **enforced** ceiling from wall-clock — `initial` debt minus `weekly_reduction` per elapsed week. Two real consequences:

**1. The required `sdk-parity` check could go red with no code change.** #9086 records the 54 → 51 roll doing exactly that while actual debt sat at 53. That trap was still armed at HEAD:

```
week 14  2026-07-31  ceiling 45  actual 44  pass
week 15  2026-08-07  ceiling 42  actual 44  RED  <- nobody touched the repo
```

Confirmed against the real code, not just arithmetic:

```
OLD time-derived ceiling on 2026-08-07: 42  vs actual 44 -> RED
```

**2. Local/CI truth divergence.** `dt.date.today()` is local-time, so the same commit passed under `TZ=America/Chicago` and failed under `TZ=UTC`. CI and a developer's laptop disagreed about whether the tree was green.

## Fix

The enforced ceiling is now an explicit committed number:

```json
{
  "max_missing_from_both_sdks": 0,
  "max_stale_python_sdk_paths": 44
}
```

It moves when a human commits a change to it, never when the calendar advances.

- **`--tighten` is the explicit roll.** It writes current debt back as the ceiling, **ratchets down only**, and refuses to write when that would raise the ceiling and launder a regression. This matches the repo's existing shrink-only conventions (code-quality ratchet, mypy shrink-only baseline).
- **The cadence fields survive as advisory.** `initial_*` / `weekly_reduction_*` still print a target line, so the debt-reduction intent stays visible — it just can no longer redden a required check.
- **A budget file with no committed ceiling fails closed** with instructions, rather than silently resurrecting time-decay.
- **`--today` remains** for deterministic tests; the default is now UTC-pinned.

The ceiling is committed at **44 = current actual**, not the old 48, so there is no hidden slack.

## Verification

| property | evidence |
|---|---|
| calendar cannot flip the verdict | identical exit 0 on `2026-07-29`, `2026-08-07`, `2026-12-01`, `2027-06-01` |
| timezone cannot flip the verdict | identical exit 0 under `UTC`, `America/Chicago`, `Asia/Tokyo`, `Pacific/Kiritimati` (UTC+14) |
| real regressions still caught | ceiling 43 vs actual 44 → `exit 1`, `FAIL: Stale Python SDK debt exceeds budget (44 > 43)` |
| the deadline was real | old logic on 2026-08-07 → ceiling 42 < actual 44 → RED |

Tests were written before the fix and observed failing (5 red), then green: `tests/scripts/test_check_sdk_parity.py` — 21 passed. The headline invariant is `test_budget_verdict_is_stable_across_dates`, which runs the same tree against three dates a year apart and asserts one verdict.

Three pre-existing budget tests were converted to the new schema; they encoded the removed time-derived semantics, so leaving them would have asserted the bug.

`docs/METRICS.md` is regenerated — main was already stale by two test files independent of this branch, and the drift job fails on a PR's own increment.

## Reviewed design tradeoffs

- **Ratchet vs. keeping a time cadence.** A pure committed ceiling loses automatic schedule pressure to pay down debt. Accepted: the standing requirement is that a gate must not redden without a code change, and the cadence survives as a printed advisory so the intent is not lost. Enforcement by calendar is what made the gate untruthful.
- **Not failing when debt drops below the ceiling.** Some ratchets fail to force immediate tightening. That would reintroduce a red the author did not cause (their PR improved things), so tightening is an explicit `--tighten` commit instead.
- **Failing closed on a legacy budget file** rather than falling back to the old computation. A silent fallback would leave the bug reachable for any file that had not been migrated.
- **Committing 44 rather than 48.** Keeping the old slack would mean four regressions could land before the gate noticed.

## Tier

**Tier 4** (`tier_4_preapproval_required`) — corrected. I originally wrote Tier 2 here by reasoning from the diff (no workflow YAML, no protection change). The canonical merge-packet classifier disagrees: `scripts/check_sdk_parity.py` backs a *required* check, so it is a preapproval surface regardless of how small the diff is. `requires_human_risk_settlement: true`.

Tier is decided by the merge-packet classifier, never inferred from the change's apparent size — the same trap recorded for governance-gate scripts previously. **Not for auto-merge.**

