### PR TITLE
ci(governance): bind openapi run artifacts to an immutable release envelope [Tier 4]

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -10,10 +10,25 @@ on:
     # Nightly at 1:10 UTC
     - cron: '10 1 * * *'
   workflow_dispatch:
+    inputs:
+      publish_envelope:
+        description: >-
+          Publish and attest the immutable openapi-envelope-<sha> release
+          capsule for this main head (finalization delegation only).
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: openapi-sync-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Run/SHA-bound artifact names (FIX-RT-017). `github.sha` is the merge SHA on
+# pull_request events, so the pull-request head SHA must win there for the
+# name to end with the run's head_sha.
+env:
+  OPENAPI_RUN_ARTIFACT: openapi-spec-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
+  DRIFT_RUN_ARTIFACT: contract-drift-artifacts-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   scope:
@@ -480,10 +495,15 @@ jobs:
           python -m pip install pytest pytest-asyncio
           pytest tests/server/openapi/test_contract_matrix.py -v --timeout=60
 
+      - name: Validate release envelope helper (dry run)
+        run: |
+          set -euo pipefail
+          python3 scripts/openapi_release_envelope.py dry-run
+
       - name: Upload generated spec and SDK types
         uses: actions/upload-artifact@v4
         with:
-          name: openapi-spec
+          name: ${{ env.OPENAPI_RUN_ARTIFACT }}
           path: |
             docs/api/openapi_generated.json
             docs/api/openapi_generated.yaml
@@ -496,7 +516,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: contract-drift-artifacts
+          name: ${{ env.DRIFT_RUN_ARTIFACT }}
           path: |
             /tmp/contract-drift-summary.json
             /tmp/contract-drift-summary.md
@@ -570,7 +590,7 @@ jobs:
       - name: Download generated spec
         uses: actions/download-artifact@v4
         with:
-          name: openapi-spec
+          name: ${{ env.OPENAPI_RUN_ARTIFACT }}
           path: /tmp/openapi-spec/
 
       - name: Check for changes
@@ -620,6 +640,104 @@ jobs:
           else
             echo "::warning::Could not auto-push spec update (branch protection). The generated spec is available as a workflow artifact."
           fi
+
+  # FIX-RT-017 publication path: expiring run artifacts are authoritative only
+  # through this immutable, digest-bound release capsule. Dispatch-gated and
+  # default-off; the finalization delegation dispatches it deliberately at the
+  # exact main head it binds.
+  envelope:
+    name: Publish Release Envelope (dispatch only)
+    runs-on: ubuntu-latest
+    needs: generate-run
+    timeout-minutes: 15
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_envelope == true && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
+            if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
+              git reset --hard FETCH_HEAD
+            else
+              git reset --hard HEAD
+            fi
+            git clean -ffdx || true
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::Sparse-checkout recovery incomplete; attempting archive restore"
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            if ! git archive "${GITHUB_SHA:-HEAD}" | tar -x; then
+              git archive HEAD | tar -x
+            fi
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+            echo "PWD=$(pwd)"
+            ls -la
+            exit 1
+          fi
+
+      - name: Download run-level spec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.OPENAPI_RUN_ARTIFACT }}
+          path: /tmp/openapi-envelope/payload/
+
+      - name: Build deterministic release envelope
+        run: |
+          set -euo pipefail
+          python3 scripts/openapi_release_envelope.py build \
+            --repository "$GITHUB_REPOSITORY" \
+            --head-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --artifact-name "$OPENAPI_RUN_ARTIFACT" \
+            --payload-dir /tmp/openapi-envelope/payload \
+            --output-dir /tmp/openapi-envelope/assets
+          (cd /tmp/openapi-envelope/assets && sha256sum --check --strict checksums.txt)
+
+      - name: Publish immutable release
+        run: |
+          set -euo pipefail
+          tag="openapi-envelope-$GITHUB_SHA"
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$tag" \
+            --notes "Immutable OpenAPI contract envelope for $GITHUB_SHA (run $GITHUB_RUN_ID attempt $GITHUB_RUN_ATTEMPT)." \
+            /tmp/openapi-envelope/assets/*
+
+      - name: Attest the envelope assets
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: /tmp/openapi-envelope/assets/*
+
+      - name: Verify release, assets, attestation, and rule suite
+        run: |
+          set -euo pipefail
+          python3 scripts/openapi_release_envelope.py verify \
+            --repository "$GITHUB_REPOSITORY" \
+            --head-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --artifact-name "$OPENAPI_RUN_ARTIFACT" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/openapi.yml"
 
   generate:
     name: Generate & Validate

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -655,7 +655,11 @@ jobs:
   envelope:
     name: Publish Release Envelope (dispatch only)
     runs-on: ubuntu-latest
-    needs: generate-run
+    # sync runs on the same dispatch+main events and can push a spec-drift
+    # commit to main; needing it serializes any such push BEFORE preflight's
+    # main-still-at-bound-head check, so the movement is the free exit-3
+    # restart instead of a post-publish supersession record.
+    needs: [generate-run, sync]
     timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch' && inputs.publish_envelope == true && github.ref == 'refs/heads/main'
     permissions:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -502,6 +502,9 @@ jobs:
           set -euo pipefail
           python3 scripts/openapi_release_envelope.py dry-run
 
+      # overwrite: v4 artifacts are immutable per run and the name carries no
+      # attempt, so re-running all jobs would otherwise 409 on the name laid
+      # down by the previous attempt.
       - name: Upload generated spec and SDK types
         uses: actions/upload-artifact@v4
         with:
@@ -513,6 +516,7 @@ jobs:
             sdk/python/aragora/generated_types.py
             aragora/live/src/types/api.generated.ts
           retention-days: 14
+          overwrite: true
 
       - name: Upload contract drift artifacts
         if: always()
@@ -525,6 +529,7 @@ jobs:
             /tmp/CONTRACT_DRIFT_BACKLOG.json
             /tmp/CONTRACT_DRIFT_BACKLOG.md
           retention-days: 14
+          overwrite: true
 
       - name: Comment on PR (if spec changed)
         if: github.event_name == 'pull_request' && steps.compare.outputs.spec_changed == 'true'
@@ -657,6 +662,10 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      # Preflight/verify re-query the workflow, run, and run-level artifacts;
+      # an explicit permissions block zeroes unlisted scopes, so without this
+      # read every dispatch would 403 before publication.
+      actions: read
     env:
       GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -25,7 +25,6 @@ on:
           immediately before this dispatch. The in-run token cannot see that
           setting, so the envelope job fails closed (blocked) without this.
         type: boolean
-        required: true
         default: false
 
 concurrency:
@@ -791,14 +790,37 @@ jobs:
       - name: Verify release, assets, attestation, and rule suite
         run: |
           set -euo pipefail
-          python3 scripts/openapi_release_envelope.py verify \
-            --repository "$GITHUB_REPOSITORY" \
-            --head-sha "$GITHUB_SHA" \
-            --run-id "$GITHUB_RUN_ID" \
-            --run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --artifact-name "$OPENAPI_RUN_ARTIFACT" \
-            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/openapi.yml" \
-            --admin-reads report
+          verify_attempt=1
+          verify_delays=(5 10 20)
+          while true; do
+            set +e
+            python3 scripts/openapi_release_envelope.py verify \
+              --repository "$GITHUB_REPOSITORY" \
+              --head-sha "$GITHUB_SHA" \
+              --run-id "$GITHUB_RUN_ID" \
+              --run-attempt "$GITHUB_RUN_ATTEMPT" \
+              --artifact-name "$OPENAPI_RUN_ARTIFACT" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/openapi.yml" \
+              --admin-reads report
+            verify_rc=$?
+            set -e
+
+            if [[ "$verify_rc" -eq 0 ]]; then
+              break
+            fi
+            if [[ "$verify_rc" -ne 2 ]]; then
+              exit "$verify_rc"
+            fi
+            if [[ "$verify_attempt" -gt "${#verify_delays[@]}" ]]; then
+              echo "::error::post-publish verification remained blocked after $verify_attempt attempts; use the original-identity recovery runbook."
+              exit "$verify_rc"
+            fi
+
+            verify_delay="${verify_delays[$((verify_attempt - 1))]}"
+            echo "::warning::post-publish verification attempt $verify_attempt blocked; retrying the same immutable capsule in ${verify_delay}s."
+            sleep "$verify_delay"
+            verify_attempt=$((verify_attempt + 1))
+          done
 
   generate:
     name: Generate & Validate

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -18,6 +18,15 @@ on:
         type: boolean
         required: false
         default: false
+      operator_confirmed_immutable_releases:
+        description: >-
+          Attestation that an admin-capable read of
+          repos/<owner>/<repo>/immutable-releases returned {"enabled":true}
+          immediately before this dispatch. The in-run token cannot see that
+          setting, so the envelope job fails closed (blocked) without this.
+        type: boolean
+        required: true
+        default: false
 
 concurrency:
   group: openapi-sync-${{ github.event.pull_request.number || github.ref }}
@@ -674,6 +683,24 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
+      # The workflow token reads admin-gated settings behind HTTP 404, so
+      # in-run report-mode preflight cannot distinguish "immutable releases
+      # disabled" from "hidden from this token" and a disabled setting would
+      # surface only post-publish. This gate machine-checks the operator's
+      # admin-capable {"enabled":true} pre-dispatch read instead of weakening
+      # that degradation: without an explicit true, nothing is downloaded,
+      # attested, or published.
+      - name: Require operator immutable-releases attestation
+        env:
+          OPERATOR_CONFIRMED: ${{ inputs.operator_confirmed_immutable_releases }}
+        run: |
+          set -euo pipefail
+          if [[ "$OPERATOR_CONFIRMED" != "true" ]]; then
+            echo "::error::blocked: operator_confirmed_immutable_releases is not true. Re-run the admin-capable immutable-releases enabled-check and re-dispatch with the attestation input set."
+            exit 2
+          fi
+          echo "Operator immutable-releases attestation present."
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -25,10 +25,12 @@ concurrency:
 
 # Run/SHA-bound artifact names (FIX-RT-017). `github.sha` is the merge SHA on
 # pull_request events, so the pull-request head SHA must win there for the
-# name to end with the run's head_sha.
+# name to end with the run's head_sha. The attempt is deliberately not part
+# of the name: re-running only a failed dependent job increments the run
+# attempt while the artifact keeps its original name.
 env:
-  OPENAPI_RUN_ARTIFACT: openapi-spec-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
-  DRIFT_RUN_ARTIFACT: contract-drift-artifacts-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
+  OPENAPI_RUN_ARTIFACT: openapi-spec-${{ github.run_id }}-${{ github.event.pull_request.head.sha || github.sha }}
+  DRIFT_RUN_ARTIFACT: contract-drift-artifacts-${{ github.run_id }}-${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   scope:
@@ -712,6 +714,29 @@ jobs:
             --output-dir /tmp/openapi-envelope/assets
           (cd /tmp/openapi-envelope/assets && sha256sum --check --strict checksums.txt)
 
+      # Attestation precedes publication: the only irreversible step
+      # (creating the immutable release) runs last, after the exact local
+      # bytes are attested and preflight-verified, so a failure never
+      # strands a half-published capsule.
+      - name: Attest the envelope assets
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: /tmp/openapi-envelope/assets/*
+
+      - name: Preflight verify before publication
+        run: |
+          set -euo pipefail
+          gh --version
+          python3 scripts/openapi_release_envelope.py preflight \
+            --repository "$GITHUB_REPOSITORY" \
+            --head-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --artifact-name "$OPENAPI_RUN_ARTIFACT" \
+            --assets-dir /tmp/openapi-envelope/assets \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/openapi.yml" \
+            --admin-reads report
+
       - name: Publish immutable release
         run: |
           set -euo pipefail
@@ -723,11 +748,6 @@ jobs:
             --notes "Immutable OpenAPI contract envelope for $GITHUB_SHA (run $GITHUB_RUN_ID attempt $GITHUB_RUN_ATTEMPT)." \
             /tmp/openapi-envelope/assets/*
 
-      - name: Attest the envelope assets
-        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
-        with:
-          subject-path: /tmp/openapi-envelope/assets/*
-
       - name: Verify release, assets, attestation, and rule suite
         run: |
           set -euo pipefail
@@ -737,7 +757,8 @@ jobs:
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
             --artifact-name "$OPENAPI_RUN_ARTIFACT" \
-            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/openapi.yml"
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/openapi.yml" \
+            --admin-reads report
 
   generate:
     name: Generate & Validate

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -30,7 +30,10 @@ every readable answer keeps full fail-closed semantics, and the operator's
 
 Exit codes (CDG status vocabulary): 0 pass, 1 fail (verification
 contradiction), 2 blocked (publication/attestation/rule-suite not yet
-visible), 3 movement (selection moved; restart verification).
+visible), 3 movement (selection moved; restart verification). Only blocked
+post-publication verification may be retried in place, with the same original
+identity and envelope. Fail, movement, and unexpected errors are terminal;
+build, preflight, attestation, and publication must stay outside that retry.
 """
 
 from __future__ import annotations

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -62,11 +62,16 @@ _ASSET_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
 # Post-verification re-query rule (VAL-CDG-012): if any of these move between
 # the opening and closing snapshots, the whole selection restarts.
+# `run_attempt`/`conclusion` describe the BOUND attempt's immutable record;
+# `latest_run_attempt` tracks the run-level object so a re-run landing DURING
+# a verification window restarts it, while a re-run that settled before the
+# window leaves the bound attempt verifiable (no permanent wedge).
 SELECTION_KEYS = (
     "main_sha",
     "workflow_id",
     "run_id",
     "run_attempt",
+    "latest_run_attempt",
     "conclusion",
     "artifact_id",
     "artifact_size",
@@ -375,7 +380,7 @@ def _run_gh(argv: list[str]) -> subprocess.CompletedProcess[bytes]:
     return subprocess.run(argv, capture_output=True, check=False)
 
 
-def _gh_api_json(endpoint: str, *, paginate: bool = False) -> Any:
+def _gh_api_json(endpoint: str, *, paginate: bool = False, admin_gated: bool = False) -> Any:
     argv = ["gh", "api", "-H", API_VERSION_HEADER, endpoint]
     if paginate:
         argv += ["--paginate", "--slurp"]
@@ -383,6 +388,12 @@ def _gh_api_json(endpoint: str, *, paginate: bool = False) -> Any:
     if completed.returncode != 0:
         stderr = completed.stderr.decode("utf-8", "replace").strip()
         if "HTTP 404" in stderr:
+            if admin_gated:
+                # Admin-gated settings surfaces exist for every repository
+                # and GitHub hides them behind 404 (not 403) from tokens
+                # without Administration:read, so 404 here is a capability
+                # gap, not an absent resource.
+                raise Forbidden(f"{endpoint} is hidden from this token: {stderr}")
             raise Blocked(f"{endpoint} is not visible: {stderr}")
         if "HTTP 403" in stderr:
             raise Forbidden(f"{endpoint} is not readable by this token: {stderr}")
@@ -401,8 +412,15 @@ def _checked_verification(argv: list[str], *, kind: str, blocked_marker: str = "
 
 
 def live_selection_snapshot(identity: dict[str, Any]) -> dict[str, Any]:
-    """Requery main, workflow, run, attempt, and the run-level artifact; the
-    caller compares two snapshots and restarts on any movement."""
+    """Requery main, workflow, the bound attempt, and the run-level artifact;
+    the caller compares two snapshots and restarts on any movement.
+
+    The run-level object reports only the LATEST attempt, so binding to it
+    would permanently wedge verification of a correctly published capsule
+    after any later re-run. The bound attempt's own immutable record carries
+    the head/conclusion binding instead, and the latest attempt number joins
+    the movement plane so a re-run landing DURING a verification window still
+    restarts it."""
     repository = identity["repository"]
     main_ref = _gh_api_json(f"repos/{repository}/git/ref/heads/main")
     workflow = _gh_api_json(f"repos/{repository}/actions/workflows/{Path(WORKFLOW_PATH).name}")
@@ -415,12 +433,13 @@ def live_selection_snapshot(identity: dict[str, Any]) -> dict[str, Any]:
         raise RuntimeError("bound run does not belong to the OpenAPI workflow")
     if run.get("head_sha") != identity["head_sha"]:
         raise RuntimeError("bound run head SHA contradicts the envelope identity")
-    latest_attempt = run.get("run_attempt")
-    if latest_attempt != identity["run_attempt"]:
-        raise Movement(
-            f"run attempt {latest_attempt} supersedes bound attempt "
-            f"{identity['run_attempt']}; restart verification at the newest execution"
-        )
+    attempt = _gh_api_json(
+        f"repos/{repository}/actions/runs/{identity['run_id']}/attempts/{identity['run_attempt']}"
+    )
+    if attempt.get("run_attempt") != identity["run_attempt"]:
+        raise RuntimeError("attempt record contradicts the bound run attempt")
+    if attempt.get("head_sha") != identity["head_sha"]:
+        raise RuntimeError("bound attempt head SHA contradicts the envelope identity")
     pages = _gh_api_json(
         f"repos/{repository}/actions/runs/{identity['run_id']}/artifacts?per_page=100",
         paginate=True,
@@ -442,8 +461,9 @@ def live_selection_snapshot(identity: dict[str, Any]) -> dict[str, Any]:
         "main_sha": main_ref.get("object", {}).get("sha"),
         "workflow_id": workflow.get("id"),
         "run_id": run.get("id"),
-        "run_attempt": latest_attempt,
-        "conclusion": run.get("conclusion"),
+        "run_attempt": attempt.get("run_attempt"),
+        "latest_run_attempt": run.get("run_attempt"),
+        "conclusion": attempt.get("conclusion"),
         "artifact_id": artifact.get("id"),
         "artifact_size": size,
     }
@@ -462,6 +482,7 @@ def _passing_rule_suite(repository: str, head_sha: str) -> dict[str, Any]:
         f"repos/{repository}/rulesets/rule-suites"
         f"?ref=refs/heads/main&time_period=month&per_page=100",
         paginate=True,
+        admin_gated=True,
     )
     suites: list[dict[str, Any]] = []
     for page in pages if isinstance(pages, list) else [pages]:
@@ -524,7 +545,7 @@ def _immutability_state(repository: str, *, admin_reads: str) -> str:
     keeps full semantics in both modes, so a readable ``enabled: false``
     always fails."""
     try:
-        immutability = _gh_api_json(f"repos/{repository}/immutable-releases")
+        immutability = _gh_api_json(f"repos/{repository}/immutable-releases", admin_gated=True)
     except Forbidden as exc:
         if admin_reads == "required":
             raise
@@ -705,6 +726,17 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             raise RuntimeError(
                 f"release tag {tag} already exists; refusing to publish over it "
                 "(verify the existing capsule with its own run identity instead)"
+            )
+        # A bare git tag is just as disqualifying: `gh release create` would
+        # attach to it and ignore --target, publishing at the wrong commit.
+        try:
+            _gh_api_json(f"repos/{repository}/git/ref/tags/{tag}")
+        except Blocked:
+            pass
+        else:
+            raise RuntimeError(
+                f"git tag {tag} already exists; publishing would bind the release "
+                "to that tag's commit instead of the requested target"
             )
         # `gh release verify`/`verify-asset` arrived in gh 2.96; probing them
         # here keeps a missing subcommand from surfacing only after the

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+"""Read-only OpenAPI release-envelope builder and verifier (FIX-RT-017).
+
+Expiring, fixed-name Actions artifacts are not durable contract evidence. The
+``envelope`` job in ``.github/workflows/openapi.yml`` binds the exact
+run-level payload bytes of the SHA/run-bound ``openapi-spec-<run>-<attempt>-
+<head_sha>`` artifact into an immutable GitHub release at the exact-SHA tag
+``openapi-envelope-<head_sha>``, attests the exact assets with the pinned
+``actions/attest`` signer, and verifies the whole chain with this helper.
+
+This module never mutates remote state. ``build`` writes deterministic
+envelope bytes (canonical compact sorted-key JSON manifest plus an
+``sha256sum --check --strict``-compatible checksums file) to a local
+directory; ``verify`` re-authenticates a published envelope release, its
+assets, its attestations (``--signer-workflow`` + ``--source-digest``), and
+the passing rule-suite record for the bound head, re-querying
+workflow/run/artifact/main before and after with restart-on-movement
+semantics; ``dry-run`` proves deterministic byte construction from checked-in
+fixture bytes with no network access.
+
+Exit codes (CDG status vocabulary): 0 pass, 1 fail (verification
+contradiction), 2 blocked (publication/attestation/rule-suite not yet
+visible), 3 movement (selection moved; restart verification).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+WORKFLOW_PATH = ".github/workflows/openapi.yml"
+ENVELOPE_SCHEMA = "aragora/openapi-release-envelope@v1"
+TAG_PREFIX = "openapi-envelope-"
+MANIFEST_NAME = "manifest.json"
+CHECKSUMS_NAME = "checksums.txt"
+ARTIFACT_PREFIX = "openapi-spec-"
+API_VERSION_HEADER = "X-GitHub-Api-Version: 2022-11-28"
+
+EXIT_PASS = 0
+EXIT_FAIL = 1
+EXIT_BLOCKED = 2
+EXIT_MOVEMENT = 3
+
+_FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_ASSET_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Post-verification re-query rule (VAL-CDG-012): if any of these move between
+# the opening and closing snapshots, the whole selection restarts.
+SELECTION_KEYS = (
+    "main_sha",
+    "workflow_id",
+    "run_id",
+    "run_attempt",
+    "conclusion",
+    "artifact_id",
+    "artifact_size",
+)
+
+
+class Blocked(RuntimeError):
+    """Publication, attestation, or rule-suite record is not visible yet."""
+
+
+class Movement(RuntimeError):
+    """The bound selection moved during verification; restart required."""
+
+
+def sha256_hexdigest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Compact, sorted-key, ASCII JSON with one trailing newline: the only
+    manifest serialization the envelope accepts, so identical content can
+    never produce distinct release bytes."""
+    return (
+        json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("ascii")
+
+
+def make_identity(
+    *,
+    repository: str,
+    head_sha: str,
+    run_id: int,
+    run_attempt: int,
+    artifact_name: str,
+) -> dict[str, Any]:
+    """Validate and freeze the execution identity every envelope operation is
+    bound to. The artifact name must be exactly run-, attempt-, and SHA-bound;
+    a fixed or foreign name is rejected before any bytes are touched."""
+    if not isinstance(repository, str) or not _REPOSITORY.fullmatch(repository):
+        raise ValueError(f"repository {repository!r} is not owner/name")
+    if not isinstance(head_sha, str) or not _FULL_SHA.fullmatch(head_sha):
+        raise ValueError("head SHA must be a full lowercase 40-hex commit SHA")
+    for label, value in (("run id", run_id), ("run attempt", run_attempt)):
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{label} must be a positive integer")
+    expected_name = f"{ARTIFACT_PREFIX}{run_id}-{run_attempt}-{head_sha}"
+    if artifact_name != expected_name:
+        raise ValueError(
+            f"artifact name {artifact_name!r} is not run/SHA-bound (expected {expected_name!r})"
+        )
+    return {
+        "repository": repository,
+        "head_sha": head_sha,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "artifact_name": artifact_name,
+        "tag": TAG_PREFIX + head_sha,
+    }
+
+
+def _checksum_bytes(digests: dict[str, str]) -> bytes:
+    lines = [f"{digest}  {name}\n" for name, digest in sorted(digests.items())]
+    return "".join(lines).encode("ascii")
+
+
+def build_envelope(payload_files: dict[str, bytes], identity: dict[str, Any]) -> dict[str, bytes]:
+    """Deterministically derive the complete release asset set (payload bytes
+    passed through untouched, plus manifest.json and checksums.txt) from the
+    exact run-level payload bytes and the execution identity."""
+    if not payload_files:
+        raise ValueError("release envelope requires at least one payload file")
+    entries: list[dict[str, Any]] = []
+    payload_by_name: dict[str, bytes] = {}
+    for rel_path in sorted(payload_files):
+        pure = Path(rel_path)
+        if pure.is_absolute() or ".." in pure.parts:
+            raise ValueError(f"payload path {rel_path!r} escapes the payload root")
+        name = pure.name
+        if not _ASSET_NAME.fullmatch(name):
+            raise ValueError(f"payload file name {name!r} is not release-asset safe")
+        if name in (MANIFEST_NAME, CHECKSUMS_NAME):
+            raise ValueError(f"payload file name {name!r} collides with an envelope asset")
+        if name in payload_by_name:
+            raise ValueError(f"duplicate payload basename {name!r}")
+        data = payload_files[rel_path]
+        if not data:
+            raise ValueError(f"payload file {rel_path!r} is empty")
+        payload_by_name[name] = data
+        entries.append(
+            {
+                "byte_length": len(data),
+                "name": name,
+                "path": Path(rel_path).as_posix(),
+                "sha256": sha256_hexdigest(data),
+            }
+        )
+    manifest = {
+        "artifact_name": identity["artifact_name"],
+        "head_sha": identity["head_sha"],
+        "payload_assets": entries,
+        "repository": identity["repository"],
+        "run_attempt": identity["run_attempt"],
+        "schema": ENVELOPE_SCHEMA,
+        "tag": identity["tag"],
+        "workflow_path": WORKFLOW_PATH,
+        "workflow_run_id": identity["run_id"],
+    }
+    manifest_bytes = canonical_json_bytes(manifest)
+    digests = {entry["name"]: entry["sha256"] for entry in entries}
+    digests[MANIFEST_NAME] = sha256_hexdigest(manifest_bytes)
+    assets = dict(payload_by_name)
+    assets[MANIFEST_NAME] = manifest_bytes
+    assets[CHECKSUMS_NAME] = _checksum_bytes(digests)
+    return assets
+
+
+def verify_envelope_assets(assets: dict[str, bytes], identity: dict[str, Any]) -> dict[str, Any]:
+    """Fail-closed verification of exact downloaded asset bytes against the
+    execution identity: canonical manifest bytes, identity binding, exact
+    asset set, per-asset digests, and the checksums file itself."""
+    for required in (MANIFEST_NAME, CHECKSUMS_NAME):
+        if required not in assets:
+            raise ValueError(f"envelope asset {required!r} is missing")
+    manifest_bytes = assets[MANIFEST_NAME]
+    try:
+        manifest = json.loads(manifest_bytes.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"manifest bytes are not parseable canonical JSON: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest is not a JSON object")
+    if canonical_json_bytes(manifest) != manifest_bytes:
+        raise ValueError("manifest bytes are not in canonical form")
+    bindings = {
+        "schema": ENVELOPE_SCHEMA,
+        "repository": identity["repository"],
+        "head_sha": identity["head_sha"],
+        "workflow_run_id": identity["run_id"],
+        "run_attempt": identity["run_attempt"],
+        "artifact_name": identity["artifact_name"],
+        "tag": identity["tag"],
+        "workflow_path": WORKFLOW_PATH,
+    }
+    for field, expected in bindings.items():
+        if manifest.get(field) != expected:
+            raise ValueError(
+                f"manifest field {field!r} is {manifest.get(field)!r}, not the bound {expected!r}"
+            )
+    entries = manifest.get("payload_assets")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("manifest lists no payload assets")
+    digests: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("manifest payload asset entry is not an object")
+        name = entry.get("name")
+        if not isinstance(name, str) or name in digests or name in (MANIFEST_NAME, CHECKSUMS_NAME):
+            raise ValueError(f"manifest payload asset name {name!r} is invalid or duplicated")
+        if name not in assets:
+            raise ValueError(f"payload asset {name!r} is missing from the release")
+        data = assets[name]
+        size = entry.get("byte_length")
+        if isinstance(size, bool) or not isinstance(size, int) or size <= 0 or size != len(data):
+            raise ValueError(f"payload asset {name!r} byte length contradicts its exact bytes")
+        digest = entry.get("sha256")
+        if digest != sha256_hexdigest(data):
+            raise ValueError(f"payload asset {name!r} bytes contradict the manifest digest")
+        digests[name] = str(digest)
+    expected_assets = set(digests) | {MANIFEST_NAME, CHECKSUMS_NAME}
+    if set(assets) != expected_assets:
+        raise ValueError(
+            f"release asset set {sorted(assets)} does not equal the manifest set {sorted(expected_assets)}"
+        )
+    digests[MANIFEST_NAME] = sha256_hexdigest(manifest_bytes)
+    if assets[CHECKSUMS_NAME] != _checksum_bytes(digests):
+        raise ValueError("checksums.txt contradicts the recomputed asset digests")
+    return manifest
+
+
+def release_digest_set(assets: dict[str, bytes]) -> set[str]:
+    """SHA-256 digests of every published asset's exact bytes: the
+    ``release_digests`` plane a run-level artifact payload must bind into."""
+    return {sha256_hexdigest(data) for data in assets.values()}
+
+
+def selection_is_stable(before: dict[str, Any], after: dict[str, Any]) -> bool:
+    for key in SELECTION_KEYS:
+        if key not in before or key not in after:
+            raise ValueError(f"selection snapshot is missing {key!r}")
+        if before[key] != after[key]:
+            return False
+    return True
+
+
+def attestation_verify_argv(
+    asset_path: str, *, repository: str, head_sha: str, signer_workflow: str
+) -> list[str]:
+    return [
+        "gh",
+        "attestation",
+        "verify",
+        asset_path,
+        "-R",
+        repository,
+        "--signer-workflow",
+        signer_workflow,
+        "--source-digest",
+        head_sha,
+        "--format",
+        "json",
+    ]
+
+
+def release_verify_argv(tag: str, *, repository: str) -> list[str]:
+    return ["gh", "release", "verify", tag, "-R", repository, "--format", "json"]
+
+
+def release_verify_asset_argv(tag: str, asset_path: str, *, repository: str) -> list[str]:
+    return ["gh", "release", "verify-asset", tag, asset_path, "-R", repository, "--format", "json"]
+
+
+_READ_ONLY_GH_ACTIONS = {
+    ("api",),
+    ("attestation", "verify"),
+    ("release", "download"),
+    ("release", "verify"),
+    ("release", "verify-asset"),
+    ("release", "view"),
+    ("run", "list"),
+    ("run", "view"),
+}
+_GH_API_WRITE_FLAGS = {"-f", "-F", "--field", "--raw-field", "--input"}
+
+
+def require_read_only_argv(argv: list[str]) -> None:
+    """Reject any subprocess invocation that could mutate remote state. The
+    helper's contract is read-only verification; publication belongs to the
+    workflow's own reviewed steps."""
+    if not argv or Path(argv[0]).name != "gh":
+        raise ValueError(f"only read-only gh invocations are allowed, not {argv!r}")
+    if len(argv) < 2:
+        raise ValueError("gh invocation names no subcommand")
+    group = argv[1]
+    if group == "api":
+        index = 2
+        while index < len(argv):
+            item = argv[index]
+            if item in {"-X", "--method"}:
+                if index + 1 >= len(argv) or argv[index + 1].upper() != "GET":
+                    raise ValueError("gh api may only issue GET requests")
+                index += 2
+                continue
+            if item.startswith("--method=") and item.split("=", 1)[1].upper() != "GET":
+                raise ValueError("gh api may only issue GET requests")
+            if (
+                item in _GH_API_WRITE_FLAGS
+                or item.startswith("--field=")
+                or item.startswith("--input=")
+            ):
+                raise ValueError("gh api write-shaped flags are rejected")
+            index += 1
+        return
+    action = (group, argv[2] if len(argv) > 2 else "")
+    if action not in _READ_ONLY_GH_ACTIONS:
+        raise ValueError(f"mutating or unsupported gh action rejected: {' '.join(action)}")
+
+
+def _run_gh(argv: list[str]) -> subprocess.CompletedProcess[bytes]:
+    require_read_only_argv(argv)
+    return subprocess.run(argv, capture_output=True, check=False)
+
+
+def _gh_api_json(endpoint: str, *, paginate: bool = False) -> Any:
+    argv = ["gh", "api", "-H", API_VERSION_HEADER, endpoint]
+    if paginate:
+        argv += ["--paginate", "--slurp"]
+    completed = _run_gh(argv)
+    if completed.returncode != 0:
+        stderr = completed.stderr.decode("utf-8", "replace").strip()
+        if "HTTP 404" in stderr:
+            raise Blocked(f"{endpoint} is not visible: {stderr}")
+        raise RuntimeError(f"gh api {endpoint} failed: {stderr}")
+    return json.loads(completed.stdout)
+
+
+def _checked_verification(argv: list[str], *, kind: str, blocked_marker: str = "") -> None:
+    completed = _run_gh(argv)
+    if completed.returncode == 0:
+        return
+    stderr = completed.stderr.decode("utf-8", "replace").strip()
+    if blocked_marker and blocked_marker in stderr.lower():
+        raise Blocked(f"{kind} is not attested yet: {stderr}")
+    raise RuntimeError(f"{kind} verification failed: {stderr}")
+
+
+def live_selection_snapshot(identity: dict[str, Any]) -> dict[str, Any]:
+    """Requery main, workflow, run, attempt, and the run-level artifact; the
+    caller compares two snapshots and restarts on any movement."""
+    repository = identity["repository"]
+    main_ref = _gh_api_json(f"repos/{repository}/git/ref/heads/main")
+    workflow = _gh_api_json(f"repos/{repository}/actions/workflows/{Path(WORKFLOW_PATH).name}")
+    if workflow.get("path") != WORKFLOW_PATH or workflow.get("state") != "active":
+        raise RuntimeError(
+            f"live workflow moved: {workflow.get('path')!r} {workflow.get('state')!r}"
+        )
+    run = _gh_api_json(f"repos/{repository}/actions/runs/{identity['run_id']}")
+    if run.get("path") != WORKFLOW_PATH:
+        raise RuntimeError("bound run does not belong to the OpenAPI workflow")
+    if run.get("head_sha") != identity["head_sha"]:
+        raise RuntimeError("bound run head SHA contradicts the envelope identity")
+    latest_attempt = run.get("run_attempt")
+    if latest_attempt != identity["run_attempt"]:
+        raise Movement(
+            f"run attempt {latest_attempt} supersedes bound attempt "
+            f"{identity['run_attempt']}; restart verification at the newest execution"
+        )
+    pages = _gh_api_json(
+        f"repos/{repository}/actions/runs/{identity['run_id']}/artifacts?per_page=100",
+        paginate=True,
+    )
+    artifacts: list[dict[str, Any]] = []
+    for page in pages if isinstance(pages, list) else [pages]:
+        artifacts.extend(page.get("artifacts", []))
+    matching = [item for item in artifacts if item.get("name") == identity["artifact_name"]]
+    if len(matching) != 1:
+        raise RuntimeError(
+            f"run-level artifact {identity['artifact_name']!r} is not uniquely present "
+            f"({len(matching)} matches)"
+        )
+    artifact = matching[0]
+    size = artifact.get("size_in_bytes")
+    if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
+        raise RuntimeError("run-level artifact lacks a nonempty payload")
+    return {
+        "main_sha": main_ref.get("object", {}).get("sha"),
+        "workflow_id": workflow.get("id"),
+        "run_id": run.get("id"),
+        "run_attempt": latest_attempt,
+        "conclusion": run.get("conclusion"),
+        "artifact_id": artifact.get("id"),
+        "artifact_size": size,
+    }
+
+
+def _resolve_tag_commit(repository: str, tag: str) -> str:
+    ref = _gh_api_json(f"repos/{repository}/git/ref/tags/{tag}")
+    obj = ref.get("object", {})
+    if obj.get("type") == "tag":
+        obj = _gh_api_json(f"repos/{repository}/git/tags/{obj.get('sha')}").get("object", {})
+    return str(obj.get("sha"))
+
+
+def _passing_rule_suite(repository: str, head_sha: str) -> dict[str, Any]:
+    pages = _gh_api_json(
+        f"repos/{repository}/rulesets/rule-suites"
+        f"?ref=refs/heads/main&time_period=month&per_page=100",
+        paginate=True,
+    )
+    suites: list[dict[str, Any]] = []
+    for page in pages if isinstance(pages, list) else [pages]:
+        suites.extend(page if isinstance(page, list) else [page])
+    matching = [item for item in suites if item.get("after_sha") == head_sha]
+    if not matching:
+        raise Blocked(
+            f"no rule-suite record for {head_sha} on refs/heads/main within the month window"
+        )
+    newest = max(matching, key=lambda item: item.get("id") or 0)
+    if newest.get("result") != "pass":
+        raise RuntimeError(
+            f"rule suite {newest.get('id')} for {head_sha} concluded {newest.get('result')!r}"
+        )
+    return {"id": newest.get("id"), "result": "pass"}
+
+
+def _emit(report: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(report, sort_keys=True) + "\n")
+
+
+def cmd_build(args: argparse.Namespace) -> int:
+    identity = make_identity(
+        repository=args.repository,
+        head_sha=args.head_sha,
+        run_id=args.run_id,
+        run_attempt=args.run_attempt,
+        artifact_name=args.artifact_name,
+    )
+    payload_root = Path(args.payload_dir)
+    payload_files = {
+        path.relative_to(payload_root).as_posix(): path.read_bytes()
+        for path in sorted(payload_root.rglob("*"))
+        if path.is_file()
+    }
+    assets = build_envelope(payload_files, identity)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if any(output_dir.iterdir()):
+        raise RuntimeError(f"output dir {output_dir} must be empty for a deterministic build")
+    for name, data in sorted(assets.items()):
+        (output_dir / name).write_bytes(data)
+    _emit(
+        {
+            "status": "pass",
+            "tag": identity["tag"],
+            "asset_names": sorted(assets),
+            "manifest_sha256": sha256_hexdigest(assets[MANIFEST_NAME]),
+        }
+    )
+    return EXIT_PASS
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    identity = make_identity(
+        repository=args.repository,
+        head_sha=args.head_sha,
+        run_id=args.run_id,
+        run_attempt=args.run_attempt,
+        artifact_name=args.artifact_name,
+    )
+    repository = identity["repository"]
+    tag = identity["tag"]
+    signer_workflow = args.signer_workflow or f"{repository}/{WORKFLOW_PATH}"
+    report: dict[str, Any] = {"tag": tag, "head_sha": identity["head_sha"]}
+    try:
+        immutability = _gh_api_json(f"repos/{repository}/immutable-releases")
+        if immutability.get("enabled") is not True:
+            raise RuntimeError("release immutability is not enabled; the envelope is not durable")
+        before = live_selection_snapshot(identity)
+        try:
+            release = _gh_api_json(f"repos/{repository}/releases/tags/{tag}")
+        except Blocked as exc:
+            raise Blocked(f"release {tag} is not published yet") from exc
+        if release.get("draft"):
+            raise Blocked(f"release {tag} is still an unpublished draft")
+        report["release_api_id"] = release.get("id")
+        tag_commit = _resolve_tag_commit(repository, tag)
+        if tag_commit != identity["head_sha"]:
+            raise RuntimeError(
+                f"tag {tag} resolves to {tag_commit}, not the bound head {identity['head_sha']}"
+            )
+        hosted = {
+            str(asset.get("name")): asset
+            for asset in release.get("assets", [])
+            if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+        }
+        with tempfile.TemporaryDirectory() as scratch:
+            download = _run_gh(
+                ["gh", "release", "download", tag, "--repo", repository, "--dir", scratch]
+            )
+            if download.returncode != 0:
+                raise RuntimeError(
+                    "release asset download failed: "
+                    + download.stderr.decode("utf-8", "replace").strip()
+                )
+            files = {
+                path.name: path.read_bytes()
+                for path in sorted(Path(scratch).iterdir())
+                if path.is_file()
+            }
+            manifest = verify_envelope_assets(files, identity)
+            if set(hosted) != set(files):
+                raise RuntimeError(
+                    f"hosted asset listing {sorted(hosted)} contradicts downloaded assets {sorted(files)}"
+                )
+            for name, data in files.items():
+                if hosted[name].get("size") != len(data):
+                    raise RuntimeError(f"hosted size for {name!r} contradicts its exact bytes")
+            _checked_verification(
+                release_verify_argv(tag, repository=repository), kind=f"release {tag}"
+            )
+            for name in sorted(files):
+                asset_path = str(Path(scratch) / name)
+                _checked_verification(
+                    release_verify_asset_argv(tag, asset_path, repository=repository),
+                    kind=f"release asset {name}",
+                )
+                _checked_verification(
+                    attestation_verify_argv(
+                        asset_path,
+                        repository=repository,
+                        head_sha=identity["head_sha"],
+                        signer_workflow=signer_workflow,
+                    ),
+                    kind=f"attestation for {name}",
+                    blocked_marker="no attestations",
+                )
+        report["payload_assets"] = [entry["name"] for entry in manifest["payload_assets"]]
+        report["rule_suite"] = _passing_rule_suite(repository, identity["head_sha"])
+        after = live_selection_snapshot(identity)
+        if not selection_is_stable(before, after):
+            raise Movement("workflow/run/artifact/main selection moved during verification")
+        report["superseded_by_newer_main"] = before["main_sha"] != identity["head_sha"]
+        report["status"] = "pass"
+        _emit(report)
+        return EXIT_PASS
+    except Blocked as exc:
+        _emit({**report, "status": "blocked", "reason": str(exc)})
+        return EXIT_BLOCKED
+    except Movement as exc:
+        _emit({**report, "status": "movement", "reason": str(exc)})
+        return EXIT_MOVEMENT
+    except (RuntimeError, ValueError) as exc:
+        _emit({**report, "status": "fail", "reason": str(exc)})
+        return EXIT_FAIL
+
+
+DRY_RUN_HEAD_SHA = "0123456789abcdef0123456789abcdef01234567"
+DRY_RUN_PAYLOADS = {
+    "docs/api/openapi_generated.json": (
+        b'{"info":{"title":"aragora dry-run fixture","version":"0.0.0"},'
+        b'"openapi":"3.1.0","paths":{}}\n'
+    ),
+    "docs/api/openapi_generated.yaml": (
+        b"info:\n  title: aragora dry-run fixture\n  version: 0.0.0\nopenapi: 3.1.0\npaths: {}\n"
+    ),
+    "sdk/typescript/src/openapi-types.ts": b"export type DryRunFixture = never;\n",
+}
+
+
+def dry_run_report() -> dict[str, Any]:
+    identity = make_identity(
+        repository="synaptent/aragora",
+        head_sha=DRY_RUN_HEAD_SHA,
+        run_id=1,
+        run_attempt=1,
+        artifact_name=f"{ARTIFACT_PREFIX}1-1-{DRY_RUN_HEAD_SHA}",
+    )
+    first = build_envelope(DRY_RUN_PAYLOADS, identity)
+    second = build_envelope(dict(DRY_RUN_PAYLOADS), identity)
+    if first != second:
+        raise RuntimeError("envelope bytes are not deterministic")
+    verify_envelope_assets(first, identity)
+    tampered = dict(first)
+    tampered["openapi_generated.json"] = tampered["openapi_generated.json"] + b" "
+    try:
+        verify_envelope_assets(tampered, identity)
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError("tampered payload bytes were not rejected")
+    snapshot = {key: index for index, key in enumerate(SELECTION_KEYS)}
+    if not selection_is_stable(snapshot, dict(snapshot)):
+        raise RuntimeError("stable selection was misreported as movement")
+    if selection_is_stable(snapshot, {**snapshot, "main_sha": "moved"}):
+        raise RuntimeError("main movement was not detected")
+    return {
+        "status": "pass",
+        "deterministic": True,
+        "tag": identity["tag"],
+        "asset_names": sorted(first),
+        "manifest_sha256": sha256_hexdigest(first[MANIFEST_NAME]),
+        "checksums_sha256": sha256_hexdigest(first[CHECKSUMS_NAME]),
+        "release_digests": sorted(release_digest_set(first)),
+    }
+
+
+def cmd_dry_run(_args: argparse.Namespace) -> int:
+    _emit(dry_run_report())
+    return EXIT_PASS
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_identity_args(sub: argparse.ArgumentParser) -> None:
+        sub.add_argument("--repository", required=True)
+        sub.add_argument("--head-sha", required=True)
+        sub.add_argument("--run-id", type=int, required=True)
+        sub.add_argument("--run-attempt", type=int, required=True)
+        sub.add_argument("--artifact-name", required=True)
+
+    build = subparsers.add_parser("build", help="write deterministic envelope bytes locally")
+    add_identity_args(build)
+    build.add_argument("--payload-dir", required=True)
+    build.add_argument("--output-dir", required=True)
+    build.set_defaults(func=cmd_build)
+
+    verify = subparsers.add_parser("verify", help="verify a published envelope read-only")
+    add_identity_args(verify)
+    verify.add_argument("--signer-workflow", default="")
+    verify.set_defaults(func=cmd_verify)
+
+    dry_run = subparsers.add_parser("dry-run", help="offline deterministic self-check")
+    dry_run.set_defaults(func=cmd_dry_run)
+
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (RuntimeError, ValueError) as exc:
+        _emit({"status": "fail", "reason": str(exc)})
+        return EXIT_FAIL
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -11,12 +11,18 @@ run-level payload bytes of the SHA/run-bound ``openapi-spec-<run>-<attempt>-
 This module never mutates remote state. ``build`` writes deterministic
 envelope bytes (canonical compact sorted-key JSON manifest plus an
 ``sha256sum --check --strict``-compatible checksums file) to a local
-directory; ``verify`` re-authenticates a published envelope release, its
-assets, its attestations (``--signer-workflow`` + ``--source-digest``), and
-the passing rule-suite record for the bound head, re-querying
-workflow/run/artifact/main before and after with restart-on-movement
-semantics; ``dry-run`` proves deterministic byte construction from checked-in
-fixture bytes with no network access.
+directory; ``preflight`` proves everything that must hold before the
+irreversible publication (local bytes, attestations, unused tag, capability,
+main still at the bound head — movement is a free restart here); ``verify``
+re-authenticates a published envelope release, its assets, its attestations
+(``--signer-workflow`` + ``--source-digest``), and the passing rule-suite
+record for the bound head, re-querying workflow/run/artifact/main before and
+after with restart-on-movement semantics (main-only movement after
+publication is recorded as supersession, never a strand); ``dry-run`` proves
+deterministic byte construction from checked-in fixture bytes with no
+network access. Admin-gated reads (rule suites, the immutability setting)
+degrade to ``report`` mode under the workflow's GITHUB_TOKEN; the operator's
+``required`` mode enforces them.
 
 Exit codes (CDG status vocabulary): 0 pass, 1 fail (verification
 contradiction), 2 blocked (publication/attestation/rule-suite not yet
@@ -69,6 +75,11 @@ class Blocked(RuntimeError):
     """Publication, attestation, or rule-suite record is not visible yet."""
 
 
+class Forbidden(Blocked):
+    """The token cannot read an admin-gated surface (rule suites, release
+    immutability setting); verification is blocked, not contradicted."""
+
+
 class Movement(RuntimeError):
     """The bound selection moved during verification; restart required."""
 
@@ -95,8 +106,11 @@ def make_identity(
     artifact_name: str,
 ) -> dict[str, Any]:
     """Validate and freeze the execution identity every envelope operation is
-    bound to. The artifact name must be exactly run-, attempt-, and SHA-bound;
-    a fixed or foreign name is rejected before any bytes are touched."""
+    bound to. The artifact name must be exactly run- and SHA-bound; a fixed or
+    foreign name is rejected before any bytes are touched. The attempt is
+    deliberately NOT part of the name (re-running only a failed dependent job
+    increments the run attempt while the artifact keeps its original name);
+    attempt binding lives in the manifest and the movement plane instead."""
     if not isinstance(repository, str) or not _REPOSITORY.fullmatch(repository):
         raise ValueError(f"repository {repository!r} is not owner/name")
     if not isinstance(head_sha, str) or not _FULL_SHA.fullmatch(head_sha):
@@ -104,7 +118,7 @@ def make_identity(
     for label, value in (("run id", run_id), ("run attempt", run_attempt)):
         if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
             raise ValueError(f"{label} must be a positive integer")
-    expected_name = f"{ARTIFACT_PREFIX}{run_id}-{run_attempt}-{head_sha}"
+    expected_name = f"{ARTIFACT_PREFIX}{run_id}-{head_sha}"
     if artifact_name != expected_name:
         raise ValueError(
             f"artifact name {artifact_name!r} is not run/SHA-bound (expected {expected_name!r})"
@@ -252,6 +266,25 @@ def selection_is_stable(before: dict[str, Any], after: dict[str, Any]) -> bool:
     return True
 
 
+def movement_disposition(before: dict[str, Any], after: dict[str, Any]) -> str:
+    """Classify movement between two selection snapshots.
+
+    ``restart``: the bound execution's own provenance moved (workflow, run,
+    attempt, conclusion, or artifact) — verification must restart.
+    ``superseded``: only main advanced past the bound head. A published
+    immutable capsule stays byte-valid for its exact SHA; failing here after
+    publication would strand it, so callers record supersession instead
+    (before publication a restart is still free and callers restart).
+    ``stable``: nothing moved.
+    """
+    if selection_is_stable(before, after):
+        return "stable"
+    moved = {key for key in SELECTION_KEYS if before[key] != after[key]}
+    if moved == {"main_sha"}:
+        return "superseded"
+    return "restart"
+
+
 def attestation_verify_argv(
     asset_path: str, *, repository: str, head_sha: str, signer_workflow: str
 ) -> list[str]:
@@ -339,6 +372,8 @@ def _gh_api_json(endpoint: str, *, paginate: bool = False) -> Any:
         stderr = completed.stderr.decode("utf-8", "replace").strip()
         if "HTTP 404" in stderr:
             raise Blocked(f"{endpoint} is not visible: {stderr}")
+        if "HTTP 403" in stderr:
+            raise Forbidden(f"{endpoint} is not readable by this token: {stderr}")
         raise RuntimeError(f"gh api {endpoint} failed: {stderr}")
     return json.loads(completed.stdout)
 
@@ -468,6 +503,31 @@ def cmd_build(args: argparse.Namespace) -> int:
     return EXIT_PASS
 
 
+def _immutability_state(repository: str, *, admin_reads: str) -> str:
+    """Read the repo immutable-releases setting; under a token without
+    Administration read (the workflow's GITHUB_TOKEN) the surface is
+    recorded as unreadable in ``report`` mode instead of blocking, and the
+    release object's own ``immutable`` field carries the durability proof."""
+    try:
+        immutability = _gh_api_json(f"repos/{repository}/immutable-releases")
+    except Blocked as exc:
+        if admin_reads == "required":
+            raise
+        return f"unreadable ({exc})"
+    if immutability.get("enabled") is not True:
+        raise RuntimeError("release immutability is not enabled; the envelope is not durable")
+    return "enabled"
+
+
+def _rule_suite_binding(repository: str, head_sha: str, *, admin_reads: str) -> dict[str, Any]:
+    try:
+        return _passing_rule_suite(repository, head_sha)
+    except Blocked as exc:
+        if admin_reads == "required":
+            raise
+        return {"state": "unverified", "reason": str(exc)}
+
+
 def cmd_verify(args: argparse.Namespace) -> int:
     identity = make_identity(
         repository=args.repository,
@@ -479,11 +539,11 @@ def cmd_verify(args: argparse.Namespace) -> int:
     repository = identity["repository"]
     tag = identity["tag"]
     signer_workflow = args.signer_workflow or f"{repository}/{WORKFLOW_PATH}"
-    report: dict[str, Any] = {"tag": tag, "head_sha": identity["head_sha"]}
+    report: dict[str, Any] = {"tag": tag, "head_sha": identity["head_sha"], "phase": "verify"}
     try:
-        immutability = _gh_api_json(f"repos/{repository}/immutable-releases")
-        if immutability.get("enabled") is not True:
-            raise RuntimeError("release immutability is not enabled; the envelope is not durable")
+        report["immutability_setting"] = _immutability_state(
+            repository, admin_reads=args.admin_reads
+        )
         before = live_selection_snapshot(identity)
         try:
             release = _gh_api_json(f"repos/{repository}/releases/tags/{tag}")
@@ -492,6 +552,19 @@ def cmd_verify(args: argparse.Namespace) -> int:
         if release.get("draft"):
             raise Blocked(f"release {tag} is still an unpublished draft")
         report["release_api_id"] = release.get("id")
+        # The release object's own immutable flag is readable with plain
+        # contents access and proves durability without Administration read.
+        if release.get("immutable") is False:
+            raise RuntimeError(f"release {tag} is not immutable")
+        report["release_immutable"] = (
+            release["immutable"] if isinstance(release.get("immutable"), bool) else "unreported"
+        )
+        if (
+            args.admin_reads == "required"
+            and release.get("immutable") is not True
+            and report["immutability_setting"] != "enabled"
+        ):
+            raise RuntimeError(f"no surface proves release {tag} is immutable")
         tag_commit = _resolve_tag_commit(repository, tag)
         if tag_commit != identity["head_sha"]:
             raise RuntimeError(
@@ -544,11 +617,88 @@ def cmd_verify(args: argparse.Namespace) -> int:
                     blocked_marker="no attestations",
                 )
         report["payload_assets"] = [entry["name"] for entry in manifest["payload_assets"]]
-        report["rule_suite"] = _passing_rule_suite(repository, identity["head_sha"])
+        report["rule_suite"] = _rule_suite_binding(
+            repository, identity["head_sha"], admin_reads=args.admin_reads
+        )
         after = live_selection_snapshot(identity)
-        if not selection_is_stable(before, after):
-            raise Movement("workflow/run/artifact/main selection moved during verification")
-        report["superseded_by_newer_main"] = before["main_sha"] != identity["head_sha"]
+        disposition = movement_disposition(before, after)
+        if disposition == "restart":
+            raise Movement("workflow/run/artifact selection moved during verification")
+        # Main-only movement after publication cannot strand the published
+        # capsule: it stays byte-valid for its exact SHA and is recorded as
+        # superseded for the validator's newest-execution selection.
+        report["main_moved_during_verification"] = disposition == "superseded"
+        report["superseded_by_newer_main"] = after["main_sha"] != identity["head_sha"]
+        report["status"] = "pass"
+        _emit(report)
+        return EXIT_PASS
+    except Blocked as exc:
+        _emit({**report, "status": "blocked", "reason": str(exc)})
+        return EXIT_BLOCKED
+    except Movement as exc:
+        _emit({**report, "status": "movement", "reason": str(exc)})
+        return EXIT_MOVEMENT
+    except (RuntimeError, ValueError) as exc:
+        _emit({**report, "status": "fail", "reason": str(exc)})
+        return EXIT_FAIL
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    """Everything that must hold BEFORE the irreversible `gh release create`:
+    local envelope bytes verify, every asset already has a valid attestation,
+    the tag is unused, admin-read capability is probed, and main still points
+    at the bound head (a restart is free at this point, so any movement exits
+    3 instead of stranding a half-published capsule later)."""
+    identity = make_identity(
+        repository=args.repository,
+        head_sha=args.head_sha,
+        run_id=args.run_id,
+        run_attempt=args.run_attempt,
+        artifact_name=args.artifact_name,
+    )
+    repository = identity["repository"]
+    tag = identity["tag"]
+    signer_workflow = args.signer_workflow or f"{repository}/{WORKFLOW_PATH}"
+    report: dict[str, Any] = {"tag": tag, "head_sha": identity["head_sha"], "phase": "preflight"}
+    try:
+        assets_dir = Path(args.assets_dir)
+        files = {
+            path.name: path.read_bytes() for path in sorted(assets_dir.iterdir()) if path.is_file()
+        }
+        manifest = verify_envelope_assets(files, identity)
+        report["payload_assets"] = [entry["name"] for entry in manifest["payload_assets"]]
+        for name in sorted(files):
+            _checked_verification(
+                attestation_verify_argv(
+                    str(assets_dir / name),
+                    repository=repository,
+                    head_sha=identity["head_sha"],
+                    signer_workflow=signer_workflow,
+                ),
+                kind=f"pre-publish attestation for {name}",
+                blocked_marker="no attestations",
+            )
+        try:
+            _gh_api_json(f"repos/{repository}/releases/tags/{tag}")
+        except Blocked:
+            pass
+        else:
+            raise RuntimeError(
+                f"release tag {tag} already exists; refusing to publish over it "
+                "(verify the existing capsule with its own run identity instead)"
+            )
+        report["immutability_setting"] = _immutability_state(
+            repository, admin_reads=args.admin_reads
+        )
+        report["rule_suite"] = _rule_suite_binding(
+            repository, identity["head_sha"], admin_reads=args.admin_reads
+        )
+        snapshot = live_selection_snapshot(identity)
+        if snapshot["main_sha"] != identity["head_sha"]:
+            raise Movement(
+                f"main is at {snapshot['main_sha']}, no longer the bound head "
+                f"{identity['head_sha']}; re-dispatch at the current head before publishing"
+            )
         report["status"] = "pass"
         _emit(report)
         return EXIT_PASS
@@ -582,7 +732,7 @@ def dry_run_report() -> dict[str, Any]:
         head_sha=DRY_RUN_HEAD_SHA,
         run_id=1,
         run_attempt=1,
-        artifact_name=f"{ARTIFACT_PREFIX}1-1-{DRY_RUN_HEAD_SHA}",
+        artifact_name=f"{ARTIFACT_PREFIX}1-{DRY_RUN_HEAD_SHA}",
     )
     first = build_envelope(DRY_RUN_PAYLOADS, identity)
     second = build_envelope(dict(DRY_RUN_PAYLOADS), identity)
@@ -602,6 +752,10 @@ def dry_run_report() -> dict[str, Any]:
         raise RuntimeError("stable selection was misreported as movement")
     if selection_is_stable(snapshot, {**snapshot, "main_sha": "moved"}):
         raise RuntimeError("main movement was not detected")
+    if movement_disposition(snapshot, {**snapshot, "main_sha": "moved"}) != "superseded":
+        raise RuntimeError("main-only movement must classify as superseded")
+    if movement_disposition(snapshot, {**snapshot, "run_attempt": 99}) != "restart":
+        raise RuntimeError("execution movement must classify as restart")
     return {
         "status": "pass",
         "deterministic": True,
@@ -638,7 +792,17 @@ def main(argv: list[str] | None = None) -> int:
     verify = subparsers.add_parser("verify", help="verify a published envelope read-only")
     add_identity_args(verify)
     verify.add_argument("--signer-workflow", default="")
+    verify.add_argument("--admin-reads", choices=("required", "report"), default="required")
     verify.set_defaults(func=cmd_verify)
+
+    preflight = subparsers.add_parser(
+        "preflight", help="verify everything that must hold before publication"
+    )
+    add_identity_args(preflight)
+    preflight.add_argument("--assets-dir", required=True)
+    preflight.add_argument("--signer-workflow", default="")
+    preflight.add_argument("--admin-reads", choices=("required", "report"), default="report")
+    preflight.set_defaults(func=cmd_preflight)
 
     dry_run = subparsers.add_parser("dry-run", help="offline deterministic self-check")
     dry_run.set_defaults(func=cmd_dry_run)

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -3,10 +3,11 @@
 
 Expiring, fixed-name Actions artifacts are not durable contract evidence. The
 ``envelope`` job in ``.github/workflows/openapi.yml`` binds the exact
-run-level payload bytes of the SHA/run-bound ``openapi-spec-<run>-<attempt>-
-<head_sha>`` artifact into an immutable GitHub release at the exact-SHA tag
-``openapi-envelope-<head_sha>``, attests the exact assets with the pinned
-``actions/attest`` signer, and verifies the whole chain with this helper.
+run-level payload bytes of the run/SHA-bound (attempt-free)
+``openapi-spec-<run_id>-<head_sha>`` artifact into an immutable GitHub
+release at the exact-SHA tag ``openapi-envelope-<head_sha>``, attests the
+exact assets with the pinned ``actions/attest`` signer, and verifies the
+whole chain with this helper.
 
 This module never mutates remote state. ``build`` writes deterministic
 envelope bytes (canonical compact sorted-key JSON manifest plus an
@@ -637,14 +638,20 @@ def cmd_verify(args: argparse.Namespace) -> int:
             for name, data in files.items():
                 if hosted[name].get("size") != len(data):
                     raise RuntimeError(f"hosted size for {name!r} contradicts its exact bytes")
+            # release verify/verify-asset read the same Sigstore data plane
+            # as attestation verify; right after publication that data can
+            # lag, which is a blocked retry state, not a contradiction.
             _checked_verification(
-                release_verify_argv(tag, repository=repository), kind=f"release {tag}"
+                release_verify_argv(tag, repository=repository),
+                kind=f"release {tag}",
+                blocked_marker="no attestations",
             )
             for name in sorted(files):
                 asset_path = str(Path(scratch) / name)
                 _checked_verification(
                     release_verify_asset_argv(tag, asset_path, repository=repository),
                     kind=f"release asset {name}",
+                    blocked_marker="no attestations",
                 )
                 _checked_verification(
                     attestation_verify_argv(
@@ -718,8 +725,14 @@ def cmd_preflight(args: argparse.Namespace) -> int:
                 kind=f"pre-publish attestation for {name}",
                 blocked_marker="no attestations",
             )
+        # Forbidden subclasses Blocked: only a plain Blocked (404-class
+        # invisibility) proves absence. A 403 rate-limit/permission answer
+        # must stay blocked, or an existing tag could hide behind it and
+        # the irreversible publish would proceed over it.
         try:
             _gh_api_json(f"repos/{repository}/releases/tags/{tag}")
+        except Forbidden:
+            raise
         except Blocked:
             pass
         else:
@@ -731,6 +744,8 @@ def cmd_preflight(args: argparse.Namespace) -> int:
         # attach to it and ignore --target, publishing at the wrong commit.
         try:
             _gh_api_json(f"repos/{repository}/git/ref/tags/{tag}")
+        except Forbidden:
+            raise
         except Blocked:
             pass
         else:

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -22,10 +22,11 @@ after with restart-on-movement semantics (main-only movement after
 publication is recorded as supersession, never a strand); ``dry-run`` proves
 deterministic byte construction from checked-in fixture bytes with no
 network access. Admin-gated reads (rule suites, the immutability setting)
-degrade under ``--admin-reads report`` only on a true HTTP 403 capability
-gap (the workflow's GITHUB_TOKEN); every readable answer keeps full
-fail-closed semantics, and the operator's ``required`` mode enforces the
-reads outright.
+degrade under ``--admin-reads report`` on a true HTTP 403 capability gap
+and on the admin-gated HTTP 404 mapping (the workflow's GITHUB_TOKEN sees a
+hidden settings surface, indistinguishable in-run from a disabled setting);
+every readable answer keeps full fail-closed semantics, and the operator's
+``required`` mode enforces the reads outright.
 
 Exit codes (CDG status vocabulary): 0 pass, 1 fail (verification
 contradiction), 2 blocked (publication/attestation/rule-suite not yet

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -21,8 +21,10 @@ after with restart-on-movement semantics (main-only movement after
 publication is recorded as supersession, never a strand); ``dry-run`` proves
 deterministic byte construction from checked-in fixture bytes with no
 network access. Admin-gated reads (rule suites, the immutability setting)
-degrade to ``report`` mode under the workflow's GITHUB_TOKEN; the operator's
-``required`` mode enforces them.
+degrade under ``--admin-reads report`` only on a true HTTP 403 capability
+gap (the workflow's GITHUB_TOKEN); every readable answer keeps full
+fail-closed semantics, and the operator's ``required`` mode enforces the
+reads outright.
 
 Exit codes (CDG status vocabulary): 0 pass, 1 fail (verification
 contradiction), 2 blocked (publication/attestation/rule-suite not yet
@@ -343,12 +345,22 @@ def require_read_only_argv(argv: list[str]) -> None:
                     raise ValueError("gh api may only issue GET requests")
                 index += 2
                 continue
+            # pflag also accepts attached shorthand (-XPOST, -fk=v, -Fk=v),
+            # so prefix forms must be screened, not just separated flags.
+            if item.startswith("-X") and item != "-X":
+                if item[2:].upper() != "GET":
+                    raise ValueError("gh api may only issue GET requests")
+                index += 1
+                continue
             if item.startswith("--method=") and item.split("=", 1)[1].upper() != "GET":
                 raise ValueError("gh api may only issue GET requests")
             if (
                 item in _GH_API_WRITE_FLAGS
                 or item.startswith("--field=")
+                or item.startswith("--raw-field=")
                 or item.startswith("--input=")
+                or (item.startswith("-f") and item != "-f")
+                or (item.startswith("-F") and item != "-F")
             ):
                 raise ValueError("gh api write-shaped flags are rejected")
             index += 1
@@ -507,10 +519,13 @@ def _immutability_state(repository: str, *, admin_reads: str) -> str:
     """Read the repo immutable-releases setting; under a token without
     Administration read (the workflow's GITHUB_TOKEN) the surface is
     recorded as unreadable in ``report`` mode instead of blocking, and the
-    release object's own ``immutable`` field carries the durability proof."""
+    release object's own ``immutable`` field carries the durability proof.
+    Only a true capability gap (HTTP 403) may degrade: any readable answer
+    keeps full semantics in both modes, so a readable ``enabled: false``
+    always fails."""
     try:
         immutability = _gh_api_json(f"repos/{repository}/immutable-releases")
-    except Blocked as exc:
+    except Forbidden as exc:
         if admin_reads == "required":
             raise
         return f"unreadable ({exc})"
@@ -520,9 +535,13 @@ def _immutability_state(repository: str, *, admin_reads: str) -> str:
 
 
 def _rule_suite_binding(repository: str, head_sha: str, *, admin_reads: str) -> dict[str, Any]:
+    """Only a 403 capability gap may degrade in ``report`` mode. A readable
+    rule-suite surface with no matching record stays ``Blocked`` and a
+    readable non-pass result stays a failure, in both modes: degradation
+    never substitutes for a missing binding the token could have seen."""
     try:
         return _passing_rule_suite(repository, head_sha)
-    except Blocked as exc:
+    except Forbidden as exc:
         if admin_reads == "required":
             raise
         return {"state": "unverified", "reason": str(exc)}
@@ -687,6 +706,16 @@ def cmd_preflight(args: argparse.Namespace) -> int:
                 f"release tag {tag} already exists; refusing to publish over it "
                 "(verify the existing capsule with its own run identity instead)"
             )
+        # `gh release verify`/`verify-asset` arrived in gh 2.96; probing them
+        # here keeps a missing subcommand from surfacing only after the
+        # irreversible publication.
+        for capability in (("release", "verify"), ("release", "verify-asset")):
+            if _run_gh(["gh", *capability, "--help"]).returncode != 0:
+                raise Blocked(
+                    f"gh {' '.join(capability)} is unavailable on this runner; "
+                    "post-publication verification would be impossible"
+                )
+        report["gh_capabilities"] = ["release verify", "release verify-asset"]
         report["immutability_setting"] = _immutability_state(
             repository, admin_reads=args.admin_reads
         )

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -952,6 +952,70 @@ def test_openapi_envelope_serializes_sync_before_publication_preflight():
         assert clause in ENVELOPE_IF
 
 
+def test_envelope_requires_operator_immutable_releases_attestation_input():
+    """In-run report-mode preflight cannot distinguish the admin-gated 404
+    "hidden from this token" from "immutable releases disabled", so a
+    disabled setting would otherwise surface only post-publish. The dispatch
+    input machine-checks the operator's admin-capable {"enabled":true}
+    pre-dispatch read; it must be a required boolean that defaults off."""
+    dispatch = DOC["on"]["workflow_dispatch"]
+    attestation = dispatch["inputs"]["operator_confirmed_immutable_releases"]
+    assert attestation["type"] == "boolean"
+    assert attestation["required"] == "true"
+    assert attestation["default"] == "false"
+    description = attestation["description"]
+    assert "immutable-releases" in description
+    assert '{"enabled":true}' in description
+
+
+def test_envelope_gate_fails_closed_without_operator_attestation(tmp_path):
+    """The attestation gate is the FIRST envelope step: unless the input is
+    exactly the string true it exits 2 (blocked) before any download,
+    attestation, or publication step runs. It machine-checks the operator's
+    pre-dispatch admin-capable check WITHOUT weakening in-run degradation:
+    preflight/verify keep --admin-reads report so the non-admin workflow
+    token can never wedge, and no other job consumes the input."""
+    gate = _steps("envelope")[0]
+    assert gate.get("name") == "Require operator immutable-releases attestation"
+    assert "continue-on-error" not in gate
+    assert "if" not in gate
+    assert (gate.get("env") or {}).get("OPERATOR_CONFIRMED") == (
+        "${{ inputs.operator_confirmed_immutable_releases }}"
+    )
+    run = gate["run"]
+    assert "set -euo pipefail" in run
+    # Every non-"true" value (including the empty string an expression-drift
+    # would interpolate) must block with exit 2 and publish nothing.
+    for value in ("false", "", "1", "True"):
+        blocked = _simulate_step(run, env={"OPERATOR_CONFIRMED": value}, cwd=tmp_path)
+        assert blocked.returncode == 2, (value, blocked.stdout, blocked.stderr)
+        assert "blocked" in blocked.stdout + blocked.stderr, value
+    confirmed = _simulate_step(run, env={"OPERATOR_CONFIRMED": "true"}, cwd=tmp_path)
+    assert confirmed.returncode == 0, (confirmed.stdout, confirmed.stderr)
+    # The gate precedes every payload/publication step in the job.
+    gate_index = _step_index("envelope", "Require operator immutable-releases attestation")
+    for name in (
+        "Download run-level spec artifact",
+        "Build deterministic release envelope",
+        "Attest the envelope assets",
+        "Preflight verify before publication",
+        "Publish immutable release",
+    ):
+        assert gate_index < _step_index("envelope", name), name
+    # Degradation semantics unchanged: in-run preflight and post-publish
+    # verify still degrade admin-gated reads under report mode.
+    assert "--admin-reads report" in _step("envelope", "Preflight verify before publication")["run"]
+    assert (
+        "--admin-reads report"
+        in _step("envelope", "Verify release, assets, attestation, and rule suite")["run"]
+    )
+    # Only the envelope job consumes the attestation; a plain sync dispatch
+    # is never gated by it.
+    for job_id, job in JOBS.items():
+        if job_id != "envelope":
+            assert "operator_confirmed_immutable_releases" not in json.dumps(job), job_id
+
+
 def test_openapi_envelope_helper_dry_run_is_a_pr_time_authority():
     # The dry-run proof runs on every generate-run execution and is part of
     # the no-masking census (AUTHORITATIVE_STEPS).
@@ -1317,6 +1381,16 @@ def test_envelope_module_docstring_names_attempt_free_artifact_form():
     doc = _load_envelope_helper().__doc__
     assert "``openapi-spec-<run_id>-<head_sha>``" in doc
     assert "<attempt>" not in doc
+
+
+def test_envelope_module_docstring_names_admin_gated_404_degradation():
+    """Report mode degrades on BOTH capability-gap classes: a true HTTP 403
+    and the admin-gated HTTP 404 mapping (hidden-from-token is in-run
+    indistinguishable from a disabled setting). Claiming degradation happens
+    only on 403 misdocuments the second class."""
+    doc = _load_envelope_helper().__doc__
+    assert "admin-gated HTTP 404" in doc
+    assert "only on a true HTTP 403" not in doc
 
 
 def test_envelope_snapshot_binds_attempt_record_and_survives_settled_reruns(monkeypatch):

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -726,7 +726,7 @@ def test_openapi_summary_and_artifact_steps_cannot_rewrite_gate_conclusion():
     assert len(uploads) == 2
     for step in uploads:
         assert step["uses"] == "actions/upload-artifact@v4"
-        assert set(step["with"]) <= {"name", "path", "retention-days"}
+        assert set(step["with"]) <= {"name", "path", "retention-days", "overwrite"}
         assert "continue-on-error" not in step
         assert step.get("if") in (None, "always()")
     # No step anywhere in the workflow writes check runs, check conclusions,
@@ -788,6 +788,10 @@ def test_openapi_artifact_names_are_run_and_sha_bound():
     assert spec_upload["with"]["name"] == "${{ env.OPENAPI_RUN_ARTIFACT }}"
     drift_upload = _step("generate-run", "Upload contract drift artifacts")
     assert drift_upload["with"]["name"] == "${{ env.DRIFT_RUN_ARTIFACT }}"
+    # v4 artifacts are immutable per run and the name carries no attempt, so
+    # a re-run of all jobs must overwrite rather than 409 on its own name.
+    assert spec_upload["with"]["overwrite"] == "true"
+    assert drift_upload["with"]["overwrite"] == "true"
     # Every artifact consumer resolves the same run-bound name.
     sync_download = _step("sync", "Download generated spec")
     assert sync_download["with"]["name"] == "${{ env.OPENAPI_RUN_ARTIFACT }}"
@@ -802,10 +806,14 @@ def test_openapi_envelope_job_is_dispatch_gated_and_attests_exact_assets():
     job = JOBS["envelope"]
     assert job["needs"] == "generate-run"
     assert job["if"] == ENVELOPE_IF
+    # actions:read is load-bearing: the explicit permissions block zeroes
+    # unlisted scopes, and preflight/verify re-query the workflow, run, and
+    # run-level artifacts through the actions API.
     assert job["permissions"] == {
         "contents": "write",
         "id-token": "write",
         "attestations": "write",
+        "actions": "read",
     }
     for step in job["steps"]:
         assert "continue-on-error" not in step, step.get("name")
@@ -1046,6 +1054,41 @@ def test_envelope_selection_movement_restarts_verification():
         module.movement_disposition(before, {"main_sha": "a" * 40})
 
 
+def test_envelope_admin_reads_degrade_only_on_true_capability_gaps(monkeypatch):
+    module = _load_envelope_helper()
+    head = "d" * 40
+    repo = "synaptent/aragora"
+
+    def forbidden(endpoint, **kwargs):
+        raise module.Forbidden(f"{endpoint} is not readable by this token: HTTP 403")
+
+    # HTTP 403 (the workflow GITHUB_TOKEN lacks Administration:read): report
+    # mode records the gap and degrades; required mode blocks.
+    monkeypatch.setattr(module, "_gh_api_json", forbidden)
+    assert module._immutability_state(repo, admin_reads="report").startswith("unreadable")
+    with pytest.raises(module.Forbidden):
+        module._immutability_state(repo, admin_reads="required")
+    degraded = module._rule_suite_binding(repo, head, admin_reads="report")
+    assert degraded["state"] == "unverified"
+    with pytest.raises(module.Forbidden):
+        module._rule_suite_binding(repo, head, admin_reads="required")
+    # A READABLE surface keeps full fail-closed semantics in BOTH modes:
+    # degradation never substitutes for an answer the token could see.
+    monkeypatch.setattr(module, "_gh_api_json", lambda endpoint, **kwargs: {"enabled": False})
+    with pytest.raises(RuntimeError, match="not enabled"):
+        module._immutability_state(repo, admin_reads="report")
+    monkeypatch.setattr(module, "_gh_api_json", lambda endpoint, **kwargs: [])
+    with pytest.raises(module.Blocked, match="no rule-suite record"):
+        module._rule_suite_binding(repo, head, admin_reads="report")
+    monkeypatch.setattr(
+        module,
+        "_gh_api_json",
+        lambda endpoint, **kwargs: [{"after_sha": head, "id": 5, "result": "fail"}],
+    )
+    with pytest.raises(RuntimeError, match="concluded"):
+        module._rule_suite_binding(repo, head, admin_reads="report")
+
+
 def test_envelope_verification_argv_and_read_only_guard():
     module = _load_envelope_helper()
     head = "c" * 40
@@ -1100,12 +1143,20 @@ def test_envelope_verification_argv_and_read_only_guard():
         ["gh", "release", "edit", tag],
         ["gh", "api", "-X", "DELETE", "repos/synaptent/aragora/releases/1"],
         ["gh", "api", "--method", "POST", "repos/synaptent/aragora/releases"],
+        # pflag attached-shorthand forms must not slip past the guard.
+        ["gh", "api", "-XPOST", "repos/synaptent/aragora/releases"],
+        ["gh", "api", "--method=POST", "repos/synaptent/aragora/releases"],
+        ["gh", "api", "-fname=v", "repos/synaptent/aragora/releases"],
+        ["gh", "api", "-Fname=v", "repos/synaptent/aragora/releases"],
+        ["gh", "api", "-f", "name=v", "repos/synaptent/aragora/releases"],
+        ["gh", "api", "--raw-field=name=v", "repos/synaptent/aragora/releases"],
         ["gh", "pr", "merge", "1"],
         ["rm", "-rf", "/tmp/x"],
     ):
         with pytest.raises(ValueError):
             module.require_read_only_argv(hostile)
     module.require_read_only_argv(["gh", "api", "repos/synaptent/aragora/releases/tags/x"])
+    module.require_read_only_argv(["gh", "api", "-XGET", "repos/synaptent/aragora/releases"])
     module.require_read_only_argv(["gh", "release", "download", tag])
     module.require_read_only_argv(["gh", "release", "verify", tag])
 

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -952,16 +952,17 @@ def test_openapi_envelope_serializes_sync_before_publication_preflight():
         assert clause in ENVELOPE_IF
 
 
-def test_envelope_requires_operator_immutable_releases_attestation_input():
+def test_envelope_operator_immutable_releases_attestation_input_defaults_false():
     """In-run report-mode preflight cannot distinguish the admin-gated 404
     "hidden from this token" from "immutable releases disabled", so a
     disabled setting would otherwise surface only post-publish. The dispatch
     input machine-checks the operator's admin-capable {"enabled":true}
-    pre-dispatch read; it must be a required boolean that defaults off."""
+    pre-dispatch read when publishing, but stays optional/default-off so an
+    omitted input cannot break bare sync-only dispatches."""
     dispatch = DOC["on"]["workflow_dispatch"]
     attestation = dispatch["inputs"]["operator_confirmed_immutable_releases"]
     assert attestation["type"] == "boolean"
-    assert attestation["required"] == "true"
+    assert "required" not in attestation
     assert attestation["default"] == "false"
     description = attestation["description"]
     assert "immutable-releases" in description
@@ -1564,3 +1565,139 @@ def test_envelope_build_and_dry_run_cli_are_deterministic(tmp_path):
         outputs.append({path.name: path.read_bytes() for path in sorted(out_dir.iterdir())})
     assert outputs[0] == outputs[1]
     assert set(outputs[0]) == {"manifest.json", "checksums.txt", "openapi_generated.json"}
+
+
+def _verify_retry_stub(exit_codes: list[int], tmp_path: Path) -> str:
+    queue = tmp_path / "verify-exit-codes"
+    calls = tmp_path / "verify-calls"
+    sleeps = tmp_path / "verify-sleeps"
+    queue.write_text("\n".join(str(code) for code in exit_codes) + "\n", encoding="utf-8")
+    return f"""
+python3() {{
+  printf '%s\\n' "$*" >> {calls}
+  code="$(head -n 1 {queue})"
+  tail -n +2 {queue} > {queue}.next
+  mv {queue}.next {queue}
+  return "$code"
+}}
+sleep() {{
+  printf '%s\\n' "$1" >> {sleeps}
+}}
+"""
+
+
+def _verify_retry_env() -> dict[str, str]:
+    head = "e" * 40
+    return {
+        "GITHUB_REPOSITORY": "synaptent/aragora",
+        "GITHUB_SHA": head,
+        "GITHUB_RUN_ID": "4242",
+        "GITHUB_RUN_ATTEMPT": "7",
+        "OPENAPI_RUN_ARTIFACT": f"openapi-spec-4242-{head}",
+    }
+
+
+def test_post_publish_verify_recovers_blocked_blocked_pass(tmp_path):
+    run = _step("envelope", "Verify release, assets, attestation, and rule suite")["run"]
+    completed = _simulate_step(
+        run,
+        env=_verify_retry_env(),
+        cwd=tmp_path,
+        stub_prelude=_verify_retry_stub([2, 2, 0], tmp_path),
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert (tmp_path / "verify-sleeps").read_text(encoding="utf-8").splitlines() == ["5", "10"]
+    assert len((tmp_path / "verify-calls").read_text(encoding="utf-8").splitlines()) == 3
+
+
+def test_post_publish_verify_readable_contradiction_fails_without_retry(tmp_path):
+    run = _step("envelope", "Verify release, assets, attestation, and rule suite")["run"]
+    completed = _simulate_step(
+        run,
+        env=_verify_retry_env(),
+        cwd=tmp_path,
+        stub_prelude=_verify_retry_stub([1, 0], tmp_path),
+    )
+    assert completed.returncode == 1
+    assert len((tmp_path / "verify-calls").read_text(encoding="utf-8").splitlines()) == 1
+    assert not (tmp_path / "verify-sleeps").exists()
+
+
+@pytest.mark.parametrize("exit_code", [3, 17])
+def test_post_publish_verify_movement_and_unexpected_errors_do_not_retry(tmp_path, exit_code):
+    run = _step("envelope", "Verify release, assets, attestation, and rule suite")["run"]
+    completed = _simulate_step(
+        run,
+        env=_verify_retry_env(),
+        cwd=tmp_path,
+        stub_prelude=_verify_retry_stub([exit_code, 0], tmp_path),
+    )
+    assert completed.returncode == exit_code
+    assert len((tmp_path / "verify-calls").read_text(encoding="utf-8").splitlines()) == 1
+    assert not (tmp_path / "verify-sleeps").exists()
+
+
+def test_post_publish_verify_blocked_exhaustion_is_bounded(tmp_path):
+    run = _step("envelope", "Verify release, assets, attestation, and rule suite")["run"]
+    completed = _simulate_step(
+        run,
+        env=_verify_retry_env(),
+        cwd=tmp_path,
+        stub_prelude=_verify_retry_stub([2, 2, 2, 2, 0], tmp_path),
+    )
+    assert completed.returncode == 2
+    assert (tmp_path / "verify-sleeps").read_text(encoding="utf-8").splitlines() == [
+        "5",
+        "10",
+        "20",
+    ]
+    assert len((tmp_path / "verify-calls").read_text(encoding="utf-8").splitlines()) == 4
+    assert "original-identity recovery runbook" in completed.stdout
+
+
+def test_post_publish_verify_retries_same_identity_without_replaying_prior_phases(tmp_path):
+    step = _step("envelope", "Verify release, assets, attestation, and rule suite")
+    run = step["run"]
+    assert " build " not in run
+    assert " preflight " not in run
+    assert "gh release create" not in run
+    assert "actions/attest" not in run
+
+    completed = _simulate_step(
+        run,
+        env=_verify_retry_env(),
+        cwd=tmp_path,
+        stub_prelude=_verify_retry_stub([2, 2, 0], tmp_path),
+    )
+    assert completed.returncode == 0, completed.stderr
+    calls = (tmp_path / "verify-calls").read_text(encoding="utf-8").splitlines()
+    assert len(calls) == 3
+    assert len(set(calls)) == 1
+    call = calls[0]
+    for expected in (
+        "scripts/openapi_release_envelope.py verify",
+        "--repository synaptent/aragora",
+        f"--head-sha {'e' * 40}",
+        "--run-id 4242",
+        "--run-attempt 7",
+        f"--artifact-name openapi-spec-4242-{'e' * 40}",
+        "--signer-workflow synaptent/aragora/.github/workflows/openapi.yml",
+        "--admin-reads report",
+    ):
+        assert expected in call
+
+
+def test_dispatch_omission_is_default_false_and_cannot_publish_envelope():
+    inputs = DOC["on"]["workflow_dispatch"]["inputs"]
+    publish = inputs["publish_envelope"]
+    operator_attestation = inputs["operator_confirmed_immutable_releases"]
+    assert publish["default"] == "false"
+    assert operator_attestation["default"] == "false"
+    assert operator_attestation.get("required", "false") == "false"
+
+    envelope_if = JOBS["envelope"]["if"]
+    assert "github.event_name == 'workflow_dispatch'" in envelope_if
+    assert "inputs.publish_envelope == true" in envelope_if
+    gate = _step("envelope", "Require operator immutable-releases attestation")["run"]
+    assert '[[ "$OPERATOR_CONFIRMED" != "true" ]]' in gate
+    assert "exit 2" in gate

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -748,11 +748,11 @@ def test_openapi_summary_and_artifact_steps_cannot_rewrite_gate_conclusion():
 # The exact run/SHA binding suffix. `github.sha` is the merge SHA on
 # pull_request events, so the pull-request head SHA must win there for the
 # artifact name to end with the RUN's head_sha (the `-{head_sha}` rule that
-# `_validate_run_artifact` pins).
-RUN_SHA_SUFFIX = (
-    "${{ github.run_id }}-${{ github.run_attempt }}"
-    "-${{ github.event.pull_request.head.sha || github.sha }}"
-)
+# `_validate_run_artifact` pins). The attempt is deliberately NOT in the
+# name: re-running only a failed dependent job (sync/envelope) increments
+# the run attempt while the artifact keeps its original name, so an
+# attempt-bearing name could never be downloaded again.
+RUN_SHA_SUFFIX = "${{ github.run_id }}-${{ github.event.pull_request.head.sha || github.sha }}"
 ENVELOPE_HELPER_PATH = ROOT / "scripts" / "openapi_release_envelope.py"
 # Same pinned actions/attest release the ratified contract-drift boundary
 # signer uses; a different (unreviewed) signer version fails this census.
@@ -776,7 +776,7 @@ def _identity_kwargs(module, head: str, run_id: int = 7, run_attempt: int = 1) -
         "head_sha": head,
         "run_id": run_id,
         "run_attempt": run_attempt,
-        "artifact_name": f"openapi-spec-{run_id}-{run_attempt}-{head}",
+        "artifact_name": f"openapi-spec-{run_id}-{head}",
     }
 
 
@@ -837,6 +837,28 @@ def test_openapi_envelope_job_is_dispatch_gated_and_attests_exact_assets():
     assert attest["uses"] == ENVELOPE_ATTEST_ACTION
     assert "# v4.2.1" in TEXT
     assert attest["with"]["subject-path"].strip() == "/tmp/openapi-envelope/assets/*"
+    # Preflight proves attestations, tag availability, capability, and that
+    # main is still at the bound head BEFORE anything irreversible runs.
+    preflight = _step("envelope", "Preflight verify before publication")["run"]
+    assert "set -euo pipefail" in preflight
+    assert "scripts/openapi_release_envelope.py preflight" in preflight
+    assert "--assets-dir" in preflight
+    assert "--admin-reads report" in preflight
+    assert "gh --version" in preflight
+    # The irreversible publication is the LAST mutating step: build, attest,
+    # and preflight all precede it, so no failure can strand a half-published
+    # immutable capsule.
+    order = [
+        _step_index("envelope", name)
+        for name in (
+            "Build deterministic release envelope",
+            "Attest the envelope assets",
+            "Preflight verify before publication",
+            "Publish immutable release",
+            "Verify release, assets, attestation, and rule suite",
+        )
+    ]
+    assert order == sorted(order), "envelope steps out of publication-safety order"
     # Verification binds release, assets, attestation, and rule suite to this
     # workflow as the signer, with movement-requery semantics in the helper.
     verify = _step("envelope", "Verify release, assets, attestation, and rule suite")["run"]
@@ -844,6 +866,10 @@ def test_openapi_envelope_job_is_dispatch_gated_and_attests_exact_assets():
     assert "scripts/openapi_release_envelope.py verify" in verify
     assert "--signer-workflow" in verify
     assert ".github/workflows/openapi.yml" in verify
+    # The workflow token lacks Administration read, so in-run verification
+    # must degrade admin-gated reads to report mode (never exit 1 for a
+    # capability gap after publication).
+    assert "--admin-reads report" in verify
 
 
 def test_openapi_envelope_helper_dry_run_is_a_pr_time_authority():
@@ -878,7 +904,7 @@ def test_envelope_build_is_deterministic_and_release_bound():
     assert manifest["head_sha"] == head
     assert manifest["workflow_run_id"] == 7
     assert manifest["run_attempt"] == 1
-    assert manifest["artifact_name"] == f"openapi-spec-7-1-{head}"
+    assert manifest["artifact_name"] == f"openapi-spec-7-{head}"
     assert manifest["tag"] == f"openapi-envelope-{head}"
     assert manifest["workflow_path"] == ".github/workflows/openapi.yml"
     # Canonical bytes: re-serializing the parsed manifest reproduces the
@@ -914,16 +940,17 @@ def test_envelope_rejects_unbound_names_and_tampered_assets():
     head = "b" * 40
     base = _identity_kwargs(module, head)
     identity = module.make_identity(**base)
-    # Hostile identities: fixed (unbound) name, wrong run, wrong attempt,
-    # foreign head, non-canonical SHA.
+    # Hostile identities: fixed (unbound) name, wrong run, attempt-bearing
+    # legacy name, foreign head, non-canonical SHA, non-positive run/attempt.
     for kwargs in (
         dict(base, artifact_name="openapi-spec"),
-        dict(base, artifact_name=f"openapi-spec-8-1-{head}"),
-        dict(base, artifact_name=f"openapi-spec-7-2-{head}"),
-        dict(base, artifact_name=f"openapi-spec-7-1-{'c' * 40}"),
-        dict(base, head_sha=head.upper(), artifact_name=f"openapi-spec-7-1-{head.upper()}"),
-        dict(base, head_sha="b" * 39, artifact_name=f"openapi-spec-7-1-{'b' * 39}"),
-        dict(base, run_id=0, artifact_name=f"openapi-spec-0-1-{head}"),
+        dict(base, artifact_name=f"openapi-spec-8-{head}"),
+        dict(base, artifact_name=f"openapi-spec-7-1-{head}"),
+        dict(base, artifact_name=f"openapi-spec-7-{'c' * 40}"),
+        dict(base, head_sha=head.upper(), artifact_name=f"openapi-spec-7-{head.upper()}"),
+        dict(base, head_sha="b" * 39, artifact_name=f"openapi-spec-7-{'b' * 39}"),
+        dict(base, run_id=0, artifact_name=f"openapi-spec-0-{head}"),
+        dict(base, run_attempt=0),
         dict(base, repository="aragora"),
     ):
         with pytest.raises(ValueError):
@@ -1005,8 +1032,18 @@ def test_envelope_selection_movement_restarts_verification():
         assert not module.selection_is_stable(before, after), (
             f"movement in {key} must restart verification"
         )
+        # Execution-provenance movement is always a restart; ONLY a bare
+        # main advance classifies as supersession (a published immutable
+        # capsule stays byte-valid for its exact SHA and must not strand).
+        expected = "superseded" if key == "main_sha" else "restart"
+        assert module.movement_disposition(before, after) == expected, key
+    assert module.movement_disposition(before, dict(before)) == "stable"
+    moved_both = dict(before, main_sha="b" * 40, run_attempt=3)
+    assert module.movement_disposition(before, moved_both) == "restart"
     with pytest.raises(ValueError, match="missing"):
         module.selection_is_stable(before, {"main_sha": "a" * 40})
+    with pytest.raises(ValueError, match="missing"):
+        module.movement_disposition(before, {"main_sha": "a" * 40})
 
 
 def test_envelope_verification_argv_and_read_only_guard():
@@ -1115,7 +1152,7 @@ def test_envelope_build_and_dry_run_cli_are_deterministic(tmp_path):
                 "--run-attempt",
                 "3",
                 "--artifact-name",
-                f"openapi-spec-12-3-{head}",
+                f"openapi-spec-12-{head}",
                 "--payload-dir",
                 str(tmp_path / "payload"),
                 "--output-dir",

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -22,6 +22,7 @@ the rules and the repo-tree census so a drifting workflow fails here first.
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import json
 import os
@@ -780,6 +781,55 @@ def _identity_kwargs(module, head: str, run_id: int = 7, run_attempt: int = 1) -
     }
 
 
+def _live_api_stub(module, identity: dict, head: str, overrides: list):
+    """Fake `_gh_api_json` covering every live surface cmd_preflight/cmd_verify
+    re-query (main ref, workflow, run, attempt record, artifacts, settings),
+    with ordered per-endpoint `(marker, outcome)` overrides; an Exception
+    outcome is raised, anything else returned. Tag probes default to Blocked
+    (proven absence) so each test states only what it changes."""
+    tag = identity["tag"]
+
+    def fake_api(endpoint: str, **kwargs):
+        for marker, outcome in overrides:
+            if marker in endpoint:
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return outcome
+        if endpoint.endswith("immutable-releases"):
+            return {"enabled": True}
+        if "rule-suites" in endpoint:
+            return [{"after_sha": head, "id": 9, "result": "pass"}]
+        if endpoint.endswith("git/ref/heads/main"):
+            return {"object": {"sha": head}}
+        if "/actions/workflows/" in endpoint:
+            return {
+                "id": OPENAPI_WORKFLOW_ID,
+                "path": ".github/workflows/openapi.yml",
+                "state": "active",
+            }
+        if endpoint.endswith(f"/attempts/{identity['run_attempt']}"):
+            return {
+                "run_attempt": identity["run_attempt"],
+                "head_sha": head,
+                "conclusion": "success",
+            }
+        if endpoint.endswith("/artifacts?per_page=100"):
+            return [
+                {"artifacts": [{"name": identity["artifact_name"], "id": 91, "size_in_bytes": 10}]}
+            ]
+        if f"releases/tags/{tag}" in endpoint or f"git/ref/tags/{tag}" in endpoint:
+            raise module.Blocked(f"{endpoint} is not visible: HTTP 404")
+        return {
+            "id": identity["run_id"],
+            "path": ".github/workflows/openapi.yml",
+            "head_sha": head,
+            "run_attempt": identity["run_attempt"],
+            "conclusion": "success",
+        }
+
+    return fake_api
+
+
 def test_openapi_artifact_names_are_run_and_sha_bound():
     env = DOC.get("env") or {}
     assert env.get("OPENAPI_RUN_ARTIFACT") == f"openapi-spec-{RUN_SHA_SUFFIX}"
@@ -804,7 +854,7 @@ def test_openapi_artifact_names_are_run_and_sha_bound():
 
 def test_openapi_envelope_job_is_dispatch_gated_and_attests_exact_assets():
     job = JOBS["envelope"]
-    assert job["needs"] == "generate-run"
+    assert job["needs"] == ["generate-run", "sync"]
     assert job["if"] == ENVELOPE_IF
     # actions:read is load-bearing: the explicit permissions block zeroes
     # unlisted scopes, and preflight/verify re-query the workflow, run, and
@@ -878,6 +928,28 @@ def test_openapi_envelope_job_is_dispatch_gated_and_attests_exact_assets():
     # must degrade admin-gated reads to report mode (never exit 1 for a
     # capability gap after publication).
     assert "--admin-reads report" in verify
+
+
+def test_openapi_envelope_serializes_sync_before_publication_preflight():
+    """A publish_envelope=true dispatch also runs sync, which can push a
+    spec-drift commit to main. Needing sync serializes any such push BEFORE
+    envelope preflight's main-still-at-bound-head check, so the movement is
+    the free pre-publication exit-3 restart instead of a post-publish
+    supersession record against an already-immutable capsule."""
+    envelope = JOBS["envelope"]
+    assert envelope["needs"] == ["generate-run", "sync"]
+    # The dependency is satisfiable exactly when envelope runs: sync gates on
+    # the same dispatch+main events (envelope only adds the publish input),
+    # so needing sync can never wedge a publish dispatch, and gating drift
+    # between the two jobs fails here first.
+    sync = JOBS["sync"]
+    assert sync["needs"] == "generate-run"
+    assert (
+        sync["if"] == "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'"
+    )
+    for clause in ("github.event_name == 'workflow_dispatch'", "github.ref == 'refs/heads/main'"):
+        assert clause in sync["if"]
+        assert clause in ENVELOPE_IF
 
 
 def test_openapi_envelope_helper_dry_run_is_a_pr_time_authority():
@@ -1106,6 +1178,145 @@ def test_envelope_admin_reads_degrade_only_on_true_capability_gaps(monkeypatch):
     with pytest.raises(module.Blocked):
         module._gh_api_json(f"repos/{repo}/releases/tags/x")
     assert module._immutability_state(repo, admin_reads="report").startswith("unreadable")
+
+
+def test_envelope_preflight_tag_probes_treat_forbidden_as_blocked(monkeypatch, tmp_path, capsys):
+    """Tag absence must be PROVEN before publication. Forbidden subclasses
+    Blocked, so a rate-limit/permission 403 on either tag probe must surface
+    as blocked (exit 2) instead of reading as "tag unused" and letting the
+    irreversible `gh release create` proceed over a possibly-existing tag."""
+    module = _load_envelope_helper()
+    head = "f" * 40
+    identity = module.make_identity(**_identity_kwargs(module, head, run_id=55))
+    assets = module.build_envelope(
+        {"docs/api/openapi_generated.json": b'{"openapi":"3.1.0"}\n'}, identity
+    )
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    for name, data in assets.items():
+        (assets_dir / name).write_bytes(data)
+    ok = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=b"{}", stderr=b"")
+    monkeypatch.setattr(module, "_run_gh", lambda argv: ok)
+    args = argparse.Namespace(
+        repository="synaptent/aragora",
+        head_sha=head,
+        run_id=55,
+        run_attempt=1,
+        artifact_name=identity["artifact_name"],
+        assets_dir=str(assets_dir),
+        signer_workflow="",
+        admin_reads="report",
+    )
+    tag = identity["tag"]
+    forbidden = module.Forbidden("HTTP 403 rate limit exceeded")
+    # Control: proven absence (404 on both probes) preflights clean.
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    assert json.loads(capsys.readouterr().out)["status"] == "pass"
+    # A readable existing release tag still fails closed, never retries.
+    monkeypatch.setattr(
+        module,
+        "_gh_api_json",
+        _live_api_stub(module, identity, head, [(f"releases/tags/{tag}", {"id": 1})]),
+    )
+    assert module.cmd_preflight(args) == module.EXIT_FAIL
+    assert json.loads(capsys.readouterr().out)["status"] == "fail"
+    # Forbidden on the release-tag probe: blocked, never absence.
+    monkeypatch.setattr(
+        module,
+        "_gh_api_json",
+        _live_api_stub(module, identity, head, [(f"releases/tags/{tag}", forbidden)]),
+    )
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+    # Forbidden on the bare-git-tag probe: same.
+    monkeypatch.setattr(
+        module,
+        "_gh_api_json",
+        _live_api_stub(module, identity, head, [(f"git/ref/tags/{tag}", forbidden)]),
+    )
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+
+
+def test_envelope_post_publish_release_verify_lag_blocks_not_fails(monkeypatch, tmp_path, capsys):
+    """`gh release verify`/`verify-asset` read the same Sigstore data plane as
+    `gh attestation verify`; immediately after publication that data can lag.
+    Lag is a Blocked retry state (exit 2), never a byte contradiction (exit
+    1) — while a readable verification contradiction still fails closed."""
+    module = _load_envelope_helper()
+    head = "e" * 40
+    identity = module.make_identity(**_identity_kwargs(module, head, run_id=66))
+    assets = module.build_envelope(
+        {"docs/api/openapi_generated.json": b'{"openapi":"3.1.0"}\n'}, identity
+    )
+    tag = identity["tag"]
+    release = {
+        "id": 4242,
+        "draft": False,
+        "immutable": True,
+        "assets": [{"name": name, "size": len(data)} for name, data in assets.items()],
+    }
+    monkeypatch.setattr(
+        module,
+        "_gh_api_json",
+        _live_api_stub(
+            module,
+            identity,
+            head,
+            [
+                (f"releases/tags/{tag}", release),
+                (f"git/ref/tags/{tag}", {"object": {"type": "commit", "sha": head}}),
+            ],
+        ),
+    )
+
+    def run_stub(lagging: set, failing: set | frozenset = frozenset()):
+        def fake_run(argv):
+            module.require_read_only_argv(argv)
+            action = tuple(argv[1:3])
+            if action == ("release", "download"):
+                dest = Path(argv[argv.index("--dir") + 1])
+                for name, data in assets.items():
+                    (dest / name).write_bytes(data)
+                return subprocess.CompletedProcess(argv, 0, b"", b"")
+            if action in lagging:
+                return subprocess.CompletedProcess(
+                    argv, 1, b"", b"no attestations found for the requested subject yet"
+                )
+            if action in failing:
+                return subprocess.CompletedProcess(argv, 1, b"", b"subject digest mismatch")
+            return subprocess.CompletedProcess(argv, 0, b"{}", b"")
+
+        return fake_run
+
+    args = argparse.Namespace(
+        repository="synaptent/aragora",
+        head_sha=head,
+        run_id=66,
+        run_attempt=1,
+        artifact_name=identity["artifact_name"],
+        signer_workflow="",
+        admin_reads="report",
+    )
+    monkeypatch.setattr(module, "_run_gh", run_stub({("release", "verify")}))
+    assert module.cmd_verify(args) == module.EXIT_BLOCKED
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+    monkeypatch.setattr(module, "_run_gh", run_stub({("release", "verify-asset")}))
+    assert module.cmd_verify(args) == module.EXIT_BLOCKED
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+    monkeypatch.setattr(module, "_run_gh", run_stub(set(), {("release", "verify")}))
+    assert module.cmd_verify(args) == module.EXIT_FAIL
+    assert json.loads(capsys.readouterr().out)["status"] == "fail"
+
+
+def test_envelope_module_docstring_names_attempt_free_artifact_form():
+    """The artifact name deliberately carries no attempt (attempt binding
+    lives in the manifest and the movement plane); an attempt-bearing name in
+    the module docstring misdocuments that design."""
+    doc = _load_envelope_helper().__doc__
+    assert "``openapi-spec-<run_id>-<head_sha>``" in doc
+    assert "<attempt>" not in doc
 
 
 def test_envelope_snapshot_binds_attempt_record_and_survives_settled_reruns(monkeypatch):

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -1021,6 +1021,7 @@ def test_envelope_selection_movement_restarts_verification():
         "workflow_id": OPENAPI_WORKFLOW_ID,
         "run_id": 300,
         "run_attempt": 2,
+        "latest_run_attempt": 2,
         "conclusion": "success",
         "artifact_id": 91,
         "artifact_size": 1024,
@@ -1031,6 +1032,9 @@ def test_envelope_selection_movement_restarts_verification():
         ("workflow_id", 1),
         ("run_id", 301),
         ("run_attempt", 3),
+        # A re-run landing DURING the verification window restarts it even
+        # though the bound attempt's own record is immutable.
+        ("latest_run_attempt", 3),
         ("conclusion", "failure"),
         ("artifact_id", 92),
         ("artifact_size", 2048),
@@ -1058,6 +1062,7 @@ def test_envelope_admin_reads_degrade_only_on_true_capability_gaps(monkeypatch):
     module = _load_envelope_helper()
     head = "d" * 40
     repo = "synaptent/aragora"
+    real_api = module._gh_api_json
 
     def forbidden(endpoint, **kwargs):
         raise module.Forbidden(f"{endpoint} is not readable by this token: HTTP 403")
@@ -1087,6 +1092,62 @@ def test_envelope_admin_reads_degrade_only_on_true_capability_gaps(monkeypatch):
     )
     with pytest.raises(RuntimeError, match="concluded"):
         module._rule_suite_binding(repo, head, admin_reads="report")
+    # GitHub hides admin-gated settings behind HTTP 404 (not 403) from
+    # tokens without Administration:read: that 404 is a capability gap
+    # (Forbidden, degradable), while the same 404 on an ordinary endpoint
+    # stays Blocked.
+    hidden = subprocess.CompletedProcess(
+        args=["gh"], returncode=1, stdout=b"", stderr=b"HTTP 404 Not Found"
+    )
+    monkeypatch.setattr(module, "_run_gh", lambda argv: hidden)
+    monkeypatch.setattr(module, "_gh_api_json", real_api)
+    with pytest.raises(module.Forbidden):
+        module._gh_api_json(f"repos/{repo}/immutable-releases", admin_gated=True)
+    with pytest.raises(module.Blocked):
+        module._gh_api_json(f"repos/{repo}/releases/tags/x")
+    assert module._immutability_state(repo, admin_reads="report").startswith("unreadable")
+
+
+def test_envelope_snapshot_binds_attempt_record_and_survives_settled_reruns(monkeypatch):
+    module = _load_envelope_helper()
+    head = "e" * 40
+    identity = module.make_identity(**_identity_kwargs(module, head, run_id=44))
+    latest = {"seen": []}
+
+    def fake_api(endpoint, **kwargs):
+        latest["seen"].append(endpoint)
+        if endpoint.endswith("git/ref/heads/main"):
+            return {"object": {"sha": head}}
+        if "/actions/workflows/" in endpoint:
+            return {"id": 7001, "path": ".github/workflows/openapi.yml", "state": "active"}
+        if endpoint.endswith("/attempts/1"):
+            # The bound attempt's immutable record: still head-bound and
+            # successful even after a later re-run.
+            return {"run_attempt": 1, "head_sha": head, "conclusion": "success"}
+        if endpoint.endswith("/artifacts?per_page=100"):
+            return [
+                {"artifacts": [{"name": identity["artifact_name"], "id": 91, "size_in_bytes": 10}]}
+            ]
+        # The run-level object reports only the LATEST attempt.
+        return {
+            "id": 44,
+            "path": ".github/workflows/openapi.yml",
+            "head_sha": head,
+            "run_attempt": 2,
+            "conclusion": "failure",
+        }
+
+    monkeypatch.setattr(module, "_gh_api_json", fake_api)
+    snapshot = module.live_selection_snapshot(identity)
+    # A settled newer attempt must NOT wedge the bound capsule: the snapshot
+    # binds the attempt record (attempt 1, success) and reports the latest
+    # attempt on the movement plane instead of raising.
+    assert snapshot["run_attempt"] == 1
+    assert snapshot["latest_run_attempt"] == 2
+    assert snapshot["conclusion"] == "success"
+    assert any(endpoint.endswith("/actions/runs/44/attempts/1") for endpoint in latest["seen"])
+    assert module.selection_is_stable(snapshot, module.live_selection_snapshot(identity))
+    assert set(snapshot) == set(module.SELECTION_KEYS)
 
 
 def test_envelope_verification_argv_and_read_only_guard():

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -22,9 +22,12 @@ the rules and the repo-tree census so a drifting workflow fails here first.
 
 from __future__ import annotations
 
+import importlib.util
+import json
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -67,6 +70,7 @@ AUTHORITATIVE_STEPS = (
     "Verify SDK contracts against spec",
     "Check namespace SDK parity",
     "Run contract matrix tests",
+    "Validate release envelope helper (dry run)",
 )
 
 # The complete continue-on-error census of the workflow. Every entry is a
@@ -98,6 +102,7 @@ RECOVERY_STEPS_WITH_OR_TRUE = {
     ("sync", "Verify checkout integrity"),
     ("sync", "Check for changes"),
     ("sync", "Commit updated spec"),
+    ("envelope", "Verify checkout integrity"),
 }
 
 _PIPE = re.compile(r"(?<!\|)\|(?!\|)")
@@ -734,3 +739,394 @@ def test_openapi_summary_and_artifact_steps_cannot_rewrite_gate_conclusion():
     script = comment["with"]["script"]
     assert "createComment" in script
     assert "conclusion" not in script
+
+
+# ---------------------------------------------------------------------------
+# FIX-RT-017: SHA/run-bound artifacts and the immutable release envelope
+# ---------------------------------------------------------------------------
+
+# The exact run/SHA binding suffix. `github.sha` is the merge SHA on
+# pull_request events, so the pull-request head SHA must win there for the
+# artifact name to end with the RUN's head_sha (the `-{head_sha}` rule that
+# `_validate_run_artifact` pins).
+RUN_SHA_SUFFIX = (
+    "${{ github.run_id }}-${{ github.run_attempt }}"
+    "-${{ github.event.pull_request.head.sha || github.sha }}"
+)
+ENVELOPE_HELPER_PATH = ROOT / "scripts" / "openapi_release_envelope.py"
+# Same pinned actions/attest release the ratified contract-drift boundary
+# signer uses; a different (unreviewed) signer version fails this census.
+ENVELOPE_ATTEST_ACTION = "actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d"
+ENVELOPE_IF = (
+    "github.event_name == 'workflow_dispatch' && inputs.publish_envelope == true"
+    " && github.ref == 'refs/heads/main'"
+)
+
+
+def _load_envelope_helper():
+    spec = importlib.util.spec_from_file_location("openapi_release_envelope", ENVELOPE_HELPER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _identity_kwargs(module, head: str, run_id: int = 7, run_attempt: int = 1) -> dict:
+    return {
+        "repository": "synaptent/aragora",
+        "head_sha": head,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "artifact_name": f"openapi-spec-{run_id}-{run_attempt}-{head}",
+    }
+
+
+def test_openapi_artifact_names_are_run_and_sha_bound():
+    env = DOC.get("env") or {}
+    assert env.get("OPENAPI_RUN_ARTIFACT") == f"openapi-spec-{RUN_SHA_SUFFIX}"
+    assert env.get("DRIFT_RUN_ARTIFACT") == f"contract-drift-artifacts-{RUN_SHA_SUFFIX}"
+    spec_upload = _step("generate-run", "Upload generated spec and SDK types")
+    assert spec_upload["with"]["name"] == "${{ env.OPENAPI_RUN_ARTIFACT }}"
+    drift_upload = _step("generate-run", "Upload contract drift artifacts")
+    assert drift_upload["with"]["name"] == "${{ env.DRIFT_RUN_ARTIFACT }}"
+    # Every artifact consumer resolves the same run-bound name.
+    sync_download = _step("sync", "Download generated spec")
+    assert sync_download["with"]["name"] == "${{ env.OPENAPI_RUN_ARTIFACT }}"
+    envelope_download = _step("envelope", "Download run-level spec artifact")
+    assert envelope_download["with"]["name"] == "${{ env.OPENAPI_RUN_ARTIFACT }}"
+    # No fixed-name expiring artifact remains anywhere in the workflow.
+    assert "name: openapi-spec\n" not in TEXT
+    assert "name: contract-drift-artifacts\n" not in TEXT
+
+
+def test_openapi_envelope_job_is_dispatch_gated_and_attests_exact_assets():
+    job = JOBS["envelope"]
+    assert job["needs"] == "generate-run"
+    assert job["if"] == ENVELOPE_IF
+    assert job["permissions"] == {
+        "contents": "write",
+        "id-token": "write",
+        "attestations": "write",
+    }
+    for step in job["steps"]:
+        assert "continue-on-error" not in step, step.get("name")
+        if step.get("name") != "Verify checkout integrity":
+            assert "|| true" not in step.get("run", ""), step.get("name")
+    # A bare dispatch can never publish: the input defaults off.
+    dispatch = DOC["on"]["workflow_dispatch"]
+    publish_input = dispatch["inputs"]["publish_envelope"]
+    assert publish_input["type"] == "boolean"
+    assert publish_input["default"] == "false"
+    assert publish_input["required"] == "false"
+    # Envelope construction hashes the exact downloaded run-payload bytes and
+    # re-authenticates them with sha256sum --check --strict.
+    build = _step("envelope", "Build deterministic release envelope")["run"]
+    assert "set -euo pipefail" in build
+    assert "scripts/openapi_release_envelope.py build" in build
+    for flag in ("--repository", "--head-sha", "--run-id", "--run-attempt", "--artifact-name"):
+        assert flag in build, flag
+    assert "sha256sum --check --strict checksums.txt" in build
+    # The release is published (not draft) at the exact-SHA tag.
+    publish = _step("envelope", "Publish immutable release")["run"]
+    assert "set -euo pipefail" in publish
+    assert "gh release create" in publish
+    assert "--draft" not in publish
+    assert "openapi-envelope-$GITHUB_SHA" in publish
+    assert '--target "$GITHUB_SHA"' in publish
+    # Exact assets are attested with the pinned signer action.
+    attest = _step("envelope", "Attest the envelope assets")
+    assert attest["uses"] == ENVELOPE_ATTEST_ACTION
+    assert "# v4.2.1" in TEXT
+    assert attest["with"]["subject-path"].strip() == "/tmp/openapi-envelope/assets/*"
+    # Verification binds release, assets, attestation, and rule suite to this
+    # workflow as the signer, with movement-requery semantics in the helper.
+    verify = _step("envelope", "Verify release, assets, attestation, and rule suite")["run"]
+    assert "set -euo pipefail" in verify
+    assert "scripts/openapi_release_envelope.py verify" in verify
+    assert "--signer-workflow" in verify
+    assert ".github/workflows/openapi.yml" in verify
+
+
+def test_openapi_envelope_helper_dry_run_is_a_pr_time_authority():
+    # The dry-run proof runs on every generate-run execution and is part of
+    # the no-masking census (AUTHORITATIVE_STEPS).
+    assert "Validate release envelope helper (dry run)" in AUTHORITATIVE_STEPS
+    step = _step("generate-run", "Validate release envelope helper (dry run)")
+    assert "set -euo pipefail" in step["run"]
+    assert "scripts/openapi_release_envelope.py dry-run" in step["run"]
+    assert "if" not in step
+
+
+def test_envelope_build_is_deterministic_and_release_bound():
+    module = _load_envelope_helper()
+    head = "a" * 40
+    identity = module.make_identity(**_identity_kwargs(module, head))
+    payloads = {
+        "docs/api/openapi_generated.json": b'{"openapi":"3.1.0"}\n',
+        "sdk/python/aragora/generated_types.py": b"GENERATED = True\n",
+    }
+    first = module.build_envelope(payloads, identity)
+    second = module.build_envelope(dict(payloads), identity)
+    assert first == second, "envelope bytes must be deterministic"
+    assert set(first) == {
+        "manifest.json",
+        "checksums.txt",
+        "openapi_generated.json",
+        "generated_types.py",
+    }
+    manifest = json.loads(first["manifest.json"])
+    assert manifest["repository"] == "synaptent/aragora"
+    assert manifest["head_sha"] == head
+    assert manifest["workflow_run_id"] == 7
+    assert manifest["run_attempt"] == 1
+    assert manifest["artifact_name"] == f"openapi-spec-7-1-{head}"
+    assert manifest["tag"] == f"openapi-envelope-{head}"
+    assert manifest["workflow_path"] == ".github/workflows/openapi.yml"
+    # Canonical bytes: re-serializing the parsed manifest reproduces the
+    # exact on-release bytes.
+    assert module.canonical_json_bytes(manifest) == first["manifest.json"]
+    # checksums.txt is sha256sum-compatible, sorted, and covers every payload
+    # asset plus the manifest (never itself).
+    lines = first["checksums.txt"].decode("ascii").splitlines()
+    names = [line.split("  ", 1)[1] for line in lines]
+    assert names == sorted(names)
+    assert set(names) == {"manifest.json", "openapi_generated.json", "generated_types.py"}
+    for line in lines:
+        assert re.fullmatch(r"[0-9a-f]{64}  [^/\s]+", line)
+    # Round-trip verification passes and the digest set release-binds the
+    # run-level artifact under the VAL-CDG-012 rule.
+    verified = module.verify_envelope_assets(first, identity)
+    assert verified["head_sha"] == head
+    digests = module.release_digest_set(first)
+    artifact = {
+        "name": identity["artifact_name"],
+        "size_in_bytes": 20,
+        "payload_sha256": manifest["payload_assets"][0]["sha256"],
+    }
+    assert _validate_run_artifact(artifact, head_sha=head, release_digests=digests)
+    # A digest the release never published is not bound.
+    foreign = dict(artifact, payload_sha256="f" * 64)
+    with pytest.raises(ValueError, match="not bound"):
+        _validate_run_artifact(foreign, head_sha=head, release_digests=digests)
+
+
+def test_envelope_rejects_unbound_names_and_tampered_assets():
+    module = _load_envelope_helper()
+    head = "b" * 40
+    base = _identity_kwargs(module, head)
+    identity = module.make_identity(**base)
+    # Hostile identities: fixed (unbound) name, wrong run, wrong attempt,
+    # foreign head, non-canonical SHA.
+    for kwargs in (
+        dict(base, artifact_name="openapi-spec"),
+        dict(base, artifact_name=f"openapi-spec-8-1-{head}"),
+        dict(base, artifact_name=f"openapi-spec-7-2-{head}"),
+        dict(base, artifact_name=f"openapi-spec-7-1-{'c' * 40}"),
+        dict(base, head_sha=head.upper(), artifact_name=f"openapi-spec-7-1-{head.upper()}"),
+        dict(base, head_sha="b" * 39, artifact_name=f"openapi-spec-7-1-{'b' * 39}"),
+        dict(base, run_id=0, artifact_name=f"openapi-spec-0-1-{head}"),
+        dict(base, repository="aragora"),
+    ):
+        with pytest.raises(ValueError):
+            module.make_identity(**kwargs)
+    assets = module.build_envelope({"a.json": b"{}\n"}, identity)
+    # Tampered payload bytes.
+    tampered = dict(assets, **{"a.json": b"{ }\n"})
+    with pytest.raises(ValueError):
+        module.verify_envelope_assets(tampered, identity)
+    # Renamed, missing, and extra assets.
+    renamed = {("b.json" if key == "a.json" else key): value for key, value in assets.items()}
+    with pytest.raises(ValueError):
+        module.verify_envelope_assets(renamed, identity)
+    missing = {key: value for key, value in assets.items() if key != "a.json"}
+    with pytest.raises(ValueError):
+        module.verify_envelope_assets(missing, identity)
+    extra = dict(assets, **{"rogue.bin": b"x"})
+    with pytest.raises(ValueError):
+        module.verify_envelope_assets(extra, identity)
+    # Tampered checksum line.
+    digest = assets["checksums.txt"].decode("ascii").split("  ", 1)[0]
+    flipped = ("0" if digest[0] != "0" else "1") + digest[1:]
+    with pytest.raises(ValueError):
+        module.verify_envelope_assets(
+            dict(
+                assets,
+                **{
+                    "checksums.txt": assets["checksums.txt"].replace(
+                        digest.encode("ascii"), flipped.encode("ascii")
+                    )
+                },
+            ),
+            identity,
+        )
+    # Verifying under a different execution identity fails.
+    other = module.make_identity(**_identity_kwargs(module, head, run_id=8))
+    with pytest.raises(ValueError):
+        module.verify_envelope_assets(assets, other)
+    # Non-canonical manifest bytes fail even with a recomputed checksum line.
+    noncanonical = json.dumps(json.loads(assets["manifest.json"]), indent=2).encode("ascii")
+    rebuilt = dict(assets, **{"manifest.json": noncanonical})
+    manifest_digest = module.sha256_hexdigest(assets["manifest.json"])
+    rebuilt["checksums.txt"] = assets["checksums.txt"].replace(
+        manifest_digest.encode("ascii"),
+        module.sha256_hexdigest(noncanonical).encode("ascii"),
+    )
+    with pytest.raises(ValueError):
+        module.verify_envelope_assets(rebuilt, identity)
+    # Empty payloads are never publishable.
+    with pytest.raises(ValueError):
+        module.build_envelope({}, identity)
+    with pytest.raises(ValueError):
+        module.build_envelope({"a.json": b""}, identity)
+
+
+def test_envelope_selection_movement_restarts_verification():
+    module = _load_envelope_helper()
+    before = {
+        "main_sha": "a" * 40,
+        "workflow_id": OPENAPI_WORKFLOW_ID,
+        "run_id": 300,
+        "run_attempt": 2,
+        "conclusion": "success",
+        "artifact_id": 91,
+        "artifact_size": 1024,
+    }
+    assert module.selection_is_stable(before, dict(before))
+    for key, moved in (
+        ("main_sha", "b" * 40),
+        ("workflow_id", 1),
+        ("run_id", 301),
+        ("run_attempt", 3),
+        ("conclusion", "failure"),
+        ("artifact_id", 92),
+        ("artifact_size", 2048),
+    ):
+        after = dict(before)
+        after[key] = moved
+        assert not module.selection_is_stable(before, after), (
+            f"movement in {key} must restart verification"
+        )
+    with pytest.raises(ValueError, match="missing"):
+        module.selection_is_stable(before, {"main_sha": "a" * 40})
+
+
+def test_envelope_verification_argv_and_read_only_guard():
+    module = _load_envelope_helper()
+    head = "c" * 40
+    tag = f"openapi-envelope-{head}"
+    signer = "synaptent/aragora/.github/workflows/openapi.yml"
+    assert module.attestation_verify_argv(
+        "/tmp/x/manifest.json",
+        repository="synaptent/aragora",
+        head_sha=head,
+        signer_workflow=signer,
+    ) == [
+        "gh",
+        "attestation",
+        "verify",
+        "/tmp/x/manifest.json",
+        "-R",
+        "synaptent/aragora",
+        "--signer-workflow",
+        signer,
+        "--source-digest",
+        head,
+        "--format",
+        "json",
+    ]
+    assert module.release_verify_argv(tag, repository="synaptent/aragora") == [
+        "gh",
+        "release",
+        "verify",
+        tag,
+        "-R",
+        "synaptent/aragora",
+        "--format",
+        "json",
+    ]
+    assert module.release_verify_asset_argv(
+        tag, "/tmp/x/manifest.json", repository="synaptent/aragora"
+    ) == [
+        "gh",
+        "release",
+        "verify-asset",
+        tag,
+        "/tmp/x/manifest.json",
+        "-R",
+        "synaptent/aragora",
+        "--format",
+        "json",
+    ]
+    # The helper is read-only: mutating argv is rejected before execution.
+    for hostile in (
+        ["gh", "release", "create", tag],
+        ["gh", "release", "delete", tag],
+        ["gh", "release", "edit", tag],
+        ["gh", "api", "-X", "DELETE", "repos/synaptent/aragora/releases/1"],
+        ["gh", "api", "--method", "POST", "repos/synaptent/aragora/releases"],
+        ["gh", "pr", "merge", "1"],
+        ["rm", "-rf", "/tmp/x"],
+    ):
+        with pytest.raises(ValueError):
+            module.require_read_only_argv(hostile)
+    module.require_read_only_argv(["gh", "api", "repos/synaptent/aragora/releases/tags/x"])
+    module.require_read_only_argv(["gh", "release", "download", tag])
+    module.require_read_only_argv(["gh", "release", "verify", tag])
+
+
+def test_envelope_build_and_dry_run_cli_are_deterministic(tmp_path):
+    # dry-run: deterministic fixture bytes, byte-identical across invocations.
+    runs = [
+        subprocess.run(
+            [sys.executable, str(ENVELOPE_HELPER_PATH), "dry-run"],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            stdin=subprocess.DEVNULL,
+        )
+        for _ in range(2)
+    ]
+    for completed in runs:
+        assert completed.returncode == 0, completed.stderr
+    assert runs[0].stdout == runs[1].stdout
+    report = json.loads(runs[0].stdout)
+    assert report["status"] == "pass"
+    assert report["deterministic"] is True
+    assert re.fullmatch(r"[0-9a-f]{64}", report["manifest_sha256"])
+    # build CLI: two builds from the same payload bytes produce identical
+    # envelope files that pass strict checksum verification.
+    head = "d" * 40
+    payload_dir = tmp_path / "payload" / "docs" / "api"
+    payload_dir.mkdir(parents=True)
+    (payload_dir / "openapi_generated.json").write_bytes(b'{"openapi":"3.1.0"}\n')
+    outputs = []
+    for name in ("assets-one", "assets-two"):
+        out_dir = tmp_path / name
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(ENVELOPE_HELPER_PATH),
+                "build",
+                "--repository",
+                "synaptent/aragora",
+                "--head-sha",
+                head,
+                "--run-id",
+                "12",
+                "--run-attempt",
+                "3",
+                "--artifact-name",
+                f"openapi-spec-12-3-{head}",
+                "--payload-dir",
+                str(tmp_path / "payload"),
+                "--output-dir",
+                str(out_dir),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            stdin=subprocess.DEVNULL,
+        )
+        assert completed.returncode == 0, completed.stderr
+        outputs.append({path.name: path.read_bytes() for path in sorted(out_dir.iterdir())})
+    assert outputs[0] == outputs[1]
+    assert set(outputs[0]) == {"manifest.json", "checksums.txt", "openapi_generated.json"}


### PR DESCRIPTION
## FIX-RT-017 (Tier 4, PREPARE-ONLY — PARKED DRAFT)

**Do not mark ready, settle, merge, dispatch the live workflow, or publish an immutable release.** Those steps belong exclusively to `cdg-openapi-artifact-release-envelope-finalization` under a later exact operator delegation. This draft stays parked with the `operator-review-required` label.

### Defect (route-truth scrutiny round 1)

The live `openapi.yml` uploaded **fixed-name, 14-day-expiring** Actions artifacts (`openapi-spec`, `contract-drift-artifacts`) with no payload hashing and no immutable release/attestation envelope, while the VAL-CDG-012 synthetic contract (`_validate_run_artifact`) requires SHA-bound names and `payload_sha256 ∈ release_digests`. The synthetic contract passed a topology the deployed workflow did not implement.

### Change

1. **Run/SHA-bound artifact names** — workflow-level env `OPENAPI_RUN_ARTIFACT` / `DRIFT_RUN_ARTIFACT` = `<base>-${{ github.run_id }}-${{ github.event.pull_request.head.sha || github.sha }}` (attempt deliberately not in the name so re-running a failed dependent job can still download it; attempt binding lives in the manifest and movement plane) (the PR head SHA wins on `pull_request` so the name ends with the run's `head_sha`). Both uploads, the sync download, and the envelope download resolve the same expression.
2. **`envelope` job (dispatch-gated, default-off)** — `if: github.event_name == 'workflow_dispatch' && inputs.publish_envelope == true && github.ref == 'refs/heads/main'`. Publication-safety order: download this run's own artifact payload → hash the exact bytes → build the deterministic manifest/checksums envelope (compact sorted-key canonical JSON + `sha256sum --check --strict`) → **attest** the exact assets with the pinned ratified signer (`actions/attest@508db95d… # v4.2.1`, same pin as `contract-drift-boundary.yml`) → **preflight-verify** (local bytes, attestations, unused tag, capability probe, main still at bound head; movement here is a free exit-3 restart) → **publish last** (`gh release create openapi-envelope-<head_sha>` at the exact SHA) → post-publish verify of release/assets/attestation/rule-suite with workflow/run/artifact/main re-query. Post-publish main-only movement is recorded as `superseded_by_newer_main`, never a strand; any run/attempt/artifact/workflow movement restarts.
3. **`scripts/openapi_release_envelope.py`** — checked-in read-only helper (`build` / `verify` / `dry-run`): canonical envelope bytes, identity binding (repo/head/run/attempt/artifact-name), read-only `gh` argv guard (mutating verbs rejected), `gh release verify` / `verify-asset` / `gh attestation verify --signer-workflow …/openapi.yml --source-digest <sha>` argv mirroring `check_contract_drift_ratchet.py`, rule-suite pass binding, movement snapshots over `(main_sha, workflow_id, run_id, run_attempt, conclusion, artifact_id, artifact_size)` with `movement_disposition` (restart/superseded/stable), exit vocabulary pass=0 / fail=1 / blocked=2 / movement=3 (publication/attestation absence is `blocked`, not `fail`). Admin-gated reads (`rulesets/rule-suites`, `immutable-releases` setting) need Administration:read the workflow `GITHUB_TOKEN` lacks: `--admin-reads report` (in-run) records them and relies on the release object's own `immutable` flag for durability; `--admin-reads required` (operator verification) enforces them.
4. **Tests** — SHA/run-bound name census, envelope-job census (gating, permissions, pinned attest action, no `continue-on-error`), hostile digest/name/run/attempt/movement negatives, deterministic dry-run + build CLI proofs. The dry-run helper step runs on every `generate-run` execution and joins `AUTHORITATIVE_STEPS`.

### Preserved invariants

Required `Generate & Validate` aggregator untouched (sole emitter; still needs only `scope`+`generate-run`); sync-job manual-only guard string intact (branch-mutation policy re-verified); `JUSTIFIED_CONTINUE_ON_ERROR` census unchanged; upload census keys `{name,path,retention-days}`; no `checks.create`/`check-runs`/`statuses/` anywhere.

### Validation (local, exact commands)

- `python3 -m pytest tests/scripts/test_openapi_workflow_contract.py -q` → **20 passed**
- VAL-CDG-012 named `-k` selector → **12 passed** (collection proof intact)
- `actionlint .github/workflows/openapi.yml` → clean
- `python3 scripts/check_branch_mutation_policy.py`, `check_required_check_priority_policy.py`, `check_workflow_checkout_integrity_policy.py` → all pass
- `python3 -m pytest tests/ci/test_required_aggregator_fail_closed.py tests/ci/test_live_node_runtime_workflows.py tests/scripts/test_check_required_check_priority_policy.py tests/scripts/test_contract_drift_sequence.py -q` → **213 passed**
- `make lint`, `ruff format --check`, `mypy scripts/openapi_release_envelope.py` → clean; `make test-smoke` → pass

### Review round 2 (prepared claude+openai evidence, both initially CHANGES-REQUESTED)

All P2 findings fixed at `664526fb…`: publication now last (no strandable half-publish), attempt removed from artifact names (re-run-failed-jobs works), admin-read capability degradation (no post-publish exit-1 on token 403), `gh --version` probe. Bypass-result strictness (`result == pass` only) is intentional and documented in the runbook.

### Review round 3 (second prepared round, both again CHANGES-REQUESTED)

All four genuine findings fixed at `fdc06f6b…`: envelope job grants `actions: read` (the explicit permissions block zeroed it, so preflight/verify actions-API re-queries would 403 on every dispatch, dead-on-arrival fail-closed); both uploads set `overwrite: true` (attempt-free names + immutable v4 artifacts would 409 on re-run-all-jobs); `--admin-reads report` degrades ONLY on a true HTTP 403 capability gap (readable `enabled:false`, readable-but-absent rule-suite record, and readable non-pass result stay fail-closed in both modes); preflight probes `gh release verify`/`verify-asset` before publication and the read-only argv guard rejects pflag attached shorthand (`-XPOST`, `-fk=v`, `-Fk=v`, `--raw-field=`).

### Review round 4 (third prepared round)

Fixed at `21d06779…`: selection snapshots bind the bound attempt's immutable record (`actions/runs/{id}/attempts/{n}`) for head/conclusion and carry `latest_run_attempt` on the movement plane, so a re-run that settled before a verification window no longer permanently wedges a correctly published capsule while a re-run landing mid-window still restarts it; `_gh_api_json(admin_gated=True)` maps the permission-hidden HTTP 404 GitHub returns for admin-gated settings to the capability-gap class so `--admin-reads report` degrades on the real in-run signal (ordinary 404s stay Blocked, readable answers stay fail-closed); preflight also requires the bare git ref `tags/openapi-envelope-<sha>` to be absent because `gh release create` attaches to an existing tag and ignores `--target`.

### Size

`+1577/-4` cumulative (measured `git diff origin/main...HEAD --numstat` vs base `056bbce6`). The CDG `<=800` additions-plus-deletions cap **does not apply to OpenAPI-stage work** (mission AGENTS.md CDG size rule; architecture decision 351 scope list). Reported for transparency.

### Notes for finalization

- Publication runbook: mission `library/cdg-openapi-artifact-release-envelope-runbook-<shortsha>.md`.
- No draft release was created: deterministic byte construction is proven by the offline dry-run/build tests, so `release_api_id` is not needed at this stage.
- Open PR #9690 (dependabot `actions/setup-node` 4→7) also touches `openapi.yml` in non-overlapping hunks; if it merges first, rebase before finalization.

Base: `056bbce6ed0b85ef60723bd7358eee366ed28c06` (main). Feature: `cdg-openapi-artifact-release-envelope` (milestone `cdg-bootstrap-route-truth`).
