### PR TITLE
[AGT-03][AGT-05] Manifold Markets → AGT-05 reputation bridge

### DIFF
--- a/aragora/reputation/manifold_bridge.py
+++ b/aragora/reputation/manifold_bridge.py
@@ -1,0 +1,162 @@
+"""Manifold Markets → AGT-05 reputation bridge (AGT-03 + AGT-05 / #6064, #6066).
+
+Bridges a resolved :class:`~aragora.connectors.prediction_markets.manifold.ManifoldMarket`
+and its :class:`~aragora.connectors.prediction_markets.manifold.ManifoldResolution` into the
+AGT-05 reputation flow, producing a :class:`~aragora.reputation.types.StakeableClaim` +
+:class:`~aragora.reputation.types.ResolvedClaim` pair ready for
+:func:`~aragora.reputation.settlement.settle_claim`.
+
+Flag: ``ARAGORA_REPUTATION_FLOW_ENABLED`` (default off).
+
+Outcome mapping: ManifoldResolution.outcome is already normalized to the ternary
+"yes" / "no" / "inconclusive" shape by the connector; this bridge passes it through
+directly, treating any unrecognized value as "inconclusive".
+
+Companion to :mod:`aragora.reputation.metaculus_bridge` (Metaculus path) and
+:mod:`aragora.reputation.bridge` (synthetic-GitHub path).
+
+Out of scope for this slice (deferred):
+- Real-time polling of Manifold API (lives in the connector layer)
+- Per-agent Brier score wiring to the evaluation layer (AGT-03 Phase 3)
+- On-chain anchoring via ReputationRegistry (downstream AGT-05 sub-deliverable)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from aragora.reputation.types import (
+    DOMAIN_PREDICTION_MARKET,
+    ClaimOutcome,
+    ResolvedClaim,
+    StakeableClaim,
+    StakePolicy,
+)
+
+if TYPE_CHECKING:
+    from aragora.connectors.prediction_markets.manifold import ManifoldMarket, ManifoldResolution
+
+_RESOLUTION_SOURCE = "manifold"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def reputation_flow_enabled() -> bool:
+    """Return True when ``ARAGORA_REPUTATION_FLOW_ENABLED`` is truthy."""
+    return os.environ.get("ARAGORA_REPUTATION_FLOW_ENABLED", "").strip().lower() in _TRUTHY
+
+
+def _ms_to_iso(ts_ms: int | None) -> str | None:
+    """Convert a Manifold millisecond timestamp to an ISO-8601 UTC string."""
+    if ts_ms is None:
+        return None
+    return datetime.fromtimestamp(ts_ms / 1000.0, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _manifold_outcome(resolution: "ManifoldResolution") -> ClaimOutcome:
+    """Map ManifoldResolution.outcome (normalized ternary) to ClaimOutcome."""
+    raw = str(resolution.outcome or "").strip().lower()
+    if raw == "yes":
+        return "yes"
+    if raw == "no":
+        return "no"
+    return "inconclusive"
+
+
+def bridge_from_manifold_market(
+    market: "ManifoldMarket",
+    resolution: "ManifoldResolution",
+    agent_id: str,
+    predicted_probability: float,
+    *,
+    stake_units: int = 1,
+    stake_policy: StakePolicy = "forfeit_on_loss",
+    resolution_source: str = _RESOLUTION_SOURCE,
+    submitted_at: str | None = None,
+    require_enabled: bool = True,
+) -> tuple[StakeableClaim, ResolvedClaim]:
+    """Return *(StakeableClaim, ResolvedClaim)* ready for :func:`~aragora.reputation.settlement.settle_claim`.
+
+    Parameters
+    ----------
+    market:
+        Resolved Manifold market (``market.is_resolved`` must be True).
+    resolution:
+        Matching :class:`ManifoldResolution` from the connector.
+    agent_id:
+        Identifier of the predicting agent.
+    predicted_probability:
+        Agent's forecast in [0.0, 1.0].
+    stake_units:
+        Internal credit units at stake (>= 1).
+    stake_policy:
+        How credits settle on resolution.
+    resolution_source:
+        Override the source tag (default "manifold").
+    submitted_at:
+        ISO-8601 UTC timestamp of when the prediction was submitted.
+        Defaults to now.
+    require_enabled:
+        When True (default), raise :exc:`RuntimeError` if the feature
+        flag is off.
+    """
+    if require_enabled and not reputation_flow_enabled():
+        raise RuntimeError(
+            "ARAGORA_REPUTATION_FLOW_ENABLED is not set; "
+            "set it to '1' or 'true' to use the Manifold reputation bridge"
+        )
+    if not market.is_resolved:
+        raise ValueError(
+            f"ManifoldMarket {market.market_id!r} is not resolved "
+            f"(resolution={market.resolution!r})"
+        )
+    if not (0.0 <= predicted_probability <= 1.0):
+        raise ValueError(
+            f"predicted_probability must be in [0.0, 1.0]; got {predicted_probability!r}"
+        )
+    if stake_units < 1:
+        raise ValueError(f"stake_units must be >= 1; got {stake_units!r}")
+
+    _now = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+    ts = submitted_at or _now
+    close_time_iso = _ms_to_iso(market.close_time_ms)
+    resolved_at_iso = _ms_to_iso(resolution.resolved_at_ms) or _now
+
+    claim = StakeableClaim.create(
+        agent_id=agent_id,
+        domain=DOMAIN_PREDICTION_MARKET,
+        statement=market.question,
+        position="yes" if predicted_probability >= 0.5 else "no",
+        predicted_probability=predicted_probability,
+        stake_units=stake_units,
+        stake_policy=stake_policy,
+        resolution_source=resolution_source,
+        resolution_id=market.market_id,
+        provenance={
+            "market_id": market.market_id,
+            "slug": market.slug,
+            "outcome_type": market.outcome_type,
+            "close_time_ms": market.close_time_ms,
+            "close_time_iso": close_time_iso,
+            "submitted_at": ts,
+        },
+        created_at=ts,
+    )
+    resolved = ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=_manifold_outcome(resolution),
+        resolved_at=resolved_at_iso,
+        resolution_source=resolution_source,
+        evidence={
+            "market_id": resolution.market_id,
+            "outcome": resolution.outcome,
+            "resolved_at_ms": resolution.resolved_at_ms,
+            "question": market.question,
+            "creator_username": market.creator_username,
+        },
+    )
+    return claim, resolved
+
+
+__all__ = ["bridge_from_manifold_market", "reputation_flow_enabled"]

--- a/tests/reputation/test_manifold_bridge.py
+++ b/tests/reputation/test_manifold_bridge.py
@@ -1,0 +1,276 @@
+"""Tests for aragora.reputation.manifold_bridge (AGT-03 + AGT-05 / #6064, #6066)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from aragora.reputation.manifold_bridge import (
+    bridge_from_manifold_market,
+    reputation_flow_enabled,
+)
+from aragora.reputation.types import DOMAIN_PREDICTION_MARKET
+
+# ---------------------------------------------------------------------------
+# Structural stubs — no connector import required in tests
+# ---------------------------------------------------------------------------
+
+_CLOSE_MS = 1_746_057_600_000  # 2025-05-01T00:00:00Z
+_RESOLVED_MS = 1_746_144_000_000  # 2025-05-02T00:00:00Z
+
+
+@dataclass(frozen=True)
+class _Market:
+    """Structural stand-in for ManifoldMarket — no network import needed."""
+
+    market_id: str
+    slug: str
+    question: str
+    creator_username: str
+    created_time_ms: int
+    close_time_ms: int | None
+    resolution: str | None
+    is_resolved: bool
+    outcome_type: str
+    total_liquidity: int | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _Resolution:
+    """Structural stand-in for ManifoldResolution."""
+
+    market_id: str
+    outcome: str  # "yes" | "no" | "inconclusive"
+    resolved_at_ms: int | None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+def _market(
+    market_id: str = "mkt_abc",
+    question: str = "Will Aragora ship crux-finding?",
+    resolution: str | None = "YES",
+    is_resolved: bool = True,
+    close_time_ms: int | None = _CLOSE_MS,
+) -> _Market:
+    return _Market(
+        market_id=market_id,
+        slug="aragora-crux-finding",
+        question=question,
+        creator_username="alice",
+        created_time_ms=1_743_465_600_000,
+        close_time_ms=close_time_ms,
+        resolution=resolution,
+        is_resolved=is_resolved,
+        outcome_type="BINARY",
+    )
+
+
+def _res(
+    outcome: str = "yes",
+    market_id: str = "mkt_abc",
+    resolved_at_ms: int | None = _RESOLVED_MS,
+) -> _Resolution:
+    return _Resolution(
+        market_id=market_id,
+        outcome=outcome,
+        resolved_at_ms=resolved_at_ms,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature gate
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureGate:
+    def test_off_by_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        assert reputation_flow_enabled() is False
+        with pytest.raises(RuntimeError, match="ARAGORA_REPUTATION_FLOW_ENABLED"):
+            bridge_from_manifold_market(_market(), _res(), "ag", 0.8)
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE"])
+    def test_truthy_values_enable(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", val)
+        assert reputation_flow_enabled() is True
+        claim, _ = bridge_from_manifold_market(_market(), _res(), "ag", 0.8)
+        assert claim.agent_id == "ag"
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy_values_block(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", val)
+        with pytest.raises(RuntimeError):
+            bridge_from_manifold_market(_market(), _res(), "ag", 0.8)
+
+    def test_require_enabled_false_bypasses_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        claim, resolved = bridge_from_manifold_market(
+            _market(), _res(), "ag", 0.8, require_enabled=False
+        )
+        assert claim.agent_id == "ag"
+        assert resolved.outcome == "yes"
+
+
+# ---------------------------------------------------------------------------
+# Outcome mapping
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeMapping:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+
+    def test_yes_outcome(self) -> None:
+        _, r = bridge_from_manifold_market(_market(), _res(outcome="yes"), "ag", 0.8)
+        assert r.outcome == "yes"
+
+    def test_no_outcome(self) -> None:
+        _, r = bridge_from_manifold_market(
+            _market(resolution="NO"), _res(outcome="no"), "ag", 0.2
+        )
+        assert r.outcome == "no"
+
+    @pytest.mark.parametrize("raw_outcome", ["inconclusive", "CANCEL", "mkt", "", "MKT"])
+    def test_inconclusive_passthrough(self, raw_outcome: str) -> None:
+        _, r = bridge_from_manifold_market(
+            _market(resolution="CANCEL"), _res(outcome="inconclusive"), "ag", 0.5
+        )
+        assert r.outcome == "inconclusive"
+
+    def test_unknown_outcome_is_inconclusive(self) -> None:
+        _, r = bridge_from_manifold_market(
+            _market(), _res(outcome="CHOOSE_ONE"), "ag", 0.5
+        )
+        assert r.outcome == "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# Claim shape
+# ---------------------------------------------------------------------------
+
+
+class TestClaimShape:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+
+    def test_domain_and_statement(self) -> None:
+        claim, _ = bridge_from_manifold_market(
+            _market(question="Will crux-finding ship?"), _res(), "ag", 0.73
+        )
+        assert claim.domain == DOMAIN_PREDICTION_MARKET
+        assert claim.statement == "Will crux-finding ship?"
+        assert claim.predicted_probability == pytest.approx(0.73)
+
+    def test_position_derived_from_probability(self) -> None:
+        yes_claim, _ = bridge_from_manifold_market(_market(), _res(), "ag", 0.5)
+        no_claim, _ = bridge_from_manifold_market(_market(), _res(), "ag", 0.49)
+        assert yes_claim.position == "yes"
+        assert no_claim.position == "no"
+
+    def test_resolution_source_default_and_override(self) -> None:
+        c, r = bridge_from_manifold_market(_market(), _res(), "ag", 0.8)
+        assert c.resolution_source == r.resolution_source == "manifold"
+        c2, r2 = bridge_from_manifold_market(_market(), _res(), "ag", 0.8, resolution_source="x")
+        assert c2.resolution_source == r2.resolution_source == "x"
+
+    def test_resolution_id_is_market_id(self) -> None:
+        claim, _ = bridge_from_manifold_market(_market(market_id="mkt_xyz"), _res(), "ag", 0.8)
+        assert claim.resolution_id == "mkt_xyz"
+
+    def test_provenance_keys(self) -> None:
+        claim, _ = bridge_from_manifold_market(_market(), _res(), "ag", 0.8)
+        for key in ("market_id", "slug", "outcome_type", "close_time_ms", "close_time_iso", "submitted_at"):
+            assert key in claim.provenance
+
+    def test_evidence_keys(self) -> None:
+        _, resolved = bridge_from_manifold_market(_market(), _res(), "ag", 0.8)
+        for key in ("market_id", "outcome", "resolved_at_ms", "question", "creator_username"):
+            assert key in resolved.evidence
+
+    def test_evidence_market_id_matches(self) -> None:
+        _, resolved = bridge_from_manifold_market(_market(market_id="mkt_q"), _res(market_id="mkt_q"), "ag", 0.8)
+        assert resolved.evidence["market_id"] == "mkt_q"
+
+    def test_claim_id_content_addressed(self) -> None:
+        m = _market()
+        c1, _ = bridge_from_manifold_market(m, _res(), "ag", 0.8, require_enabled=False)
+        c2, _ = bridge_from_manifold_market(m, _res(), "ag", 0.8, require_enabled=False)
+        assert c1.claim_id == c2.claim_id
+
+    def test_claim_id_differs_by_agent(self) -> None:
+        m = _market()
+        ca, _ = bridge_from_manifold_market(m, _res(), "ag_a", 0.8, require_enabled=False)
+        cb, _ = bridge_from_manifold_market(m, _res(), "ag_b", 0.8, require_enabled=False)
+        assert ca.claim_id != cb.claim_id
+
+    def test_claim_id_matches_resolved_claim_id(self) -> None:
+        claim, resolved = bridge_from_manifold_market(
+            _market(), _res(), "ag", 0.8, require_enabled=False
+        )
+        assert claim.claim_id == resolved.claim_id
+
+    def test_resolved_at_from_ms(self) -> None:
+        _, r = bridge_from_manifold_market(
+            _market(), _res(resolved_at_ms=_RESOLVED_MS), "ag", 0.8, require_enabled=False
+        )
+        assert "2025-05-02" in r.resolved_at
+
+    def test_resolved_at_none_falls_back_to_now(self) -> None:
+        _, r = bridge_from_manifold_market(
+            _market(), _res(resolved_at_ms=None), "ag", 0.8, require_enabled=False
+        )
+        assert r.resolved_at  # non-empty fallback
+
+    def test_close_time_none_is_none_in_provenance(self) -> None:
+        claim, _ = bridge_from_manifold_market(
+            _market(close_time_ms=None), _res(), "ag", 0.7, require_enabled=False
+        )
+        assert claim.provenance["close_time_ms"] is None
+        assert claim.provenance["close_time_iso"] is None
+
+    def test_stake_params_forwarded(self) -> None:
+        claim, r = bridge_from_manifold_market(
+            _market(), _res(), "ag", 0.8,
+            stake_units=5, stake_policy="scaled", require_enabled=False
+        )
+        assert claim.stake_units == 5
+        assert claim.stake_policy == "scaled"
+        assert claim.claim_id == r.claim_id
+
+    def test_boundary_probabilities_valid(self) -> None:
+        c0, _ = bridge_from_manifold_market(_market(), _res(), "ag", 0.0, require_enabled=False)
+        c1, _ = bridge_from_manifold_market(_market(), _res(), "ag", 1.0, require_enabled=False)
+        assert c0.predicted_probability == pytest.approx(0.0)
+        assert c1.predicted_probability == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCases:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+
+    def test_unresolved_market_raises(self) -> None:
+        with pytest.raises(ValueError, match="not resolved"):
+            bridge_from_manifold_market(
+                _market(is_resolved=False, resolution=None), _res(), "ag", 0.8
+            )
+
+    @pytest.mark.parametrize("prob", [1.001, -0.001, 2.0, -1.0])
+    def test_out_of_range_probability_raises(self, prob: float) -> None:
+        with pytest.raises(ValueError, match="predicted_probability"):
+            bridge_from_manifold_market(_market(), _res(), "ag", prob)
+
+    @pytest.mark.parametrize("units", [0, -1, -100])
+    def test_invalid_stake_units_raises(self, units: int) -> None:
+        with pytest.raises(ValueError, match="stake_units"):
+            bridge_from_manifold_market(_market(), _res(), "ag", 0.8, stake_units=units)

--- a/tests/reputation/test_manifold_bridge.py
+++ b/tests/reputation/test_manifold_bridge.py
@@ -129,9 +129,7 @@ class TestOutcomeMapping:
         assert r.outcome == "yes"
 
     def test_no_outcome(self) -> None:
-        _, r = bridge_from_manifold_market(
-            _market(resolution="NO"), _res(outcome="no"), "ag", 0.2
-        )
+        _, r = bridge_from_manifold_market(_market(resolution="NO"), _res(outcome="no"), "ag", 0.2)
         assert r.outcome == "no"
 
     @pytest.mark.parametrize("raw_outcome", ["inconclusive", "CANCEL", "mkt", "", "MKT"])
@@ -142,9 +140,7 @@ class TestOutcomeMapping:
         assert r.outcome == "inconclusive"
 
     def test_unknown_outcome_is_inconclusive(self) -> None:
-        _, r = bridge_from_manifold_market(
-            _market(), _res(outcome="CHOOSE_ONE"), "ag", 0.5
-        )
+        _, r = bridge_from_manifold_market(_market(), _res(outcome="CHOOSE_ONE"), "ag", 0.5)
         assert r.outcome == "inconclusive"
 
 
@@ -184,7 +180,14 @@ class TestClaimShape:
 
     def test_provenance_keys(self) -> None:
         claim, _ = bridge_from_manifold_market(_market(), _res(), "ag", 0.8)
-        for key in ("market_id", "slug", "outcome_type", "close_time_ms", "close_time_iso", "submitted_at"):
+        for key in (
+            "market_id",
+            "slug",
+            "outcome_type",
+            "close_time_ms",
+            "close_time_iso",
+            "submitted_at",
+        ):
             assert key in claim.provenance
 
     def test_evidence_keys(self) -> None:
@@ -193,7 +196,9 @@ class TestClaimShape:
             assert key in resolved.evidence
 
     def test_evidence_market_id_matches(self) -> None:
-        _, resolved = bridge_from_manifold_market(_market(market_id="mkt_q"), _res(market_id="mkt_q"), "ag", 0.8)
+        _, resolved = bridge_from_manifold_market(
+            _market(market_id="mkt_q"), _res(market_id="mkt_q"), "ag", 0.8
+        )
         assert resolved.evidence["market_id"] == "mkt_q"
 
     def test_claim_id_content_addressed(self) -> None:
@@ -235,8 +240,13 @@ class TestClaimShape:
 
     def test_stake_params_forwarded(self) -> None:
         claim, r = bridge_from_manifold_market(
-            _market(), _res(), "ag", 0.8,
-            stake_units=5, stake_policy="scaled", require_enabled=False
+            _market(),
+            _res(),
+            "ag",
+            0.8,
+            stake_units=5,
+            stake_policy="scaled",
+            require_enabled=False,
         )
         assert claim.stake_units == 5
         assert claim.stake_policy == "scaled"


### PR DESCRIPTION
## Slice

Adds `aragora/reputation/manifold_bridge.py` — a direct companion to the existing `metaculus_bridge.py` — that converts a resolved `ManifoldMarket` + `ManifoldResolution` (from the connector layer) into a `(StakeableClaim, ResolvedClaim)` pair ready for `settle_claim`. The Manifold connector and Brier scorer already existed; this bridges the resolution signal into the AGT-05 reputation flow so per-agent Brier deltas can be computed from external Manifold markets.

## Gating

- Default: OFF (flag: `ARAGORA_REPUTATION_FLOW_ENABLED` — same flag as `metaculus_bridge.py` and `bridge.py`)
- Live queue effect: none
- Advances issue: #6064 (AGT-03 Manifold Markets integration), #6066 (AGT-05 reputation flow)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Related to #6064 (AGT-03), Related to #6066 (AGT-05)

## Tests

- `TestFeatureGate` — flag off by default raises, truthy values enable, `require_enabled=False` bypasses, falsy values block
- `TestOutcomeMapping` — yes/no passthrough, inconclusive passthrough, unknown outcome → inconclusive
- `TestClaimShape` — domain, statement, probability, position, source override, resolution_id, provenance keys, evidence keys, content-addressed claim_id, claim_id differs by agent, claim_id matches resolved, resolved_at from ms, fallback for None resolved_at, None close_time, stake params forwarded, boundary probabilities valid
- `TestErrorCases` — unresolved market raises, out-of-range probability raises, invalid stake_units raises

## Validation

```
pytest tests/reputation/test_manifold_bridge.py -v — 43 passed
ruff check aragora/reputation/manifold_bridge.py tests/reputation/test_manifold_bridge.py — clean
mypy aragora/reputation/manifold_bridge.py --ignore-missing-imports — clean
```

## Out of scope

- Real-time polling of the Manifold API (lives in the connector layer, AGT-03 Phase 2)
- Per-agent Brier score wiring to `aragora.evaluation.manifold_brier` (AGT-03 Phase 3)
- On-chain anchoring via `ReputationRegistry` (downstream AGT-05 sub-deliverable)
- `bridge_from_manifold_market` export in `aragora/reputation/__init__.py` (intentionally deferred — mirrors the metaculus bridge pattern which is also not re-exported from `__init__`)

## Additional Notes

Vision-layer PR — flag-gated default off, no `boss-ready` label per NEXT_STEPS_CANONICAL queue policy for AGT-* until the substrate-first gate opens.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WdeCGPEk5iTfSiySBx2We)_