### PR TITLE
test(swarm): isolate quorum-evidence dissent tests from ambient severity flag

### DIFF
--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1374,14 +1374,21 @@ def test_grounded_review_still_counts() -> None:
     assert _grounding_item("claude", "pass", grounded=True).would_count is True
 
 
-def test_ungrounded_dissent_never_blocks() -> None:
+def test_ungrounded_dissent_never_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
     # The live case this fixes: three ungrounded CHANGES-REQUESTED reviews on #9505
     # asserted facts about a registry tag and unlisted files they were never shown.
+    # Pin the default strict regime: ambient ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=1
+    # would make these [P2]-only dissents advisory, passing vacuously without
+    # exercising the groundedness veto this test exists to pin.
+    monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)
     assert _grounding_item("claude", "changes_requested", grounded=False).dissenting is False
     assert _grounding_item("grok", "changes_requested", grounded=False).dissenting is False
 
 
-def test_grounded_dissent_still_blocks() -> None:
+def test_grounded_dissent_still_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Pin the default strict regime: ambient ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=1
+    # would downgrade this [P2]-only dissent to advisory and flip the assertion.
+    monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)
     assert _grounding_item("claude", "changes_requested", grounded=True).dissenting is True
 
 
@@ -3364,7 +3371,13 @@ def test_apply_relaxed_artifact_posts_when_both_regimes_relaxed(tmp_path, monkey
     assert posted == [_prepared_body("claude")]
 
 
-def test_apply_prepared_evidence_rederives_verdict_from_body(tmp_path) -> None:
+def test_apply_prepared_evidence_rederives_verdict_from_body(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Pin the default strict regime: ambient ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=1
+    # would relax the finding-free CHANGES-REQUESTED body to advisory and flip the
+    # expected prepare/dissent outcome.
+    monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)
     prepared = _prepared_outcome_file(
         tmp_path,
         items=[


### PR DESCRIPTION
## Summary

Tests-only env-isolation fix (mission feature `misc-severity-gated-dissent-test-isolation`, tracked from the 2026-08-15 PR #9770 prep handoff; the gap was independently confirmed by the reviewer there).

Ambient `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=1` in the invoking shell flipped two pre-existing tests in `tests/swarm/test_quorum_evidence.py`:

- `test_grounded_dissent_still_blocks` — its `[P2]`-only grounded dissent goes advisory under the gate (`assert False is True`).
- `test_apply_prepared_evidence_rederives_verdict_from_body` — its finding-free CHANGES-REQUESTED prepared body stops dissenting (`assert [] == ['claude']`).
- Sibling `test_ungrounded_dissent_never_blocks` did not fail but passed **vacuously** under the gate (the `[P2]`-only bodies stop dissenting for severity reasons, so the groundedness veto is never exercised).

Fix: pin the default strict regime inside all three tests with `monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)`. No production source change; the diff is bounded to the one test file (+16/−3).

All other dissent/severity sites in the file were audited and are env-robust: `[P1]` bodies always block, explicit `severity_gated=` kwargs pin construction, other tests already monkeypatch the flag, and the `run_collect_cli` clean-shortfall classifier keys on `item.supportive` (never affected by the gate).

## Red-first evidence (base `63865c52`)

- With ambient flag =1: `test_grounded_dissent_still_blocks` FAILED, `test_apply_prepared_evidence_rederives_verdict_from_body` FAILED, sibling passed vacuously (2 failed, 1 passed).
- Flag unset: 3 passed.

## Validation (worktree, post-fix)

- Targeted 3 tests: pass with ambient flag =1 and with it unset.
- Full file `tests/swarm/test_quorum_evidence.py`: **371 passed under both regimes** (flag unset and ambient =1).
- Seed sweep (file-scoped, seeds 1/42/100/2024/12345): 371 passed each.
- `make lint`: all checks passed; `ruff format --check`: clean.
- `bash scripts/preflight_mypy.sh --diff-base origin/main`: no gated python changes.
- Smoke tier (`scripts/test_tiers.sh smoke`): 138 passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok, changed files = exactly this test file.

## Path-freeze census

Fresh full open-PR census (92 PRs, no file-list truncation) run before the edit and rechecked immediately before push: all live foreign owners of the six governed paths match the 2026-08-16 ratified ten-PR pinned-head set byte-for-byte (9 pin-matches; #9348 closed unmerged with head unchanged = contention reduction). No new foreign owner. The ratified foreign PRs were not touched.

Expected tier: tests-only (Tier ≤2) self-merge with clean quorum.
