### PR TITLE
fix(ci): name transient probe-failure classes before marker drift [Tier 4]

### DIFF
--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -683,9 +683,12 @@ def _append_step_summary(report: dict[str, Any]) -> None:
         "",
     ]
     block = "\n".join(lines) + "\n"
+    # The summary file is shared with every other step in the job and may
+    # hold arbitrary non-UTF-8 bytes; dedupe on raw bytes so no decode error
+    # can escape the finally-block append and flip a verification exit.
     try:
-        with open(path, "r", encoding="utf-8") as stream:
-            if block in stream.read():
+        with open(path, "rb") as stream:
+            if block.encode("utf-8") in stream.read():
                 return
     except OSError:
         pass

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -73,6 +73,22 @@ EXIT_MOVEMENT = 3
 NO_ATTESTATIONS_MARKER = "no attestations"
 ATTESTATIONS_API_PATH_MARKER = "/attestations/sha256:"
 BLOCKED_MARKER_PROBE_NAME = "blocked-marker-probe.bin"
+# Transient transport shapes for `_probe_transient_class` (observed live on
+# gh 2.96.0, 2026-08-18): before verifier initialization a dead network
+# surfaces as the Sigstore verifier-init failure, after it as Go net
+# dial/lookup text. Message-only classification; never an exit-class input.
+PROBE_NETWORK_STDERR_MARKERS = (
+    "no valid sigstore verifiers could be initialized",
+    "dial tcp",
+    "proxyconnect",
+    "no such host",
+    "connection refused",
+    "connection reset",
+    "i/o timeout",
+    "tls handshake",
+    "context deadline exceeded",
+    "temporary failure in name resolution",
+)
 # Pre-publish attestation lag ladder; mirrors the workflow's post-publish
 # retry step (4 attempts, 5/10/20s waits), blocked class only.
 PREPUBLISH_RETRY_DELAYS = (5, 10, 20)
@@ -436,6 +452,20 @@ def _is_absent_attestation_stderr(stderr: str, marker: str) -> bool:
     return "http 404" in lowered and ATTESTATIONS_API_PATH_MARKER in lowered
 
 
+def _probe_transient_class(stderr: str) -> str | None:
+    """Message-only hint for a probe stderr that matched no absent-attestation
+    shape: an HTTP 403 answer or a network/Sigstore transport death never
+    carried a verification verdict, so attributing it to marker drift would
+    misdirect the operator. Anything unrecognized is genuine drift, and the
+    caller's fail-closed blocked exit is identical for every class."""
+    lowered = stderr.lower()
+    if "http 403" in lowered:
+        return "http-403"
+    if any(marker in lowered for marker in PROBE_NETWORK_STDERR_MARKERS):
+        return "network"
+    return None
+
+
 def _checked_verification(argv: list[str], *, kind: str, blocked_marker: str = "") -> None:
     completed = _run_gh(argv)
     if completed.returncode == 0:
@@ -636,7 +666,9 @@ def _append_step_summary(report: dict[str, Any]) -> None:
 
     The in-job token soft-reports these surfaces by design (``--admin-reads
     report``); the summary makes the degraded state visible to the operator
-    without hard-failing non-admin tokens. Summary IO is cosmetic and must
+    without hard-failing non-admin tokens. Blocked-class retries re-invoke
+    this process against the same summary file, so an identical block that
+    already landed is not appended again. Summary IO is cosmetic and must
     never flip a verification outcome."""
     path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not path:
@@ -650,9 +682,16 @@ def _append_step_summary(report: dict[str, Any]) -> None:
         "- authoritative for these surfaces: the external `verify --admin-reads required` run",
         "",
     ]
+    block = "\n".join(lines) + "\n"
+    try:
+        with open(path, "r", encoding="utf-8") as stream:
+            if block in stream.read():
+                return
+    except OSError:
+        pass
     try:
         with open(path, "a", encoding="utf-8") as stream:
-            stream.write("\n".join(lines) + "\n")
+            stream.write(block)
     except OSError:
         return
 
@@ -871,6 +910,21 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             )
         probe_stderr = probe.stderr.decode("utf-8", "replace").strip()
         if not _is_absent_attestation_stderr(probe_stderr, NO_ATTESTATIONS_MARKER):
+            transient = _probe_transient_class(probe_stderr)
+            if transient == "http-403":
+                raise Blocked(
+                    f"blocked-marker probe was answered with HTTP 403 (transient "
+                    f"rate-limit/permission class), so no live no-attestation "
+                    f"error shape was observed; retry when the attestations API "
+                    f"answers reads; observed: {probe_stderr[:300]}"
+                )
+            if transient == "network":
+                raise Blocked(
+                    f"blocked-marker probe died in the network/Sigstore transport "
+                    f"(transient infrastructure class) before any verification "
+                    f"verdict; retry when the runner has connectivity; "
+                    f"observed: {probe_stderr[:300]}"
+                )
             raise Blocked(
                 f"runner gh reports a missing attestation with neither the "
                 f"{NO_ATTESTATIONS_MARKER!r} marker nor the attestations-API "

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -1873,6 +1873,64 @@ def test_envelope_preflight_validates_blocked_marker_against_live_gh(monkeypatch
     assert state["probe_calls"] == 1
 
 
+def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
+    monkeypatch, tmp_path, capsys
+):
+    """A probe answered by HTTP 403 or killed in the network/Sigstore
+    transport never observed a verification verdict, so the blocked report
+    must name the transient cause instead of claiming marker drift. The
+    exit class is message-only cosmetics: every class stays blocked
+    pre-publication with the observed stderr embedded and no per-asset
+    verification attempted, and an unrecognized shape still reads as
+    genuine drift."""
+    module = _load_envelope_helper()
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_sleep", lambda _delay: None)
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
+    transient_shapes = {
+        "HTTP 403": (
+            b"Error: HTTP 403: API rate limit exceeded (https://api.github.com/"
+            b"repos/synaptent/aragora/attestations/sha256:ab12?per_page=30)"
+        ),
+        # Both live network shapes (gh 2.96.0, observed 2026-08-18): transport
+        # death before verifier initialization, and a post-init API dial
+        # failure whose stderr carries the attestations path but no HTTP 404.
+        "no valid Sigstore verifiers could be initialized": (
+            b"error creating Sigstore verifier: no valid Sigstore verifiers could be initialized"
+        ),
+        "connection refused": (
+            b'Error: Get "https://api.github.com/repos/synaptent/aragora/'
+            b'attestations/sha256:ab12?per_page=30": proxyconnect tcp: '
+            b"dial tcp 127.0.0.1:9: connect: connection refused"
+        ),
+    }
+    for observed, stderr in transient_shapes.items():
+        fake_run, state = _preflight_gh_stub(module, probe_stderr=stderr)
+        monkeypatch.setattr(module, "_run_gh", fake_run)
+        assert module.cmd_preflight(args) == module.EXIT_BLOCKED, observed
+        report = json.loads(capsys.readouterr().out)
+        assert report["status"] == "blocked", observed
+        assert "transient" in report["reason"], observed
+        assert "neither the" not in report["reason"], observed
+        assert "observed:" in report["reason"], observed
+        assert observed in report["reason"], observed
+        assert state["probe_calls"] == 1, observed
+        assert state["asset_attempts"] == {}, observed
+    # Boundary: an unrecognized shape (HTTP 500 here) is NOT transient-classed;
+    # it keeps the marker-drift wording so genuine drift is never soft-pedaled.
+    fake_run, state = _preflight_gh_stub(
+        module, probe_stderr=b"attestation lookup failed: HTTP 500"
+    )
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "transient" not in report["reason"]
+    assert "neither the" in report["reason"]
+    assert state["asset_attempts"] == {}
+
+
 def test_absent_attestation_http_404_shape_is_blocked_lag_not_contradiction(
     monkeypatch, tmp_path, capsys
 ):
@@ -2013,6 +2071,43 @@ def test_envelope_admin_gated_degradation_lands_in_step_summary(monkeypatch, tmp
     monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, degraded))
     assert module.cmd_preflight(args) == module.EXIT_PASS
     assert json.loads(capsys.readouterr().out)["status"] == "pass"
+
+
+def test_envelope_step_summary_dedupes_repeated_degraded_sections(monkeypatch, tmp_path, capsys):
+    """The workflow's post-publish step re-invokes verify inside one job step
+    on the blocked class, and every invocation appends to the same
+    GITHUB_STEP_SUMMARY file; an identical degradation block must land once,
+    while a genuinely different block (another phase here) still appends."""
+    module = _load_envelope_helper()
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_sleep", lambda _delay: None)
+    fake_run, _state = _preflight_gh_stub(module)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    degraded = [
+        ("immutable-releases", module.Forbidden("immutable-releases hidden: HTTP 404")),
+        ("rule-suites", module.Forbidden("rule-suites not readable: HTTP 403")),
+    ]
+    summary = tmp_path / "retry-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, degraded))
+    for _attempt in range(2):
+        assert module.cmd_preflight(args) == module.EXIT_PASS
+        capsys.readouterr()
+    preflight_heading = "### OpenAPI envelope preflight: admin-read-gated reads degraded"
+    text = summary.read_text(encoding="utf-8")
+    assert text.count(preflight_heading) == 1
+    # Dedupe is exact-block only: a different phase's block still appends.
+    module._append_step_summary(
+        {
+            "phase": "verify",
+            "immutability_setting": "unreadable (HTTP 403)",
+            "rule_suite": {"state": "unverified"},
+        }
+    )
+    text = summary.read_text(encoding="utf-8")
+    assert text.count(preflight_heading) == 1
+    assert text.count("### OpenAPI envelope verify: admin-read-gated reads degraded") == 1
 
 
 def test_sync_copies_use_the_artifact_nested_layout():

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -2110,6 +2110,34 @@ def test_envelope_step_summary_dedupes_repeated_degraded_sections(monkeypatch, t
     assert text.count("### OpenAPI envelope verify: admin-read-gated reads degraded") == 1
 
 
+def test_envelope_step_summary_tolerates_foreign_undecodable_bytes(monkeypatch, tmp_path, capsys):
+    """GITHUB_STEP_SUMMARY is shared with every other step in the job, so its
+    existing content can be arbitrary non-UTF-8 bytes; the dedupe read must
+    never let a decode error escape the finally-block append and flip a
+    verification outcome (summary IO stays cosmetic), and dedupe must still
+    work across repeat runs against the poisoned file."""
+    module = _load_envelope_helper()
+    identity, args = _preflight_fixture(module, tmp_path)
+    head = args.head_sha
+    monkeypatch.setattr(module, "_sleep", lambda _delay: None)
+    fake_run, _state = _preflight_gh_stub(module)
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    degraded = [
+        ("immutable-releases", module.Forbidden("immutable-releases hidden: HTTP 404")),
+        ("rule-suites", module.Forbidden("rule-suites not readable: HTTP 403")),
+    ]
+    summary = tmp_path / "poisoned-summary.md"
+    summary.write_bytes(b"\xff\xfe\x80 foreign step bytes\n")
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, degraded))
+    for _attempt in range(2):
+        assert module.cmd_preflight(args) == module.EXIT_PASS
+        assert json.loads(capsys.readouterr().out)["status"] == "pass"
+    raw = summary.read_bytes()
+    assert raw.startswith(b"\xff\xfe\x80")
+    assert raw.count(b"### OpenAPI envelope preflight: admin-read-gated reads degraded") == 1
+
+
 def test_sync_copies_use_the_artifact_nested_layout():
     """download-artifact@v4 preserves the upload's repo-root-relative layout
     (the five payload paths share the repository root as their least common


### PR DESCRIPTION
## Summary

Bounded cosmetic micro-batch from PR #9788 settlement (round-2 claude [P3] #2, recorded in `library/misc-openapi-envelope-p3-followups-settlement.md`), plus the round-1 duplicate-summary cosmetic folded in, plus one bounded in-scope [P2] fix from this PR's own round-1 review.

**1. Probe message classes (`scripts/openapi_release_envelope.py`)**

The blocked-marker probe's non-matching branch attributed ANY non-marker stderr to marker drift. The exit class was correct (blocked, pre-publication, observed stderr embedded), but the fixed prefix could misdirect an operator chasing "marker drift" when the probe actually hit a transient HTTP 403 or died on the network. The message now branches on transient classes BEFORE the marker-drift wording:

- `http-403` class: stderr containing `HTTP 403` (same token `_gh_api_json` already keys on)
- `network` class: Sigstore verifier-init failure or Go net dial/lookup text
- anything unrecognized: the existing marker-drift wording, byte-unchanged

**Exit classes and fail-closed semantics are byte-for-byte unchanged**: every branch still raises `Blocked` (exit 2) pre-publication with `probe_stderr[:300]` embedded, before any per-asset verification. `_probe_transient_class` is message-only and is never an exit-class input.

**2. Step-summary dedupe (round-1 cosmetic)**

The workflow's post-publish step re-invokes `verify` up to 4 times inside one job step on the blocked class; every invocation appended an identical admin-read-gated degradation block to the same `GITHUB_STEP_SUMMARY` file. `_append_step_summary` now skips a block already present (exact-block dedupe only; a different phase's block still appends). Summary IO remains cosmetic and can never flip a verification outcome.

**3. Byte-level dedupe read (this PR's round-1 claude [P2], empirically confirmed)**

The first dedupe implementation decoded the shared summary file as UTF-8 while guarding only `OSError`; `UnicodeDecodeError` is a `ValueError`, and `_append_step_summary` runs in `finally` blocks, so one foreign non-UTF-8 byte from any earlier job step would have escaped as a traceback and flipped a pass/blocked exit into exit 1. The dedupe now compares the encoded block against raw bytes (`open(path, "rb")`), so no decode can ever occur on the read path; the append path is unchanged.

## Empirical grounding (live gh 2.96.0, 2026-08-18)

Captured with the byte-exact production `attestation verify` argv:

- Network death before verifier init (connection-refused AND DNS-failure proxies): rc=1, stderr `error creating Sigstore verifier: no valid Sigstore verifiers could be initialized`
- Post-init API dial failure (Sigstore endpoints direct, api.github.com through a dead proxy): rc=1, stderr `Error: Get "https://api.github.com/repos/synaptent/aragora/attestations/sha256:...": proxyconnect tcp: dial tcp 127.0.0.1:9: connect: connection refused`
- Control 404 at an unattested digest: `Error: HTTP 404: Not Found (https://api.github.com/repos/.../attestations/sha256:...)` — confirms gh embeds `HTTP <code>:` tokens for API answers, grounding the `HTTP 403` predicate
- The `UnicodeDecodeError` escape was reproduced live against the pre-fix head before the fix was written

## Tests (all red-first, failure captured before each fix)

- `test_envelope_preflight_probe_names_transient_classes_before_marker_drift` — pins all three transient shapes to blocked + transient wording + embedded stderr + zero per-asset attempts, and pins the boundary: HTTP 500 stays marker-drift wording
- `test_envelope_step_summary_dedupes_repeated_degraded_sections` — two identical preflight runs land one block; a different phase's block still appends
- `test_envelope_step_summary_tolerates_foreign_undecodable_bytes` — a poisoned (non-UTF-8) shared summary file never changes the exit code, and byte-level dedupe still holds across repeat runs

## Validation (at head `0dae34d899`)

- Contract suite: 46/46 passed
- Exact VAL-CDG-012 selector: 12 passed; all 12 selector tests proven **byte-identical to origin/main** via AST source-segment compare
- `scripts/preflight_mypy.sh --diff-base origin/main`: clean on both changed files
- `ruff check` + `ruff format --check`: clean; `make lint`: clean
- `make test-smoke`: passed; smoke tier (`scripts/test_tiers.sh smoke`): 138 passed
- `automation_pr_preflight.sh origin/main HEAD`: ok
- Diff: +182/-2 across the two in-scope files only (no workflow file)

## Review evidence

Round 1 (head `0c96a7ddf2`): openai PASS (auto-posted below by the tier-2 auto-poster), claude CHANGES-REQUESTED with one [P2] (the decode escape above) — confirmed empirically and fixed by `0dae34d899`. Round 2 (exact head `0dae34d899`, prepare-only, unposted): **claude PASS + openai PASS**, both countable and grounded, zero dissent. Artifacts and digests are recorded in the mission settlement packet.

## Parked draft — operator-review-required

This PR is prepared-only and parked as a draft per the mission feature (no ready, posting, settlement, merge, workflow dispatch, release action, or publication by the worker). Note for the operator: the merge gate itself scores this diff **tier 2** (helper + tests only, no workflow file), so the standard tier-2 settlement flow applies once you take it off draft.
