### PR TITLE
fix(governance): add REST-resilient evidence settlement

### DIFF
--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import sys
 import tempfile
+from datetime import datetime
 from typing import Any
 from urllib.parse import quote
 
@@ -166,6 +167,62 @@ def _check_state(check: dict[str, Any]) -> tuple[str, str, bool | None]:
     return name, conclusion, is_required if isinstance(is_required, bool) else None
 
 
+def _check_attempt_timestamp(check: dict[str, Any]) -> datetime | None:
+    """Return the best attempt-ordering timestamp, or ``None`` if unprovable."""
+    for key in (
+        "startedAt",
+        "started_at",
+        "completedAt",
+        "completed_at",
+        "updatedAt",
+        "updated_at",
+    ):
+        raw = check.get(key)
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        try:
+            parsed = datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo is not None else None
+    return None
+
+
+def _latest_check_attempts(checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Select the uniquely newest row per check name; ambiguity becomes pending."""
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    selected: list[dict[str, Any]] = []
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        name = str(check.get("name") or check.get("context") or "").strip()
+        if not name:
+            selected.append(check)
+            continue
+        grouped.setdefault(name, []).append(check)
+    for name, attempts in grouped.items():
+        if len(attempts) == 1:
+            selected.append(attempts[0])
+            continue
+        timestamps = [_check_attempt_timestamp(attempt) for attempt in attempts]
+        if any(timestamp is None for timestamp in timestamps):
+            newest: list[dict[str, Any]] = []
+        else:
+            latest = max(timestamp for timestamp in timestamps if timestamp is not None)
+            newest = [
+                attempt for attempt, timestamp in zip(attempts, timestamps) if timestamp == latest
+            ]
+        if len(newest) == 1:
+            selected.append(newest[0])
+            continue
+        disclosed = [attempt.get("isRequired") for attempt in attempts]
+        is_required = (
+            True if True in disclosed else False if all(v is False for v in disclosed) else None
+        )
+        selected.append({"name": name, "conclusion": "", "isRequired": is_required})
+    return selected
+
+
 def _summarize_checks(
     checks: list[dict[str, Any]],
     *,
@@ -182,17 +239,12 @@ def _summarize_checks(
     real_pending = False
     quorum_conclusion = ""
     seen_names: set[str] = set()
-    for check in checks:
-        if not isinstance(check, dict):
-            continue
+    for check in _latest_check_attempts(checks):
         name, conclusion, disclosed_required = _check_state(check)
         if name:
             seen_names.add(name)
         if name == QUORUM_CHECK_NAME:
-            # GitHub returns duplicate workflow attempts newest-first. Preserve
-            # the first conclusion instead of letting an older run overwrite it.
-            if not quorum_conclusion:
-                quorum_conclusion = conclusion
+            quorum_conclusion = conclusion
             continue
         if disclosed_required is not None:
             required = disclosed_required
@@ -375,12 +427,21 @@ def _fetch_pr_context_rest(repo: str, pr: int, *, env: dict[str, str]) -> dict[s
                 {
                     "name": name,
                     "conclusion": check.get("conclusion") or check.get("status"),
+                    "started_at": check.get("started_at"),
+                    "completed_at": check.get("completed_at"),
+                    "updated_at": check.get("updated_at"),
                 },
             )
     for status in statuses:
         context = str(status.get("context") or "").strip()
         if context:
-            checks.append({"context": context, "state": status.get("state")})
+            checks.append(
+                {
+                    "context": context,
+                    "state": status.get("state"),
+                    "updated_at": status.get("updated_at"),
+                }
+            )
     required_names = _required_check_names(repo, str(base.get("ref") or ""), env=env)
     quorum_conclusion, real_failure, real_pending = _summarize_checks(
         checks, required_names=required_names

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 from typing import Any
+from urllib.parse import quote
 
 from aragora.swarm import github_app_auth
 from aragora.swarm.merge_quorum_reconcile import (
@@ -29,7 +30,18 @@ QUORUM_CHECK_NAME = "aragora-merge-quorum"
 QUORUM_WORKFLOW_FILE = "aragora-merge-quorum.yml"
 HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
 _SHADOW_MARKERS = ("shadow", "advisory")
-_FAILED_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ERROR", "STARTUP_FAILURE"}
+_FAILED_CONCLUSIONS = {
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "ERROR",
+    "FAILURE",
+    "STALE",
+    "STARTUP_FAILURE",
+    "TIMED_OUT",
+}
+_SUCCESS_CONCLUSIONS = {"NEUTRAL", "SKIPPED", "SUCCESS"}
+_REST_PAGE_SIZE = 100
+_REST_MAX_PAGES = 100
 _MERGE_PACKET_TIMEOUT = 120
 _EVIDENCE_LINT_TIMEOUT = 90
 _GH_TIMEOUT = 60
@@ -83,12 +95,22 @@ def _read_env() -> dict[str, str]:
 
 
 def run(
-    args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = _GH_TIMEOUT
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    timeout: int | None = _GH_TIMEOUT,
+    input_text: str | None = None,
 ) -> subprocess.CompletedProcess:
     # Default to a bounded timeout so no bare call can hang the reconciler;
     # callers that need longer (model-review CLIs) pass an explicit timeout.
     return subprocess.run(
-        args, capture_output=True, text=True, check=False, env=env, timeout=timeout
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=timeout,
+        input=input_text,
     )
 
 
@@ -136,8 +158,257 @@ def list_open_prs(repo: str, *, limit: int, author: str | None) -> list[int]:
     return numbers
 
 
-def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
-    """Head SHA, head committedDate, quorum conclusion, and real-failure flag."""
+def _check_state(check: dict[str, Any]) -> tuple[str, str, bool | None]:
+    """Normalize a GraphQL status/check row for settlement-stability checks."""
+    name = str(check.get("name") or check.get("context") or "").strip()
+    conclusion = str(check.get("conclusion") or check.get("state") or "").upper()
+    is_required = check.get("isRequired")
+    return name, conclusion, is_required if isinstance(is_required, bool) else None
+
+
+def _summarize_checks(
+    checks: list[dict[str, Any]],
+    *,
+    required_names: set[str] | None = None,
+) -> tuple[str, bool, bool]:
+    """Return quorum conclusion plus non-quorum required failure/pending flags.
+
+    ``required_names=None`` means GitHub could not disclose the required-check
+    set. In that case every non-shadow failure or pending row is treated as
+    required. This can delay evidence publication, but can never promote an
+    unstable head during a degraded API incident.
+    """
+    real_failure = False
+    real_pending = False
+    quorum_conclusion = ""
+    seen_names: set[str] = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        name, conclusion, disclosed_required = _check_state(check)
+        if name:
+            seen_names.add(name)
+        if name == QUORUM_CHECK_NAME:
+            # GitHub returns duplicate workflow attempts newest-first. Preserve
+            # the first conclusion instead of letting an older run overwrite it.
+            if not quorum_conclusion:
+                quorum_conclusion = conclusion
+            continue
+        if disclosed_required is not None:
+            required = disclosed_required
+        elif required_names is not None:
+            required = name in required_names
+        else:
+            required = not _looks_like_shadow(name)
+        if not required:
+            continue
+        if conclusion in _FAILED_CONCLUSIONS:
+            real_failure = True
+        elif conclusion not in _SUCCESS_CONCLUSIONS:
+            real_pending = True
+    if required_names is not None:
+        missing_required = required_names - seen_names - {QUORUM_CHECK_NAME}
+        if missing_required:
+            real_pending = True
+    return quorum_conclusion, real_failure, real_pending
+
+
+def _mergeable_from_rest(data: dict[str, Any]) -> str:
+    mergeable = data.get("mergeable")
+    if mergeable is True:
+        return "MERGEABLE"
+    if mergeable is False and str(data.get("mergeable_state") or "").lower() == "dirty":
+        return "CONFLICTING"
+    return "UNKNOWN"
+
+
+def _merge_state_from_rest(data: dict[str, Any]) -> str:
+    state = str(data.get("mergeable_state") or "").strip().lower()
+    mapping = {
+        "behind": "BEHIND",
+        "blocked": "BLOCKED",
+        "clean": "CLEAN",
+        "dirty": "DIRTY",
+        "draft": "DRAFT",
+        "has_hooks": "HAS_HOOKS",
+        "unstable": "UNSTABLE",
+        "unknown": "UNKNOWN",
+    }
+    if state in mapping:
+        return mapping[state]
+    if data.get("mergeable") is True:
+        return "CLEAN"
+    if data.get("mergeable") is False:
+        return "CONFLICTING"
+    return "UNKNOWN"
+
+
+def _with_page(endpoint: str, page: int) -> str:
+    separator = "&" if "?" in endpoint else "?"
+    return f"{endpoint}{separator}page={page}"
+
+
+def _rest_list(endpoint: str, *, env: dict[str, str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for page in range(1, _REST_MAX_PAGES + 1):
+        payload = run_json(["gh", "api", "--method", "GET", _with_page(endpoint, page)], env=env)
+        if not isinstance(payload, list):
+            raise RuntimeError(f"REST endpoint returned a non-list payload: {endpoint}")
+        rows.extend(row for row in payload if isinstance(row, dict))
+        if len(payload) < _REST_PAGE_SIZE:
+            break
+    return rows
+
+
+def _rest_check_runs(endpoint: str, *, env: dict[str, str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for page in range(1, _REST_MAX_PAGES + 1):
+        payload = run_json(["gh", "api", "--method", "GET", _with_page(endpoint, page)], env=env)
+        page_rows = payload.get("check_runs") if isinstance(payload, dict) else None
+        if not isinstance(page_rows, list):
+            raise RuntimeError(f"REST endpoint returned no check-runs list: {endpoint}")
+        rows.extend(row for row in page_rows if isinstance(row, dict))
+        if len(page_rows) < _REST_PAGE_SIZE:
+            break
+    return rows
+
+
+def _required_check_names(repo: str, base_ref: str, *, env: dict[str, str]) -> set[str] | None:
+    if not base_ref:
+        return None
+    ambient_env = aragora_env()
+    candidates = [env]
+    if env.get("GH_TOKEN") != ambient_env.get("GH_TOKEN"):
+        candidates.append(ambient_env)
+    for candidate_env in candidates:
+        try:
+            payload = run_json(
+                [
+                    "gh",
+                    "api",
+                    "--method",
+                    "GET",
+                    f"repos/{repo}/branches/{quote(base_ref, safe='')}/protection/required_status_checks",
+                ],
+                env=candidate_env,
+            )
+        except RuntimeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        names = {str(name).strip() for name in payload.get("contexts") or [] if str(name).strip()}
+        for check in payload.get("checks") or []:
+            if isinstance(check, dict) and str(check.get("context") or "").strip():
+                names.add(str(check["context"]).strip())
+        # An empty classic-protection result cannot prove that repository
+        # rulesets impose no required checks. Keep trying, then fail closed.
+        if names:
+            return names
+    return None
+
+
+def _fetch_required_pr_checks(repo: str, pr: int, *, env: dict[str, str]) -> list[dict[str, Any]]:
+    """Fetch GitHub's canonical required-check surface for a pull request."""
+    args = [
+        "gh",
+        "pr",
+        "checks",
+        str(pr),
+        "--repo",
+        repo,
+        "--required",
+        "--json",
+        "name,state,bucket",
+    ]
+    try:
+        proc = run(args, env=env)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"required-check query timed out for {repo}#{pr}") from exc
+    try:
+        payload = json.loads(proc.stdout or "")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"required-check query failed ({proc.returncode}) for {repo}#{pr}: "
+            f"{(proc.stderr or '').strip()[:200]}"
+        ) from exc
+    if not isinstance(payload, list):
+        raise RuntimeError(f"required-check query returned a non-list payload for {repo}#{pr}")
+    return [
+        {
+            "name": row.get("name"),
+            "conclusion": row.get("state") or row.get("bucket"),
+            "isRequired": True,
+        }
+        for row in payload
+        if isinstance(row, dict)
+    ]
+
+
+def _fetch_pr_context_rest(repo: str, pr: int, *, env: dict[str, str]) -> dict[str, Any]:
+    data = run_json(["gh", "api", "--method", "GET", f"repos/{repo}/pulls/{pr}"], env=env)
+    if not isinstance(data, dict):
+        raise RuntimeError(f"REST pull request payload was not an object for {repo}#{pr}")
+    raw_head = data.get("head")
+    raw_base = data.get("base")
+    head: dict[str, Any] = raw_head if isinstance(raw_head, dict) else {}
+    base: dict[str, Any] = raw_base if isinstance(raw_base, dict) else {}
+    head_sha = str(head.get("sha") or "").strip()
+    if not head_sha:
+        raise RuntimeError(f"REST pull request payload omitted head SHA for {repo}#{pr}")
+    commit = run_json(["gh", "api", "--method", "GET", f"repos/{repo}/commits/{head_sha}"], env=env)
+    commit_payload = commit.get("commit") if isinstance(commit, dict) else {}
+    committer = commit_payload.get("committer") if isinstance(commit_payload, dict) else {}
+    head_committed_at = str((committer.get("date") if isinstance(committer, dict) else "") or "")
+    check_runs = _rest_check_runs(
+        f"repos/{repo}/commits/{head_sha}/check-runs?per_page={_REST_PAGE_SIZE}", env=env
+    )
+    statuses = _rest_list(
+        f"repos/{repo}/commits/{head_sha}/statuses?per_page={_REST_PAGE_SIZE}", env=env
+    )
+    checks: list[dict[str, Any]] = []
+    check_by_name: dict[str, dict[str, Any]] = {}
+    for check in check_runs:
+        if not isinstance(check, dict):
+            continue
+        name = str(check.get("name") or "").strip()
+        if name:
+            check_by_name.setdefault(
+                name,
+                {
+                    "name": name,
+                    "conclusion": check.get("conclusion") or check.get("status"),
+                },
+            )
+    checks.extend(check_by_name.values())
+    status_by_context: dict[str, dict[str, Any]] = {}
+    for status in statuses:
+        context = str(status.get("context") or "").strip()
+        if context and context not in check_by_name:
+            status_by_context.setdefault(
+                context, {"context": context, "state": status.get("state")}
+            )
+    checks.extend(status_by_context.values())
+    required_names = _required_check_names(repo, str(base.get("ref") or ""), env=env)
+    quorum_conclusion, real_failure, real_pending = _summarize_checks(
+        checks, required_names=required_names
+    )
+    pr_state = "MERGED" if data.get("merged_at") else str(data.get("state") or "").upper()
+    return {
+        "head_sha": head_sha,
+        "head_committed_at": head_committed_at,
+        "quorum_conclusion": quorum_conclusion,
+        "has_real_required_failure": real_failure,
+        "has_real_required_pending": real_pending,
+        "is_draft": bool(data.get("draft")),
+        "pr_state": pr_state,
+        "mergeable": _mergeable_from_rest(data),
+        "merge_state_status": _merge_state_from_rest(data),
+        "context_source": "rest",
+        "required_checks_disclosed": required_names is not None,
+    }
+
+
+def _fetch_pr_context_graphql(repo: str, pr: int, *, env: dict[str, str]) -> dict[str, Any]:
     data = run_json(
         [
             "gh",
@@ -147,10 +418,12 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
             "--repo",
             repo,
             "--json",
-            "headRefOid,commits,statusCheckRollup",
+            "headRefOid,commits,statusCheckRollup,isDraft,state,mergeable,mergeStateStatus",
         ],
-        env=_read_env(),
+        env=env,
     )
+    if not isinstance(data, dict):
+        raise RuntimeError(f"GraphQL pull request payload was not an object for {repo}#{pr}")
     head_sha = str(data.get("headRefOid") or "").strip()
     commits = data.get("commits") or []
     head_committed_at = ""
@@ -162,37 +435,63 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
         # The head may be beyond the returned commit slice; fetch its date
         # directly rather than guessing from the last listed commit.
         try:
-            commit = (
-                run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}"], env=_read_env()) or {}
-            )
+            commit = run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}"], env=env) or {}
         except RuntimeError:
             commit = {}
         committer = (commit.get("commit") or {}).get("committer") or {}
         head_committed_at = str(committer.get("date") or "")
 
-    real_failure = False
-    quorum_conclusion = ""
-    for check in data.get("statusCheckRollup") or []:
-        if not isinstance(check, dict):
-            continue
-        name = str(check.get("name") or check.get("context") or "")
-        conclusion = str(check.get("conclusion") or check.get("state") or "").upper()
-        if name == QUORUM_CHECK_NAME:
-            quorum_conclusion = conclusion
-            continue
-        if conclusion not in _FAILED_CONCLUSIONS:
-            continue
-        is_required = check.get("isRequired")
-        if is_required is True:
-            real_failure = True
-        elif is_required is None and not _looks_like_shadow(name):
-            real_failure = True
+    required_checks = _fetch_required_pr_checks(repo, pr, env=env)
+    _, real_failure, real_pending = _summarize_checks(required_checks)
+    quorum_conclusion, _, _ = _summarize_checks(data.get("statusCheckRollup") or [])
+    if not quorum_conclusion:
+        quorum_conclusion, _, _ = _summarize_checks(required_checks)
     return {
         "head_sha": head_sha,
         "head_committed_at": head_committed_at,
         "quorum_conclusion": quorum_conclusion,
         "has_real_required_failure": real_failure,
+        "has_real_required_pending": real_pending,
+        "is_draft": bool(data.get("isDraft")),
+        "pr_state": str(data.get("state") or "").upper(),
+        "mergeable": str(data.get("mergeable") or "").upper(),
+        "merge_state_status": str(data.get("mergeStateStatus") or "").upper(),
+        "context_source": "graphql",
+        "required_checks_disclosed": True,
     }
+
+
+def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
+    """Fetch exact-head settlement context, preferring GraphQL then REST.
+
+    REST is a resilience path for GitHub GraphQL incidents, not a relaxation:
+    if branch protection cannot disclose required contexts, every non-shadow
+    failure or pending check is conservatively treated as required.
+    """
+    env = _read_env()
+    try:
+        return _fetch_pr_context_graphql(repo, pr, env=env)
+    except RuntimeError as graphql_error:
+        rest_errors: list[str] = []
+        rest_envs = [env]
+        ambient_env = aragora_env()
+        if env.get("GH_TOKEN") != ambient_env.get("GH_TOKEN"):
+            rest_envs.append(ambient_env)
+        context: dict[str, Any] | None = None
+        for rest_env in rest_envs:
+            try:
+                context = _fetch_pr_context_rest(repo, pr, env=rest_env)
+                break
+            except RuntimeError as rest_error:
+                rest_errors.append(str(rest_error))
+        if context is None:
+            joined_rest_errors = "; ".join(rest_errors)
+            raise RuntimeError(
+                f"could not fetch PR context via GraphQL ({graphql_error}) "
+                f"or REST ({joined_rest_errors})"
+            ) from graphql_error
+        context["graphql_error"] = str(graphql_error)[:500]
+        return context
 
 
 def fetch_latest_quorum_run(repo: str, head_sha: str) -> QuorumRun | None:

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -366,28 +366,21 @@ def _fetch_pr_context_rest(repo: str, pr: int, *, env: dict[str, str]) -> dict[s
         f"repos/{repo}/commits/{head_sha}/statuses?per_page={_REST_PAGE_SIZE}", env=env
     )
     checks: list[dict[str, Any]] = []
-    check_by_name: dict[str, dict[str, Any]] = {}
     for check in check_runs:
         if not isinstance(check, dict):
             continue
         name = str(check.get("name") or "").strip()
         if name:
-            check_by_name.setdefault(
-                name,
+            checks.append(
                 {
                     "name": name,
                     "conclusion": check.get("conclusion") or check.get("status"),
                 },
             )
-    checks.extend(check_by_name.values())
-    status_by_context: dict[str, dict[str, Any]] = {}
     for status in statuses:
         context = str(status.get("context") or "").strip()
-        if context and context not in check_by_name:
-            status_by_context.setdefault(
-                context, {"context": context, "state": status.get("state")}
-            )
-    checks.extend(status_by_context.values())
+        if context:
+            checks.append({"context": context, "state": status.get("state")})
     required_names = _required_check_names(repo, str(base.get("ref") or ""), env=env)
     quorum_conclusion, real_failure, real_pending = _summarize_checks(
         checks, required_names=required_names

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -325,6 +325,75 @@ def _rest_check_runs(endpoint: str, *, env: dict[str, str]) -> list[dict[str, An
     return rows
 
 
+def _applied_branch_rules(repo: str, base_ref: str, *, env: dict[str, str]) -> list[dict[str, Any]]:
+    """Fetch every applied branch rule, rejecting incomplete pagination or schema."""
+    endpoint = f"repos/{repo}/rules/branches/{quote(base_ref, safe='')}?per_page={_REST_PAGE_SIZE}"
+    rows: list[dict[str, Any]] = []
+    for page in range(1, _REST_MAX_PAGES + 1):
+        payload = run_json(["gh", "api", "--method", "GET", _with_page(endpoint, page)], env=env)
+        if not isinstance(payload, list) or any(not isinstance(row, dict) for row in payload):
+            raise RuntimeError("applied branch rules returned an invalid payload")
+        rows.extend(payload)
+        if len(payload) < _REST_PAGE_SIZE:
+            return rows
+    raise RuntimeError("applied branch rules exceeded the pagination limit")
+
+
+def _required_context(value: Any, source: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise RuntimeError(f"{source} contained an invalid context")
+    return value
+
+
+def _classic_required_check_names(payload: Any) -> set[str]:
+    """Normalize classic branch-protection requirements without coercing bad data."""
+    if not isinstance(payload, dict):
+        raise RuntimeError("classic required checks returned a non-object payload")
+    contexts = payload.get("contexts")
+    checks = payload.get("checks")
+    if not isinstance(contexts, list) or not isinstance(checks, list):
+        raise RuntimeError("classic required checks omitted contexts or checks")
+    names: set[str] = set()
+    for context in contexts:
+        names.add(_required_context(context, "classic required checks"))
+    for check in checks:
+        if not isinstance(check, dict):
+            raise RuntimeError("classic required checks contained a non-object check")
+        names.add(_required_context(check.get("context"), "classic required checks"))
+    return names
+
+
+def _ruleset_required_check_names(rules: list[dict[str, Any]]) -> set[str]:
+    """Normalize required contexts from a complete applied-rules response."""
+    names: set[str] = set()
+    for rule in rules:
+        rule_type = rule.get("type")
+        if not isinstance(rule_type, str) or not rule_type or rule_type != rule_type.strip():
+            raise RuntimeError("applied branch rules contained an invalid rule type")
+        if rule_type != "required_status_checks":
+            continue
+        parameters = rule.get("parameters")
+        if not isinstance(parameters, dict):
+            raise RuntimeError("required_status_checks rule omitted parameters")
+        requirements = parameters.get("required_status_checks")
+        if not isinstance(requirements, list):
+            raise RuntimeError("required_status_checks rule omitted its requirements")
+        for requirement in requirements:
+            if not isinstance(requirement, dict):
+                raise RuntimeError("required_status_checks contained a non-object requirement")
+            context = requirement.get("context")
+            name = requirement.get("name")
+            if context is not None and name is not None and context != name:
+                raise RuntimeError("required_status_checks contained conflicting context names")
+            names.add(
+                _required_context(
+                    context if context is not None else name,
+                    "required_status_checks",
+                )
+            )
+    return names
+
+
 def _required_check_names(repo: str, base_ref: str, *, env: dict[str, str]) -> set[str] | None:
     if not base_ref:
         return None
@@ -334,7 +403,7 @@ def _required_check_names(repo: str, base_ref: str, *, env: dict[str, str]) -> s
         candidates.append(ambient_env)
     for candidate_env in candidates:
         try:
-            payload = run_json(
+            classic_payload = run_json(
                 [
                     "gh",
                     "api",
@@ -344,18 +413,12 @@ def _required_check_names(repo: str, base_ref: str, *, env: dict[str, str]) -> s
                 ],
                 env=candidate_env,
             )
+            rules = _applied_branch_rules(repo, base_ref, env=candidate_env)
+            names = _classic_required_check_names(classic_payload)
+            names.update(_ruleset_required_check_names(rules))
         except RuntimeError:
             continue
-        if not isinstance(payload, dict):
-            continue
-        names = {str(name).strip() for name in payload.get("contexts") or [] if str(name).strip()}
-        for check in payload.get("checks") or []:
-            if isinstance(check, dict) and str(check.get("context") or "").strip():
-                names.add(str(check["context"]).strip())
-        # An empty classic-protection result cannot prove that repository
-        # rulesets impose no required checks. Keep trying, then fail closed.
-        if names:
-            return names
+        return names
     return None
 
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2796,27 +2796,22 @@ def default_linter(
 
 
 def default_poster(repo: str, pr: int, body: str) -> None:
-    import os
-    import tempfile
-
-    path = ""
-    try:
-        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as fh:
-            path = fh.name
-            fh.write(body)
-        proc = merge_quorum_io.run(
-            ["gh", "pr", "comment", str(pr), "--repo", repo, "--body-file", path],
-            env=merge_quorum_io.aragora_env(),
-            timeout=60,
-        )
-        if proc.returncode != 0:
-            raise RuntimeError(f"gh pr comment failed: {(proc.stderr or '').strip()[:200]}")
-    finally:
-        if path:
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
+    proc = merge_quorum_io.run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/issues/{pr}/comments",
+            "--input",
+            "-",
+        ],
+        env=merge_quorum_io.aragora_env(),
+        timeout=60,
+        input_text=json.dumps({"body": body}),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh api comment post failed: {(proc.stderr or '').strip()[:200]}")
 
 
 def resolve_author(default: str = "local") -> str:
@@ -3562,6 +3557,52 @@ def _validate_prepared_item_families(
         seen.add(family)
 
 
+_SETTLEMENT_CONTEXT_FIELDS = frozenset(
+    (
+        "has_real_required_failure",
+        "has_real_required_pending",
+        "is_draft",
+        "merge_state_status",
+        "mergeable",
+        "pr_state",
+    )
+)
+
+
+def _settlement_stability_problem(context: dict[str, Any]) -> str:
+    """Return the live-state reason that forbids countable evidence posting.
+
+    Dependency-injected legacy callers that disclose none of the settlement
+    fields preserve their historical behavior. The canonical context fetcher
+    always discloses all fields and therefore enforces the complete gate.
+    """
+    disclosed = _SETTLEMENT_CONTEXT_FIELDS.intersection(context)
+    if not disclosed:
+        return ""
+    missing = sorted(_SETTLEMENT_CONTEXT_FIELDS - context.keys())
+    if missing:
+        return f"settlement-stability context incomplete ({', '.join(missing)})"
+    if str(context.get("pr_state") or "").upper() != "OPEN":
+        return f"PR state is {str(context.get('pr_state') or 'unknown').upper()}"
+    if context.get("is_draft") is not False:
+        return "PR is draft or draft state is unknown"
+    if str(context.get("mergeable") or "").upper() != "MERGEABLE":
+        return f"mergeable is {str(context.get('mergeable') or 'unknown').upper()}"
+    merge_state = str(context.get("merge_state_status") or "").upper()
+    if merge_state not in {"BLOCKED", "CLEAN"}:
+        return f"mergeStateStatus is {merge_state or 'UNKNOWN'}"
+    if context.get("has_real_required_failure") is not False:
+        return "a non-quorum required check is failing or required-check state is unknown"
+    if context.get("has_real_required_pending") is not False:
+        return "a non-quorum required check is pending or required-check state is unknown"
+    if (
+        context.get("context_source") == "rest"
+        and context.get("required_checks_disclosed") is not True
+    ):
+        return "required-check set is unavailable through the REST fallback"
+    return ""
+
+
 def apply_prepared_evidence(
     *,
     repo: str,
@@ -3655,6 +3696,14 @@ def apply_prepared_evidence(
         )
         return outcome
 
+    stability_problem = _settlement_stability_problem(ctx)
+    if stability_problem:
+        outcome.action = "prepare"
+        outcome.action_reason = (
+            f"head is not settlement-stable ({stability_problem}); prepared only"
+        )
+        return outcome
+
     relinted_items: list[EvidenceItem] = []
     for item in outcome.items:
         lint = linter(pr, head_sha, head_committed_at, author, item.body, env or {})
@@ -3710,7 +3759,8 @@ def apply_prepared_evidence(
         return outcome
 
     try:
-        recheck_head = str((context_fetcher(repo, pr) or {}).get("head_sha") or "").strip()
+        recheck_context = context_fetcher(repo, pr) or {}
+        recheck_head = str(recheck_context.get("head_sha") or "").strip()
         recheck_tier = tier_fetcher(repo, pr)
     except Exception as exc:
         outcome.action = "prepare"
@@ -3720,12 +3770,14 @@ def apply_prepared_evidence(
         _record_review_adjudication_if_applicable(outcome)
         return outcome
     recheck_action, recheck_reason = decide_action(recheck_tier, apply)
-    if recheck_head != head_sha or recheck_action != "post":
+    recheck_stability_problem = _settlement_stability_problem(recheck_context)
+    if recheck_head != head_sha or recheck_action != "post" or recheck_stability_problem:
         outcome.action = "prepare"
         outcome.action_reason = (
             f"head/tier changed before posting "
             f"(head {head_sha[:7]}->{recheck_head[:7] or 'none'}, "
-            f"tier {tier}->{recheck_tier}); prepared only: {recheck_reason}"
+            f"tier {tier}->{recheck_tier}); prepared only: "
+            f"{recheck_stability_problem or recheck_reason}"
         )
         _record_review_adjudication_if_applicable(outcome)
         return outcome

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 import subprocess
 
+import pytest
+
 from aragora.swarm import merge_quorum_io as m
 
 
@@ -48,13 +50,217 @@ def test_fetch_pr_context_routes_reads_through_app_token(monkeypatch) -> None:
 
     def capture_run(args, *, env=None, timeout=m._GH_TIMEOUT):
         captured_envs.append(env or {})
-        return _proc(json.dumps({"headRefOid": "abc", "commits": [], "statusCheckRollup": []}))
+        if args[1:3] == ["pr", "checks"]:
+            return _proc("[]")
+        return _proc(
+            json.dumps(
+                {
+                    "headRefOid": "abc",
+                    "commits": [],
+                    "statusCheckRollup": [],
+                    "isDraft": False,
+                    "state": "OPEN",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                }
+            )
+        )
 
     monkeypatch.setattr(m, "run", capture_run)
     m.fetch_pr_context("o/r", 1)
     assert captured_envs, "expected fetch_pr_context to shell out to gh"
     assert captured_envs[0].get("GH_TOKEN") == "fake-app-token"
     assert captured_envs[0].get("ARAGORA_GITHUB_AUTH_SOURCE") == "github_app_installation"
+
+
+def test_fetch_pr_context_uses_required_check_surface_not_raw_rollup(monkeypatch) -> None:
+    def fake_run(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if args[1:3] == ["pr", "view"]:
+            return _proc(
+                json.dumps(
+                    {
+                        "headRefOid": "abc",
+                        "commits": [{"oid": "abc", "committedDate": "2026-08-17T12:00:00Z"}],
+                        "statusCheckRollup": [
+                            {
+                                "name": m.QUORUM_CHECK_NAME,
+                                "conclusion": "FAILURE",
+                            },
+                            {"name": "non-required historical job", "conclusion": "FAILURE"},
+                            {
+                                "name": m.QUORUM_CHECK_NAME,
+                                "conclusion": "SUCCESS",
+                            },
+                        ],
+                        "isDraft": False,
+                        "state": "OPEN",
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "BLOCKED",
+                    }
+                )
+            )
+        if args[1:3] == ["pr", "checks"]:
+            return _proc(
+                json.dumps(
+                    [
+                        {"name": "lint", "state": "SUCCESS", "bucket": "pass"},
+                        {
+                            "name": m.QUORUM_CHECK_NAME,
+                            "state": "FAILURE",
+                            "bucket": "fail",
+                        },
+                    ]
+                )
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(m, "run", fake_run)
+
+    context = m.fetch_pr_context("o/r", 1)
+
+    assert context["quorum_conclusion"] == "FAILURE"
+    assert context["has_real_required_failure"] is False
+    assert context["has_real_required_pending"] is False
+
+
+def test_fetch_pr_context_falls_back_to_rest_with_complete_stability_state(monkeypatch) -> None:
+    head = "a" * 40
+
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if args[1:3] == ["pr", "view"]:
+            raise RuntimeError("GraphQL 503")
+        endpoint = args[-1]
+        if endpoint == "repos/o/r/pulls/7":
+            return {
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "head": {"sha": head},
+                "base": {"ref": "main"},
+            }
+        if endpoint == f"repos/o/r/commits/{head}":
+            return {"commit": {"committer": {"date": "2026-08-17T12:00:00Z"}}}
+        if endpoint.startswith(f"repos/o/r/commits/{head}/check-runs"):
+            return {
+                "check_runs": [
+                    {"name": m.QUORUM_CHECK_NAME, "conclusion": "failure"},
+                    {"name": "lint", "conclusion": "failure"},
+                    {"name": "typecheck", "status": "in_progress"},
+                ]
+            }
+        if endpoint.startswith(f"repos/o/r/commits/{head}/statuses"):
+            return []
+        if endpoint.endswith("branches/main/protection/required_status_checks"):
+            return {
+                "contexts": [m.QUORUM_CHECK_NAME, "lint", "typecheck"],
+                "checks": [],
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+
+    context = m.fetch_pr_context("o/r", 7)
+
+    assert context["context_source"] == "rest"
+    assert context["head_sha"] == head
+    assert context["head_committed_at"] == "2026-08-17T12:00:00Z"
+    assert context["pr_state"] == "OPEN"
+    assert context["is_draft"] is False
+    assert context["mergeable"] == "MERGEABLE"
+    assert context["merge_state_status"] == "BLOCKED"
+    assert context["quorum_conclusion"] == "FAILURE"
+    assert context["has_real_required_failure"] is True
+    assert context["has_real_required_pending"] is True
+    assert context["required_checks_disclosed"] is True
+    assert "GraphQL 503" in context["graphql_error"]
+
+
+def test_fetch_pr_context_rest_fails_closed_when_required_set_unavailable(monkeypatch) -> None:
+    head = "b" * 40
+
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if args[1:3] == ["pr", "view"]:
+            raise RuntimeError("GraphQL unavailable")
+        endpoint = args[-1]
+        if endpoint == "repos/o/r/pulls/8":
+            return {
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "head": {"sha": head},
+                "base": {"ref": "main"},
+            }
+        if endpoint == f"repos/o/r/commits/{head}":
+            return {"commit": {"committer": {"date": "2026-08-17T12:00:00Z"}}}
+        if endpoint.startswith(f"repos/o/r/commits/{head}/check-runs"):
+            return {
+                "check_runs": [
+                    {"name": "optional integration", "conclusion": "failure"},
+                    {"name": "preview shadow", "conclusion": "failure"},
+                ]
+            }
+        if endpoint.startswith(f"repos/o/r/commits/{head}/statuses"):
+            return []
+        if endpoint.endswith("branches/main/protection/required_status_checks"):
+            raise RuntimeError("403")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+
+    context = m.fetch_pr_context("o/r", 8)
+
+    assert context["required_checks_disclosed"] is False
+    assert context["has_real_required_failure"] is True
+
+
+def test_fetch_pr_context_reports_graphql_and_rest_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        m,
+        "run_json",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("service unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="GraphQL.*or REST"):
+        m.fetch_pr_context("o/r", 9)
+
+
+def test_summarize_checks_treats_missing_or_unknown_required_check_as_pending() -> None:
+    assert m._summarize_checks([], required_names={"lint"}) == ("", False, True)
+    assert m._summarize_checks(
+        [{"name": "lint", "conclusion": "new-provider-state"}],
+        required_names={"lint"},
+    ) == ("", False, True)
+
+
+def test_summarize_checks_accepts_green_required_checks() -> None:
+    assert m._summarize_checks(
+        [
+            {"name": "lint", "conclusion": "success"},
+            {"context": "types", "state": "success"},
+        ],
+        required_names={"lint", "types"},
+    ) == ("", False, False)
+
+
+def test_required_check_names_retries_with_ambient_operator_auth(monkeypatch) -> None:
+    seen_tokens: list[str] = []
+
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        token = str((env or {}).get("GH_TOKEN") or "")
+        seen_tokens.append(token)
+        if token == "app-token":
+            raise RuntimeError("403 Resource not accessible by integration")
+        return {"contexts": ["lint"], "checks": [{"context": "types", "app_id": 1}]}
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    monkeypatch.setattr(m, "aragora_env", lambda: {"GH_TOKEN": "operator-token"})
+
+    names = m._required_check_names("o/r", "release/2026-08-17", env={"GH_TOKEN": "app-token"})
+
+    assert names == {"lint", "types"}
+    assert seen_tokens == ["app-token", "operator-token"]
 
 
 def test_fetch_pr_tier_reads_nested_entries(monkeypatch) -> None:

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -22,7 +22,14 @@ _OLDER = "2026-08-17T10:00:00Z"
 _NEWER = "2026-08-17T11:00:00Z"
 
 
-def _rest_context_stub(head: str, pr: int, check_runs: list[dict], required: list[str] | None):
+def _rest_context_stub(
+    head: str,
+    pr: int,
+    check_runs: list[dict],
+    required: list[str] | None,
+    *,
+    rules: object = None,
+):
     def fake(args, *, env=None, timeout=m._GH_TIMEOUT):
         if args[1:3] == ["pr", "view"]:
             raise RuntimeError("GraphQL unavailable")
@@ -46,6 +53,10 @@ def _rest_context_stub(head: str, pr: int, check_runs: list[dict], required: lis
             if required is None:
                 raise RuntimeError("403")
             return {"contexts": required, "checks": []}
+        if "rules/branches/main" in endpoint:
+            if isinstance(rules, Exception):
+                raise rules
+            return [] if rules is None else rules
         raise AssertionError(args)
 
     return fake
@@ -216,21 +227,210 @@ def test_summarize_checks_missing_or_tied_ordering_fails_closed() -> None:
         assert m._summarize_checks(rows, required_names={"lint"}) == ("", False, True)
 
 
-def test_required_check_names_retries_with_ambient_operator_auth(monkeypatch) -> None:
-    seen_tokens: list[str] = []
+def test_required_check_names_unions_classic_and_ruleset_requirements(monkeypatch) -> None:
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        endpoint = args[-1]
+        if "/protection/required_status_checks" in endpoint:
+            return {"contexts": ["lint"], "checks": [{"context": "types", "app_id": 1}]}
+        if "/rules/branches/" in endpoint:
+            return [
+                {"type": "non_fast_forward"},
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "required_status_checks": [
+                            {"context": "ruleset-only", "integration_id": 1},
+                            {"name": "named-requirement"},
+                        ]
+                    },
+                },
+            ]
+        raise AssertionError(args)
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    names = m._required_check_names("o/r", "release/2026-08-17", env={})
+    assert names == {"lint", "types", "ruleset-only", "named-requirement"}
+
+
+def test_required_check_names_accepts_ruleset_only_requirements(monkeypatch) -> None:
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if "/protection/required_status_checks" in args[-1]:
+            return {"contexts": [], "checks": []}
+        return [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": "ruleset-only"}]},
+            }
+        ]
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    assert m._required_check_names("o/r", "main", env={}) == {"ruleset-only"}
+
+
+@pytest.mark.parametrize(
+    ("check_runs", "has_failure", "has_pending"),
+    [
+        ([{"name": "ruleset-only", "conclusion": "failure"}], True, False),
+        ([], False, True),
+    ],
+)
+def test_fetch_pr_context_rest_blocks_failed_or_missing_ruleset_requirement(
+    monkeypatch, check_runs, has_failure, has_pending
+) -> None:
+    head = "c" * 40
+    rules = [
+        {
+            "type": "required_status_checks",
+            "parameters": {"required_status_checks": [{"context": "ruleset-only"}]},
+        }
+    ]
+    monkeypatch.setattr(
+        m,
+        "run_json",
+        _rest_context_stub(head, 10, check_runs, [], rules=rules),
+    )
+
+    context = m.fetch_pr_context("o/r", 10)
+
+    assert context["required_checks_disclosed"] is True
+    assert context["has_real_required_failure"] is has_failure
+    assert context["has_real_required_pending"] is has_pending
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        RuntimeError("403"),
+        {"unexpected": "object"},
+        ["not-a-rule"],
+        [{"ruleset_id": 1}],
+        [{"type": "required_status_checks"}],
+        [{"type": "required_status_checks", "parameters": {}}],
+        [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": "lint"},
+            }
+        ],
+        [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{}]},
+            }
+        ],
+        [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": " lint"}]},
+            }
+        ],
+        [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": "lint", "name": "types"}]},
+            }
+        ],
+    ],
+)
+def test_required_check_names_fails_closed_on_unavailable_or_malformed_rules(
+    monkeypatch, rules
+) -> None:
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if "/protection/required_status_checks" in args[-1]:
+            return {"contexts": ["lint"], "checks": []}
+        if isinstance(rules, Exception):
+            raise rules
+        return rules
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    assert m._required_check_names("o/r", "main", env={}) is None
+
+
+@pytest.mark.parametrize(
+    "classic",
+    [None, {}, {"contexts": "lint", "checks": []}, {"contexts": [], "checks": [{}]}],
+)
+def test_required_check_names_fails_closed_on_malformed_classic_policy(
+    monkeypatch, classic
+) -> None:
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        return classic if "/protection/required_status_checks" in args[-1] else []
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    assert m._required_check_names("o/r", "main", env={}) is None
+
+
+def test_required_check_names_accepts_applied_rules_without_status_checks(monkeypatch) -> None:
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if "/protection/required_status_checks" in args[-1]:
+            return {"contexts": ["lint"], "checks": []}
+        return [{"type": "non_fast_forward"}, {"type": "deletion"}]
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    assert m._required_check_names("o/r", "main", env={}) == {"lint"}
+
+
+def test_required_check_names_fails_closed_when_classic_protection_unavailable(
+    monkeypatch,
+) -> None:
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if "/protection/required_status_checks" in args[-1]:
+            raise RuntimeError("404")
+        return [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": "ruleset-only"}]},
+            }
+        ]
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    assert m._required_check_names("o/r", "main", env={}) is None
+
+
+def test_applied_branch_rules_reads_every_page(monkeypatch) -> None:
+    pages: list[int] = []
+
+    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
+        page = int(args[-1].rsplit("page=", 1)[-1])
+        pages.append(page)
+        return [{"type": "deletion"}] * 100 if page == 1 else [{"type": "non_fast_forward"}]
+
+    monkeypatch.setattr(m, "run_json", fake_run_json)
+    assert len(m._applied_branch_rules("o/r", "main", env={})) == 101
+    assert pages == [1, 2]
+
+
+def test_required_check_names_retries_complete_policy_with_ambient_operator_auth(
+    monkeypatch,
+) -> None:
+    seen: list[tuple[str, str]] = []
 
     def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
         token = str((env or {}).get("GH_TOKEN") or "")
-        seen_tokens.append(token)
-        if token == "app-token":
+        endpoint = args[-1]
+        surface = "rules" if "/rules/branches/" in endpoint else "classic"
+        seen.append((token, surface))
+        if token == "app-token" and surface == "rules":
             raise RuntimeError("403 Resource not accessible by integration")
-        return {"contexts": ["lint"], "checks": [{"context": "types", "app_id": 1}]}
+        if surface == "classic":
+            return {"contexts": ["lint"], "checks": []}
+        return [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": "types"}]},
+            }
+        ]
 
     monkeypatch.setattr(m, "run_json", fake_run_json)
     monkeypatch.setattr(m, "aragora_env", lambda: {"GH_TOKEN": "operator-token"})
     names = m._required_check_names("o/r", "release/2026-08-17", env={"GH_TOKEN": "app-token"})
     assert names == {"lint", "types"}
-    assert seen_tokens == ["app-token", "operator-token"]
+    assert seen == [
+        ("app-token", "classic"),
+        ("app-token", "rules"),
+        ("operator-token", "classic"),
+        ("operator-token", "rules"),
+    ]
 
 
 def test_fetch_pr_tier_reads_nested_entries(monkeypatch) -> None:

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -18,6 +18,39 @@ def _proc(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
 
 
+_OLDER = "2026-08-17T10:00:00Z"
+_NEWER = "2026-08-17T11:00:00Z"
+
+
+def _rest_context_stub(head: str, pr: int, check_runs: list[dict], required: list[str] | None):
+    def fake(args, *, env=None, timeout=m._GH_TIMEOUT):
+        if args[1:3] == ["pr", "view"]:
+            raise RuntimeError("GraphQL unavailable")
+        endpoint = args[-1]
+        if endpoint == f"repos/o/r/pulls/{pr}":
+            return {
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "head": {"sha": head},
+                "base": {"ref": "main"},
+            }
+        if endpoint == f"repos/o/r/commits/{head}":
+            return {"commit": {"committer": {"date": "2026-08-17T12:00:00Z"}}}
+        if "/check-runs" in endpoint:
+            return {"check_runs": check_runs}
+        if "/statuses" in endpoint:
+            return []
+        if endpoint.endswith("branches/main/protection/required_status_checks"):
+            if required is None:
+                raise RuntimeError("403")
+            return {"contexts": required, "checks": []}
+        raise AssertionError(args)
+
+    return fake
+
+
 def test_read_env_prefers_app_installation_token(monkeypatch) -> None:
     from aragora.swarm import github_app_auth
 
@@ -50,21 +83,8 @@ def test_fetch_pr_context_routes_reads_through_app_token(monkeypatch) -> None:
 
     def capture_run(args, *, env=None, timeout=m._GH_TIMEOUT):
         captured_envs.append(env or {})
-        if args[1:3] == ["pr", "checks"]:
-            return _proc("[]")
-        return _proc(
-            json.dumps(
-                {
-                    "headRefOid": "abc",
-                    "commits": [],
-                    "statusCheckRollup": [],
-                    "isDraft": False,
-                    "state": "OPEN",
-                    "mergeable": "MERGEABLE",
-                    "mergeStateStatus": "CLEAN",
-                }
-            )
-        )
+        payload = [] if args[1:3] == ["pr", "checks"] else {"headRefOid": "abc"}
+        return _proc(json.dumps(payload))
 
     monkeypatch.setattr(m, "run", capture_run)
     m.fetch_pr_context("o/r", 1)
@@ -74,44 +94,29 @@ def test_fetch_pr_context_routes_reads_through_app_token(monkeypatch) -> None:
 
 
 def test_fetch_pr_context_uses_required_check_surface_not_raw_rollup(monkeypatch) -> None:
+    view = {
+        "headRefOid": "abc",
+        "commits": [{"oid": "abc", "committedDate": "2026-08-17T12:00:00Z"}],
+        "statusCheckRollup": [
+            {"name": m.QUORUM_CHECK_NAME, "conclusion": "FAILURE", "startedAt": _NEWER},
+            {"name": "non-required historical job", "conclusion": "FAILURE"},
+            {"name": m.QUORUM_CHECK_NAME, "conclusion": "SUCCESS", "startedAt": _OLDER},
+        ],
+        "isDraft": False,
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "BLOCKED",
+    }
+    required = [
+        {"name": "lint", "state": "SUCCESS", "bucket": "pass"},
+        {"name": m.QUORUM_CHECK_NAME, "state": "FAILURE", "bucket": "fail"},
+    ]
+
     def fake_run(args, *, env=None, timeout=m._GH_TIMEOUT):
         if args[1:3] == ["pr", "view"]:
-            return _proc(
-                json.dumps(
-                    {
-                        "headRefOid": "abc",
-                        "commits": [{"oid": "abc", "committedDate": "2026-08-17T12:00:00Z"}],
-                        "statusCheckRollup": [
-                            {
-                                "name": m.QUORUM_CHECK_NAME,
-                                "conclusion": "FAILURE",
-                            },
-                            {"name": "non-required historical job", "conclusion": "FAILURE"},
-                            {
-                                "name": m.QUORUM_CHECK_NAME,
-                                "conclusion": "SUCCESS",
-                            },
-                        ],
-                        "isDraft": False,
-                        "state": "OPEN",
-                        "mergeable": "MERGEABLE",
-                        "mergeStateStatus": "BLOCKED",
-                    }
-                )
-            )
+            return _proc(json.dumps(view))
         if args[1:3] == ["pr", "checks"]:
-            return _proc(
-                json.dumps(
-                    [
-                        {"name": "lint", "state": "SUCCESS", "bucket": "pass"},
-                        {
-                            "name": m.QUORUM_CHECK_NAME,
-                            "state": "FAILURE",
-                            "bucket": "fail",
-                        },
-                    ]
-                )
-            )
+            return _proc(json.dumps(required))
         raise AssertionError(args)
 
     monkeypatch.setattr(m, "run", fake_run)
@@ -125,42 +130,18 @@ def test_fetch_pr_context_uses_required_check_surface_not_raw_rollup(monkeypatch
 
 def test_fetch_pr_context_falls_back_to_rest_with_complete_stability_state(monkeypatch) -> None:
     head = "a" * 40
-
-    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
-        if args[1:3] == ["pr", "view"]:
-            raise RuntimeError("GraphQL 503")
-        endpoint = args[-1]
-        if endpoint == "repos/o/r/pulls/7":
-            return {
-                "state": "open",
-                "draft": False,
-                "mergeable": True,
-                "mergeable_state": "blocked",
-                "head": {"sha": head},
-                "base": {"ref": "main"},
-            }
-        if endpoint == f"repos/o/r/commits/{head}":
-            return {"commit": {"committer": {"date": "2026-08-17T12:00:00Z"}}}
-        if endpoint.startswith(f"repos/o/r/commits/{head}/check-runs"):
-            return {
-                "check_runs": [
-                    {"name": m.QUORUM_CHECK_NAME, "conclusion": "failure"},
-                    {"name": "lint", "conclusion": "success"},
-                    {"name": "lint", "conclusion": "failure"},
-                    {"name": "typecheck", "conclusion": "success"},
-                    {"name": "typecheck", "status": "in_progress"},
-                ]
-            }
-        if endpoint.startswith(f"repos/o/r/commits/{head}/statuses"):
-            return []
-        if endpoint.endswith("branches/main/protection/required_status_checks"):
-            return {
-                "contexts": [m.QUORUM_CHECK_NAME, "lint", "typecheck"],
-                "checks": [],
-            }
-        raise AssertionError(args)
-
-    monkeypatch.setattr(m, "run_json", fake_run_json)
+    runs = [
+        {"name": m.QUORUM_CHECK_NAME, "conclusion": "failure"},
+        {"name": "lint", "conclusion": "success", "completed_at": _OLDER},
+        {"name": "lint", "conclusion": "failure", "completed_at": _NEWER},
+        {"name": "typecheck", "conclusion": "success", "started_at": _OLDER},
+        {"name": "typecheck", "status": "in_progress", "started_at": _NEWER},
+    ]
+    monkeypatch.setattr(
+        m,
+        "run_json",
+        _rest_context_stub(head, 7, runs, [m.QUORUM_CHECK_NAME, "lint", "typecheck"]),
+    )
 
     context = m.fetch_pr_context("o/r", 7)
 
@@ -175,44 +156,17 @@ def test_fetch_pr_context_falls_back_to_rest_with_complete_stability_state(monke
     assert context["has_real_required_failure"] is True
     assert context["has_real_required_pending"] is True
     assert context["required_checks_disclosed"] is True
-    assert "GraphQL 503" in context["graphql_error"]
+    assert "GraphQL unavailable" in context["graphql_error"]
 
 
 def test_fetch_pr_context_rest_fails_closed_when_required_set_unavailable(monkeypatch) -> None:
     head = "b" * 40
-
-    def fake_run_json(args, *, env=None, timeout=m._GH_TIMEOUT):
-        if args[1:3] == ["pr", "view"]:
-            raise RuntimeError("GraphQL unavailable")
-        endpoint = args[-1]
-        if endpoint == "repos/o/r/pulls/8":
-            return {
-                "state": "open",
-                "draft": False,
-                "mergeable": True,
-                "mergeable_state": "clean",
-                "head": {"sha": head},
-                "base": {"ref": "main"},
-            }
-        if endpoint == f"repos/o/r/commits/{head}":
-            return {"commit": {"committer": {"date": "2026-08-17T12:00:00Z"}}}
-        if endpoint.startswith(f"repos/o/r/commits/{head}/check-runs"):
-            return {
-                "check_runs": [
-                    {"name": "optional integration", "conclusion": "failure"},
-                    {"name": "preview shadow", "conclusion": "failure"},
-                ]
-            }
-        if endpoint.startswith(f"repos/o/r/commits/{head}/statuses"):
-            return []
-        if endpoint.endswith("branches/main/protection/required_status_checks"):
-            raise RuntimeError("403")
-        raise AssertionError(args)
-
-    monkeypatch.setattr(m, "run_json", fake_run_json)
-
+    runs = [
+        {"name": "optional integration", "conclusion": "failure"},
+        {"name": "preview shadow", "conclusion": "failure"},
+    ]
+    monkeypatch.setattr(m, "run_json", _rest_context_stub(head, 8, runs, None))
     context = m.fetch_pr_context("o/r", 8)
-
     assert context["required_checks_disclosed"] is False
     assert context["has_real_required_failure"] is True
 
@@ -228,22 +182,38 @@ def test_fetch_pr_context_reports_graphql_and_rest_failure(monkeypatch) -> None:
         m.fetch_pr_context("o/r", 9)
 
 
-def test_summarize_checks_treats_missing_or_unknown_required_check_as_pending() -> None:
+def test_summarize_checks_required_state_and_newest_status() -> None:
     assert m._summarize_checks([], required_names={"lint"}) == ("", False, True)
     assert m._summarize_checks(
         [{"name": "lint", "conclusion": "new-provider-state"}],
         required_names={"lint"},
     ) == ("", False, True)
-
-
-def test_summarize_checks_accepts_green_required_checks() -> None:
     assert m._summarize_checks(
-        [
-            {"name": "lint", "conclusion": "success"},
-            {"context": "types", "state": "success"},
-        ],
+        [{"name": "lint", "conclusion": "success"}, {"context": "types", "state": "success"}],
         required_names={"lint", "types"},
     ) == ("", False, False)
+    assert m._summarize_checks(
+        [
+            {"context": "lint", "state": "failure", "updated_at": _OLDER},
+            {"context": "lint", "state": "success", "updated_at": _NEWER},
+        ],
+        required_names={"lint"},
+    ) == ("", False, False)
+
+
+def test_summarize_checks_missing_or_tied_ordering_fails_closed() -> None:
+    cases = (
+        [
+            {"name": "lint", "conclusion": "success"},
+            {"name": "lint", "conclusion": "failure"},
+        ],
+        [
+            {"name": "lint", "conclusion": "success", "startedAt": _OLDER},
+            {"name": "lint", "conclusion": "failure", "startedAt": _OLDER},
+        ],
+    )
+    for rows in cases:
+        assert m._summarize_checks(rows, required_names={"lint"}) == ("", False, True)
 
 
 def test_required_check_names_retries_with_ambient_operator_auth(monkeypatch) -> None:
@@ -258,9 +228,7 @@ def test_required_check_names_retries_with_ambient_operator_auth(monkeypatch) ->
 
     monkeypatch.setattr(m, "run_json", fake_run_json)
     monkeypatch.setattr(m, "aragora_env", lambda: {"GH_TOKEN": "operator-token"})
-
     names = m._required_check_names("o/r", "release/2026-08-17", env={"GH_TOKEN": "app-token"})
-
     assert names == {"lint", "types"}
     assert seen_tokens == ["app-token", "operator-token"]
 

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -145,7 +145,9 @@ def test_fetch_pr_context_falls_back_to_rest_with_complete_stability_state(monke
             return {
                 "check_runs": [
                     {"name": m.QUORUM_CHECK_NAME, "conclusion": "failure"},
+                    {"name": "lint", "conclusion": "success"},
                     {"name": "lint", "conclusion": "failure"},
+                    {"name": "typecheck", "conclusion": "success"},
                     {"name": "typecheck", "status": "in_progress"},
                 ]
             }

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -3132,6 +3132,31 @@ def test_collect_missing_head_raises() -> None:
         collect_evidence(repo="o/r", pr=1, families=["claude"], author="me", apply=True, **fakes)
 
 
+def test_default_poster_uses_rest_issue_comment_endpoint(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(qe.merge_quorum_io, "run", fake_run)
+
+    qe.default_poster("o/r", 17, "prepared evidence body")
+
+    assert captured["args"] == [
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        "repos/o/r/issues/17/comments",
+        "--input",
+        "-",
+    ]
+    assert json.loads(captured["input_text"]) == {"body": "prepared evidence body"}
+    assert captured["timeout"] == 60
+
+
 def _prepared_body(family: str, verdict: str = "PASS") -> str:
     return f"Verdict: {verdict}\n\n{family} body\n"
 
@@ -3160,6 +3185,28 @@ def _prepared_outcome_file(
     path = tmp_path / "prepared.json"
     path.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
     return path
+
+
+def _stable_apply_context(**overrides) -> dict:
+    context = {
+        "head_sha": HEAD,
+        "head_committed_at": COMMITTED,
+        "has_real_required_failure": False,
+        "has_real_required_pending": False,
+        "is_draft": False,
+        "pr_state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "merge_state_status": "CLEAN",
+        "context_source": "graphql",
+        "required_checks_disclosed": True,
+    }
+    context.update(overrides)
+    return context
+
+
+def _counting_prepared_lint(pr, head_sha, head_committed_at, author, body, env) -> dict:
+    family = "claude" if "claude body" in body else "grok"
+    return {"would_count": True, "counted_reviewer_ids": [family], "problems": []}
 
 
 def test_apply_prepared_evidence_posts_without_rerunning_reviewers(tmp_path) -> None:
@@ -3200,6 +3247,73 @@ def test_apply_prepared_evidence_posts_without_rerunning_reviewers(tmp_path) -> 
     assert "without reviewer regeneration" in outcome.action_reason
     assert outcome.posted == ["claude", "grok"]
     assert posted == [("o/r", _prepared_body("claude")), ("o/r", _prepared_body("grok"))]
+
+
+@pytest.mark.parametrize(
+    ("override", "reason"),
+    [
+        ({"is_draft": True}, "draft"),
+        ({"pr_state": "CLOSED"}, "PR state"),
+        ({"mergeable": "UNKNOWN"}, "mergeable"),
+        ({"merge_state_status": "BEHIND"}, "mergeStateStatus"),
+        ({"has_real_required_failure": True}, "required check is failing"),
+        ({"has_real_required_pending": True}, "required check is pending"),
+        (
+            {"context_source": "rest", "required_checks_disclosed": False},
+            "required-check set is unavailable",
+        ),
+    ],
+)
+def test_apply_prepared_evidence_rejects_unstable_live_context(
+    tmp_path, override: dict, reason: str
+) -> None:
+    prepared = _prepared_outcome_file(tmp_path)
+    posted: list[str] = []
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        families=["claude", "grok"],
+        context_fetcher=lambda repo, pr: _stable_apply_context(**override),
+        tier_fetcher=lambda repo, pr: 1,
+        linter=lambda *args, **kwargs: pytest.fail("unstable evidence must not be relinted"),
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "prepare"
+    assert reason in outcome.action_reason
+    assert posted == []
+
+
+def test_apply_prepared_evidence_rechecks_full_stability_before_posting(tmp_path) -> None:
+    prepared = _prepared_outcome_file(tmp_path)
+    contexts = iter(
+        [
+            _stable_apply_context(),
+            _stable_apply_context(merge_state_status="BEHIND"),
+        ]
+    )
+    posted: list[str] = []
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        families=["claude", "grok"],
+        context_fetcher=lambda repo, pr: next(contexts),
+        tier_fetcher=lambda repo, pr: 1,
+        linter=_counting_prepared_lint,
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "prepare"
+    assert "mergeStateStatus is BEHIND" in outcome.action_reason
+    assert posted == []
 
 
 def test_apply_prepared_evidence_recomputes_exact_head_adjudication(


### PR DESCRIPTION
## Summary

- keep GraphQL as the preferred exact-head PR context path and fall back to paginated REST reads during GraphQL incidents
- derive non-quorum required-check stability from the canonical required-check surface, with App-to-operator read fallback for protected-branch REST data
- enforce open, non-draft, mergeable, non-quorum-green settlement stability before and immediately before prepared evidence publication
- post evidence through the REST issue-comment endpoint with stdin JSON

## Risk and governance

This changes evidence/settlement authority and is therefore Tier 4. The operator preapproved this bounded implementation cycle before source changes. This PR must remain draft until exact-head CI, heterogeneous grounded review, a verified DecisionReceipt, and separate exact-head human risk settlement are complete. No merge is authorized by the implementation approval.

The implementation fails closed when REST cannot prove required-check or merge stability. It does not change workflows, branch protection, review_queue.py, or PR #9757.

## Verification

- 463 focused merge-quorum/evidence/reconciliation tests passed
- Ruff check and format passed
- touched-module MyPy passed
- all-files pre-commit passed
- automation PR preflight passed
- normal pre-push hooks passed
- read-only dogfood: GraphQL and forced REST agreed on PR #9757 exact head and settlement stability

## Rollback

Remote tag: elves/codex/github-rest-settlement-resilience-20260817/pre-batch-1
