### PR TITLE
fix(scripts): enforce committed SDK-parity ceilings instead of clock-derived budgets [Tier 4]

### DIFF
--- a/scripts/baselines/check_sdk_parity_budget.json
+++ b/scripts/baselines/check_sdk_parity_budget.json
@@ -1,7 +1,12 @@
 {
-  "start_date": "2026-04-24",
-  "initial_missing_from_both_sdks": 32,
-  "weekly_reduction_missing_from_both_sdks": 3,
-  "initial_stale_python_sdk_paths": 87,
-  "weekly_reduction_stale_python_sdk_paths": 3
+  "schema": "check-sdk-parity-committed-budget-v1",
+  "committed_max_missing_from_both_sdks": 0,
+  "committed_max_stale_python_sdk_paths": 36,
+  "advisory_cadence": {
+    "start_date": "2026-04-24",
+    "initial_missing_from_both_sdks": 32,
+    "weekly_reduction_missing_from_both_sdks": 3,
+    "initial_stale_python_sdk_paths": 87,
+    "weekly_reduction_stale_python_sdk_paths": 3
+  }
 }

--- a/scripts/check_sdk_parity.py
+++ b/scripts/check_sdk_parity.py
@@ -836,6 +836,7 @@ def _run_tighten(args: argparse.Namespace) -> int:
         )
         with os.fdopen(fd, "wb") as handle:
             handle.write(target_bytes)
+        os.chmod(tmp_name, 0o644)  # mkstemp defaults to 0600; keep the budget world-readable
         os.replace(tmp_name, str(args.budget))
         tmp_name = None
     except OSError as exc:
@@ -1026,7 +1027,7 @@ def main() -> int:
 
     if budget_failure_rc is not None:
         if budget_failure_msg:
-            print(f"\n{budget_failure_msg}")
+            print(f"\n{budget_failure_msg}", file=sys.stderr if args.json else sys.stdout)
         return budget_failure_rc
 
     # Strict mode: fail if gaps exceed threshold

--- a/scripts/check_sdk_parity.py
+++ b/scripts/check_sdk_parity.py
@@ -5,12 +5,17 @@ Compares handler endpoints against SDK namespace methods to detect
 coverage drift. Intended for CI integration to fail when new handler
 routes lack corresponding SDK bindings.
 
+Budget enforcement compares measured debt against the explicit committed
+ceilings in the budget file; wall-clock dates and timezones never affect
+pass/fail. ``--today`` only shapes the non-enforcing advisory target.
+
 Usage:
     python scripts/check_sdk_parity.py             # Report only
     python scripts/check_sdk_parity.py --strict    # Exit 1 if gaps found
     python scripts/check_sdk_parity.py --strict --allow-missing  # transitional override
     python scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json
     python scripts/check_sdk_parity.py --json       # JSON output
+    python scripts/check_sdk_parity.py --tighten    # Lower committed ceilings to measured debt
 """
 
 from __future__ import annotations
@@ -20,8 +25,10 @@ import datetime as dt
 import importlib
 import inspect
 import json
+import os
 import re
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -636,11 +643,217 @@ def _expected_budget_max(
     start_date: dt.date,
     today: dt.date,
 ) -> int:
-    """Compute expected maximum debt after weekly reduction cadence."""
+    """Compute the advisory-only paydown target after a weekly reduction cadence."""
     if weekly_reduction <= 0 or today <= start_date:
         return initial
     weeks_elapsed = (today - start_date).days // 7
     return max(0, initial - (weeks_elapsed * weekly_reduction))
+
+
+BUDGET_SCHEMA = "check-sdk-parity-committed-budget-v1"
+COMMITTED_MISSING_KEY = "committed_max_missing_from_both_sdks"
+COMMITTED_STALE_KEY = "committed_max_stale_python_sdk_paths"
+ADVISORY_CADENCE_KEY = "advisory_cadence"
+_LEGACY_CADENCE_KEYS = (
+    "start_date",
+    "initial_missing_from_both_sdks",
+    "weekly_reduction_missing_from_both_sdks",
+    "initial_stale_python_sdk_paths",
+    "weekly_reduction_stale_python_sdk_paths",
+)
+
+
+@dataclass(frozen=True)
+class CommittedBudget:
+    max_missing_from_both: int
+    max_stale_python: int
+    advisory_cadence: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class BudgetLoadResult:
+    budget: CommittedBudget | None = None
+    error_kind: str | None = None  # "missing" | "malformed" | "legacy"
+    error_detail: str | None = None
+    raw: dict[str, Any] | None = None
+    raw_bytes: bytes | None = None
+
+
+def _as_committed_ceiling(value: Any, key: str) -> int:
+    # bool is an int subclass and must not slip through as a ceiling.
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{key} must be a nonnegative integer, got {value!r}")
+    return value
+
+
+def load_committed_budget(path: Path) -> BudgetLoadResult:
+    """Load and classify a committed-ceiling budget file.
+
+    Only explicit committed ceilings are enforceable; a file carrying just
+    the retired clock-derived cadence keys classifies as ``legacy``.
+    """
+    if not path.exists():
+        return BudgetLoadResult(error_kind="missing", error_detail=f"{path} does not exist")
+    try:
+        raw_bytes = path.read_bytes()
+        data = json.loads(raw_bytes.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return BudgetLoadResult(error_kind="malformed", error_detail=str(exc))
+    if not isinstance(data, dict):
+        return BudgetLoadResult(error_kind="malformed", error_detail="budget must be a JSON object")
+
+    if COMMITTED_MISSING_KEY not in data or COMMITTED_STALE_KEY not in data:
+        legacy_keys = [key for key in _LEGACY_CADENCE_KEYS if key in data]
+        detail = (
+            f"clock-derived cadence keys ({', '.join(legacy_keys)}) without committed ceilings"
+            if legacy_keys
+            else f"missing required keys {COMMITTED_MISSING_KEY} and {COMMITTED_STALE_KEY}"
+        )
+        kind = "legacy" if legacy_keys else "malformed"
+        return BudgetLoadResult(error_kind=kind, error_detail=detail, raw=data, raw_bytes=raw_bytes)
+
+    try:
+        max_missing = _as_committed_ceiling(data[COMMITTED_MISSING_KEY], COMMITTED_MISSING_KEY)
+        max_stale = _as_committed_ceiling(data[COMMITTED_STALE_KEY], COMMITTED_STALE_KEY)
+    except ValueError as exc:
+        return BudgetLoadResult(error_kind="malformed", error_detail=str(exc), raw=data)
+
+    advisory = data.get(ADVISORY_CADENCE_KEY)
+    if not isinstance(advisory, dict) or not advisory:
+        advisory = None
+    return BudgetLoadResult(
+        budget=CommittedBudget(
+            max_missing_from_both=max_missing,
+            max_stale_python=max_stale,
+            advisory_cadence=advisory,
+        ),
+        raw=data,
+        raw_bytes=raw_bytes,
+    )
+
+
+def _resolve_advisory_date(today_arg: dt.date | None) -> dt.date:
+    """Resolve the date used ONLY for the non-enforcing advisory target."""
+    return today_arg if today_arg is not None else dt.date.today()
+
+
+def _advisory_target(cadence: dict[str, Any], as_of: dt.date) -> dict[str, Any] | None:
+    """Compute the non-enforcing advisory paydown target, or None when unusable."""
+    try:
+        start_date = dt.date.fromisoformat(str(cadence["start_date"]).strip())
+        initial_missing = int(cadence["initial_missing_from_both_sdks"])
+        weekly_missing = int(cadence.get("weekly_reduction_missing_from_both_sdks", 0))
+        initial_stale = int(cadence["initial_stale_python_sdk_paths"])
+        weekly_stale = int(cadence.get("weekly_reduction_stale_python_sdk_paths", 0))
+    except (KeyError, TypeError, ValueError):
+        return None
+    return {
+        "as_of": as_of.isoformat(),
+        "missing_from_both_sdks_max": _expected_budget_max(
+            initial=initial_missing,
+            weekly_reduction=weekly_missing,
+            start_date=start_date,
+            today=as_of,
+        ),
+        "stale_python_sdk_paths_max": _expected_budget_max(
+            initial=initial_stale,
+            weekly_reduction=weekly_stale,
+            start_date=start_date,
+            today=as_of,
+        ),
+    }
+
+
+def _canonical_budget_bytes(
+    max_missing: int, max_stale: int, advisory_cadence: dict[str, Any] | None
+) -> bytes:
+    payload: dict[str, Any] = {
+        "schema": BUDGET_SCHEMA,
+        COMMITTED_MISSING_KEY: max_missing,
+        COMMITTED_STALE_KEY: max_stale,
+    }
+    if advisory_cadence:
+        payload[ADVISORY_CADENCE_KEY] = advisory_cadence
+    return (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+
+
+def _run_tighten(args: argparse.Namespace) -> int:
+    """Write measured debt as the committed ceilings (never raises a ceiling)."""
+    handler_result = extract_handler_routes_with_status()
+    if not handler_result.available:
+        print(f"FAIL: --tighten requires handler route extraction ({handler_result.error})")
+        return 2
+    report = build_parity_report(
+        handler_result.routes,
+        extract_sdk_paths_python(),
+        extract_sdk_paths_typescript(),
+        None if args.include_undocumented else extract_openapi_routes(),
+        handler_routes_available=handler_result.available,
+        handler_routes_error=handler_result.error,
+    )
+    measured_missing = int(report["summary"]["routes_missing_from_both_sdks"])
+    measured_stale = len(report["gaps"]["stale_python_sdk_paths"])
+
+    loaded = load_committed_budget(args.budget)
+    if loaded.error_kind == "malformed":
+        print(
+            f"FAIL: refusing to overwrite malformed budget file ({args.budget}): "
+            f"{loaded.error_detail}"
+        )
+        return 2
+
+    advisory_cadence: dict[str, Any] | None = None
+    if loaded.budget is not None:
+        ceilings = loaded.budget
+        over = []
+        if measured_missing > ceilings.max_missing_from_both:
+            over.append(
+                f"missing_from_both {measured_missing} > committed {ceilings.max_missing_from_both}"
+            )
+        if measured_stale > ceilings.max_stale_python:
+            over.append(f"stale_python {measured_stale} > committed {ceilings.max_stale_python}")
+        if over:
+            print("FAIL: --tighten refuses to raise committed ceilings: " + "; ".join(over))
+            return 1
+        advisory_cadence = ceilings.advisory_cadence
+    elif loaded.error_kind == "legacy" and loaded.raw is not None:
+        advisory_cadence = {
+            key: loaded.raw[key] for key in _LEGACY_CADENCE_KEYS if key in loaded.raw
+        }
+
+    target_bytes = _canonical_budget_bytes(measured_missing, measured_stale, advisory_cadence)
+    if loaded.raw_bytes == target_bytes:
+        print(
+            f"Budget already tight: missing_from_both<={measured_missing} "
+            f"| stale_python<={measured_stale} (no write)"
+        )
+        return 0
+
+    tmp_name: str | None = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".check_sdk_parity_budget.", dir=str(args.budget.parent)
+        )
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(target_bytes)
+        os.replace(tmp_name, str(args.budget))
+        tmp_name = None
+    except OSError as exc:
+        print(f"FAIL: cannot write budget file ({args.budget}): {exc}")
+        return 2
+    finally:
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+
+    print(
+        "Tightened committed budget ceilings to measured debt: "
+        f"missing_from_both<={measured_missing} | stale_python<={measured_stale} "
+        f"-> {args.budget}"
+    )
+    return 0
 
 
 def main() -> int:
@@ -677,11 +890,26 @@ def main() -> int:
     )
     parser.add_argument(
         "--today",
-        type=str,
+        type=dt.date.fromisoformat,
         default=None,
-        help="Override current date (YYYY-MM-DD) for deterministic budget checks",
+        metavar="YYYY-MM-DD",
+        help=(
+            "Advisory-only date for the non-enforcing paydown target; "
+            "never affects exit status or enforced ceilings"
+        ),
+    )
+    parser.add_argument(
+        "--tighten",
+        action="store_true",
+        help=(
+            "Measure current debt and write it as the committed budget ceilings "
+            "(bootstraps missing/legacy files; never raises an existing ceiling)"
+        ),
     )
     args = parser.parse_args()
+
+    if args.tighten:
+        return _run_tighten(args)
 
     # Extract data
     handler_result = extract_handler_routes_with_status()
@@ -700,9 +928,7 @@ def main() -> int:
         handler_routes_error=handler_result.error,
     )
 
-    if args.json:
-        print(json.dumps(report, indent=2))
-    else:
+    if not args.json:
         print_report(report)
         if handler_result.error:
             print(f"\nHandler route detail: {handler_result.error}")
@@ -720,57 +946,88 @@ def main() -> int:
         if len(new_missing) > 20:
             print(f"  ... and {len(new_missing) - 20} more")
 
-    budget_status: dict[str, int] | None = None
-    if handler_result.available and args.budget and args.budget.exists():
-        try:
-            budget_data = json.loads(args.budget.read_text(encoding="utf-8"))
-            start_date_str = str(budget_data.get("start_date", "")).strip()
-            if not start_date_str:
-                raise ValueError("budget.start_date is required")
-            start_date = dt.date.fromisoformat(start_date_str)
-            today = dt.date.fromisoformat(args.today) if args.today else dt.date.today()
+    # Committed ceilings are the only enforced budget; the clock never affects pass/fail.
+    loaded_budget = load_committed_budget(args.budget)
+    budget_block: dict[str, Any] = {"path": str(args.budget)}
+    budget_failure_rc: int | None = None
+    budget_failure_msg: str | None = None
+    budget_passing: bool | None = None
+    committed: CommittedBudget | None = None
 
-            initial_missing = int(
-                budget_data.get(
-                    "initial_missing_from_both_sdks",
-                    report["summary"]["routes_missing_from_both_sdks"],
+    if loaded_budget.error_kind is not None:
+        budget_block["error"] = loaded_budget.error_kind
+        budget_block["detail"] = loaded_budget.error_detail
+    if loaded_budget.error_kind == "missing":
+        if args.strict:
+            budget_failure_rc = 2
+            budget_failure_msg = (
+                f"FAIL: SDK parity budget file not found ({args.budget}); "
+                "strict mode requires explicit committed ceilings"
+            )
+    elif loaded_budget.error_kind == "legacy":
+        budget_failure_rc = 2
+        budget_failure_msg = (
+            f"FAIL: Legacy clock-derived SDK parity budget ({args.budget}): "
+            f"{loaded_budget.error_detail}; bootstrap committed ceilings with --tighten"
+        )
+    elif loaded_budget.error_kind == "malformed":
+        budget_failure_rc = 2
+        budget_failure_msg = (
+            f"FAIL: Invalid SDK parity budget file ({args.budget}): {loaded_budget.error_detail}"
+        )
+    else:
+        committed = loaded_budget.budget
+
+    if committed is not None:
+        budget_block["schema"] = BUDGET_SCHEMA
+        budget_block[COMMITTED_MISSING_KEY] = committed.max_missing_from_both
+        budget_block[COMMITTED_STALE_KEY] = committed.max_stale_python
+        if handler_result.available:
+            current_missing = int(report["summary"]["routes_missing_from_both_sdks"])
+            current_stale = len(report["gaps"]["stale_python_sdk_paths"])
+            budget_passing = (
+                current_missing <= committed.max_missing_from_both
+                and current_stale <= committed.max_stale_python
+            )
+            budget_block["current_missing_from_both_sdks"] = current_missing
+            budget_block["current_stale_python_sdk_paths"] = current_stale
+            budget_block["passing"] = budget_passing
+            advisory_target = None
+            if committed.advisory_cadence:
+                advisory_target = _advisory_target(
+                    committed.advisory_cadence, _resolve_advisory_date(args.today)
                 )
-            )
-            weekly_missing = int(budget_data.get("weekly_reduction_missing_from_both_sdks", 0))
-            expected_missing = _expected_budget_max(
-                initial=initial_missing,
-                weekly_reduction=weekly_missing,
-                start_date=start_date,
-                today=today,
-            )
-
-            stale_current = len(report["gaps"]["stale_python_sdk_paths"])
-            initial_stale = int(budget_data.get("initial_stale_python_sdk_paths", stale_current))
-            weekly_stale = int(budget_data.get("weekly_reduction_stale_python_sdk_paths", 0))
-            expected_stale = _expected_budget_max(
-                initial=initial_stale,
-                weekly_reduction=weekly_stale,
-                start_date=start_date,
-                today=today,
-            )
-
-            budget_status = {
-                "expected_missing_max": expected_missing,
-                "current_missing": report["summary"]["routes_missing_from_both_sdks"],
-                "expected_stale_python_max": expected_stale,
-                "current_stale_python": stale_current,
-            }
+            budget_block["advisory_target"] = advisory_target
             if not args.json:
                 print(
-                    "\nBudget status: "
-                    f"missing_from_both {budget_status['current_missing']}/{budget_status['expected_missing_max']} "
-                    f"| stale_python {budget_status['current_stale_python']}/{budget_status['expected_stale_python_max']}"
+                    "\nBudget status (committed ceilings): "
+                    f"missing_from_both {current_missing}/{committed.max_missing_from_both} "
+                    f"| stale_python {current_stale}/{committed.max_stale_python}"
                 )
-        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
-            print(f"\nFAIL: Invalid SDK parity budget file ({args.budget}): {exc}")
-            return 2
-    elif not args.json and args.budget and args.budget.exists():
-        print("\nBudget status: skipped because handler routes are unavailable in this environment")
+                if advisory_target is not None:
+                    print(
+                        "Advisory paydown target (non-enforcing, as of "
+                        f"{advisory_target['as_of']}): missing_from_both<="
+                        f"{advisory_target['missing_from_both_sdks_max']} | stale_python<="
+                        f"{advisory_target['stale_python_sdk_paths_max']}"
+                    )
+        else:
+            budget_block["skipped"] = "handler routes unavailable in this environment"
+            if not args.json:
+                print(
+                    "\nBudget status: skipped because handler routes are unavailable "
+                    "in this environment"
+                )
+
+    report["budget"] = budget_block
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+
+    if budget_failure_rc is not None:
+        if budget_failure_msg:
+            print(f"\n{budget_failure_msg}")
+        return budget_failure_rc
 
     # Strict mode: fail if gaps exceed threshold
     if args.strict:
@@ -792,20 +1049,20 @@ def main() -> int:
             )
             print("Run with --allow-missing only as a temporary migration override.")
             return 1
-        if budget_status:
-            if budget_status["current_missing"] > budget_status["expected_missing_max"]:
+        if committed is not None and budget_passing is False:
+            current = budget_block["current_missing_from_both_sdks"]
+            if current > committed.max_missing_from_both:
                 print(
-                    "\nFAIL: Missing-from-both debt exceeds budget "
-                    f"({budget_status['current_missing']} > {budget_status['expected_missing_max']})."
+                    "\nFAIL: Missing-from-both debt exceeds committed ceiling "
+                    f"({current} > {committed.max_missing_from_both})."
                 )
                 return 1
-            if budget_status["current_stale_python"] > budget_status["expected_stale_python_max"]:
-                print(
-                    "\nFAIL: Stale Python SDK debt exceeds budget "
-                    f"({budget_status['current_stale_python']} > "
-                    f"{budget_status['expected_stale_python_max']})."
-                )
-                return 1
+            stale = budget_block["current_stale_python_sdk_paths"]
+            print(
+                "\nFAIL: Stale Python SDK debt exceeds committed ceiling "
+                f"({stale} > {committed.max_stale_python})."
+            )
+            return 1
 
     return 0
 

--- a/tests/scripts/test_check_sdk_parity.py
+++ b/tests/scripts/test_check_sdk_parity.py
@@ -2,15 +2,48 @@
 
 from __future__ import annotations
 
+import datetime as dt
+import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 import scripts.check_sdk_parity as check_sdk_parity
+
+
+def _write_committed_budget(
+    path: Path,
+    *,
+    max_missing: int = 10,
+    max_stale: int = 10,
+    advisory: dict[str, Any] | None = None,
+) -> Path:
+    payload: dict[str, Any] = {
+        "schema": "check-sdk-parity-committed-budget-v1",
+        "committed_max_missing_from_both_sdks": max_missing,
+        "committed_max_stale_python_sdk_paths": max_stale,
+    }
+    if advisory is not None:
+        payload["advisory_cadence"] = advisory
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+_LEGACY_CADENCE = {
+    "start_date": "2026-01-01",
+    "initial_missing_from_both_sdks": 2,
+    "weekly_reduction_missing_from_both_sdks": 0,
+    "initial_stale_python_sdk_paths": 4,
+    "weekly_reduction_stale_python_sdk_paths": 0,
+}
+_LEGACY_BUDGET_TEXT = json.dumps(_LEGACY_CADENCE, indent=2) + "\n"
 
 
 def _patch_report(
@@ -42,18 +75,25 @@ def _patch_report(
     )
     monkeypatch.setattr(check_sdk_parity, "extract_sdk_paths_python", lambda: {})
     monkeypatch.setattr(check_sdk_parity, "extract_sdk_paths_typescript", lambda: {})
+    monkeypatch.setattr(check_sdk_parity, "extract_openapi_routes", lambda *_, **__: set())
     monkeypatch.setattr(check_sdk_parity, "build_parity_report", lambda *_, **__: report)
     monkeypatch.setattr(check_sdk_parity, "print_report", lambda *_: None)
 
 
-def test_strict_fails_when_missing_routes_without_override(monkeypatch):
+def test_strict_fails_when_missing_routes_without_override(monkeypatch, tmp_path):
     _patch_report(monkeypatch, missing=3)
-    monkeypatch.setattr(sys, "argv", ["check_sdk_parity.py", "--strict"])
+    budget = _write_committed_budget(tmp_path / "budget.json")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_sdk_parity.py", "--strict", "--budget", str(budget)],
+    )
     assert check_sdk_parity.main() == 1
 
 
 def test_strict_allows_missing_routes_with_explicit_override(monkeypatch, tmp_path):
     _patch_report(monkeypatch, missing=3)
+    budget = _write_committed_budget(tmp_path / "budget.json")
     monkeypatch.setattr(
         sys,
         "argv",
@@ -62,15 +102,20 @@ def test_strict_allows_missing_routes_with_explicit_override(monkeypatch, tmp_pa
             "--strict",
             "--allow-missing",
             "--budget",
-            str(tmp_path / "no-budget.json"),
+            str(budget),
         ],
     )
     assert check_sdk_parity.main() == 0
 
 
-def test_strict_threshold_still_enforced(monkeypatch):
+def test_strict_threshold_still_enforced(monkeypatch, tmp_path):
     _patch_report(monkeypatch, missing=0, py_cov=75.0, ts_cov=88.0)
-    monkeypatch.setattr(sys, "argv", ["check_sdk_parity.py", "--strict", "--threshold", "90"])
+    budget = _write_committed_budget(tmp_path / "budget.json")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_sdk_parity.py", "--strict", "--threshold", "90", "--budget", str(budget)],
+    )
     assert check_sdk_parity.main() == 1
 
 
@@ -81,6 +126,7 @@ def test_strict_passes_when_missing_routes_are_in_baseline(monkeypatch, tmp_path
         '{"missing_from_both_sdks": ["/api/a", "/api/b"]}\n',
         encoding="utf-8",
     )
+    budget = _write_committed_budget(tmp_path / "budget.json")
     monkeypatch.setattr(
         sys,
         "argv",
@@ -90,28 +136,15 @@ def test_strict_passes_when_missing_routes_are_in_baseline(monkeypatch, tmp_path
             "--baseline",
             str(baseline),
             "--budget",
-            str(tmp_path / "no-budget.json"),
+            str(budget),
         ],
     )
     assert check_sdk_parity.main() == 0
 
 
-def test_strict_budget_fails_when_missing_exceeds_budget(monkeypatch, tmp_path):
+def test_strict_budget_fails_when_missing_exceeds_committed_ceiling(monkeypatch, tmp_path):
     _patch_report(monkeypatch, missing=3, stale_python=1)
-    budget = tmp_path / "budget.json"
-    budget.write_text(
-        """
-{
-  "start_date": "2026-01-01",
-  "initial_missing_from_both_sdks": 2,
-  "weekly_reduction_missing_from_both_sdks": 0,
-  "initial_stale_python_sdk_paths": 1,
-  "weekly_reduction_stale_python_sdk_paths": 0
-}
-""".strip()
-        + "\n",
-        encoding="utf-8",
-    )
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=2, max_stale=1)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -121,29 +154,14 @@ def test_strict_budget_fails_when_missing_exceeds_budget(monkeypatch, tmp_path):
             "--allow-missing",
             "--budget",
             str(budget),
-            "--today",
-            "2026-02-13",
         ],
     )
     assert check_sdk_parity.main() == 1
 
 
-def test_strict_budget_fails_when_stale_exceeds_budget(monkeypatch, tmp_path):
+def test_strict_budget_fails_when_stale_exceeds_committed_ceiling(monkeypatch, tmp_path):
     _patch_report(monkeypatch, missing=0, stale_python=5)
-    budget = tmp_path / "budget.json"
-    budget.write_text(
-        """
-{
-  "start_date": "2026-01-01",
-  "initial_missing_from_both_sdks": 0,
-  "weekly_reduction_missing_from_both_sdks": 0,
-  "initial_stale_python_sdk_paths": 4,
-  "weekly_reduction_stale_python_sdk_paths": 0
-}
-""".strip()
-        + "\n",
-        encoding="utf-8",
-    )
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=4)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -153,34 +171,19 @@ def test_strict_budget_fails_when_stale_exceeds_budget(monkeypatch, tmp_path):
             "--allow-missing",
             "--budget",
             str(budget),
-            "--today",
-            "2026-02-13",
         ],
     )
     assert check_sdk_parity.main() == 1
 
 
-def test_strict_budget_passes_when_within_budget(monkeypatch, tmp_path):
+def test_strict_budget_passes_at_exact_committed_ceiling(monkeypatch, tmp_path):
     _patch_report(monkeypatch, missing=2, stale_python=10)
     baseline = tmp_path / "baseline.json"
     baseline.write_text(
         '{"missing_from_both_sdks": ["/api/a", "/api/b"]}\n',
         encoding="utf-8",
     )
-    budget = tmp_path / "budget.json"
-    budget.write_text(
-        """
-{
-  "start_date": "2026-02-13",
-  "initial_missing_from_both_sdks": 2,
-  "weekly_reduction_missing_from_both_sdks": 1,
-  "initial_stale_python_sdk_paths": 10,
-  "weekly_reduction_stale_python_sdk_paths": 2
-}
-""".strip()
-        + "\n",
-        encoding="utf-8",
-    )
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=2, max_stale=10)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -192,8 +195,6 @@ def test_strict_budget_passes_when_within_budget(monkeypatch, tmp_path):
             str(baseline),
             "--budget",
             str(budget),
-            "--today",
-            "2026-02-13",
         ],
     )
     assert check_sdk_parity.main() == 0
@@ -359,3 +360,284 @@ def test_handler_coverage_excludes_internal_route_families():
     assert report["gaps"]["missing_from_python_sdk"] == []
     assert report["gaps"]["missing_from_typescript_sdk"] == []
     assert report["gaps"]["missing_from_both_sdks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Committed-ceiling budget semantics
+# ---------------------------------------------------------------------------
+
+
+def _strict_argv(budget: Path, *extra: str) -> list[str]:
+    return ["check_sdk_parity.py", "--strict", "--allow-missing", "--budget", str(budget), *extra]
+
+
+def test_exit_status_is_invariant_across_today_values(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=10)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=10)
+    for today in ("2026-01-01", "2026-08-18", "2099-12-31"):
+        monkeypatch.setattr(sys, "argv", _strict_argv(budget, "--today", today))
+        assert check_sdk_parity.main() == 0, today
+
+    _patch_report(monkeypatch, missing=0, stale_python=11)
+    for today in ("2026-01-01", "2099-12-31"):
+        monkeypatch.setattr(sys, "argv", _strict_argv(budget, "--today", today))
+        assert check_sdk_parity.main() == 1, today
+
+
+def test_exit_status_is_invariant_across_system_dates(monkeypatch, tmp_path):
+    advisory = {
+        "start_date": "2026-01-01",
+        "initial_missing_from_both_sdks": 10,
+        "weekly_reduction_missing_from_both_sdks": 1,
+        "initial_stale_python_sdk_paths": 20,
+        "weekly_reduction_stale_python_sdk_paths": 2,
+    }
+    budget = _write_committed_budget(
+        tmp_path / "budget.json", max_missing=0, max_stale=10, advisory=advisory
+    )
+
+    for missing, stale, expected in ((0, 10, 0), (0, 11, 1), (1, 0, 1)):
+        _patch_report(monkeypatch, missing=missing, stale_python=stale)
+        results = set()
+        for fake_today in (dt.date(2026, 1, 2), dt.date(2199, 12, 31)):
+            monkeypatch.setattr(
+                check_sdk_parity, "_resolve_advisory_date", lambda _arg, d=fake_today: d
+            )
+            monkeypatch.setattr(sys, "argv", _strict_argv(budget))
+            results.add(check_sdk_parity.main())
+        assert results == {expected}
+
+
+def test_strict_missing_budget_fails_closed(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0)
+    monkeypatch.setattr(sys, "argv", _strict_argv(tmp_path / "no-budget.json"))
+    assert check_sdk_parity.main() == 2
+
+
+def test_non_strict_missing_budget_is_tolerated(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_sdk_parity.py", "--budget", str(tmp_path / "no-budget.json")],
+    )
+    assert check_sdk_parity.main() == 0
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_legacy_budget_fails_closed(monkeypatch, tmp_path, strict):
+    _patch_report(monkeypatch, missing=0)
+    budget = tmp_path / "budget.json"
+    budget.write_text(_LEGACY_BUDGET_TEXT, encoding="utf-8")
+    argv = ["check_sdk_parity.py", "--budget", str(budget)]
+    if strict:
+        argv.insert(1, "--strict")
+    monkeypatch.setattr(sys, "argv", argv)
+    assert check_sdk_parity.main() == 2
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "not json {",
+        "[]",
+        "{}",
+        '{"committed_max_missing_from_both_sdks": -1, "committed_max_stale_python_sdk_paths": 0}',
+        '{"committed_max_missing_from_both_sdks": true, "committed_max_stale_python_sdk_paths": 0}',
+        '{"committed_max_missing_from_both_sdks": "3", "committed_max_stale_python_sdk_paths": 0}',
+    ],
+)
+def test_malformed_budget_fails_closed(monkeypatch, tmp_path, content):
+    _patch_report(monkeypatch, missing=0)
+    budget = tmp_path / "budget.json"
+    budget.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget))
+    assert check_sdk_parity.main() == 2
+
+
+def test_extraction_unavailable_strict_semantics(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0)
+    monkeypatch.setattr(
+        check_sdk_parity,
+        "extract_handler_routes_with_status",
+        lambda: check_sdk_parity.HandlerRouteExtractionResult(
+            routes={}, available=False, error="handlers unavailable"
+        ),
+    )
+    budget = _write_committed_budget(tmp_path / "budget.json")
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget))
+    # Capability skip is preserved when the committed budget itself is valid.
+    assert check_sdk_parity.main() == 0
+    monkeypatch.setattr(sys, "argv", _strict_argv(tmp_path / "no-budget.json"))
+    # A budget config error fails closed even when extraction is unavailable.
+    assert check_sdk_parity.main() == 2
+
+
+def test_json_budget_block_exposes_ceilings_and_pass_state(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, stale_python=10)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=10)
+    argv = ["check_sdk_parity.py", "--json", "--budget", str(budget)]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert check_sdk_parity.main() == 0
+    block = json.loads(capsys.readouterr().out)["budget"]
+    assert block["committed_max_missing_from_both_sdks"] == 0
+    assert block["committed_max_stale_python_sdk_paths"] == 10
+    assert block["current_missing_from_both_sdks"] == 0
+    assert block["current_stale_python_sdk_paths"] == 10
+    assert block["passing"] is True
+    assert block["advisory_target"] is None
+
+    _patch_report(monkeypatch, missing=0, stale_python=11)
+    monkeypatch.setattr(sys, "argv", argv)
+    assert check_sdk_parity.main() == 0
+    block = json.loads(capsys.readouterr().out)["budget"]
+    assert block["passing"] is False
+    assert block["current_stale_python_sdk_paths"] == 11
+
+
+def test_today_shapes_advisory_target_only(monkeypatch, tmp_path, capsys):
+    advisory = {
+        "start_date": "2026-01-01",
+        "initial_missing_from_both_sdks": 10,
+        "weekly_reduction_missing_from_both_sdks": 1,
+        "initial_stale_python_sdk_paths": 20,
+        "weekly_reduction_stale_python_sdk_paths": 2,
+    }
+    budget = _write_committed_budget(
+        tmp_path / "budget.json", max_missing=5, max_stale=20, advisory=advisory
+    )
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    for today, missing_max, stale_max in (("2026-01-15", 8, 16), ("2099-12-31", 0, 0)):
+        argv = ["check_sdk_parity.py", "--json", "--budget", str(budget), "--today", today]
+        monkeypatch.setattr(sys, "argv", argv)
+        assert check_sdk_parity.main() == 0
+        block = json.loads(capsys.readouterr().out)["budget"]
+        assert block["passing"] is True
+        assert block["advisory_target"] == {
+            "as_of": today,
+            "missing_from_both_sdks_max": missing_max,
+            "stale_python_sdk_paths_max": stale_max,
+        }
+
+
+def test_caller_compatibility_production_argv(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=5)
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text('{"missing_from_both_sdks": []}\n', encoding="utf-8")
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=36)
+    strict = ["check_sdk_parity.py", "--strict", "--baseline", str(baseline)]
+    strict += ["--budget", str(budget)]
+    for argv in (
+        strict,
+        [*strict, "--today", "2026-08-14"],
+        ["check_sdk_parity.py", "--json", "--budget", str(budget)],
+    ):
+        monkeypatch.setattr(sys, "argv", argv)
+        assert check_sdk_parity.main() == 0, argv
+
+
+# ---------------------------------------------------------------------------
+# --tighten semantics
+# ---------------------------------------------------------------------------
+
+
+def _tighten_argv(budget: Path) -> list[str]:
+    return ["check_sdk_parity.py", "--tighten", "--budget", str(budget)]
+
+
+def test_tighten_bootstraps_missing_budget(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=1, stale_python=7)
+    budget = tmp_path / "budget.json"
+    monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
+    assert check_sdk_parity.main() == 0
+    data = json.loads(budget.read_text(encoding="utf-8"))
+    assert data["committed_max_missing_from_both_sdks"] == 1
+    assert data["committed_max_stale_python_sdk_paths"] == 7
+    assert "advisory_cadence" not in data
+
+
+def test_tighten_bootstraps_legacy_budget_preserving_cadence_as_advisory(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    budget = tmp_path / "budget.json"
+    budget.write_text(_LEGACY_BUDGET_TEXT, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
+    assert check_sdk_parity.main() == 0
+    data = json.loads(budget.read_text(encoding="utf-8"))
+    assert data["committed_max_missing_from_both_sdks"] == 0
+    assert data["committed_max_stale_python_sdk_paths"] == 3
+    assert data["advisory_cadence"] == _LEGACY_CADENCE
+
+
+def test_tighten_is_idempotent_when_already_tight(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    budget = tmp_path / "budget.json"
+    monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
+    assert check_sdk_parity.main() == 0
+    first_bytes = budget.read_bytes()
+    assert check_sdk_parity.main() == 0
+    assert budget.read_bytes() == first_bytes
+
+
+def test_tighten_lowers_existing_ceilings_to_measured_debt(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=5, max_stale=50)
+    monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
+    assert check_sdk_parity.main() == 0
+    data = json.loads(budget.read_text(encoding="utf-8"))
+    assert data["committed_max_missing_from_both_sdks"] == 0
+    assert data["committed_max_stale_python_sdk_paths"] == 3
+
+
+def test_tighten_refuses_to_raise_and_preserves_bytes(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=12)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=10)
+    before = budget.read_bytes()
+    monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
+    assert check_sdk_parity.main() == 1
+    assert budget.read_bytes() == before
+
+
+def test_tighten_exits_2_without_writing_when_extraction_unavailable(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    monkeypatch.setattr(
+        check_sdk_parity,
+        "extract_handler_routes_with_status",
+        lambda: check_sdk_parity.HandlerRouteExtractionResult(
+            routes={}, available=False, error="handlers unavailable"
+        ),
+    )
+    missing_budget = tmp_path / "budget.json"
+    monkeypatch.setattr(sys, "argv", _tighten_argv(missing_budget))
+    assert check_sdk_parity.main() == 2
+    assert not missing_budget.exists()
+
+    existing = _write_committed_budget(tmp_path / "existing.json", max_missing=9, max_stale=9)
+    before = existing.read_bytes()
+    monkeypatch.setattr(sys, "argv", _tighten_argv(existing))
+    assert check_sdk_parity.main() == 2
+    assert existing.read_bytes() == before
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="directory permissions are bypassed as root")
+def test_tighten_exits_2_when_budget_path_unwritable(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    locked_dir = tmp_path / "locked"
+    locked_dir.mkdir()
+    budget = locked_dir / "budget.json"
+    locked_dir.chmod(0o500)
+    try:
+        monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
+        assert check_sdk_parity.main() == 2
+        assert not budget.exists()
+    finally:
+        locked_dir.chmod(0o700)
+
+
+def test_tighten_refuses_malformed_budget_without_writing(monkeypatch, tmp_path):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    budget = tmp_path / "budget.json"
+    budget.write_text("not json {", encoding="utf-8")
+    before = budget.read_bytes()
+    monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
+    assert check_sdk_parity.main() == 2
+    assert budget.read_bytes() == before

--- a/tests/scripts/test_check_sdk_parity.py
+++ b/tests/scripts/test_check_sdk_parity.py
@@ -408,10 +408,14 @@ def test_exit_status_is_invariant_across_system_dates(monkeypatch, tmp_path):
         assert results == {expected}
 
 
-def test_strict_missing_budget_fails_closed(monkeypatch, tmp_path):
+def test_strict_missing_budget_fails_closed(monkeypatch, tmp_path, capsys):
     _patch_report(monkeypatch, missing=0)
     monkeypatch.setattr(sys, "argv", _strict_argv(tmp_path / "no-budget.json"))
     assert check_sdk_parity.main() == 2
+    monkeypatch.setattr(sys, "argv", _strict_argv(tmp_path / "no-budget.json", "--json"))
+    capsys.readouterr()
+    assert check_sdk_parity.main() == 2
+    assert json.loads(capsys.readouterr().out)["budget"]["error"] == "missing"
 
 
 def test_non_strict_missing_budget_is_tolerated(monkeypatch, tmp_path):
@@ -618,7 +622,7 @@ def test_tighten_exits_2_without_writing_when_extraction_unavailable(monkeypatch
     assert existing.read_bytes() == before
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="directory permissions are bypassed as root")
+@pytest.mark.skipif(sys.platform == "win32" or os.geteuid() == 0, reason="needs POSIX non-root")
 def test_tighten_exits_2_when_budget_path_unwritable(monkeypatch, tmp_path):
     _patch_report(monkeypatch, missing=0, stale_python=3)
     locked_dir = tmp_path / "locked"


### PR DESCRIPTION
## Source

Mission feature `misc-sdk-parity-committed-ceiling-semantics` (milestone `cdg-bootstrap-route-truth`) — Tier-4-labeled, preparation-only, parked draft for separate exact-head operator settlement (AskUser strategy decision 2026-08-14; single-use path-freeze overlap lift recorded 2026-08-18 in mission AGENTS.md and library/operator-approvals.md). Fresh implementation; foreign PR #9675 is untouched (its OPEN overlap on these three paths is tolerated for this feature only).

## What changes

Replaces clock-derived SDK-parity budget enforcement with explicit committed ceilings so unchanged code can never become red solely because a date/timezone boundary passes.

- `scripts/check_sdk_parity.py`
  - New committed budget schema `check-sdk-parity-committed-budget-v1` with explicit nonnegative `committed_max_missing_from_both_sdks` / `committed_max_stale_python_sdk_paths`; optional `advisory_cadence` retained as non-enforcing metadata.
  - Strict mode fails closed with exit 2 on a missing, malformed, or legacy (clock-cadence-only) budget instead of silently skipping; legacy/malformed budgets fail closed in non-strict mode too.
  - `--today` remains accepted for all existing callers but is advisory-only: it shapes the non-enforcing advisory paydown target and can never affect exit status or enforced ceilings.
  - New `--tighten`: measures current debt before parsing enforcement ceilings, bootstraps a missing/legacy file, writes measured debt as ceilings (atomic tempfile + `os.replace`), is idempotent when already tight (no write), refuses to raise any existing ceiling with exit 1 and a byte-preserved file, and exits 2 without writing when handler extraction is unavailable or the path is unwritable.
  - Gate output and `--json` expose current values, committed ceilings, pass state, and the optional advisory target; no clock data participates in pass/fail.
- `scripts/baselines/check_sdk_parity_budget.json`
  - Rewritten by the new `--tighten` bootstrap against real extraction on this head: ceilings 0 missing-from-both / 36 stale-Python (measured after the paydown), legacy cadence preserved as `advisory_cadence`.
- `tests/scripts/test_check_sdk_parity.py`
  - Focused battery: today/system-date/TZ invariance, at/above ceiling, missing/malformed/legacy fail-closed, extraction-unavailable semantics, JSON budget block, `--tighten` bootstrap (missing and legacy), idempotence, refuse-to-raise byte-preservation, unavailable-extraction and unwritable-path failures, and production caller argv compatibility.

All five production callers (`.github/workflows/sdk-parity.yml`, `.github/workflows/release.yml`, `Makefile` ci-required, `scripts/pre_release_check.py`, `scripts/pristine_main_health.py`) use `--strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json`; argv is preserved and none pass `--today`.

## Validation (worktree at head 85b04b53523a3bc916f62fd3947f379024841217, base 1bee1e03db016a6b3c61df04eef57dc80242e405)

- `python3 -m pytest tests/scripts/test_check_sdk_parity.py -q` → 38 passed (red-first: 25 failed / 15 passed before implementation).
- Seed sweep `-p randomly --randomly-seed={1,42,100,2024,12345}` on the same file → 38 passed on every seed.
- Live invariance with the exact production argv: rc=0 for no `--today`, `--today 2020-01-01`, `--today 2099-12-31`, `TZ=Pacific/Kiritimati` (UTC+14), and `TZ=Pacific/Pago_Pago` (UTC-11); the enforced line is stable at `missing_from_both 0/0 | stale_python 36/36`; only the advisory `as_of` moves.
- Live `--tighten` idempotence: second run prints `Budget already tight: missing_from_both<=0 | stale_python<=36 (no write)`; budget SHA-256 unchanged (`f92ef463161a61e57f31c2b56bb411c5fcfa0bfa1baeec6f2363be06a11413c8`).
- Pre-change fail-closed proof: against the legacy on-disk budget, the new checker exited 2 before the bootstrap rewrote it.
- `make lint`; `ruff format --check aragora/ tests/ scripts/`; `bash scripts/preflight_mypy.sh --diff-base origin/main` (Success: no issues found in 2 source files); `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke`; `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` (138 passed); `bash scripts/automation_pr_preflight.sh origin/main HEAD` → all rc=0.
- Diff: 3 files, +669/−125 = 794 changed lines (≤800 cap), measured after `ruff format`.

## Risks

- The behavior change is fail-closed by design: a missing/malformed/legacy budget now exits 2 in strict mode (previously the legacy cadence silently derived ceilings from the wall clock). The committed budget in this PR keeps all five production callers green (proven live above).
- If future paydown lowers measured debt, `--tighten` re-tightens downward idempotently; raising a ceiling requires an explicit human edit (the tool refuses with exit 1 and preserves bytes).
- No workflow, SDK, handler, parity-drift-baseline, accepted-authority-inventory, or generated-doc changes; no production caller passes `--today`.

## Settlement

Parked draft labeled `operator-review-required`. Prepare-only, UNPOSTED Claude+OpenAI evidence is collected with apply=False at this exact head; tier is read from the collector JSON (the gate computes tier from the DIFF — this scripts+tests diff may score sub-Tier-4 against the Tier-4 mission label; any mismatch is disclosed in the settlement packet). No ready, evidence-posting, settlement, merge, workflow, PR #9752, or PR #9675 action is taken.
