### PR TITLE
ci(governance): enforce aragora-verify dependency policy [Tier 4]

### DIFF
--- a/.github/actions/pr-scope-classifier/action.yml
+++ b/.github/actions/pr-scope-classifier/action.yml
@@ -58,6 +58,7 @@ runs:
             - 'scripts/**'
           lint_python:
             - 'aragora/**'
+            - 'aragora-verify/**'
             - 'tests/**'
             - 'scripts/**'
             - 'pyproject.toml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Enforce workflow pip install policy
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_workflow_pip_install_policy.py
 
+      - name: Enforce aragora-verify dependency policy
+        run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_aragora_verify_dependency_policy.py
+
       - name: Enforce self-hosted checkout integrity policy
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_workflow_checkout_integrity_policy.py
 

--- a/scripts/check_aragora_verify_dependency_policy.py
+++ b/scripts/check_aragora_verify_dependency_policy.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Fail when aragora-verify declares dependencies outside its adopted policy."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "aragora-verify" / "pyproject.toml"
+DEPENDENCY_POLICY = {
+    "build-system.requires": frozenset({"hatchling"}),
+    "project.dependencies": frozenset({"cryptography"}),
+    "project.optional-dependencies.schema": frozenset({"jsonschema"}),
+    "project.optional-dependencies.dev": frozenset({"pytest"}),
+}
+
+
+def _table(value: object, label: str, errors: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{label} must be a TOML table")
+    return {}
+
+
+def _requirement_names(value: object, label: str, errors: list[str]) -> set[str]:
+    if not isinstance(value, list):
+        errors.append(f"{label} must be a TOML array")
+        return set()
+
+    names: set[str] = set()
+    for raw in value:
+        if not isinstance(raw, str):
+            errors.append(f"{label} contains a non-string requirement")
+            continue
+        try:
+            names.add(canonicalize_name(Requirement(raw).name))
+        except InvalidRequirement as exc:
+            errors.append(f"{label} contains invalid PEP 508 requirement {raw!r}: {exc}")
+    return names
+
+
+def check_manifest(path: Path) -> list[str]:
+    """Return policy violations for an aragora-verify pyproject manifest."""
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError) as exc:
+        return [f"cannot parse {path}: {exc}"]
+
+    errors: list[str] = []
+    build_system = _table(document.get("build-system"), "build-system", errors)
+    project = _table(document.get("project"), "project", errors)
+    optional = _table(project.get("optional-dependencies"), "project.optional-dependencies", errors)
+    declared: dict[str, object] = {
+        "build-system.requires": build_system.get("requires"),
+        "project.dependencies": project.get("dependencies"),
+    }
+    declared.update(
+        {
+            f"project.optional-dependencies.{group}": requirements
+            for group, requirements in optional.items()
+        }
+    )
+
+    for label in sorted(set(DEPENDENCY_POLICY) | set(declared)):
+        actual = _requirement_names(declared.get(label), label, errors)
+        expected = DEPENDENCY_POLICY.get(label, frozenset())
+        for name in sorted(actual - expected):
+            errors.append(f"{label} declares unadopted dependency {name!r}")
+        for name in sorted(expected - actual):
+            errors.append(f"{label} is missing adopted dependency {name!r}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", type=Path, default=DEFAULT_MANIFEST)
+    args = parser.parse_args()
+
+    errors = check_manifest(args.pyproject)
+    if not errors:
+        print("aragora-verify dependency policy passed")
+        return 0
+
+    print("aragora-verify dependency policy violations:")
+    for error in errors:
+        print(f"- {error}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_aragora_verify_dependency_policy.py
+++ b/tests/scripts/test_check_aragora_verify_dependency_policy.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.check_aragora_verify_dependency_policy import check_manifest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE_MANIFEST = """
+[build-system]
+requires = ["hatchling>=1"]
+
+[project]
+dependencies = ["cryptography>=48"]
+
+[project.optional-dependencies]
+schema = ["jsonschema>=4"]
+dev = ["pytest>=8"]
+"""
+
+
+def _check(tmp_path: Path, content: str) -> list[str]:
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(content, encoding="utf-8")
+    return check_manifest(manifest)
+
+
+def test_current_manifest_matches_policy() -> None:
+    assert check_manifest(REPO_ROOT / "aragora-verify" / "pyproject.toml") == []
+
+
+@pytest.mark.parametrize(
+    ("needle", "replacement", "dependency"),
+    [
+        ('requires = ["hatchling>=1"]', 'requires = ["hatchling>=1", "setuptools"]', "setuptools"),
+        (
+            'dependencies = ["cryptography>=48"]',
+            'dependencies = ["cryptography>=48", "httpx"]',
+            "httpx",
+        ),
+        ('schema = ["jsonschema>=4"]', 'schema = ["jsonschema>=4", "referencing"]', "referencing"),
+        ('dev = ["pytest>=8"]', 'dev = ["pytest>=8", "ruff"]', "ruff"),
+    ],
+)
+def test_rejects_unadopted_dependency(
+    tmp_path: Path, needle: str, replacement: str, dependency: str
+) -> None:
+    errors = _check(tmp_path, BASE_MANIFEST.replace(needle, replacement))
+    assert any("unadopted dependency" in error and dependency in error for error in errors)
+
+
+def test_rejects_new_optional_dependency_group(tmp_path: Path) -> None:
+    errors = _check(tmp_path, BASE_MANIFEST + 'qa = ["tox"]\n')
+    assert any("optional-dependencies.qa" in error and "tox" in error for error in errors)
+
+
+def test_normalizes_names_with_extras_and_markers(tmp_path: Path) -> None:
+    content = BASE_MANIFEST.replace(
+        '"hatchling>=1"', "\"Hatchling[cli]>=1; python_version >= '3.10'\""
+    ).replace('"jsonschema>=4"', "\"JSONSchema[format]>=4; platform_system != 'Plan9'\"")
+    assert _check(tmp_path, content) == []
+
+
+def test_rejects_missing_adopted_dependency(tmp_path: Path) -> None:
+    errors = _check(tmp_path, BASE_MANIFEST.replace('dev = ["pytest>=8"]', "dev = []"))
+    assert any("missing adopted dependency 'pytest'" in error for error in errors)
+
+
+def test_fails_closed_on_malformed_toml(tmp_path: Path) -> None:
+    errors = _check(tmp_path, "[project\ndependencies = []")
+    assert len(errors) == 1
+    assert errors[0].startswith("cannot parse ")
+
+
+def test_fails_closed_on_malformed_requirement(tmp_path: Path) -> None:
+    errors = _check(tmp_path, BASE_MANIFEST.replace('"pytest>=8"', '"@@@"'))
+    assert any("invalid PEP 508 requirement" in error for error in errors)
+
+
+def test_lint_workflow_invokes_checker_once() -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/lint.yml").read_text())
+    steps = workflow["jobs"]["lint-run"]["steps"]
+    matching = [
+        step
+        for step in steps
+        if "scripts/check_aragora_verify_dependency_policy.py" in str(step.get("run", ""))
+    ]
+    assert len(matching) == 1
+    assert matching[0]["name"] == "Enforce aragora-verify dependency policy"
+
+
+def test_verifier_changes_enter_lint_scope() -> None:
+    classifier = yaml.safe_load(
+        (REPO_ROOT / ".github/actions/pr-scope-classifier/action.yml").read_text()
+    )
+    filters = classifier["runs"]["steps"][0]["with"]["filters"]
+    lint_python = filters.split("lint_python:", 1)[1].split("quality:", 1)[0]
+    assert "- 'aragora-verify/**'" in lint_python


### PR DESCRIPTION
## Summary
- parse `aragora-verify/pyproject.toml` structurally with `tomllib` and the Python 3.10 `tomli` fallback
- enforce the exact adopted build, runtime, and optional dependency names after PEP 508 normalization
- run the checker in the existing lint policy block and include verifier-only changes in `lint_python` scope

## Scope
This is the standalone dependency-policy replacement for the parked draft #9592. That PR remains untouched as module-edge design history; this PR does not implement import scanning, frozen edge baselines, or policy for other packages.

Base at implementation: `aec0ae5723720c3ed10d462ed50f18e333e727d6`
Changed lines: 207, below the 300-line preferred bound.

## Validation
- `python -m pytest -q tests/scripts/test_check_aragora_verify_dependency_policy.py` (12 passed)
- `python -m ruff check scripts/check_aragora_verify_dependency_policy.py tests/scripts/test_check_aragora_verify_dependency_policy.py`
- `python -m ruff format --check scripts/check_aragora_verify_dependency_policy.py tests/scripts/test_check_aragora_verify_dependency_policy.py`
- `python -m mypy scripts/check_aragora_verify_dependency_policy.py`
- `python scripts/check_aragora_verify_dependency_policy.py`
- `actionlint`
- `python scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Governance
Tier 4 because this adds a workflow policy gate. Implementation was operator-preapproved. Keep draft until fresh exact-head Tier-4 review and separate human settlement authority; no evidence or settlement has been posted.
