### PR TITLE
[DIC-22] repair-spec → debate adapter: RepairDebateAgent protocol + CruxReceipt output

### DIFF
--- a/aragora/epistemic/repair_debate.py
+++ b/aragora/epistemic/repair_debate.py
@@ -129,9 +129,9 @@ def run_repair_debate(
         ev["agent"] = agent.name
         evaluations.append(ev)
 
-    crux_entries, seen_ids = _collect_crux_entries(spec, evaluations)
+    crux_entries = _collect_crux_entries(spec, evaluations)
 
-    support_count = sum(1 for ev in evaluations if ev.get("supports_repair"))
+    support_count = sum(1 for ev in evaluations if ev.get("supports_repair") is True)
     consensus = support_count > len(evaluations) / 2
     recommended_action = "proceed_with_repair" if consensus else "request_human_review"
 
@@ -154,46 +154,60 @@ def run_repair_debate(
 def _collect_crux_entries(
     spec: RepairSpec,
     evaluations: list[dict[str, Any]],
-) -> tuple[list[CruxEntry], set[str]]:
+) -> list[CruxEntry]:
     """Build the ordered, deduplicated list of :class:`CruxEntry` objects."""
     crux_entries: list[CruxEntry] = []
-    seen_ids: set[str] = set()
+    entries_by_id: dict[str, CruxEntry] = {}
 
     for ev in evaluations:
         for cand in ev.get("crux_candidates", []):
             cid = str(cand.get("crux_id") or "")
-            if not cid or cid in seen_ids:
+            if not cid:
                 continue
-            seen_ids.add(cid)
-            crux_entries.append(
-                CruxEntry(
-                    crux_id=cid,
-                    statement=str(cand.get("statement") or ""),
-                    load_bearing_score=float(cand.get("load_bearing_score") or 0.5),
-                    uncertainty_score=float(cand.get("uncertainty_score") or 0.5),
-                    contesting_agents=[ev["agent"]],
-                    affected_claims=list(spec.linked_claims),
-                    resolution_impact=float(cand.get("resolution_impact") or 0.5),
-                )
+            existing = entries_by_id.get(cid)
+            if existing is not None:
+                if ev["agent"] not in existing.contesting_agents:
+                    existing.contesting_agents.append(ev["agent"])
+                continue
+            entry = CruxEntry(
+                crux_id=cid,
+                statement=str(cand.get("statement") or ""),
+                load_bearing_score=_score_or_default(cand, "load_bearing_score"),
+                uncertainty_score=_score_or_default(cand, "uncertainty_score"),
+                contesting_agents=[ev["agent"]],
+                affected_claims=list(spec.linked_claims),
+                resolution_impact=_score_or_default(cand, "resolution_impact"),
             )
+            entries_by_id[cid] = entry
+            crux_entries.append(entry)
 
     for crux_id in spec.linked_crux_ids:
-        if crux_id in seen_ids:
+        if crux_id in entries_by_id:
             continue
-        seen_ids.add(crux_id)
-        crux_entries.append(
-            CruxEntry(
-                crux_id=crux_id,
-                statement=f"Unresolved crux from decay signal: {crux_id}",
-                load_bearing_score=0.7,
-                uncertainty_score=0.5,
-                contesting_agents=[],
-                affected_claims=list(spec.linked_claims),
-                resolution_impact=0.5,
-            )
+        entry = CruxEntry(
+            crux_id=crux_id,
+            statement=f"Unresolved crux from decay signal: {crux_id}",
+            load_bearing_score=0.7,
+            uncertainty_score=0.5,
+            contesting_agents=[],
+            affected_claims=list(spec.linked_claims),
+            resolution_impact=0.5,
         )
+        entries_by_id[crux_id] = entry
+        crux_entries.append(entry)
 
-    return crux_entries, seen_ids
+    return crux_entries
+
+
+def _score_or_default(candidate: dict[str, Any], key: str, default: float = 0.5) -> float:
+    """Preserve numeric zeroes and bound malformed agent scores to a neutral default."""
+    value = candidate.get(key, default)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _build_receipt(
@@ -215,11 +229,12 @@ def _build_receipt(
             "debate_id": debate_id,
             "question": question,
             "cruxes": [c.to_dict() for c in crux_entries],
-            "convergence_barrier": convergence_barrier,
+            "convergence_barrier": round(convergence_barrier, 4),
         },
         sort_keys=True,
+        separators=(",", ":"),
     )
-    checksum = hashlib.sha256(checksum_material.encode()).hexdigest()
+    checksum = hashlib.sha256(checksum_material.encode("utf-8")).hexdigest()
 
     return CruxReceipt(
         receipt_id=receipt_id,

--- a/aragora/epistemic/repair_debate.py
+++ b/aragora/epistemic/repair_debate.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import uuid
 from dataclasses import dataclass
 from typing import Any, Protocol, Sequence
@@ -73,16 +74,7 @@ class RepairDebateResult:
             "spec_id": self.spec_id,
             "consensus_reached": self.consensus_reached,
             "recommended_action": self.recommended_action,
-            "receipt": {
-                "receipt_id": self.receipt.receipt_id,
-                "debate_id": self.receipt.debate_id,
-                "question": self.receipt.question,
-                "convergence_barrier": self.receipt.convergence_barrier,
-                "checksum": self.receipt.checksum,
-                "cruxes": [c.to_dict() for c in self.receipt.cruxes],
-                "agents": self.receipt.agents,
-                "metadata": self.receipt.metadata,
-            },
+            "receipt": self.receipt.to_dict(),
             "agent_evaluations": self.agent_evaluations,
         }
 
@@ -118,9 +110,9 @@ def run_repair_debate(
     context: dict[str, Any] = {
         "code_unit_id": spec.code_unit_id,
         "repair_kind": spec.repair_kind,
-        "linked_claims": spec.linked_claims,
-        "linked_crux_ids": spec.linked_crux_ids,
-        "validation_commands": spec.validation_commands,
+        "linked_claims": list(spec.linked_claims),
+        "linked_crux_ids": list(spec.linked_crux_ids),
+        "validation_commands": list(spec.validation_commands),
     }
 
     evaluations: list[dict[str, Any]] = []
@@ -160,7 +152,12 @@ def _collect_crux_entries(
     entries_by_id: dict[str, CruxEntry] = {}
 
     for ev in evaluations:
-        for cand in ev.get("crux_candidates", []):
+        candidates = ev.get("crux_candidates") or []
+        if not isinstance(candidates, list):
+            continue
+        for cand in candidates:
+            if not isinstance(cand, dict):
+                continue
             cid = str(cand.get("crux_id") or "")
             if not cid:
                 continue
@@ -205,9 +202,12 @@ def _score_or_default(candidate: dict[str, Any], key: str, default: float = 0.5)
     if value is None:
         return default
     try:
-        return float(value)
+        score = float(value)
     except (TypeError, ValueError):
         return default
+    if not math.isfinite(score):
+        return default
+    return min(1.0, max(0.0, score))
 
 
 def _build_receipt(

--- a/aragora/epistemic/repair_debate.py
+++ b/aragora/epistemic/repair_debate.py
@@ -1,0 +1,247 @@
+"""Repair-spec → debate adapter for DIC-22 verified replacement pipeline (#6033).
+
+Bridges a :class:`~aragora.epistemic.repair.RepairSpec` to a lightweight
+agent debate and produces a :class:`~aragora.epistemic.crux_receipt.CruxReceipt`.
+
+Invariants:
+- Requires ``ARAGORA_REPAIR_PIPELINE_ENABLED`` (inherited from repair.py, default off).
+- No live Arena, no queue mutation, no issue creation.
+- Callers inject a :class:`RepairDebateAgent` protocol so tests run without
+  API keys or network access.
+- Output is a receipt-bearing :class:`RepairDebateResult`; no live routing.
+
+Flag gate: ``ARAGORA_REPAIR_PIPELINE_ENABLED`` — same flag as repair.py.
+DIC-22 / issue #6033.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, Protocol, Sequence
+
+from aragora.epistemic.crux_receipt import CruxEntry, CruxReceipt
+from aragora.epistemic.repair import RepairSpec, repair_pipeline_enabled
+
+
+class RepairDebateAgent(Protocol):
+    """Minimal agent protocol consumed by :func:`run_repair_debate`.
+
+    Implementations may wrap a real LLM call or return mock data in tests.
+    The protocol is deliberately narrow: one ``name`` property and one
+    ``evaluate`` method so tests can inject lightweight stubs.
+    """
+
+    @property
+    def name(self) -> str:
+        """Stable identifier for this agent (used in receipt and provenance)."""
+        ...
+
+    def evaluate(self, spec: RepairSpec, context: dict[str, Any]) -> dict[str, Any]:
+        """Evaluate *spec* and return a dict with keys:
+
+        - ``supports_repair`` (bool) — whether the agent endorses the repair
+        - ``crux_candidates`` (list[dict]) — each with ``crux_id``, ``statement``,
+          ``load_bearing_score``, ``uncertainty_score``, ``resolution_impact``
+        - ``notes`` (str, optional) — free-form rationale
+
+        Missing keys are treated as falsy / empty.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class RepairDebateResult:
+    """Output of a repair-spec debate.
+
+    ``receipt`` carries the SHA-256-checksummed :class:`CruxReceipt` for
+    downstream provenance and audit. ``consensus_reached`` reflects whether
+    a majority of agents supported the repair; ``recommended_action`` is the
+    bounded string recommendation (never a live routing instruction).
+    """
+
+    spec_id: str
+    receipt: CruxReceipt
+    agent_evaluations: list[dict[str, Any]]
+    consensus_reached: bool
+    recommended_action: str  # "proceed_with_repair" | "request_human_review"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "spec_id": self.spec_id,
+            "consensus_reached": self.consensus_reached,
+            "recommended_action": self.recommended_action,
+            "receipt": {
+                "receipt_id": self.receipt.receipt_id,
+                "debate_id": self.receipt.debate_id,
+                "question": self.receipt.question,
+                "convergence_barrier": self.receipt.convergence_barrier,
+                "checksum": self.receipt.checksum,
+                "cruxes": [c.to_dict() for c in self.receipt.cruxes],
+                "agents": self.receipt.agents,
+                "metadata": self.receipt.metadata,
+            },
+            "agent_evaluations": self.agent_evaluations,
+        }
+
+
+def run_repair_debate(
+    spec: RepairSpec,
+    agents: Sequence[RepairDebateAgent],
+    *,
+    question_override: str | None = None,
+) -> RepairDebateResult:
+    """Run a bounded debate over *spec* using *agents* and return a receipted result.
+
+    Requires ``ARAGORA_REPAIR_PIPELINE_ENABLED=1``.  Raises :exc:`RuntimeError`
+    otherwise.  Raises :exc:`ValueError` when *agents* is empty.
+
+    No live routing, no queue mutation, no issue creation.  The returned
+    :class:`RepairDebateResult` is the sole side-effect; callers decide what
+    to do with the receipt.
+    """
+    if not repair_pipeline_enabled():
+        raise RuntimeError(
+            "run_repair_debate requires ARAGORA_REPAIR_PIPELINE_ENABLED=1; "
+            "set the flag or keep repair_kind='report_only'"
+        )
+    if not agents:
+        raise ValueError("run_repair_debate requires at least one agent")
+
+    question = question_override or (
+        f"Is the proposed repair for {spec.code_unit_id!r} (kind={spec.repair_kind!r}) "
+        "sound and bounded?"
+    )
+
+    context: dict[str, Any] = {
+        "code_unit_id": spec.code_unit_id,
+        "repair_kind": spec.repair_kind,
+        "linked_claims": spec.linked_claims,
+        "linked_crux_ids": spec.linked_crux_ids,
+        "validation_commands": spec.validation_commands,
+    }
+
+    evaluations: list[dict[str, Any]] = []
+    for agent in agents:
+        ev = dict(agent.evaluate(spec, context))
+        ev["agent"] = agent.name
+        evaluations.append(ev)
+
+    crux_entries, seen_ids = _collect_crux_entries(spec, evaluations)
+
+    support_count = sum(1 for ev in evaluations if ev.get("supports_repair"))
+    consensus = support_count > len(evaluations) / 2
+    recommended_action = "proceed_with_repair" if consensus else "request_human_review"
+
+    receipt = _build_receipt(spec, question, crux_entries, evaluations, consensus)
+
+    return RepairDebateResult(
+        spec_id=spec.spec_id,
+        receipt=receipt,
+        agent_evaluations=evaluations,
+        consensus_reached=consensus,
+        recommended_action=recommended_action,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_crux_entries(
+    spec: RepairSpec,
+    evaluations: list[dict[str, Any]],
+) -> tuple[list[CruxEntry], set[str]]:
+    """Build the ordered, deduplicated list of :class:`CruxEntry` objects."""
+    crux_entries: list[CruxEntry] = []
+    seen_ids: set[str] = set()
+
+    for ev in evaluations:
+        for cand in ev.get("crux_candidates", []):
+            cid = str(cand.get("crux_id") or "")
+            if not cid or cid in seen_ids:
+                continue
+            seen_ids.add(cid)
+            crux_entries.append(
+                CruxEntry(
+                    crux_id=cid,
+                    statement=str(cand.get("statement") or ""),
+                    load_bearing_score=float(cand.get("load_bearing_score") or 0.5),
+                    uncertainty_score=float(cand.get("uncertainty_score") or 0.5),
+                    contesting_agents=[ev["agent"]],
+                    affected_claims=list(spec.linked_claims),
+                    resolution_impact=float(cand.get("resolution_impact") or 0.5),
+                )
+            )
+
+    for crux_id in spec.linked_crux_ids:
+        if crux_id in seen_ids:
+            continue
+        seen_ids.add(crux_id)
+        crux_entries.append(
+            CruxEntry(
+                crux_id=crux_id,
+                statement=f"Unresolved crux from decay signal: {crux_id}",
+                load_bearing_score=0.7,
+                uncertainty_score=0.5,
+                contesting_agents=[],
+                affected_claims=list(spec.linked_claims),
+                resolution_impact=0.5,
+            )
+        )
+
+    return crux_entries, seen_ids
+
+
+def _build_receipt(
+    spec: RepairSpec,
+    question: str,
+    crux_entries: list[CruxEntry],
+    evaluations: list[dict[str, Any]],
+    consensus: bool,
+) -> CruxReceipt:
+    """Assemble and checksum the :class:`CruxReceipt`."""
+    receipt_id = str(uuid.uuid4())
+    debate_id = f"repair-debate-{spec.spec_id}"
+    agent_names = [ev["agent"] for ev in evaluations]
+    convergence_barrier = 0.0 if consensus else 1.0
+
+    checksum_material = json.dumps(
+        {
+            "receipt_id": receipt_id,
+            "debate_id": debate_id,
+            "question": question,
+            "cruxes": [c.to_dict() for c in crux_entries],
+            "convergence_barrier": convergence_barrier,
+        },
+        sort_keys=True,
+    )
+    checksum = hashlib.sha256(checksum_material.encode()).hexdigest()
+
+    return CruxReceipt(
+        receipt_id=receipt_id,
+        debate_id=debate_id,
+        question=question,
+        cruxes=crux_entries,
+        convergence_barrier=convergence_barrier,
+        counterfactuals=[],
+        agents=agent_names,
+        rounds=1,
+        metadata={
+            "spec_id": spec.spec_id,
+            "code_unit_id": spec.code_unit_id,
+            "repair_kind": spec.repair_kind,
+            "repair_provenance_hash": spec.provenance_hash,
+        },
+        checksum=checksum,
+    )
+
+
+__all__ = [
+    "RepairDebateAgent",
+    "RepairDebateResult",
+    "run_repair_debate",
+]

--- a/tests/epistemic/test_repair_debate.py
+++ b/tests/epistemic/test_repair_debate.py
@@ -94,6 +94,26 @@ class _NamedCruxAgent:
         }
 
 
+class _MalformedCandidatesAgent:
+    name = "mock-malformed-candidates"
+
+    def __init__(self, candidates) -> None:
+        self.candidates = candidates
+
+    def evaluate(self, spec, context):
+        return {"supports_repair": False, "crux_candidates": self.candidates}
+
+
+class _ContextMutatingAgent:
+    name = "mock-context-mutator"
+
+    def evaluate(self, spec, context):
+        context["linked_claims"].append("mutated-claim")
+        context["linked_crux_ids"].append("mutated-crux")
+        context["validation_commands"].append("rm -rf ignored")
+        return {"supports_repair": False, "crux_candidates": []}
+
+
 # ---------------------------------------------------------------------------
 # Flag gate
 # ---------------------------------------------------------------------------
@@ -216,6 +236,13 @@ class TestReceipt:
         result = run_repair_debate(spec, [_SupportAgent()])
         assert result.receipt.rounds == 1
 
+    def test_result_serialization_preserves_complete_receipt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert result.to_dict()["receipt"] == result.receipt.to_dict()
+
 
 # ---------------------------------------------------------------------------
 # Crux entry propagation
@@ -271,6 +298,48 @@ class TestCruxPropagation:
         assert shared.load_bearing_score == 0.0
         assert shared.uncertainty_score == 0.5
         assert shared.resolution_impact == 0.5
+
+    @pytest.mark.parametrize(
+        ("scores", "expected"),
+        [
+            ({"load_bearing_score": float("nan")}, 0.5),
+            ({"load_bearing_score": float("inf")}, 0.5),
+            ({"load_bearing_score": -0.25}, 0.0),
+            ({"load_bearing_score": 1.25}, 1.0),
+        ],
+    )
+    def test_non_finite_scores_default_and_finite_scores_are_clamped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        scores: dict[str, float],
+        expected: float,
+    ) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_NamedCruxAgent("agent-a", **scores)])
+        shared = next(crux for crux in result.receipt.cruxes if crux.crux_id == "crux.shared")
+        assert shared.load_bearing_score == expected
+        json.dumps(result.receipt.to_dict(), allow_nan=False)
+
+    @pytest.mark.parametrize("candidates", [None, "not-a-list", ["not-a-dict"]])
+    def test_malformed_crux_candidates_are_treated_as_empty(
+        self, monkeypatch: pytest.MonkeyPatch, candidates
+    ) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_MalformedCandidatesAgent(candidates)])
+        assert {crux.crux_id for crux in result.receipt.cruxes} == set(spec.linked_crux_ids)
+
+    def test_agent_cannot_mutate_repair_spec_through_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = _spec(monkeypatch)
+        original_claims = list(spec.linked_claims)
+        original_crux_ids = list(spec.linked_crux_ids)
+        original_commands = list(spec.validation_commands)
+        result = run_repair_debate(spec, [_ContextMutatingAgent()])
+        assert spec.linked_claims == original_claims
+        assert spec.linked_crux_ids == original_crux_ids
+        assert spec.validation_commands == original_commands
+        assert all(crux.affected_claims == original_claims for crux in result.receipt.cruxes)
 
     def test_crux_affected_claims_match_spec(self, monkeypatch: pytest.MonkeyPatch) -> None:
         spec = _spec(monkeypatch)

--- a/tests/epistemic/test_repair_debate.py
+++ b/tests/epistemic/test_repair_debate.py
@@ -1,0 +1,265 @@
+"""Tests for DIC-22 repair-spec → debate adapter (aragora.epistemic.repair_debate).
+
+Covers: flag gate, empty-agents guard, consensus math, CruxReceipt content,
+linked crux propagation, no-hot-swap proof, and serialisation.
+All tests run without network access or real LLM keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
+from aragora.epistemic.repair import propose_repair
+from aragora.epistemic.repair_debate import RepairDebateResult, run_repair_debate
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _signal() -> DecaySignal:
+    return DecaySignal(
+        code_unit_id="unit.proof.test",
+        integrity_score=0.35,
+        reasons=[
+            DecayReason(kind="failed_claim", detail="claim expired", claim_id="claim.b0.fresh"),
+            DecayReason(kind="unresolved_crux", detail="", crux_id="crux.soak.policy"),
+        ],
+        recommended_action="repair_required",
+    )
+
+
+def _spec(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ARAGORA_REPAIR_PIPELINE_ENABLED", "1")
+    return propose_repair(
+        _signal(),
+        repair_kind="pr_candidate",
+        validation_commands=["pytest tests/epistemic/"],
+    )
+
+
+class _SupportAgent:
+    name = "mock-support"
+
+    def evaluate(self, spec, context):
+        return {
+            "supports_repair": True,
+            "crux_candidates": [
+                {
+                    "crux_id": "crux.mock.boundary",
+                    "statement": "Is the patch within safe scope?",
+                    "load_bearing_score": 0.8,
+                    "uncertainty_score": 0.3,
+                    "resolution_impact": 0.7,
+                }
+            ],
+            "notes": "Repair is bounded and claim-linked.",
+        }
+
+
+class _OpposeAgent:
+    name = "mock-oppose"
+
+    def evaluate(self, spec, context):
+        return {"supports_repair": False, "crux_candidates": [], "notes": "Needs more evidence."}
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGate:
+    def test_requires_pipeline_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        sig = _signal()
+        spec = propose_repair(sig)  # report_only is always allowed
+        with pytest.raises(RuntimeError, match="ARAGORA_REPAIR_PIPELINE_ENABLED"):
+            run_repair_debate(spec, [_SupportAgent()])
+
+    def test_empty_agents_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        with pytest.raises(ValueError, match="at least one agent"):
+            run_repair_debate(spec, [])
+
+
+# ---------------------------------------------------------------------------
+# Consensus arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestConsensus:
+    def test_majority_support_reaches_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent(), _SupportAgent(), _OpposeAgent()])
+        assert result.consensus_reached
+        assert result.recommended_action == "proceed_with_repair"
+
+    def test_majority_oppose_blocks_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_OpposeAgent(), _OpposeAgent(), _SupportAgent()])
+        assert not result.consensus_reached
+        assert result.recommended_action == "request_human_review"
+
+    def test_single_supporting_agent_is_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert result.consensus_reached
+
+    def test_single_opposing_agent_blocks_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_OpposeAgent()])
+        assert not result.consensus_reached
+
+    def test_tie_blocks_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent(), _OpposeAgent()])
+        assert not result.consensus_reached
+
+    def test_convergence_barrier_zero_on_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert result.receipt.convergence_barrier == 0.0
+
+    def test_convergence_barrier_one_on_no_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_OpposeAgent()])
+        assert result.receipt.convergence_barrier == 1.0
+
+
+# ---------------------------------------------------------------------------
+# CruxReceipt content
+# ---------------------------------------------------------------------------
+
+
+class TestReceipt:
+    def test_receipt_has_64char_sha256_checksum(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert len(result.receipt.checksum) == 64
+        assert all(c in "0123456789abcdef" for c in result.receipt.checksum)
+
+    def test_receipt_links_spec_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        meta = result.receipt.metadata
+        assert meta["spec_id"] == spec.spec_id
+        assert meta["code_unit_id"] == spec.code_unit_id
+        assert meta["repair_kind"] == spec.repair_kind
+        assert meta["repair_provenance_hash"] == spec.provenance_hash
+
+    def test_receipt_debate_id_contains_spec_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert result.receipt.debate_id == f"repair-debate-{spec.spec_id}"
+
+    def test_receipt_agent_names_recorded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent(), _OpposeAgent()])
+        assert set(result.receipt.agents) == {"mock-support", "mock-oppose"}
+
+    def test_receipt_rounds_is_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert result.receipt.rounds == 1
+
+
+# ---------------------------------------------------------------------------
+# Crux entry propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCruxPropagation:
+    def test_agent_crux_candidates_included(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        crux_ids = {c.crux_id for c in result.receipt.cruxes}
+        assert "crux.mock.boundary" in crux_ids
+
+    def test_spec_linked_crux_ids_included(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        crux_ids = {c.crux_id for c in result.receipt.cruxes}
+        assert "crux.soak.policy" in crux_ids
+
+    def test_no_duplicate_crux_ids(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent(), _SupportAgent()])
+        crux_ids = [c.crux_id for c in result.receipt.cruxes]
+        assert len(crux_ids) == len(set(crux_ids))
+
+    def test_crux_affected_claims_match_spec(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        for entry in result.receipt.cruxes:
+            assert entry.affected_claims == spec.linked_claims
+
+    def test_empty_crux_candidates_still_includes_signal_cruxes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_OpposeAgent()])
+        crux_ids = {c.crux_id for c in result.receipt.cruxes}
+        assert "crux.soak.policy" in crux_ids
+
+
+# ---------------------------------------------------------------------------
+# No-hot-swap proof
+# ---------------------------------------------------------------------------
+
+
+class TestNoHotswap:
+    def test_recommended_action_is_bounded_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        for agents in ([_SupportAgent()], [_OpposeAgent()]):
+            result = run_repair_debate(spec, agents)
+            assert result.recommended_action in {"proceed_with_repair", "request_human_review"}
+
+    def test_result_carries_no_live_routing_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        d = result.to_dict()
+        for key in d:
+            assert "live" not in key.lower(), f"Unexpected live-routing key: {key!r}"
+
+    def test_spec_repair_kind_not_live_swap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        assert spec.repair_kind != "live_swap"
+
+
+# ---------------------------------------------------------------------------
+# Question override and serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestMisc:
+    def test_question_override_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()], question_override="Is it safe?")
+        assert result.receipt.question == "Is it safe?"
+
+    def test_default_question_contains_spec_id_substring(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert spec.code_unit_id in result.receipt.question
+
+    def test_spec_id_on_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        assert result.spec_id == spec.spec_id
+
+    def test_to_dict_round_trips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_SupportAgent()])
+        d = result.to_dict()
+        assert d["spec_id"] == spec.spec_id
+        assert d["consensus_reached"] is True
+        assert d["recommended_action"] == "proceed_with_repair"
+        assert "receipt" in d
+        assert len(d["receipt"]["checksum"]) == 64
+        assert "cruxes" in d["receipt"]
+        assert isinstance(d["agent_evaluations"], list)

--- a/tests/epistemic/test_repair_debate.py
+++ b/tests/epistemic/test_repair_debate.py
@@ -7,6 +7,9 @@ All tests run without network access or real LLM keys.
 
 from __future__ import annotations
 
+import hashlib
+import json
+
 import pytest
 
 from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
@@ -66,6 +69,31 @@ class _OpposeAgent:
         return {"supports_repair": False, "crux_candidates": [], "notes": "Needs more evidence."}
 
 
+class _StringSupportAgent:
+    name = "mock-string-support"
+
+    def evaluate(self, spec, context):
+        return {"supports_repair": "false", "crux_candidates": []}
+
+
+class _NamedCruxAgent:
+    def __init__(self, name: str, **scores) -> None:
+        self.name = name
+        self.scores = scores
+
+    def evaluate(self, spec, context):
+        return {
+            "supports_repair": True,
+            "crux_candidates": [
+                {
+                    "crux_id": "crux.shared",
+                    "statement": "Shared concern",
+                    **self.scores,
+                }
+            ],
+        }
+
+
 # ---------------------------------------------------------------------------
 # Flag gate
 # ---------------------------------------------------------------------------
@@ -118,6 +146,12 @@ class TestConsensus:
         result = run_repair_debate(spec, [_SupportAgent(), _OpposeAgent()])
         assert not result.consensus_reached
 
+    def test_truthy_non_boolean_support_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(spec, [_StringSupportAgent()])
+        assert not result.consensus_reached
+        assert result.recommended_action == "request_human_review"
+
     def test_convergence_barrier_zero_on_consensus(self, monkeypatch: pytest.MonkeyPatch) -> None:
         spec = _spec(monkeypatch)
         result = run_repair_debate(spec, [_SupportAgent()])
@@ -140,6 +174,23 @@ class TestReceipt:
         result = run_repair_debate(spec, [_SupportAgent()])
         assert len(result.receipt.checksum) == 64
         assert all(c in "0123456789abcdef" for c in result.receipt.checksum)
+
+    def test_receipt_checksum_uses_canonical_crux_serialization(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = _spec(monkeypatch)
+        receipt = run_repair_debate(spec, [_SupportAgent()]).receipt
+        material = {
+            "receipt_id": receipt.receipt_id,
+            "debate_id": receipt.debate_id,
+            "question": receipt.question,
+            "cruxes": [crux.to_dict() for crux in receipt.cruxes],
+            "convergence_barrier": round(receipt.convergence_barrier, 4),
+        }
+        expected = hashlib.sha256(
+            json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        assert receipt.checksum == expected
 
     def test_receipt_links_spec_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
         spec = _spec(monkeypatch)
@@ -189,6 +240,37 @@ class TestCruxPropagation:
         result = run_repair_debate(spec, [_SupportAgent(), _SupportAgent()])
         crux_ids = [c.crux_id for c in result.receipt.cruxes]
         assert len(crux_ids) == len(set(crux_ids))
+
+    def test_duplicate_crux_collects_all_contesting_agents(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(
+            spec,
+            [_NamedCruxAgent("agent-a"), _NamedCruxAgent("agent-b")],
+        )
+        shared = next(crux for crux in result.receipt.cruxes if crux.crux_id == "crux.shared")
+        assert shared.contesting_agents == ["agent-a", "agent-b"]
+
+    def test_zero_scores_are_preserved_and_malformed_scores_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = _spec(monkeypatch)
+        result = run_repair_debate(
+            spec,
+            [
+                _NamedCruxAgent(
+                    "agent-a",
+                    load_bearing_score=0.0,
+                    uncertainty_score="high",
+                    resolution_impact=None,
+                )
+            ],
+        )
+        shared = next(crux for crux in result.receipt.cruxes if crux.crux_id == "crux.shared")
+        assert shared.load_bearing_score == 0.0
+        assert shared.uncertainty_score == 0.5
+        assert shared.resolution_impact == 0.5
 
     def test_crux_affected_claims_match_spec(self, monkeypatch: pytest.MonkeyPatch) -> None:
         spec = _spec(monkeypatch)


### PR DESCRIPTION
## Slice

Adds `aragora/epistemic/repair_debate.py` — the Arena-debate integration that `repair.py` explicitly deferred to "downstream consumers." A `RepairDebateAgent` protocol (injectable, mockable) evaluates a `RepairSpec`, and `run_repair_debate()` collects crux candidates, merges them with the spec's linked crux IDs, computes majority consensus, and returns a `RepairDebateResult` carrying a SHA-256-checksummed `CruxReceipt` for downstream provenance.

## Gating

- Default: OFF (flag: `ARAGORA_REPAIR_PIPELINE_ENABLED` — same gate as `repair.py`)
- Live queue effect: none
- Advances issue: #6033

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Related to #6033

## Tests

- `TestFlagGate` — requires `ARAGORA_REPAIR_PIPELINE_ENABLED=1`; empty-agents raises `ValueError`
- `TestConsensus` — majority/minority/tie arithmetic; `convergence_barrier` 0.0 vs 1.0
- `TestReceipt` — 64-char SHA-256 checksum; spec metadata linked; debate_id contains spec_id; agent names recorded
- `TestCruxPropagation` — agent candidates included; spec linked_crux_ids merged; no duplicates; affected_claims match spec; signal cruxes included even when agent returns no candidates
- `TestNoHotswap` — `recommended_action` is bounded string; no `live` key in `to_dict()`; repair_kind never `live_swap`
- `TestMisc` — question override; default question contains code_unit_id; spec_id on result; `to_dict()` round-trip

## Validation

- `pytest tests/epistemic/test_repair_debate.py --noconftest` — **26 passed** in 0.22s
- `ruff check aragora/epistemic/repair_debate.py tests/epistemic/test_repair_debate.py` — clean
- `mypy aragora/epistemic/repair_debate.py --ignore-missing-imports` — clean

## Out of scope

- Wiring to a real LLM Arena (callers inject the protocol; no live API calls here)
- Verifier hook execution (the `validation_commands` field exists on `RepairSpec`; running them is DIC-22 follow-up)
- Issue creation from repair results (explicitly prohibited per DIC-22 non-goals)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4Rh2ag59uXcEHmmHKqMrd)_