### PR TITLE
ci(openapi): probe post-publish verify semantics pre-publication and fix sync copy layout [Tier 4]

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -611,12 +611,16 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          # Copy generated files to compare
-          cp /tmp/openapi-spec/openapi_generated.json docs/api/openapi.json 2>/dev/null || true
-          cp /tmp/openapi-spec/openapi_generated.yaml docs/api/openapi.yaml 2>/dev/null || true
-          cp /tmp/openapi-spec/openapi-types.ts sdk/typescript/src/openapi-types.ts 2>/dev/null || true
-          cp /tmp/openapi-spec/generated_types.py sdk/python/aragora/generated_types.py 2>/dev/null || true
-          cp /tmp/openapi-spec/aragora/live/src/types/api.generated.ts aragora/live/src/types/api.generated.ts 2>/dev/null || true
+          # download-artifact@v4 preserves the upload's repo-root-relative
+          # layout, so the sources sit at their full nested paths. A flat
+          # basename copy matches nothing, and masking that turned the whole
+          # sync push into a silent no-op; a missing source now fails the
+          # job loudly (the dependent envelope job is then skipped).
+          cp /tmp/openapi-spec/docs/api/openapi_generated.json docs/api/openapi.json
+          cp /tmp/openapi-spec/docs/api/openapi_generated.yaml docs/api/openapi.yaml
+          cp /tmp/openapi-spec/sdk/typescript/src/openapi-types.ts sdk/typescript/src/openapi-types.ts
+          cp /tmp/openapi-spec/sdk/python/aragora/generated_types.py sdk/python/aragora/generated_types.py
+          cp /tmp/openapi-spec/aragora/live/src/types/api.generated.ts aragora/live/src/types/api.generated.ts
           git diff --quiet docs/api/ sdk/typescript/src/openapi-types.ts sdk/python/aragora/generated_types.py aragora/live/src/types/api.generated.ts || echo "changes=true" >> $GITHUB_OUTPUT
 
       - name: Commit updated spec
@@ -630,12 +634,13 @@ jobs:
           git fetch origin main
           git reset --hard origin/main
 
-          # Re-apply the generated spec and SDK type files from temp location
-          cp /tmp/openapi-spec/openapi_generated.json docs/api/openapi.json 2>/dev/null || true
-          cp /tmp/openapi-spec/openapi_generated.yaml docs/api/openapi.yaml 2>/dev/null || true
-          cp /tmp/openapi-spec/openapi-types.ts sdk/typescript/src/openapi-types.ts 2>/dev/null || true
-          cp /tmp/openapi-spec/generated_types.py sdk/python/aragora/generated_types.py 2>/dev/null || true
-          cp /tmp/openapi-spec/aragora/live/src/types/api.generated.ts aragora/live/src/types/api.generated.ts 2>/dev/null || true
+          # Re-apply the generated files from the artifact's nested layout
+          # (same sources as "Check for changes"; no masking).
+          cp /tmp/openapi-spec/docs/api/openapi_generated.json docs/api/openapi.json
+          cp /tmp/openapi-spec/docs/api/openapi_generated.yaml docs/api/openapi.yaml
+          cp /tmp/openapi-spec/sdk/typescript/src/openapi-types.ts sdk/typescript/src/openapi-types.ts
+          cp /tmp/openapi-spec/sdk/python/aragora/generated_types.py sdk/python/aragora/generated_types.py
+          cp /tmp/openapi-spec/aragora/live/src/types/api.generated.ts aragora/live/src/types/api.generated.ts
 
           # Check if there are actual changes
           if git diff --quiet docs/api/ sdk/typescript/src/openapi-types.ts sdk/python/aragora/generated_types.py aragora/live/src/types/api.generated.ts 2>/dev/null; then

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -66,10 +66,12 @@ EXIT_FAIL = 1
 EXIT_BLOCKED = 2
 EXIT_MOVEMENT = 3
 
-# The single stderr marker `_checked_verification` keys blocked-vs-fail on.
-# cmd_preflight validates it against the live runner gh (blocked-marker
-# probe) so the marker and the detection can never drift apart silently.
+# The stderr shapes `_checked_verification` keys blocked-vs-fail on (see
+# `_is_absent_attestation_stderr`). cmd_preflight validates them against the
+# live runner gh (blocked-marker probe) so the detection and the runner's
+# actual error shape can never drift apart silently.
 NO_ATTESTATIONS_MARKER = "no attestations"
+ATTESTATIONS_API_PATH_MARKER = "/attestations/sha256:"
 BLOCKED_MARKER_PROBE_NAME = "blocked-marker-probe.bin"
 # Pre-publish attestation lag ladder; mirrors the workflow's post-publish
 # retry step (4 attempts, 5/10/20s waits), blocked class only.
@@ -422,12 +424,24 @@ def _gh_api_json(endpoint: str, *, paginate: bool = False, admin_gated: bool = F
     return json.loads(completed.stdout)
 
 
+def _is_absent_attestation_stderr(stderr: str, marker: str) -> bool:
+    """Both shapes gh uses for an absent (or not-yet-propagated) attestation:
+    the textual marker family, and the raw attestations-API HTTP 404 that
+    newer gh emits instead (2.96.0, observed live 2026-08-18). The 404 is
+    scoped to the attestations endpoint so a missing release or any other
+    404 stays a readable contradiction."""
+    lowered = stderr.lower()
+    if marker in lowered:
+        return True
+    return "http 404" in lowered and ATTESTATIONS_API_PATH_MARKER in lowered
+
+
 def _checked_verification(argv: list[str], *, kind: str, blocked_marker: str = "") -> None:
     completed = _run_gh(argv)
     if completed.returncode == 0:
         return
     stderr = completed.stderr.decode("utf-8", "replace").strip()
-    if blocked_marker and blocked_marker in stderr.lower():
+    if blocked_marker and _is_absent_attestation_stderr(stderr, blocked_marker):
         raise Blocked(f"{kind} is not attested yet: {stderr}")
     raise RuntimeError(f"{kind} verification failed: {stderr}")
 
@@ -835,10 +849,10 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             "release verify-asset",
         ]
         # `_checked_verification` distinguishes retryable lag from a readable
-        # contradiction by NO_ATTESTATIONS_MARKER. Verifying a per-identity
-        # scratch subject that provably has no attestation forces the live
-        # runner gh to emit its no-attestation error NOW, so marker drift
-        # blocks here instead of hard-failing after publication.
+        # contradiction by `_is_absent_attestation_stderr`. Verifying a
+        # per-identity scratch subject that provably has no attestation forces
+        # the live runner gh to emit its no-attestation error NOW, so marker
+        # drift blocks here instead of hard-failing after publication.
         with tempfile.TemporaryDirectory() as probe_dir:
             probe_path = Path(probe_dir) / BLOCKED_MARKER_PROBE_NAME
             probe_path.write_bytes(f"unattested probe subject for {tag}\n".encode())
@@ -856,10 +870,11 @@ def cmd_preflight(args: argparse.Namespace) -> int:
                 "subject; this runner's gh verification verdicts cannot be trusted"
             )
         probe_stderr = probe.stderr.decode("utf-8", "replace").strip()
-        if NO_ATTESTATIONS_MARKER not in probe_stderr.lower():
+        if not _is_absent_attestation_stderr(probe_stderr, NO_ATTESTATIONS_MARKER):
             raise Blocked(
-                f"runner gh reports a missing attestation without the "
-                f"{NO_ATTESTATIONS_MARKER!r} marker, so post-publish propagation lag "
+                f"runner gh reports a missing attestation with neither the "
+                f"{NO_ATTESTATIONS_MARKER!r} marker nor the attestations-API "
+                f"HTTP 404 shape, so post-publish propagation lag "
                 f"would hard-fail instead of retrying; observed: {probe_stderr[:300]}"
             )
         report["blocked_marker_probe"] = "validated"

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -30,10 +30,13 @@ every readable answer keeps full fail-closed semantics, and the operator's
 
 Exit codes (CDG status vocabulary): 0 pass, 1 fail (verification
 contradiction), 2 blocked (publication/attestation/rule-suite not yet
-visible), 3 movement (selection moved; restart verification). Only blocked
-post-publication verification may be retried in place, with the same original
-identity and envelope. Fail, movement, and unexpected errors are terminal;
-build, preflight, attestation, and publication must stay outside that retry.
+visible), 3 movement (selection moved; restart verification). Retries are
+bounded, deterministic, and blocked-class only: ``preflight`` retries its
+read-only pre-publish attestation checks on the 5/10/20s ladder before
+concluding blocked, and only blocked post-publication verification may be
+retried in place, with the same original identity and envelope. Fail,
+movement, and unexpected errors are terminal; build, attestation (signing),
+publication, and every other phase stay outside any retry.
 """
 
 from __future__ import annotations
@@ -41,10 +44,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -60,6 +65,17 @@ EXIT_PASS = 0
 EXIT_FAIL = 1
 EXIT_BLOCKED = 2
 EXIT_MOVEMENT = 3
+
+# The single stderr marker `_checked_verification` keys blocked-vs-fail on.
+# cmd_preflight validates it against the live runner gh (blocked-marker
+# probe) so the marker and the detection can never drift apart silently.
+NO_ATTESTATIONS_MARKER = "no attestations"
+BLOCKED_MARKER_PROBE_NAME = "blocked-marker-probe.bin"
+# Pre-publish attestation lag ladder; mirrors the workflow's post-publish
+# retry step (4 attempts, 5/10/20s waits), blocked class only.
+PREPUBLISH_RETRY_DELAYS = (5, 10, 20)
+
+_sleep = time.sleep
 
 _FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 _REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
@@ -416,6 +432,23 @@ def _checked_verification(argv: list[str], *, kind: str, blocked_marker: str = "
     raise RuntimeError(f"{kind} verification failed: {stderr}")
 
 
+def _verification_with_lag_retry(
+    argv: list[str], *, kind: str, delays: tuple[int, ...] = PREPUBLISH_RETRY_DELAYS
+) -> None:
+    """Bounded deterministic retry for the blocked class only. Attestation
+    data written by actions/attest propagates to the verification data plane
+    asynchronously, so a pre-publish read can lag the signing step inside
+    the same run; a readable contradiction (RuntimeError) is terminal on the
+    first read and never retried."""
+    for delay in delays:
+        try:
+            _checked_verification(argv, kind=kind, blocked_marker=NO_ATTESTATIONS_MARKER)
+            return
+        except Blocked:
+            _sleep(delay)
+    _checked_verification(argv, kind=kind, blocked_marker=NO_ATTESTATIONS_MARKER)
+
+
 def live_selection_snapshot(identity: dict[str, Any]) -> dict[str, Any]:
     """Requery main, workflow, the bound attempt, and the run-level artifact;
     the caller compares two snapshots and restarts on any movement.
@@ -573,6 +606,43 @@ def _rule_suite_binding(repository: str, head_sha: str, *, admin_reads: str) -> 
         return {"state": "unverified", "reason": str(exc)}
 
 
+def _admin_gated_notes(report: dict[str, Any]) -> list[str]:
+    notes: list[str] = []
+    setting = report.get("immutability_setting")
+    if isinstance(setting, str) and setting.startswith("unreadable"):
+        notes.append("immutable-releases setting: unreadable (Administration:read gated)")
+    suite = report.get("rule_suite")
+    if isinstance(suite, dict) and suite.get("state") == "unverified":
+        notes.append("rule-suite binding: unverified (Administration:read gated)")
+    return notes
+
+
+def _append_step_summary(report: dict[str, Any]) -> None:
+    """Surface admin-read-gated degradation distinctly in the job summary.
+
+    The in-job token soft-reports these surfaces by design (``--admin-reads
+    report``); the summary makes the degraded state visible to the operator
+    without hard-failing non-admin tokens. Summary IO is cosmetic and must
+    never flip a verification outcome."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    notes = _admin_gated_notes(report)
+    if not notes:
+        return
+    lines = [
+        f"### OpenAPI envelope {report.get('phase', 'run')}: admin-read-gated reads degraded",
+        *[f"- {note}" for note in notes],
+        "- authoritative for these surfaces: the external `verify --admin-reads required` run",
+        "",
+    ]
+    try:
+        with open(path, "a", encoding="utf-8") as stream:
+            stream.write("\n".join(lines) + "\n")
+    except OSError:
+        return
+
+
 def cmd_verify(args: argparse.Namespace) -> int:
     identity = make_identity(
         repository=args.repository,
@@ -648,14 +718,14 @@ def cmd_verify(args: argparse.Namespace) -> int:
             _checked_verification(
                 release_verify_argv(tag, repository=repository),
                 kind=f"release {tag}",
-                blocked_marker="no attestations",
+                blocked_marker=NO_ATTESTATIONS_MARKER,
             )
             for name in sorted(files):
                 asset_path = str(Path(scratch) / name)
                 _checked_verification(
                     release_verify_asset_argv(tag, asset_path, repository=repository),
                     kind=f"release asset {name}",
-                    blocked_marker="no attestations",
+                    blocked_marker=NO_ATTESTATIONS_MARKER,
                 )
                 _checked_verification(
                     attestation_verify_argv(
@@ -665,7 +735,7 @@ def cmd_verify(args: argparse.Namespace) -> int:
                         signer_workflow=signer_workflow,
                     ),
                     kind=f"attestation for {name}",
-                    blocked_marker="no attestations",
+                    blocked_marker=NO_ATTESTATIONS_MARKER,
                 )
         report["payload_assets"] = [entry["name"] for entry in manifest["payload_assets"]]
         report["rule_suite"] = _rule_suite_binding(
@@ -692,6 +762,8 @@ def cmd_verify(args: argparse.Namespace) -> int:
     except (RuntimeError, ValueError) as exc:
         _emit({**report, "status": "fail", "reason": str(exc)})
         return EXIT_FAIL
+    finally:
+        _append_step_summary(report)
 
 
 def cmd_preflight(args: argparse.Namespace) -> int:
@@ -718,8 +790,81 @@ def cmd_preflight(args: argparse.Namespace) -> int:
         }
         manifest = verify_envelope_assets(files, identity)
         report["payload_assets"] = [entry["name"] for entry in manifest["payload_assets"]]
+        # `gh release verify`/`verify-asset` arrived in gh 2.96; probing the
+        # subcommands AND every flag of the exact post-publish argv (built by
+        # the same builders the post-publish steps run) keeps a runner-gh
+        # mismatch from surfacing only after the irreversible publication.
+        sample_asset = str(assets_dir / MANIFEST_NAME)
+        for capability, probe_argv in (
+            (("release", "verify"), release_verify_argv(tag, repository=repository)),
+            (
+                ("release", "verify-asset"),
+                release_verify_asset_argv(tag, sample_asset, repository=repository),
+            ),
+            (
+                ("attestation", "verify"),
+                attestation_verify_argv(
+                    sample_asset,
+                    repository=repository,
+                    head_sha=identity["head_sha"],
+                    signer_workflow=signer_workflow,
+                ),
+            ),
+        ):
+            helped = _run_gh(["gh", *capability, "--help"])
+            if helped.returncode != 0:
+                raise Blocked(
+                    f"gh {' '.join(capability)} is unavailable on this runner; "
+                    "post-publication verification would be impossible"
+                )
+            help_text = (helped.stdout + helped.stderr).decode("utf-8", "replace")
+            missing = [
+                flag
+                for flag in sorted({token for token in probe_argv if token.startswith("-")})
+                if flag not in help_text
+            ]
+            if missing:
+                raise Blocked(
+                    f"gh {' '.join(capability)} on this runner does not accept "
+                    f"{', '.join(missing)}; the exact post-publish verification argv "
+                    "would be rejected only after the irreversible publication"
+                )
+        report["gh_capabilities"] = [
+            "attestation verify",
+            "release verify",
+            "release verify-asset",
+        ]
+        # `_checked_verification` distinguishes retryable lag from a readable
+        # contradiction by NO_ATTESTATIONS_MARKER. Verifying a per-identity
+        # scratch subject that provably has no attestation forces the live
+        # runner gh to emit its no-attestation error NOW, so marker drift
+        # blocks here instead of hard-failing after publication.
+        with tempfile.TemporaryDirectory() as probe_dir:
+            probe_path = Path(probe_dir) / BLOCKED_MARKER_PROBE_NAME
+            probe_path.write_bytes(f"unattested probe subject for {tag}\n".encode())
+            probe = _run_gh(
+                attestation_verify_argv(
+                    str(probe_path),
+                    repository=repository,
+                    head_sha=identity["head_sha"],
+                    signer_workflow=signer_workflow,
+                )
+            )
+        if probe.returncode == 0:
+            raise Blocked(
+                "blocked-marker probe unexpectedly verified an unattested scratch "
+                "subject; this runner's gh verification verdicts cannot be trusted"
+            )
+        probe_stderr = probe.stderr.decode("utf-8", "replace").strip()
+        if NO_ATTESTATIONS_MARKER not in probe_stderr.lower():
+            raise Blocked(
+                f"runner gh reports a missing attestation without the "
+                f"{NO_ATTESTATIONS_MARKER!r} marker, so post-publish propagation lag "
+                f"would hard-fail instead of retrying; observed: {probe_stderr[:300]}"
+            )
+        report["blocked_marker_probe"] = "validated"
         for name in sorted(files):
-            _checked_verification(
+            _verification_with_lag_retry(
                 attestation_verify_argv(
                     str(assets_dir / name),
                     repository=repository,
@@ -727,7 +872,6 @@ def cmd_preflight(args: argparse.Namespace) -> int:
                     signer_workflow=signer_workflow,
                 ),
                 kind=f"pre-publish attestation for {name}",
-                blocked_marker="no attestations",
             )
         # Forbidden subclasses Blocked: only a plain Blocked (404-class
         # invisibility) proves absence. A 403 rate-limit/permission answer
@@ -757,16 +901,6 @@ def cmd_preflight(args: argparse.Namespace) -> int:
                 f"git tag {tag} already exists; publishing would bind the release "
                 "to that tag's commit instead of the requested target"
             )
-        # `gh release verify`/`verify-asset` arrived in gh 2.96; probing them
-        # here keeps a missing subcommand from surfacing only after the
-        # irreversible publication.
-        for capability in (("release", "verify"), ("release", "verify-asset")):
-            if _run_gh(["gh", *capability, "--help"]).returncode != 0:
-                raise Blocked(
-                    f"gh {' '.join(capability)} is unavailable on this runner; "
-                    "post-publication verification would be impossible"
-                )
-        report["gh_capabilities"] = ["release verify", "release verify-asset"]
         report["immutability_setting"] = _immutability_state(
             repository, admin_reads=args.admin_reads
         )
@@ -791,6 +925,8 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     except (RuntimeError, ValueError) as exc:
         _emit({**report, "status": "fail", "reason": str(exc)})
         return EXIT_FAIL
+    finally:
+        _append_step_summary(report)
 
 
 DRY_RUN_HEAD_SHA = "0123456789abcdef0123456789abcdef01234567"

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -1873,6 +1873,58 @@ def test_envelope_preflight_validates_blocked_marker_against_live_gh(monkeypatch
     assert state["probe_calls"] == 1
 
 
+def test_absent_attestation_http_404_shape_is_blocked_lag_not_contradiction(
+    monkeypatch, tmp_path, capsys
+):
+    """Newer gh (2.96.0, observed live 2026-08-18) reports an unattested or
+    not-yet-propagated subject as a raw attestations-API HTTP 404 instead of
+    the textual `no attestations` marker. Both shapes must class as the
+    retryable blocked state, while a 404 from any OTHER endpoint stays a
+    readable contradiction that fails on the first read with no retry."""
+    module = _load_envelope_helper()
+    attestation_404 = (
+        b"Error: HTTP 404: Not Found (https://api.github.com/repos/"
+        b"synaptent/aragora/attestations/sha256:ab12?per_page=30)"
+    )
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
+    # The live probe accepts the 404 shape as a validated blocked marker.
+    monkeypatch.setattr(module, "_sleep", lambda _delay: None)
+    fake_run, state = _preflight_gh_stub(module, probe_stderr=attestation_404)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    assert json.loads(capsys.readouterr().out)["blocked_marker_probe"] == "validated"
+    assert state["probe_calls"] == 1
+    # The same shape is retryable propagation lag for the per-asset reads.
+    sleeps: list[int] = []
+    monkeypatch.setattr(module, "_sleep", sleeps.append)
+    fake_run, state = _preflight_gh_stub(module, asset_lag=1, asset_stderr=attestation_404)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    assert json.loads(capsys.readouterr().out)["status"] == "pass"
+    assert set(state["asset_attempts"].values()) == {2}
+    assert sleeps == [5] * len(state["asset_attempts"])
+    # A 404 from any non-attestations endpoint is a contradiction, not lag:
+    # the first read fails and the ladder never sleeps.
+    release_404 = (
+        b"HTTP 404: Not Found (https://api.github.com/repos/"
+        b"synaptent/aragora/releases/tags/openapi-envelope-x)"
+    )
+    sleeps.clear()
+    monkeypatch.setattr(
+        module,
+        "_run_gh",
+        lambda argv: subprocess.CompletedProcess(argv, 1, b"", release_404),
+    )
+    with pytest.raises(RuntimeError, match="release probe"):
+        module._verification_with_lag_retry(
+            ["gh", "release", "verify", "openapi-envelope-x", "-R", "synaptent/aragora"],
+            kind="release probe",
+        )
+    assert sleeps == []
+
+
 def test_envelope_preflight_attestation_lag_retry_is_bounded_and_deterministic(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -101,7 +101,6 @@ RECOVERY_STEPS_WITH_OR_TRUE = {
     ("generate-run", "Ensure python toolchain is available"),
     ("generate-run", "Fix npm cache ownership"),
     ("sync", "Verify checkout integrity"),
-    ("sync", "Check for changes"),
     ("sync", "Commit updated spec"),
     ("envelope", "Verify checkout integrity"),
 }
@@ -1260,8 +1259,8 @@ def test_envelope_preflight_tag_probes_treat_forbidden_as_blocked(monkeypatch, t
     assets_dir.mkdir()
     for name, data in assets.items():
         (assets_dir / name).write_bytes(data)
-    ok = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=b"{}", stderr=b"")
-    monkeypatch.setattr(module, "_run_gh", lambda argv: ok)
+    fake_run, _state = _preflight_gh_stub(module)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
     args = argparse.Namespace(
         repository="synaptent/aragora",
         head_sha=head,
@@ -1701,3 +1700,328 @@ def test_dispatch_omission_is_default_false_and_cannot_publish_envelope():
     gate = _step("envelope", "Require operator immutable-releases attestation")["run"]
     assert '[[ "$OPERATOR_CONFIRMED" != "true" ]]' in gate
     assert "exit 2" in gate
+
+
+# ---------------------------------------------------------------------------
+# PR #9781 P3 follow-ups: exact post-publish argv + blocked-marker probes,
+# bounded pre-publish attestation lag retry, admin-gated degradation in the
+# job summary, and the sync copy layout
+# ---------------------------------------------------------------------------
+
+SYNC_COPY_STEPS = ("Check for changes", "Commit updated spec")
+
+_GH_HELP_TEXT = b"-R, --repo | --format | --signer-workflow | --source-digest"
+
+
+def _upload_payload_paths() -> list[str]:
+    raw = _step("generate-run", "Upload generated spec and SDK types")["with"]["path"]
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _sync_cp_lines(step_name: str) -> list[str]:
+    return [
+        line.strip()
+        for line in _step("sync", step_name)["run"].splitlines()
+        if line.strip().startswith("cp ")
+    ]
+
+
+def _preflight_gh_stub(
+    module,
+    *,
+    help_text: bytes = _GH_HELP_TEXT,
+    broken_help: tuple[str, ...] = (),
+    probe_rc: int = 1,
+    probe_stderr: bytes = b"HTTP 404: no attestations found for subject",
+    asset_lag: int = 0,
+    asset_stderr: bytes = b"no attestations found for the requested subject yet",
+):
+    """Fake `_run_gh` covering cmd_preflight's direct gh surfaces: the
+    `--help` capability probes, the scratch blocked-marker probe, and the
+    per-asset pre-publish attestation verifies (which lag `asset_lag` reads
+    before succeeding). Tag probes and settings go through `_gh_api_json`
+    and are stubbed separately."""
+    state: dict = {"help": [], "probe_calls": 0, "asset_attempts": {}}
+
+    def fake_run(argv):
+        module.require_read_only_argv(argv)
+        if argv[-1] == "--help":
+            action = " ".join(argv[1:-1])
+            state["help"].append(action)
+            if action in broken_help:
+                return subprocess.CompletedProcess(argv, 1, b"", b"unknown command")
+            return subprocess.CompletedProcess(argv, 0, help_text, b"")
+        assert tuple(argv[1:3]) == ("attestation", "verify"), argv
+        subject = argv[3]
+        if subject.endswith(module.BLOCKED_MARKER_PROBE_NAME):
+            state["probe_calls"] += 1
+            return subprocess.CompletedProcess(argv, probe_rc, b"", probe_stderr)
+        attempts = state["asset_attempts"].get(subject, 0) + 1
+        state["asset_attempts"][subject] = attempts
+        if attempts <= asset_lag:
+            return subprocess.CompletedProcess(argv, 1, b"", asset_stderr)
+        return subprocess.CompletedProcess(argv, 0, b"{}", b"")
+
+    return fake_run, state
+
+
+def _preflight_fixture(module, tmp_path, head: str = "a1" * 20, run_id: int = 77):
+    identity = module.make_identity(**_identity_kwargs(module, head, run_id=run_id))
+    assets = module.build_envelope(
+        {"docs/api/openapi_generated.json": b'{"openapi":"3.1.0"}\n'}, identity
+    )
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    for name, data in assets.items():
+        (assets_dir / name).write_bytes(data)
+    args = argparse.Namespace(
+        repository="synaptent/aragora",
+        head_sha=head,
+        run_id=run_id,
+        run_attempt=1,
+        artifact_name=identity["artifact_name"],
+        assets_dir=str(assets_dir),
+        signer_workflow="",
+        admin_reads="report",
+    )
+    return identity, args
+
+
+def test_envelope_preflight_pins_exact_post_publish_verify_argv(monkeypatch, tmp_path, capsys):
+    """The capability probe must validate the exact post-publish argv shape
+    (every flag the shared builders emit) and the attestation subcommand
+    itself, so a runner-gh mismatch surfaces as blocked BEFORE `gh release
+    create` instead of as a hard exit 1 after the irreversible publication."""
+    module = _load_envelope_helper()
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_sleep", lambda _delay: None)
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
+    # Control: a gh advertising every builder flag preflights clean and
+    # reports all three probed capabilities.
+    fake_run, state = _preflight_gh_stub(module)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "pass"
+    assert report["gh_capabilities"] == [
+        "attestation verify",
+        "release verify",
+        "release verify-asset",
+    ]
+    assert set(state["help"]) == {"release verify", "release verify-asset", "attestation verify"}
+    # Exact-argv drift: help output missing `--format` blocks pre-publication
+    # naming the rejected flag, before any per-asset verification runs.
+    fake_run, state = _preflight_gh_stub(module, help_text=b"-R, --repo only")
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "--format" in report["reason"]
+    assert state["asset_attempts"] == {}
+    assert state["probe_calls"] == 0
+    # A missing subcommand still blocks (the pre-existing guarantee, now
+    # covering `gh attestation verify` too).
+    fake_run, state = _preflight_gh_stub(module, broken_help=("attestation verify",))
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "attestation verify" in report["reason"]
+    assert state["asset_attempts"] == {}
+
+
+def test_envelope_preflight_validates_blocked_marker_against_live_gh(monkeypatch, tmp_path, capsys):
+    """`_checked_verification` keys blocked-vs-fail on the `no attestations`
+    stderr marker. Preflight forces the runner's gh to emit its live
+    no-attestation error against a guaranteed-unattested scratch subject, so
+    marker drift blocks pre-publication instead of turning post-publish
+    propagation lag into a hard failure."""
+    module = _load_envelope_helper()
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_sleep", lambda _delay: None)
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
+    # Marker drift: the probe fails without the marker -> blocked, naming
+    # the observed stderr, before any per-asset verification.
+    fake_run, state = _preflight_gh_stub(
+        module, probe_stderr=b"attestation lookup failed: HTTP 500"
+    )
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "no attestations" in report["reason"]
+    assert "HTTP 500" in report["reason"]
+    assert state["probe_calls"] == 1
+    assert state["asset_attempts"] == {}
+    # A probe that unexpectedly verifies an unattested subject is just as
+    # disqualifying: the runner's verification verdicts cannot be trusted.
+    fake_run, state = _preflight_gh_stub(module, probe_rc=0)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "unattested" in report["reason"]
+    assert state["asset_attempts"] == {}
+    # Healthy runner: the probe validates the marker and preflight records it.
+    fake_run, state = _preflight_gh_stub(module)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    report = json.loads(capsys.readouterr().out)
+    assert report["blocked_marker_probe"] == "validated"
+    assert state["probe_calls"] == 1
+
+
+def test_envelope_preflight_attestation_lag_retry_is_bounded_and_deterministic(
+    monkeypatch, tmp_path, capsys
+):
+    """Pre-publish attestation reads can lag the actions/attest step inside
+    the same run. The retry mirrors the post-publish ladder (4 attempts,
+    5/10/20s waits), retries ONLY the blocked class, and weakens no
+    fail-closed outcome: exhaustion stays blocked (exit 2, nothing
+    published) and a readable contradiction still fails on the first read."""
+    module = _load_envelope_helper()
+    assert module.PREPUBLISH_RETRY_DELAYS == (5, 10, 20)
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
+    sleeps: list[int] = []
+    monkeypatch.setattr(module, "_sleep", sleeps.append)
+    # Two lagging reads per asset recover without failing the run.
+    fake_run, state = _preflight_gh_stub(module, asset_lag=2)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    assert json.loads(capsys.readouterr().out)["status"] == "pass"
+    assert set(state["asset_attempts"].values()) == {3}
+    assert sleeps == [5, 10] * len(state["asset_attempts"])
+    # Persistent lag exhausts the bounded ladder on the first asset and
+    # stays blocked; the ladder never grows and never loops.
+    sleeps.clear()
+    fake_run, state = _preflight_gh_stub(module, asset_lag=10)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "not attested yet" in report["reason"]
+    assert state["asset_attempts"] == {
+        min(state["asset_attempts"]): 1 + len(module.PREPUBLISH_RETRY_DELAYS)
+    }
+    assert sleeps == [5, 10, 20]
+    # A readable contradiction never retries and never sleeps.
+    sleeps.clear()
+    fake_run, state = _preflight_gh_stub(
+        module, asset_lag=10, asset_stderr=b"subject digest mismatch"
+    )
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_FAIL
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "fail"
+    assert "digest mismatch" in report["reason"]
+    assert set(state["asset_attempts"].values()) == {1}
+    assert len(state["asset_attempts"]) == 1
+    assert sleeps == []
+
+
+def test_envelope_admin_gated_degradation_lands_in_step_summary(monkeypatch, tmp_path, capsys):
+    """The in-run token soft-reports admin-gated surfaces by design
+    (``--admin-reads report``); the job summary must surface that degraded
+    state distinctly WITHOUT hard-failing the non-admin token, stay silent
+    when nothing degraded, and never affect the verification outcome when no
+    summary surface exists."""
+    module = _load_envelope_helper()
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_sleep", lambda _delay: None)
+    fake_run, _state = _preflight_gh_stub(module)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    degraded = [
+        ("immutable-releases", module.Forbidden("immutable-releases hidden: HTTP 404")),
+        ("rule-suites", module.Forbidden("rule-suites not readable: HTTP 403")),
+    ]
+    summary = tmp_path / "step-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, degraded))
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    assert json.loads(capsys.readouterr().out)["status"] == "pass"
+    text = summary.read_text(encoding="utf-8")
+    assert "admin-read-gated" in text
+    assert "immutable-releases setting: unreadable" in text
+    assert "rule-suite binding: unverified" in text
+    assert "--admin-reads required" in text
+    # Nothing degraded: nothing written.
+    clean_summary = tmp_path / "clean-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(clean_summary))
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    capsys.readouterr()
+    assert not clean_summary.exists()
+    # No summary surface at all: degradation still soft-reports cleanly.
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY")
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, degraded))
+    assert module.cmd_preflight(args) == module.EXIT_PASS
+    assert json.loads(capsys.readouterr().out)["status"] == "pass"
+
+
+def test_sync_copies_use_the_artifact_nested_layout():
+    """download-artifact@v4 preserves the upload's repo-root-relative layout
+    (the five payload paths share the repository root as their least common
+    ancestor), so the artifact sources sit at their full nested paths. A
+    flat basename copy matches nothing, and with ``2>/dev/null || true``
+    masking it silently reduced the whole sync push to a no-op."""
+    payload_paths = _upload_payload_paths()
+    assert len(payload_paths) == 5
+    expected_sources = {f"/tmp/openapi-spec/{path}" for path in payload_paths}
+    for step_name in SYNC_COPY_STEPS:
+        cp_lines = _sync_cp_lines(step_name)
+        assert len(cp_lines) == len(payload_paths), (step_name, cp_lines)
+        sources = {line.split()[1] for line in cp_lines}
+        assert sources == expected_sources, (step_name, sorted(sources))
+        for line in cp_lines:
+            assert "|| true" not in line, (step_name, line)
+            assert "2>/dev/null" not in line, (step_name, line)
+
+
+def test_sync_check_step_applies_copies_and_fails_loudly_on_layout_drift(tmp_path):
+    """Behavioral: with the artifact tree laid out the way the upload step
+    produces it, every copy lands and drift is reported; a missing source
+    (layout drift) fails the step instead of no-opping, which fails the sync
+    job and skips the dependent envelope job (fail-closed, nothing
+    published)."""
+    payload_paths = _upload_payload_paths()
+    destinations = {
+        "docs/api/openapi_generated.json": "docs/api/openapi.json",
+        "docs/api/openapi_generated.yaml": "docs/api/openapi.yaml",
+        "sdk/typescript/src/openapi-types.ts": "sdk/typescript/src/openapi-types.ts",
+        "sdk/python/aragora/generated_types.py": "sdk/python/aragora/generated_types.py",
+        "aragora/live/src/types/api.generated.ts": "aragora/live/src/types/api.generated.ts",
+    }
+    assert set(destinations) == set(payload_paths)
+    artifact_root = tmp_path / "openapi-spec"
+    for path in payload_paths:
+        source = artifact_root / path
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(f"generated {path}\n", encoding="utf-8")
+        destination = tmp_path / destinations[path]
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text("stale\n", encoding="utf-8")
+    run = _relocated(_step("sync", "Check for changes")["run"], tmp_path)
+    output = tmp_path / "github-output"
+    env = {"GITHUB_OUTPUT": str(output)}
+    drift_stub = "git() { return 1; }\n"
+    result = _simulate_step(run, env=env, cwd=tmp_path, stub_prelude=drift_stub)
+    assert result.returncode == 0, result.stderr
+    for path, destination in destinations.items():
+        copied = (tmp_path / destination).read_text(encoding="utf-8")
+        assert copied == f"generated {path}\n", destination
+    assert "changes=true" in output.read_text(encoding="utf-8")
+    # No drift: no changes output is emitted.
+    output.write_text("", encoding="utf-8")
+    clean_stub = "git() { return 0; }\n"
+    result = _simulate_step(run, env=env, cwd=tmp_path, stub_prelude=clean_stub)
+    assert result.returncode == 0, result.stderr
+    assert "changes=true" not in output.read_text(encoding="utf-8")
+    # Layout drift: a missing source must fail the step loudly.
+    (artifact_root / payload_paths[0]).unlink()
+    result = _simulate_step(run, env=env, cwd=tmp_path, stub_prelude=drift_stub)
+    assert result.returncode != 0, "missing artifact source no-opped silently"


### PR DESCRIPTION
## Bounded post-merge P3 follow-up batch (PR #9781 final evidence)

Implements the three actionable design-accepted claude [P3] advisories from the PR #9781 final evidence artifact (sha256 `56c46784ea987f34056b669ee1e938ad16396e28f2f492ad13af9037d29a947d`), plus the optional in-run token-degradation reporting item. Feature `misc-openapi-envelope-p3-followups`, milestone cdg-bootstrap-route-truth. Exactly three files, +567/-35 = 602 LOC.

### 1. Preflight pins the exact post-publish verify argv + blocked marker (advisory 1)
`cmd_preflight`'s capability probe now (a) probes all three verification subcommands including `gh attestation verify`, (b) requires every flag of the exact post-publish argv (built by the same `release_verify_argv`/`release_verify_asset_argv`/`attestation_verify_argv` builders the post-publish steps run) to appear in the runner's `--help` output, and (c) forces the live runner gh to emit its no-attestation error against a guaranteed-unattested per-identity scratch subject, requiring the `no attestations` marker that `_checked_verification` keys blocked-vs-fail on. Any mismatch exits 2 (blocked) BEFORE `gh release create`; previously it surfaced only as a hard post-publish exit 1. The marker literal is now the single `NO_ATTESTATIONS_MARKER` constant at every call site, so probe and detection cannot drift apart. A follow-up commit pins BOTH absent-attestation stderr shapes (`_is_absent_attestation_stderr`): the textual `no attestations` family AND the raw attestations-API `HTTP 404 (...)/attestations/sha256:...` that modern gh (2.96.0, verified live 2026-08-18 with the byte-exact builder argv) emits instead; the 404 is endpoint-scoped so a missing release or any other 404 remains a first-read hard contradiction.

### 2. Bounded deterministic pre-publish attestation retry (advisory 2)
The per-asset PRE-publish `gh attestation verify` now retries ONLY the blocked class ("no attestations" propagation lag) on the deterministic 5/10/20s ladder (4 attempts total), mirroring the reviewed post-publish retry step. Fail-closed behavior is unweakened: a readable contradiction fails on the FIRST read with no retry and no sleep; exhaustion stays blocked (exit 2, nothing published); build/attest/publication remain outside any retry. Module docstring updated to name the new ladder truthfully.

### 3. Sync flat-copy no-op fixed (advisory 3 — pre-existing, live-proven)
`actions/download-artifact@v4` preserves the upload's repo-root-relative layout (the five payload paths share the repo root as their LCA), so `/tmp/openapi-spec/` contains `docs/api/...`, `sdk/...`, `aragora/...` — the flat basename copies matched nothing and `2>/dev/null || true` masked it. **Live proof (run 32103433669, sync job 95608874991):** the sync commit `3774dae6` contained only `api.generated.ts` (the one full-path copy); the four flat copies silently no-opped; job still concluded `success`. Both sync steps now copy from the exact nested artifact paths (lockstep-pinned against the upload step's path list by a new test) with no masking: a missing source fails the step loudly under bash `-e`, failing the sync job and skipping the dependent envelope job (fail-closed, nothing published). `("sync", "Check for changes")` is removed from `RECOVERY_STEPS_WITH_OR_TRUE` (the step no longer carries `|| true`); the `Commit updated spec` publish path keeps its justified `continue-on-error` + push fallback unchanged.

### 4. Admin-read-gated degradation in the job summary (optional item)
When in-run reads degrade by design (`--admin-reads report`: immutable-releases setting unreadable / rule-suite unverified behind the non-admin token), preflight/verify now append a distinct note to `GITHUB_STEP_SUMMARY` naming the degraded surfaces and the authoritative external `verify --admin-reads required` run. Summary IO is cosmetic: it runs in a `finally`, swallows `OSError`, never changes any exit code, and in-job checks still never hard-fail on non-admin tokens.

### Deliberate design decisions (reviewer context)
- The flag probe greps help text (the advisory's own suggested dry-invoke mechanism); the marker probe then exercises the real attestation argv live, so both flag acceptance and error semantics are validated end-to-end pre-publication. `gh release verify`'s positional tag cannot be dry-run against a nonexistent release without conflating argv rejection with data-plane 404s; flags + subcommand presence + the live attestation-argv probe are the deliberate pre-publication bound.
- A probe that unexpectedly VERIFIES the unattested scratch subject also blocks (untrustworthy verifier), and a marker mismatch blocks with the observed stderr excerpt so the fix is a one-line marker update.
- Retry catches `Blocked` only; `Forbidden` cannot arise there (`_checked_verification` raises only `Blocked`/`RuntimeError`).
- The capability+marker probes moved AHEAD of the per-asset verifies for precise diagnosis; the main-still-at-bound-head snapshot remains the LAST preflight check, closest to publication. Nothing that held before was weakened; tag-probe, immutability, and rule-suite semantics are byte-unchanged.

### Validation (all local, this head)
- Contract suite 43/43 (36 existing + 7 new red-first tests, each captured failing pre-implementation).
- The 12 VAL-CDG-012 selector tests: byte-identical to origin/main (AST-extracted source segments compared) and green via the exact pinned selector command (12 passed / 30 deselected collection proof).
- actionlint on openapi.yml: pass. All three workflow policy checks (branch-mutation, required-check-priority, checkout-integrity): pass.
- Adjacent suites: 183 passed/1 skipped (contract-drift workflow, generate/export/validate openapi, live-node runtime workflows, checkout-integrity + pip-install policy tests) + 169 passed (required-aggregator fail-closed, sdk-test workflow).
- mypy on the helper: clean. ruff check + ruff format --check: clean. make lint: pass. make test-smoke: pass. Smoke tier: 138/138.

### Tier 4 — parked draft
Tier-4 surface (`.github/workflows/openapi.yml`). This PR stays a **parked draft** labeled `operator-review-required`: no ready flip, no evidence posting, no settlement, no merge, no workflow dispatch, no release action. Fresh exact-head prepare-only UNPOSTED claude+openai evidence accompanies the settlement packet in the mission library. Path census at push time: dependabot #9690 (OPEN/unmerged at `777ad334`, setup-node hunk only) remains the sole narrow openapi.yml overlap — the operator-ratified baseline of ledger lines 388/527/529/533/537; hunks are disjoint (sync copy steps vs setup-node `uses:` line).

### Post-review bounded fix (single sanctioned round)
The prepare-only claude review raised a [P3]: the live runner's absent-attestation stderr shape was unverified. Empirical check with the byte-exact builder argv against an unattested scratch subject confirmed modern gh emits the attestations-API HTTP 404 without the textual marker, so the marker-only detection would have preflight-blocked every dispatch (loud fail-closed, nothing publishable). One bounded in-scope commit (`01775d09`) pins both shapes red-first and the live end-to-end classification was re-verified as the retryable Blocked class. Evidence was UNPOSTED at the time of the fix (`action=prepare`, `posted_families=[]`); a single fresh re-collection at the new head accompanies the settlement packet.
