### PR TITLE
[DIC-17] coherence-scan --emit-followup: wire DIC-26 monitor → DIC-17 follow-up bridge

### DIFF
--- a/aragora/cli/commands/dic26_coherence.py
+++ b/aragora/cli/commands/dic26_coherence.py
@@ -8,7 +8,7 @@ Reads a JSON file where each element is a BeliefEntry dict:
 
 Flag: ``ARAGORA_COHERENCE_MONITOR_ENABLED`` (default OFF).
 Live queue effect: none — read-only operator report.
-Advances: issue #6220 (DIC-26).
+Advances: issue #6220 (DIC-26), issue #6027 (DIC-17 followup bridge).
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -25,10 +26,12 @@ from aragora.epistemic.coherence import (
     coherence_monitor_enabled,
     scan_coherence,
 )
+from aragora.epistemic.followup import FollowupProposal
 
 logger = logging.getLogger(__name__)
 
 _FLAG = "ARAGORA_COHERENCE_MONITOR_ENABLED"
+_FOLLOWUP_FLAG = "ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED"
 _DEFAULT_GAP: float = 0.5
 _DEFAULT_MIN_CONFIDENCE: float = 0.3
 
@@ -59,6 +62,21 @@ def _load_entries(path: Path) -> list[BeliefEntry]:
     return entries
 
 
+def _render_proposals(proposals: list[FollowupProposal], *, followup_enabled: bool) -> None:
+    """Print DIC-17 follow-up proposals in text mode."""
+    print()
+    if proposals:
+        print(f"  DIC-17 follow-up proposals: {len(proposals)}")
+        for p in proposals:
+            print(f"    [{p.source_key}] {p.title}")
+            print(f"      {p.rationale}")
+            print(f"      labels: {', '.join(p.labels)}")
+    else:
+        print("  DIC-17 follow-up proposals: none")
+        if not followup_enabled:
+            print(f"    (set {_FOLLOWUP_FLAG}=1 to enable proposal generation)")
+
+
 def cmd_coherence_scan(args: argparse.Namespace) -> int:
     """Handle the ``aragora coherence-scan`` subcommand."""
     if not coherence_monitor_enabled():
@@ -79,16 +97,31 @@ def cmd_coherence_scan(args: argparse.Namespace) -> int:
         print(f"error: failed to load {input_path}: {exc}", file=sys.stderr)
         return 1
 
+    emit_followup: bool = bool(getattr(args, "emit_followup", False))
+
     report = scan_coherence(
         entries,
         contradiction_gap=float(getattr(args, "contradiction_gap", _DEFAULT_GAP)),
         min_confidence=float(getattr(args, "min_confidence", _DEFAULT_MIN_CONFIDENCE)),
         enabled=True,
+        emit_followup_proposals=emit_followup,
     )
 
     as_json: bool = getattr(args, "json", False)
     if as_json:
-        print(json.dumps(report.to_dict(), indent=2))
+        d = report.to_dict()
+        if emit_followup and report.proposals:
+            d["proposals"] = [
+                {
+                    "source_key": p.source_key,
+                    "source_kind": p.source_kind,
+                    "title": p.title,
+                    "rationale": p.rationale,
+                    "labels": list(p.labels),
+                }
+                for p in report.proposals
+            ]
+        print(json.dumps(d, indent=2))
         return 0
 
     print(f"Coherence scan: {input_path}")
@@ -103,4 +136,14 @@ def cmd_coherence_scan(args: argparse.Namespace) -> int:
             ids = ", ".join(issue.belief_ids)
             print(f"  [{issue.severity}] {issue.kind.value}: {ids}")
             print(f"    {issue.detail}")
+
+    if emit_followup:
+        followup_enabled = str(os.environ.get(_FOLLOWUP_FLAG) or "").strip().lower() in {
+            "1", "true", "yes", "on"
+        }
+        _render_proposals(report.proposals, followup_enabled=followup_enabled)
+
     return 0
+
+
+__all__ = ["cmd_coherence_scan"]

--- a/aragora/cli/commands/dic26_coherence.py
+++ b/aragora/cli/commands/dic26_coherence.py
@@ -139,7 +139,10 @@ def cmd_coherence_scan(args: argparse.Namespace) -> int:
 
     if emit_followup:
         followup_enabled = str(os.environ.get(_FOLLOWUP_FLAG) or "").strip().lower() in {
-            "1", "true", "yes", "on"
+            "1",
+            "true",
+            "yes",
+            "on",
         }
         _render_proposals(report.proposals, followup_enabled=followup_enabled)
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -728,6 +728,16 @@ def _add_coherence_scan_parser(subparsers) -> None:
         help="Minimum confidence threshold for rot detection (default: 0.3)",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    p.add_argument(
+        "--emit-followup",
+        dest="emit_followup",
+        action="store_true",
+        default=False,
+        help=(
+            "Emit DIC-17 follow-up proposals for error-severity issues. "
+            "Requires ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1 to generate proposals."
+        ),
+    )
     p.set_defaults(func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan"))
 
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -651,7 +651,6 @@ def _add_proof_units_parser(subparsers) -> None:
         "--multi-hop",
         dest="multi_hop",
         action="store_true",
-        default=False,
         help="Include transitively impacted units via dependency edges",
     )
     p.add_argument(
@@ -727,8 +726,12 @@ def _add_coherence_scan_parser(subparsers) -> None:
         help="Minimum confidence threshold for rot detection (default: 0.3)",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
-    p.add_argument("--emit-followup", dest="emit_followup", action="store_true",
-                   help="DIC-17 proposals for errors (requires ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1).")
+    p.add_argument(
+        "--emit-followup",
+        dest="emit_followup",
+        action="store_true",
+        help="DIC-17 proposals for errors (requires ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1).",
+    )
     p.set_defaults(func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan"))
 
 
@@ -909,13 +912,11 @@ def _add_epistemic_check_parser(subparsers) -> None:
     p.add_argument(
         "--json",
         action="store_true",
-        default=False,
         help="Emit machine-readable JSON (schema_version, results, summary)",
     )
     p.add_argument(
         "--dry-run",
         action="store_true",
-        default=False,
         help=(
             "Skip command execution; return UNSUPPORTED for command-kind claims. "
             "This is already the DEFAULT behavior — the flag is accepted for "
@@ -925,7 +926,6 @@ def _add_epistemic_check_parser(subparsers) -> None:
     p.add_argument(
         "--execute",
         action="store_true",
-        default=False,
         help=(
             "Opt in to running manifest-provided verification commands as "
             "subprocesses. Off by default: command-kind claims are skipped "

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -658,7 +658,6 @@ def _add_proof_units_parser(subparsers) -> None:
         "--json",
         dest="json",
         action="store_true",
-        default=False,
         help="Emit JSON output",
     )
     p.set_defaults(func=_lazy("aragora.cli.commands.dic19_proof_units", "cmd_proof_units"))
@@ -728,16 +727,8 @@ def _add_coherence_scan_parser(subparsers) -> None:
         help="Minimum confidence threshold for rot detection (default: 0.3)",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
-    p.add_argument(
-        "--emit-followup",
-        dest="emit_followup",
-        action="store_true",
-        default=False,
-        help=(
-            "Emit DIC-17 follow-up proposals for error-severity issues. "
-            "Requires ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1 to generate proposals."
-        ),
-    )
+    p.add_argument("--emit-followup", dest="emit_followup", action="store_true",
+                   help="DIC-17 proposals for errors (requires ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1).")
     p.set_defaults(func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan"))
 
 

--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -6,10 +6,11 @@ Exposes:
 - DIC-14: executable claim verification (:class:`ClaimVerifier`)
 - DIC-16: signed CruxReceipt for crux-finder debate runs
   (:class:`CruxEntry`, :class:`CruxReceipt`, :func:`build_crux_receipt`)
-- DIC-17: follow-up-issue bridge for load-bearing cruxes and
-  sharply-losing claims (:class:`FollowupProposal`,
+- DIC-17: follow-up-issue bridge for load-bearing cruxes, sharply-losing
+  claims, and coherence-monitor error issues (:class:`FollowupProposal`,
   :func:`propose_followup_for_crux`, :func:`propose_followup_for_cruxset`,
-  :func:`propose_followup_for_failed_claim`)
+  :func:`propose_followup_for_failed_claim`,
+  :func:`propose_followup_for_coherence_issue`)
 - DIC-18: organizational truth map report (:class:`OrgTruthMapReport`,
   :func:`build_truth_map`, :func:`build_truth_map_from_manifests`)
 - DIC-20: epistemic decay monitor (:class:`DecaySignal`,
@@ -137,6 +138,7 @@ from .followup import (
     DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
     DEFAULT_DELTA_LOSS_THRESHOLD,
     FollowupProposal,
+    propose_followup_for_coherence_issue,
     propose_followup_for_crux,
     propose_followup_for_cruxset,
     propose_followup_for_failed_claim,
@@ -298,6 +300,7 @@ __all__ = [
     "world_event_to_claim_results",
     "world_events_enabled",
     "from_belief_node",
+    "propose_followup_for_coherence_issue",
     "propose_followup_for_crux",
     "propose_followup_for_cruxset",
     "propose_followup_for_failed_claim",

--- a/tests/cli/test_dic26_coherence_followup.py
+++ b/tests/cli/test_dic26_coherence_followup.py
@@ -1,0 +1,212 @@
+"""CLI tests: ``aragora coherence-scan --emit-followup`` (DIC-17 × DIC-26 bridge).
+
+Verifies that the ``--emit-followup`` flag on ``coherence-scan``:
+- Is off by default (no proposals emitted without the flag).
+- Requires ``ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1`` to generate proposals.
+- Emits DIC-17 proposals in text mode when both flags are set and
+  error-severity issues are present.
+- Emits DIC-17 proposals in JSON mode (rich dict with source_key / title /
+  rationale / labels).
+- Produces no proposals for warning-severity issues only.
+- Omits the ``proposals`` JSON key when there are no proposals.
+
+Gating: ``ARAGORA_COHERENCE_MONITOR_ENABLED`` + ``ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED``
+must both be set for proposals to flow. Default is OFF; live queue is unaffected.
+
+Advances: issue #6027 (DIC-17), issue #6220 (DIC-26).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.dic26_coherence import cmd_coherence_scan
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _args(
+    input_path: str,
+    *,
+    json_output: bool = False,
+    emit_followup: bool = False,
+    gap: float = 0.5,
+    min_conf: float = 0.3,
+) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.input = input_path
+    ns.json = json_output
+    ns.emit_followup = emit_followup
+    ns.contradiction_gap = gap
+    ns.min_confidence = min_conf
+    return ns
+
+
+def _write(tmp_path: Path, data: object, name: str = "beliefs.json") -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+_CONTRADICTING = [
+    {"belief_id": "b1", "subject": "rate-limiter", "confidence": 0.95, "status": "pass"},
+    {"belief_id": "b2", "subject": "rate-limiter", "confidence": 0.04, "status": "fail"},
+]
+
+_WARNING_ONLY = [
+    {
+        "belief_id": "b3",
+        "subject": "auth-pass",
+        "confidence": 0.40,
+        "status": "pass",
+        "evidence_paths": ["docs/auth.md"],
+    },
+    {
+        "belief_id": "b4",
+        "subject": "auth-fail",
+        "confidence": 0.60,
+        "status": "fail",
+        "evidence_paths": ["docs/auth.md"],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmitFollowupDefault:
+    def test_no_proposals_without_emit_followup_flag(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Without --emit-followup, proposals section never appears."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _CONTRADICTING)
+        rc = cmd_coherence_scan(_args(str(p), emit_followup=False))
+        assert rc == 0
+        assert "follow-up" not in capsys.readouterr().out
+
+    def test_json_no_proposals_key_without_emit_followup_flag(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """JSON output omits proposals key when --emit-followup is not set."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _CONTRADICTING)
+        rc = cmd_coherence_scan(_args(str(p), json_output=True, emit_followup=False))
+        assert rc == 0
+        d = json.loads(capsys.readouterr().out)
+        assert "proposals" not in d
+
+
+class TestEmitFollowupGating:
+    def test_no_proposals_when_followup_flag_unset(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--emit-followup with ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED unset yields no proposals."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.delenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", raising=False)
+        p = _write(tmp_path, _CONTRADICTING)
+        rc = cmd_coherence_scan(_args(str(p), emit_followup=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "DIC-17 follow-up proposals: none" in out
+        assert "ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED" in out
+
+    def test_json_no_proposals_key_when_followup_flag_unset(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.delenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", raising=False)
+        p = _write(tmp_path, _CONTRADICTING)
+        rc = cmd_coherence_scan(_args(str(p), json_output=True, emit_followup=True))
+        assert rc == 0
+        d = json.loads(capsys.readouterr().out)
+        assert "proposals" not in d
+
+
+class TestEmitFollowupWithBothFlagsSet:
+    def test_proposals_appear_in_text_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _CONTRADICTING)
+        rc = cmd_coherence_scan(_args(str(p), emit_followup=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "DIC-17 follow-up proposals:" in out
+        assert "none" not in out
+        assert "source_key" not in out  # rich dict in JSON only; text uses bracket format
+
+    def test_proposals_source_key_in_text_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _CONTRADICTING)
+        cmd_coherence_scan(_args(str(p), emit_followup=True))
+        out = capsys.readouterr().out
+        assert "[coherence_issue_" in out
+
+    def test_no_boss_ready_label_in_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Queue-governance invariant: boss-ready must never appear in proposals."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _CONTRADICTING)
+        cmd_coherence_scan(_args(str(p), emit_followup=True))
+        assert "boss-ready" not in capsys.readouterr().out
+
+    def test_proposals_in_json_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _CONTRADICTING)
+        rc = cmd_coherence_scan(_args(str(p), json_output=True, emit_followup=True))
+        assert rc == 0
+        d = json.loads(capsys.readouterr().out)
+        assert "proposals" in d
+        assert len(d["proposals"]) >= 1
+        prop = d["proposals"][0]
+        assert prop["source_kind"] == "coherence_issue"
+        assert "source_key" in prop
+        assert "title" in prop
+        assert "rationale" in prop
+        assert "labels" in prop
+        assert "boss-ready" not in prop["labels"]
+
+
+class TestEmitFollowupWarningsOnly:
+    def test_warning_issues_produce_no_proposals(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Warning-severity evidence conflicts must not generate follow-up proposals."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _WARNING_ONLY)
+        rc = cmd_coherence_scan(_args(str(p), emit_followup=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "DIC-17 follow-up proposals: none" in out
+
+    def test_json_no_proposals_for_warnings(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        p = _write(tmp_path, _WARNING_ONLY)
+        rc = cmd_coherence_scan(_args(str(p), json_output=True, emit_followup=True))
+        assert rc == 0
+        d = json.loads(capsys.readouterr().out)
+        assert "proposals" not in d


### PR DESCRIPTION
## Summary

- Adds `--emit-followup` flag to `aragora coherence-scan` (DIC-26 CLI surface) that surfaces DIC-17 `FollowupProposal` objects for every error-severity coherence issue in the scanned belief ledger.
- Exports `propose_followup_for_coherence_issue` from `aragora.epistemic` package API (was in `followup.__all__` but missing from the package-level `__init__.py`).
- 10 focused tests covering flag-gating, text/JSON output, warning-only no-proposal behaviour, and the `boss-ready`-exclusion queue-governance invariant.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test improvement

## Related Issues

Related to #6027 (DIC-17 — failed-claim / open-crux follow-up bridge)
Related to #6220 (DIC-26 — belief coherence monitor)

## Checklist

### Before Submitting

- [x] My code follows the project's code style (ruff clean, mypy clean on touched modules)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`tests/cli/test_dic26_coherence{,_followup}.py`, `tests/epistemic/test_coherence*.py` — 41 tests passing)
- [x] My commit messages follow conventional commit format

### Code Quality

- [x] New code has type hints
- [x] No hardcoded secrets or credentials
- [x] Error handling is appropriate

### For New Features

- [x] Feature is tested with unit tests
- [x] Feature integrates with existing systems appropriately

## Test Plan

```bash
# All 10 new CLI tests + 31 existing coherence + followup tests
pytest tests/cli/test_dic26_coherence_followup.py tests/cli/test_dic26_coherence.py tests/epistemic/test_coherence_followup_bridge.py tests/epistemic/test_coherence.py -v
# → 41 passed

# Smoke: package-level export
python3 -c "from aragora.epistemic import propose_followup_for_coherence_issue; print('OK')"
```

## Additional Notes

**Flag gating:** both `ARAGORA_COHERENCE_MONITOR_ENABLED=1` and `ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1` must be set for proposals to flow. Default is OFF. Live queue effect: none — read-only operator surface.

**Queue governance:** `boss-ready` label is never applied to generated proposals (tested explicitly). Proposals are DIC-17 planning-truth output only; the proof-first Foreman gate controls promotion.

**Net diff:** 273 LOC (61 modified, 212 new test lines). No changes to `scripts/`, dispatch, boss loop, or swarm supervisor.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191Ev3QHqtQziTvKkyiiEQy)_