### PR TITLE
feat(governance): enforce Boundary 2 module edges [Tier 4]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -146,6 +146,9 @@ jobs:
       - name: Enforce aragora-verify dependency policy
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_aragora_verify_dependency_policy.py
 
+      - name: Enforce Boundary 2 module-edge policy
+        run: ${{ steps.lint_python.outputs.python_bin }} scripts/ci/check_boundary_edges.py
+
       - name: Enforce self-hosted checkout integrity policy
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_workflow_checkout_integrity_policy.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Pre-commit hooks for Aragora
 # See https://pre-commit.com for more information
-# Install: pre-commit install
+# Install: pre-commit install --hook-type pre-commit --hook-type pre-push
 # Run all: pre-commit run --all-files
 
 repos:
@@ -180,6 +180,17 @@ repos:
         entry: python3 scripts/check_portability.py
         language: system
         types: [text]
+
+  # Boundary 2 quarantine: report new or stale receipts+verifier module edges.
+  - repo: local
+    hooks:
+      - id: boundary2-edges
+        name: Boundary 2 receipts+verifier fail-on-new edges
+        entry: python3 scripts/ci/check_boundary_edges.py
+        language: system
+        pass_filenames: false
+        files: ^(?:\.pre-commit-config\.yaml|aragora/.*|aragora-verify/src/aragora_verify/.*|scripts/baselines/boundary2_edges_baseline\.json|scripts/ci/boundary_maps/receipts_verifier\.json|scripts/ci/check_boundary_edges\.py)$
+        stages: [pre-commit, pre-push]
 
   # Security checks
   - repo: https://github.com/PyCQA/bandit

--- a/scripts/baselines/boundary2_edges_baseline.json
+++ b/scripts/baselines/boundary2_edges_baseline.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "boundary": {"id": 2, "name": "receipts+verifier"},
+  "map": "scripts/ci/boundary_maps/receipts_verifier.json",
+  "frozen_from_ref": "31c243aa7f3b06ffdfe857b3a5dfa2118d913f75",
+  "violations": [
+    "import aragora.gauntlet.odr_export -> aragora.ranking.calibration_report",
+    "import aragora.gauntlet.receipt -> aragora.gauntlet.receipt_exporters",
+    "import aragora.gauntlet.receipt_models -> aragora.compliance.artifact_generator",
+    "import aragora.gauntlet.receipt_models -> aragora.debate.crux_mode",
+    "import aragora.gauntlet.receipt_models -> aragora.debate.provider_diversity",
+    "import aragora.gauntlet.receipt_models -> aragora.gauntlet.receipt_exporters",
+    "import aragora.gauntlet.receipt_models -> aragora.gauntlet.result",
+    "import aragora.gauntlet.receipt_models -> aragora.gauntlet.signing",
+    "import aragora.receipts -> aragora.export.decision_receipt",
+    "import aragora.receipts.provenance -> aragora.gauntlet.signing",
+    "import aragora.receipts.provenance -> aragora.pipeline.receipt_store_facade"
+  ]
+}

--- a/scripts/ci/boundary_maps/receipts_verifier.json
+++ b/scripts/ci/boundary_maps/receipts_verifier.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1, "boundary": {"id": 2, "name": "receipts+verifier", "provenance": "docs/architecture/MODULE_QUARANTINE_PROPOSAL.md#boundary-2--receiptsverifier"},
+  "module_roots": [
+    {"path": "aragora", "package": "aragora"},
+    {"path": "aragora-verify/src/aragora_verify", "package": "aragora_verify"}
+  ],
+  "sources": [
+    "aragora/gauntlet/receipt_models.py",
+    "aragora/gauntlet/receipt.py",
+    "aragora/receipts",
+    "aragora/gauntlet/odr_export.py",
+    "aragora/gauntlet/odr_signing.py",
+    "aragora/gauntlet/odr_verify.py",
+    "aragora-verify/src/aragora_verify"
+  ],
+  "allowed_internal_prefixes": [
+    "aragora.core",
+    "aragora.core_types",
+    "aragora.errors",
+    "aragora.exceptions",
+    "aragora.agents",
+    "aragora.memory",
+    "aragora.knowledge",
+    "aragora.config",
+    "aragora.storage",
+    "aragora.db",
+    "aragora.persistence",
+    "aragora.observability",
+    "aragora.telemetry",
+    "aragora.gauntlet.receipt_models",
+    "aragora.gauntlet.receipt",
+    "aragora.receipts",
+    "aragora.gauntlet.odr_export",
+    "aragora.gauntlet.odr_signing",
+    "aragora.gauntlet.odr_verify"
+  ],
+  "hook": {"id": "boundary2-edges", "files": "^(?:\\.pre-commit-config\\.yaml|aragora/.*|aragora-verify/src/aragora_verify/.*|scripts/baselines/boundary2_edges_baseline\\.json|scripts/ci/boundary_maps/receipts_verifier\\.json|scripts/ci/check_boundary_edges\\.py)$"}
+}

--- a/scripts/ci/check_boundary_edges.py
+++ b/scripts/ci/check_boundary_edges.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Reject new or stale internal module edges in Boundary 2."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAP_PATH = Path("scripts/ci/boundary_maps/receipts_verifier.json")
+BASELINE_PATH = Path("scripts/baselines/boundary2_edges_baseline.json")
+CHECKER_PATH = Path("scripts/ci/check_boundary_edges.py")
+HOOK_PATH = Path(".pre-commit-config.yaml")
+
+
+class PolicyError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ModuleRoot:
+    path: Path
+    package: str
+
+
+@dataclass(frozen=True)
+class Policy:
+    roots: tuple[ModuleRoot, ...]
+    sources: tuple[Path, ...]
+    allowed: tuple[str, ...]
+    hook_id: str
+    hook_files: str
+
+
+def _json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PolicyError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PolicyError(f"{label} must be a JSON object")
+    return value
+
+
+def _strings(value: object, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise PolicyError(f"{label} must be a non-empty array")
+    if any(not isinstance(item, str) or not item for item in value):
+        raise PolicyError(f"{label} entries must be non-empty strings")
+    items = tuple(value)
+    if len(items) != len(set(items)):
+        raise PolicyError(f"{label} contains duplicate entries")
+    return items
+
+
+def _path(root: Path, value: object, label: str) -> Path:
+    if not isinstance(value, str) or not value:
+        raise PolicyError(f"{label} must be a non-empty path")
+    relative = Path(value)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise PolicyError(f"{label} must stay within the repository")
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PolicyError(f"{label} escapes the repository") from exc
+    return resolved
+
+
+def _covered(pattern: re.Pattern[str], repo_root: Path, path: Path) -> bool:
+    relative = path.relative_to(repo_root).as_posix()
+    probe = f"{relative}/__boundary_probe__.py" if path.is_dir() else relative
+    return pattern.fullmatch(probe) is not None
+
+
+def load_policy(repo_root: Path, map_path: Path) -> Policy:
+    root = repo_root.resolve()
+    data = _json_object(map_path, "boundary map")
+    if data.get("schema_version") != 1:
+        raise PolicyError("boundary map schema_version must be 1")
+    boundary = data.get("boundary")
+    if not isinstance(boundary, dict) or boundary.get("id") != 2:
+        raise PolicyError("boundary map must identify Boundary 2")
+    if boundary.get("name") != "receipts+verifier" or not boundary.get("provenance"):
+        raise PolicyError("boundary name or provenance is invalid")
+
+    raw_roots = data.get("module_roots")
+    if not isinstance(raw_roots, list) or not raw_roots:
+        raise PolicyError("module_roots must be a non-empty array")
+    roots: list[ModuleRoot] = []
+    for index, raw in enumerate(raw_roots):
+        if not isinstance(raw, dict):
+            raise PolicyError(f"module_roots[{index}] must be an object")
+        package = raw.get("package")
+        if not isinstance(package, str) or not package.isidentifier():
+            raise PolicyError(f"module_roots[{index}].package must be an identifier")
+        roots.append(
+            ModuleRoot(_path(root, raw.get("path"), f"module_roots[{index}].path"), package)
+        )
+    if len({item.path for item in roots}) != len(roots) or len(
+        {item.package for item in roots}
+    ) != len(roots):
+        raise PolicyError("module_roots contains duplicate paths or packages")
+
+    sources = tuple(
+        _path(root, value, f"sources[{index}]")
+        for index, value in enumerate(_strings(data.get("sources"), "sources"))
+    )
+    allowed = _strings(data.get("allowed_internal_prefixes"), "allowed_internal_prefixes")
+    if any(not item.startswith("aragora.") for item in allowed):
+        raise PolicyError("allowed_internal_prefixes entries must start with aragora.")
+
+    hook = data.get("hook")
+    if not isinstance(hook, dict) or not isinstance(hook.get("id"), str):
+        raise PolicyError("hook.id must be a string")
+    hook_files = hook.get("files")
+    if not isinstance(hook_files, str) or not hook_files:
+        raise PolicyError("hook.files must be a non-empty regex")
+    try:
+        pattern = re.compile(hook_files)
+    except re.error as exc:
+        raise PolicyError(f"hook.files is invalid: {exc}") from exc
+
+    for item in [*(entry.path for entry in roots), *sources]:
+        if not item.exists():
+            raise PolicyError(f"mapped path does not exist: {item.relative_to(root)}")
+        if not any(item.is_relative_to(entry.path) for entry in roots):
+            raise PolicyError(f"source is outside module_roots: {item.relative_to(root)}")
+        if not _covered(pattern, root, item):
+            raise PolicyError(f"hook.files does not cover {item.relative_to(root)}")
+    for relative in (HOOK_PATH, MAP_PATH, BASELINE_PATH, CHECKER_PATH):
+        if not pattern.fullmatch(relative.as_posix()):
+            raise PolicyError(f"hook.files does not cover {relative}")
+    return Policy(tuple(roots), sources, allowed, hook["id"], hook_files)
+
+
+def _python_files(path: Path) -> list[Path]:
+    if path.is_file():
+        if path.suffix != ".py":
+            raise PolicyError(f"mapped source is not Python: {path}")
+        return [path]
+    return sorted(item for item in path.rglob("*.py") if "__pycache__" not in item.parts)
+
+
+def _module(path: Path, policy: Policy) -> tuple[str, bool]:
+    matches = [root for root in policy.roots if path.is_relative_to(root.path)]
+    if not matches:
+        raise PolicyError(f"source has no module root: {path}")
+    root = max(matches, key=lambda item: len(item.path.parts))
+    relative = path.relative_to(root.path)
+    parts = [root.package, *relative.with_suffix("").parts]
+    is_package = path.name == "__init__.py"
+    if is_package:
+        parts.pop()
+    return ".".join(parts), is_package
+
+
+def _known_modules(policy: Policy) -> set[str]:
+    known: set[str] = set()
+    for root in policy.roots:
+        for path in _python_files(root.path):
+            name, _ = _module(path, policy)
+            parts = name.split(".")
+            known.update(".".join(parts[:index]) for index in range(1, len(parts) + 1))
+    return known
+
+
+def _relative_base(module: str, is_package: bool, node: ast.ImportFrom) -> str:
+    package = module.split(".") if is_package else module.split(".")[:-1]
+    keep = len(package) - (node.level - 1)
+    if keep < 1:
+        raise PolicyError(f"relative import escapes package in {module}")
+    parts = package[:keep]
+    if node.module:
+        parts.extend(node.module.split("."))
+    return ".".join(parts)
+
+
+def _targets(tree: ast.AST, module: str, is_package: bool, known: set[str]) -> set[str]:
+    targets: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            targets.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            base = _relative_base(module, is_package, node) if node.level else node.module
+            if not base:
+                raise PolicyError(f"empty import target in {module}")
+            for alias in node.names:
+                candidate = f"{base}.{alias.name}"
+                targets.add(candidate if alias.name != "*" and candidate in known else base)
+    return targets
+
+
+def _allowed(target: str, prefixes: tuple[str, ...]) -> bool:
+    return any(target == prefix or target.startswith(f"{prefix}.") for prefix in prefixes)
+
+
+def scan(repo_root: Path, policy: Policy) -> set[str]:
+    violations: set[str] = set()
+    known = _known_modules(policy)
+    seen: set[Path] = set()
+    for source in policy.sources:
+        for path in _python_files(source):
+            if path in seen:
+                continue
+            seen.add(path)
+            module, is_package = _module(path, policy)
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except (OSError, UnicodeError, SyntaxError) as exc:
+                raise PolicyError(f"cannot parse {path.relative_to(repo_root)}: {exc}") from exc
+            for target in _targets(tree, module, is_package, known):
+                if module == "aragora_verify" or module.startswith("aragora_verify."):
+                    if target == "aragora" or target.startswith("aragora."):
+                        violations.add(f"offline {module} -> {target}")
+                elif (target == "aragora" or target.startswith("aragora.")) and not _allowed(
+                    target, policy.allowed
+                ):
+                    violations.add(f"import {module} -> {target}")
+    return violations
+
+
+def _hook_values(path: Path, hook_id: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    matches = 0
+    active = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- id:"):
+            active = stripped.split(":", 1)[1].strip() == hook_id
+            matches += int(active)
+            continue
+        if active and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            if key in {"entry", "language", "pass_filenames", "files", "stages"}:
+                values[key] = value.strip().strip("'\"")
+    if matches != 1:
+        raise PolicyError(f"expected exactly one {hook_id!r} hook, found {matches}")
+    return values
+
+
+def validate_hook(repo_root: Path, policy: Policy) -> None:
+    hook_path = repo_root / HOOK_PATH
+    try:
+        text = hook_path.read_text(encoding="utf-8")
+        values = _hook_values(hook_path, policy.hook_id)
+    except OSError as exc:
+        raise PolicyError(f"cannot read {HOOK_PATH}: {exc}") from exc
+    expected = {
+        "entry": "python3 scripts/ci/check_boundary_edges.py",
+        "language": "system",
+        "pass_filenames": "false",
+        "files": policy.hook_files,
+        "stages": "[pre-commit, pre-push]",
+    }
+    if values != expected:
+        raise PolicyError(f"{policy.hook_id} hook drift: expected {expected}, found {values}")
+    install = "pre-commit install --hook-type pre-commit --hook-type pre-push"
+    if install not in "\n".join(text.splitlines()[:10]):
+        raise PolicyError("documented default hook installation omits pre-commit or pre-push")
+
+
+def load_baseline(path: Path) -> set[str]:
+    data = _json_object(path, "boundary baseline")
+    if data.get("schema_version") != 1 or data.get("boundary") != {
+        "id": 2,
+        "name": "receipts+verifier",
+    }:
+        raise PolicyError("boundary baseline identity is invalid")
+    if data.get("map") != MAP_PATH.as_posix():
+        raise PolicyError("boundary baseline map path is invalid")
+    frozen_ref = data.get("frozen_from_ref")
+    if not isinstance(frozen_ref, str) or not re.fullmatch(r"[0-9a-f]{40}", frozen_ref):
+        raise PolicyError("frozen_from_ref must be an informational 40-character SHA")
+    raw_items = data.get("violations")
+    if not isinstance(raw_items, list) or any(
+        not isinstance(item, str) or not item for item in raw_items
+    ):
+        raise PolicyError("baseline violations must be a string array")
+    items = tuple(raw_items)
+    if len(items) != len(set(items)):
+        raise PolicyError("baseline violations contains duplicate entries")
+    if list(items) != sorted(items):
+        raise PolicyError("baseline violations must be sorted")
+    return set(items)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--map", type=Path, default=MAP_PATH)
+    parser.add_argument("--baseline", type=Path, default=BASELINE_PATH)
+    parser.add_argument("--print-current", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    root = args.repo_root.resolve()
+    map_path = args.map if args.map.is_absolute() else root / args.map
+    baseline_path = args.baseline if args.baseline.is_absolute() else root / args.baseline
+    try:
+        policy = load_policy(root, map_path)
+        validate_hook(root, policy)
+        current = scan(root, policy)
+        if args.print_current:
+            print(
+                json.dumps(sorted(current), indent=2) if args.json else "\n".join(sorted(current))
+            )
+            return 0
+        baseline = load_baseline(baseline_path)
+    except PolicyError as exc:
+        print(f"ERROR: {exc}")
+        return 2
+
+    new = current - baseline
+    stale = baseline - current
+    result = {"ok": not new and not stale, "new": sorted(new), "stale": sorted(stale)}
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        for item in sorted(new):
+            print(f"NEW: {item}")
+        for item in sorted(stale):
+            print(f"STALE: {item}")
+        if result["ok"]:
+            print(f"Boundary 2 module-edge policy passed ({len(baseline)} baseline edges)")
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_check_boundary_edges.py
+++ b/tests/ci/test_check_boundary_edges.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.ci import check_boundary_edges as checker
 
@@ -193,3 +194,13 @@ def test_repository_policy_is_current() -> None:
     assert checker.scan(REPO_ROOT, policy) == checker.load_baseline(
         REPO_ROOT / checker.BASELINE_PATH
     )
+
+
+def test_required_lint_job_runs_boundary_checker() -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/lint.yml").read_text())
+    steps = workflow["jobs"]["lint-run"]["steps"]
+    matching = [
+        step for step in steps if "scripts/ci/check_boundary_edges.py" in str(step.get("run", ""))
+    ]
+    assert len(matching) == 1
+    assert matching[0]["name"] == "Enforce Boundary 2 module-edge policy"

--- a/tests/ci/test_check_boundary_edges.py
+++ b/tests/ci/test_check_boundary_edges.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import check_boundary_edges as checker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATTERN = (
+    r"^(?:\.pre-commit-config\.yaml|aragora/.*|aragora-verify/src/aragora_verify/.*|"
+    r"scripts/baselines/boundary2_edges_baseline\.json|"
+    r"scripts/ci/boundary_maps/receipts_verifier\.json|"
+    r"scripts/ci/check_boundary_edges\.py)$"
+)
+
+
+def _write_repo(tmp_path: Path, source: str = "") -> tuple[Path, Path]:
+    files = {
+        "aragora/__init__.py": "",
+        "aragora/core/__init__.py": "",
+        "aragora/gauntlet/__init__.py": "",
+        "aragora/gauntlet/odr_export.py": "",
+        "aragora/gauntlet/runner.py": "",
+        "aragora/receipts/__init__.py": source,
+        "aragora-verify/src/aragora_verify/__init__.py": "",
+        "scripts/ci/check_boundary_edges.py": "",
+    }
+    for relative, content in files.items():
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    map_path = tmp_path / checker.MAP_PATH
+    map_path.parent.mkdir(parents=True, exist_ok=True)
+    policy = {
+        "schema_version": 1,
+        "boundary": {"id": 2, "name": "receipts+verifier", "provenance": "test"},
+        "module_roots": [
+            {"path": "aragora", "package": "aragora"},
+            {"path": "aragora-verify/src/aragora_verify", "package": "aragora_verify"},
+        ],
+        "sources": ["aragora/receipts", "aragora-verify/src/aragora_verify"],
+        "allowed_internal_prefixes": ["aragora.core", "aragora.gauntlet.odr_export"],
+        "hook": {"id": "boundary2-edges", "files": HOOK_PATTERN},
+    }
+    map_path.write_text(json.dumps(policy), encoding="utf-8")
+    baseline_path = tmp_path / checker.BASELINE_PATH
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_baseline(baseline_path, [])
+    _write_hook(tmp_path)
+    return map_path, baseline_path
+
+
+def _write_baseline(path: Path, violations: list[str], frozen_ref: str = "f" * 40) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "boundary": {"id": 2, "name": "receipts+verifier"},
+                "map": checker.MAP_PATH.as_posix(),
+                "frozen_from_ref": frozen_ref,
+                "violations": violations,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_hook(
+    tmp_path: Path, *, files: str = HOOK_PATTERN, stages: str = "[pre-commit, pre-push]"
+) -> None:
+    (tmp_path / checker.HOOK_PATH).write_text(
+        "# Install: pre-commit install --hook-type pre-commit --hook-type pre-push\n"
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: boundary2-edges\n"
+        "        entry: python3 scripts/ci/check_boundary_edges.py\n"
+        "        language: system\n"
+        "        pass_filenames: false\n"
+        f"        files: {files}\n"
+        f"        stages: {stages}\n",
+        encoding="utf-8",
+    )
+
+
+def _run(tmp_path: Path, map_path: Path, baseline_path: Path) -> int:
+    return checker.main(
+        ["--repo-root", str(tmp_path), "--map", str(map_path), "--baseline", str(baseline_path)]
+    )
+
+
+def test_resolves_absolute_relative_and_offline_imports(tmp_path: Path) -> None:
+    source = "\n".join(
+        [
+            "from aragora import core",
+            "from aragora.gauntlet import runner",
+            "from ..gauntlet import odr_export",
+        ]
+    )
+    map_path, _ = _write_repo(tmp_path, source)
+    verifier = tmp_path / "aragora-verify/src/aragora_verify/verifier.py"
+    verifier.write_text("import aragora.core\n", encoding="utf-8")
+    policy = checker.load_policy(tmp_path, map_path)
+    assert checker.scan(tmp_path, policy) == {
+        "import aragora.receipts -> aragora.gauntlet.runner",
+        "offline aragora_verify.verifier -> aragora.core",
+    }
+
+
+def test_dotted_child_is_not_absorbed_by_baselined_parent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    map_path, baseline_path = _write_repo(tmp_path, "from aragora.gauntlet import runner\n")
+    _write_baseline(baseline_path, ["import aragora.receipts -> aragora.gauntlet"])
+    assert _run(tmp_path, map_path, baseline_path) == 1
+    output = capsys.readouterr().out
+    assert "NEW: import aragora.receipts -> aragora.gauntlet.runner" in output
+    assert "STALE: import aragora.receipts -> aragora.gauntlet" in output
+
+
+def test_stale_baseline_entry_fails(tmp_path: Path) -> None:
+    map_path, baseline_path = _write_repo(tmp_path)
+    _write_baseline(baseline_path, ["import aragora.receipts -> aragora.debate"])
+    assert _run(tmp_path, map_path, baseline_path) == 1
+
+
+def test_unreachable_frozen_ref_is_informational(tmp_path: Path) -> None:
+    map_path, baseline_path = _write_repo(tmp_path)
+    _write_baseline(baseline_path, [], frozen_ref="0" * 40)
+    assert _run(tmp_path, map_path, baseline_path) == 0
+
+
+def test_malformed_python_fails_closed(tmp_path: Path) -> None:
+    map_path, baseline_path = _write_repo(tmp_path, "from [\n")
+    assert _run(tmp_path, map_path, baseline_path) == 2
+
+
+def test_duplicate_map_entry_is_rejected(tmp_path: Path) -> None:
+    map_path, _ = _write_repo(tmp_path)
+    data = json.loads(map_path.read_text())
+    data["sources"].append(data["sources"][0])
+    map_path.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(checker.PolicyError, match="duplicate"):
+        checker.load_policy(tmp_path, map_path)
+
+
+def test_new_map_root_without_hook_coverage_is_rejected(tmp_path: Path) -> None:
+    map_path, _ = _write_repo(tmp_path)
+    extra = tmp_path / "other_boundary"
+    extra.mkdir()
+    (extra / "__init__.py").write_text("", encoding="utf-8")
+    data = json.loads(map_path.read_text())
+    data["module_roots"].append({"path": "other_boundary", "package": "other_boundary"})
+    data["sources"].append("other_boundary")
+    map_path.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(checker.PolicyError, match="hook.files does not cover"):
+        checker.load_policy(tmp_path, map_path)
+
+
+@pytest.mark.parametrize(
+    ("files", "stages"),
+    [(r"^aragora/.*$", "[pre-commit, pre-push]"), (HOOK_PATTERN, "[pre-push]")],
+)
+def test_hook_drift_fails_closed(tmp_path: Path, files: str, stages: str) -> None:
+    map_path, _ = _write_repo(tmp_path)
+    _write_hook(tmp_path, files=files, stages=stages)
+    policy = checker.load_policy(tmp_path, map_path)
+    with pytest.raises(checker.PolicyError, match="hook drift"):
+        checker.validate_hook(tmp_path, policy)
+
+
+@pytest.mark.parametrize(
+    "violations",
+    [
+        ["z", "a"],
+        ["duplicate", "duplicate"],
+    ],
+)
+def test_baseline_must_be_sorted_and_unique(tmp_path: Path, violations: list[str]) -> None:
+    path = tmp_path / "baseline.json"
+    _write_baseline(path, violations)
+    with pytest.raises(checker.PolicyError):
+        checker.load_baseline(path)
+
+
+def test_repository_policy_is_current() -> None:
+    policy = checker.load_policy(REPO_ROOT, REPO_ROOT / checker.MAP_PATH)
+    checker.validate_hook(REPO_ROOT, policy)
+    assert checker.scan(REPO_ROOT, policy) == checker.load_baseline(
+        REPO_ROOT / checker.BASELINE_PATH
+    )


### PR DESCRIPTION
## Summary

Replacement for parked draft #9592 from current main, split from the standalone verifier dependency-policy enforcement merged in #9785.

- add a machine-readable Boundary 2 receipts+verifier module map
- resolve absolute and relative `ImportFrom` targets against real modules enumerated from mapped source roots
- reject both new forbidden edges and stale baseline entries without mutating policy
- verify map-to-hook source coverage and run the checker at pre-commit and pre-push

No GitHub workflow, reviewer pin, dependency-policy, or branch-protection behavior changes.

## Baseline

- Base: `31c243aa7f3b06ffdfe857b3a5dfa2118d913f75`
- Frozen module-edge violations: **11**
- `frozen_from_ref` is informational only; the checker never reads git history.

The parked #9592 baseline carried 12 module edges before dependency entries were added. The precise resolver removes the coarse `aragora.gauntlet` false positive and keeps real dotted children distinct. Dependency declarations remain solely governed by #9785.

## Validation

- `python -m pytest -q tests/ci/test_check_boundary_edges.py` — 12 passed
- focused mutation dogfood for dotted-child, stale-baseline, and hook-coverage failure — 3 passed
- Ruff check and format — passed
- MyPy on checker and focused tests — passed
- direct checker against the 11-edge baseline — passed
- full pre-commit and pre-push hook stages — passed
- pre-commit configuration validation — passed
- quality ratchet — passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — passed
- `git diff --check origin/main...HEAD` — passed

## Scope

Five files, 598 insertions and one deletion: **599 total changed lines**, below the preferred 600-line target and the 800-line hard limit.

This is a draft Tier-4 governance PR. No model evidence, settlement, or merge action is authorized by this implementation cycle.