### PR TITLE
fix(governance): pin TLS-trust probe markers and drop the http-403 transience promise

### DIFF
--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -77,6 +77,8 @@ BLOCKED_MARKER_PROBE_NAME = "blocked-marker-probe.bin"
 # gh 2.96.0, 2026-08-18): before verifier initialization a dead network
 # surfaces as the Sigstore verifier-init failure, after it as Go net
 # dial/lookup text. Message-only classification; never an exit-class input.
+# The verifier-init marker also matches a stale or corrupt local TUF cache,
+# so `network` can name a cache state; every class stays blocked either way.
 PROBE_NETWORK_STDERR_MARKERS = (
     "no valid sigstore verifiers could be initialized",
     "dial tcp",
@@ -88,6 +90,14 @@ PROBE_NETWORK_STDERR_MARKERS = (
     "tls handshake",
     "context deadline exceeded",
     "temporary failure in name resolution",
+    # Corporate-MITM trust failures on the attestations-API read, pinned
+    # live 2026-08-18 with the byte-exact production argv (gh 2.96.0). The
+    # crypto/tls umbrella prefix is load-bearing: an untrusted interceptor
+    # reports unknown authority even when its certificate is expired, so a
+    # `certificate has expired` literal can never be pinned against a MITM;
+    # the umbrella covers that trusted-but-expired shape instead.
+    "tls: failed to verify certificate",
+    "x509: certificate signed by unknown authority",
 )
 # Pre-publish attestation lag ladder; mirrors the workflow's post-publish
 # retry step (4 attempts, 5/10/20s waits), blocked class only.
@@ -651,6 +661,10 @@ def _rule_suite_binding(repository: str, head_sha: str, *, admin_reads: str) -> 
 
 
 def _admin_gated_notes(report: dict[str, Any]) -> list[str]:
+    # `_append_step_summary` dedupes on the exact bytes of the rendered
+    # block, so these note strings must stay static for a given report
+    # state; rewording them would make blocked-class retries append a
+    # duplicate block instead of deduping.
     notes: list[str] = []
     setting = report.get("immutability_setting")
     if isinstance(setting, str) and setting.startswith("unreadable"):
@@ -916,10 +930,11 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             transient = _probe_transient_class(probe_stderr)
             if transient == "http-403":
                 raise Blocked(
-                    f"blocked-marker probe was answered with HTTP 403 (transient "
-                    f"rate-limit/permission class), so no live no-attestation "
-                    f"error shape was observed; retry when the attestations API "
-                    f"answers reads; observed: {probe_stderr[:300]}"
+                    f"blocked-marker probe was answered with HTTP 403, so no "
+                    f"live no-attestation error shape was observed; a "
+                    f"rate-limited read clears on retry, but a token-permission "
+                    f"403 persists until this token can read the attestations "
+                    f"API; observed: {probe_stderr[:300]}"
                 )
             if transient == "network":
                 raise Blocked(

--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -90,12 +90,16 @@ PROBE_NETWORK_STDERR_MARKERS = (
     "tls handshake",
     "context deadline exceeded",
     "temporary failure in name resolution",
-    # Corporate-MITM trust failures on the attestations-API read, pinned
-    # live 2026-08-18 with the byte-exact production argv (gh 2.96.0). The
-    # crypto/tls umbrella prefix is load-bearing: an untrusted interceptor
-    # reports unknown authority even when its certificate is expired, so a
-    # `certificate has expired` literal can never be pinned against a MITM;
-    # the umbrella covers that trusted-but-expired shape instead.
+)
+# Corporate-MITM trust failures on the attestations-API read, pinned live
+# 2026-08-18 with the byte-exact production argv (gh 2.96.0). The crypto/tls
+# umbrella prefix is load-bearing: an untrusted interceptor reports unknown
+# authority even when its certificate is expired, so a `certificate has
+# expired` literal can never be pinned against a MITM; the umbrella covers
+# that trusted-but-expired shape instead. Kept separate from the network
+# markers because a trust failure is a persistent runner configuration
+# state, so its wording must not promise that a retry clears it.
+PROBE_TLS_TRUST_STDERR_MARKERS = (
     "tls: failed to verify certificate",
     "x509: certificate signed by unknown authority",
 )
@@ -464,13 +468,16 @@ def _is_absent_attestation_stderr(stderr: str, marker: str) -> bool:
 
 def _probe_transient_class(stderr: str) -> str | None:
     """Message-only hint for a probe stderr that matched no absent-attestation
-    shape: an HTTP 403 answer or a network/Sigstore transport death never
-    carried a verification verdict, so attributing it to marker drift would
-    misdirect the operator. Anything unrecognized is genuine drift, and the
-    caller's fail-closed blocked exit is identical for every class."""
+    shape: an HTTP 403 answer, a TLS certificate-verification failure, or a
+    network/Sigstore transport death never carried a verification verdict,
+    so attributing it to marker drift would misdirect the operator. Anything
+    unrecognized is genuine drift, and the caller's fail-closed blocked exit
+    is identical for every class."""
     lowered = stderr.lower()
     if "http 403" in lowered:
         return "http-403"
+    if any(marker in lowered for marker in PROBE_TLS_TRUST_STDERR_MARKERS):
+        return "tls-trust"
     if any(marker in lowered for marker in PROBE_NETWORK_STDERR_MARKERS):
         return "network"
     return None
@@ -935,6 +942,15 @@ def cmd_preflight(args: argparse.Namespace) -> int:
                     f"rate-limited read clears on retry, but a token-permission "
                     f"403 persists until this token can read the attestations "
                     f"API; observed: {probe_stderr[:300]}"
+                )
+            if transient == "tls-trust":
+                raise Blocked(
+                    f"blocked-marker probe failed TLS certificate verification "
+                    f"toward the attestations API before any verification "
+                    f"verdict (corporate-proxy interception or an untrusted or "
+                    f"expired chain); this persists until the runner trusts "
+                    f"the presented chain, so repair the runner trust store or "
+                    f"proxy configuration; observed: {probe_stderr[:300]}"
                 )
             if transient == "network":
                 raise Blocked(

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -1876,15 +1876,17 @@ def test_envelope_preflight_validates_blocked_marker_against_live_gh(monkeypatch
 def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
     monkeypatch, tmp_path, capsys
 ):
-    """A probe answered by HTTP 403 or killed in the network/Sigstore
-    transport never observed a verification verdict, so the blocked report
-    must name the observed cause instead of claiming marker drift: network
-    shapes as the transient infrastructure class, HTTP 403 without any
-    transience promise (a token-permission 403 persists until the token can
-    read the attestations API). The exit class is message-only cosmetics:
-    every class stays blocked pre-publication with the observed stderr
-    embedded and no per-asset verification attempted, and an unrecognized
-    shape still reads as genuine drift."""
+    """A probe answered by HTTP 403, failed by TLS certificate
+    verification, or killed in the network/Sigstore transport never
+    observed a verification verdict, so the blocked report must name the
+    observed cause instead of claiming marker drift: network shapes as the
+    transient infrastructure class, TLS-trust and HTTP 403 shapes without
+    any transience promise (a corporate-MITM trust failure and a
+    token-permission 403 persist until the runner/token configuration
+    changes). The exit class is message-only cosmetics: every class stays
+    blocked pre-publication with the observed stderr embedded and no
+    per-asset verification attempted, and an unrecognized shape still
+    reads as genuine drift."""
     module = _load_envelope_helper()
     identity, args = _preflight_fixture(module, tmp_path)
     head = args.head_sha
@@ -1902,10 +1904,26 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
             b'attestations/sha256:ab12?per_page=30": proxyconnect tcp: '
             b"dial tcp 127.0.0.1:9: connect: connection refused"
         ),
-        # Corporate-MITM trust failures, pinned live 2026-08-18 against the
-        # byte-exact production argv (gh 2.96.0): an untrusted interceptor
-        # reports unknown authority even when its own certificate is expired,
-        # so the expired-chain shape rides on the crypto/tls umbrella prefix.
+    }
+    for observed, stderr in transient_shapes.items():
+        fake_run, state = _preflight_gh_stub(module, probe_stderr=stderr)
+        monkeypatch.setattr(module, "_run_gh", fake_run)
+        assert module.cmd_preflight(args) == module.EXIT_BLOCKED, observed
+        report = json.loads(capsys.readouterr().out)
+        assert report["status"] == "blocked", observed
+        assert "transient" in report["reason"], observed
+        assert "neither the" not in report["reason"], observed
+        assert "observed:" in report["reason"], observed
+        assert observed in report["reason"], observed
+        assert state["probe_calls"] == 1, observed
+        assert state["asset_attempts"] == {}, observed
+    # TLS-trust failures (corporate-MITM interception, untrusted or expired
+    # chains), pinned live 2026-08-18 against the byte-exact production argv
+    # (gh 2.96.0): an untrusted interceptor reports unknown authority even
+    # when its own certificate is expired, so the expired-chain shape rides
+    # on the crypto/tls umbrella prefix. These are persistent runner
+    # configuration states, so their wording promises no transience.
+    tls_trust_shapes = {
         "x509: certificate signed by unknown authority": (
             b'Error: Get "https://api.github.com/repos/synaptent/aragora/'
             b'attestations/sha256:ab12?per_page=30": tls: failed to verify '
@@ -1918,13 +1936,15 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
             b"current time 2026-08-18T12:00:00Z is after 2026-08-17T18:40:37Z"
         ),
     }
-    for observed, stderr in transient_shapes.items():
+    for observed, stderr in tls_trust_shapes.items():
         fake_run, state = _preflight_gh_stub(module, probe_stderr=stderr)
         monkeypatch.setattr(module, "_run_gh", fake_run)
         assert module.cmd_preflight(args) == module.EXIT_BLOCKED, observed
         report = json.loads(capsys.readouterr().out)
         assert report["status"] == "blocked", observed
-        assert "transient" in report["reason"], observed
+        assert "failed TLS certificate verification" in report["reason"], observed
+        assert "persists until the runner trusts" in report["reason"], observed
+        assert "transient" not in report["reason"], observed
         assert "neither the" not in report["reason"], observed
         assert "observed:" in report["reason"], observed
         assert observed in report["reason"], observed

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -1878,22 +1878,20 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
 ):
     """A probe answered by HTTP 403 or killed in the network/Sigstore
     transport never observed a verification verdict, so the blocked report
-    must name the transient cause instead of claiming marker drift. The
-    exit class is message-only cosmetics: every class stays blocked
-    pre-publication with the observed stderr embedded and no per-asset
-    verification attempted, and an unrecognized shape still reads as
-    genuine drift."""
+    must name the observed cause instead of claiming marker drift: network
+    shapes as the transient infrastructure class, HTTP 403 without any
+    transience promise (a token-permission 403 persists until the token can
+    read the attestations API). The exit class is message-only cosmetics:
+    every class stays blocked pre-publication with the observed stderr
+    embedded and no per-asset verification attempted, and an unrecognized
+    shape still reads as genuine drift."""
     module = _load_envelope_helper()
     identity, args = _preflight_fixture(module, tmp_path)
     head = args.head_sha
     monkeypatch.setattr(module, "_sleep", lambda _delay: None)
     monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
     transient_shapes = {
-        "HTTP 403": (
-            b"Error: HTTP 403: API rate limit exceeded (https://api.github.com/"
-            b"repos/synaptent/aragora/attestations/sha256:ab12?per_page=30)"
-        ),
-        # Both live network shapes (gh 2.96.0, observed 2026-08-18): transport
+        # Live network shapes (gh 2.96.0, observed 2026-08-18): transport
         # death before verifier initialization, and a post-init API dial
         # failure whose stderr carries the attestations path but no HTTP 404.
         "no valid Sigstore verifiers could be initialized": (
@@ -1903,6 +1901,21 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
             b'Error: Get "https://api.github.com/repos/synaptent/aragora/'
             b'attestations/sha256:ab12?per_page=30": proxyconnect tcp: '
             b"dial tcp 127.0.0.1:9: connect: connection refused"
+        ),
+        # Corporate-MITM trust failures, pinned live 2026-08-18 against the
+        # byte-exact production argv (gh 2.96.0): an untrusted interceptor
+        # reports unknown authority even when its own certificate is expired,
+        # so the expired-chain shape rides on the crypto/tls umbrella prefix.
+        "x509: certificate signed by unknown authority": (
+            b'Error: Get "https://api.github.com/repos/synaptent/aragora/'
+            b'attestations/sha256:ab12?per_page=30": tls: failed to verify '
+            b"certificate: x509: certificate signed by unknown authority"
+        ),
+        "tls: failed to verify certificate": (
+            b'Error: Get "https://api.github.com/repos/synaptent/aragora/'
+            b'attestations/sha256:ab12?per_page=30": tls: failed to verify '
+            b"certificate: x509: certificate has expired or is not yet valid: "
+            b"current time 2026-08-18T12:00:00Z is after 2026-08-17T18:40:37Z"
         ),
     }
     for observed, stderr in transient_shapes.items():
@@ -1917,8 +1930,32 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
         assert observed in report["reason"], observed
         assert state["probe_calls"] == 1, observed
         assert state["asset_attempts"] == {}, observed
+    # HTTP 403 is named without any transience promise: a rate-limited read
+    # clears on retry, but a token-permission 403 persists until the token
+    # can read the attestations API, and calling it transient would
+    # misdirect the operator toward waiting out a permission gap.
+    fake_run, state = _preflight_gh_stub(
+        module,
+        probe_stderr=(
+            b"Error: HTTP 403: API rate limit exceeded (https://api.github.com/"
+            b"repos/synaptent/aragora/attestations/sha256:ab12?per_page=30)"
+        ),
+    )
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "HTTP 403" in report["reason"]
+    assert "transient" not in report["reason"]
+    assert "rate-limited read clears on retry" in report["reason"]
+    assert "persists until" in report["reason"]
+    assert "neither the" not in report["reason"]
+    assert "observed:" in report["reason"]
+    assert state["probe_calls"] == 1
+    assert state["asset_attempts"] == {}
     # Boundary: an unrecognized shape (HTTP 500 here) is NOT transient-classed;
-    # it keeps the marker-drift wording so genuine drift is never soft-pedaled.
+    # it keeps the marker-drift wording, byte-unchanged, so genuine drift is
+    # never soft-pedaled.
     fake_run, state = _preflight_gh_stub(
         module, probe_stderr=b"attestation lookup failed: HTTP 500"
     )
@@ -1928,6 +1965,8 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
     assert report["status"] == "blocked"
     assert "transient" not in report["reason"]
     assert "neither the" in report["reason"]
+    assert "runner gh reports a missing attestation with neither the" in report["reason"]
+    assert "would hard-fail instead of retrying" in report["reason"]
     assert state["asset_attempts"] == {}
 
 


### PR DESCRIPTION
Bounded prep-only micro-batch closing the PR #9789 claude [P3] advisories on `scripts/openapi_release_envelope.py` (recorded in `library/misc-envelope-probe-message-cosmetics-settlement.md`). Message/marker cosmetics only: every probe-classification branch still raises `Blocked` (exit 2) pre-publication; exit classes byte-unchanged; no workflow file touched.

## PARKED DRAFT — operator review required

This PR is intentionally parked as a DRAFT with fresh unposted exact-head 2-family evidence prepared with `apply=False`. **No ready, evidence posting, settlement, or merge is authorized for this session.** The gate computes the tier from the diff (expected tier 2).

## What changed

**1. New `PROBE_TLS_TRUST_STDERR_MARKERS` with two corporate-MITM trust shapes (both empirically pinned live BEFORE implementation)**

- `tls: failed to verify certificate` (crypto/tls umbrella prefix)
- `x509: certificate signed by unknown authority`

Corporate-proxy runners now classify these with a dedicated message-only `tls-trust` class and distinct Blocked wording instead of falling through to marker-drift wording. The wording names the persistent state and promises no transience: `blocked-marker probe failed TLS certificate verification toward the attestations API before any verification verdict (corporate-proxy interception or an untrusted or expired chain); this persists until the runner trusts the presented chain, so repair the runner trust store or proxy configuration; observed: …` (Round-1 claude [P2] correctly flagged the first iteration for routing these into the generic network wording, whose "transient … retry when the runner has connectivity" promise is wrong for a trust-configuration state; fixed in the second commit.)

**2. http-403 Blocked wording no longer promises transience**

Before: `... HTTP 403 (transient rate-limit/permission class), so no live no-attestation error shape was observed; retry when the attestations API answers reads; observed: ...`

After: `... HTTP 403, so no live no-attestation error shape was observed; a rate-limited read clears on retry, but a token-permission 403 persists until this token can read the attestations API; observed: ...`

**3. Bounded notes (advisory item 3)**

- Comment at `_admin_gated_notes` recording the exact-bytes step-summary dedupe assumption (note strings must stay static or blocked-class retries duplicate the block).
- Comment on the markers tuple recording that the sigstore verifier-init marker also matches stale/corrupt local TUF-cache states (still blocked either way).

**Byte-unchanged:** the marker-drift fall-through wording (now pinned by exact-substring assertions), the network-class wording (which keeps its transience promise only for genuinely transient dial/lookup/timeout shapes), all exit classes, and the workflow file.

## Live error-shape pinning (mandatory before implementation)

All scenarios ran the byte-exact production argv (`attestation_verify_argv` values from `.github/workflows/openapi.yml`) on live gh 2.96.0, 2026-08-18, against a scratch probe file:

```
gh attestation verify <probe> -R synaptent/aragora \
  --signer-workflow synaptent/aragora/.github/workflows/openapi.yml \
  --source-digest 0f5a572c877a50e7eb8b15ea2c832b1c3281a3a1 --format json
```

| Scenario | Env | Observed stderr (exact) | rc |
|---|---|---|---|
| Control (no proxy) | — | `Error: HTTP 404: Not Found (https://api.github.com/repos/synaptent/aragora/attestations/sha256:d96db04c…?per_page=30&predicate_type=…)` | 1 |
| MITM CONNECT proxy, valid-dates self-signed cert for api.github.com | `HTTPS_PROXY=http://127.0.0.1:39441 NO_PROXY=sigstore.dev` | `Error: Get "https://api.github.com/repos/synaptent/aragora/attestations/sha256:…": tls: failed to verify certificate: x509: certificate signed by unknown authority` | 1 |
| MITM CONNECT proxy, EXPIRED self-signed cert | `HTTPS_PROXY=http://127.0.0.1:39442 NO_PROXY=sigstore.dev` | identical `…tls: failed to verify certificate: x509: certificate signed by unknown authority` | 1 |
| Same two MITM scenarios under `GODEBUG=x509usefallbackroots=1` | as above | identical unknown-authority shape both times | 1 |
| DNS-dead proxy host | `HTTPS_PROXY=http://ghpin-7aa3.invalid:3128 NO_PROXY=sigstore.dev` | `Error: Get "…": proxyconnect tcp: dial tcp: lookup ghpin-7aa3.invalid: no such host` | 1 |
| Dead TCP proxy (existing-marker sanity) | `HTTPS_PROXY=http://127.0.0.1:9 NO_PROXY=sigstore.dev` | `Error: Get "…": proxyconnect tcp: dial tcp 127.0.0.1:9: connect: connection refused` | 1 |

**Pinning decisions (empiricism gates every marker):**

- `certificate has expired` literal NOT added: an untrusted interceptor reports unknown authority even when its own certificate is expired (verified under both the platform verifier and Go fallback roots), so the literal can only surface for a trusted-but-expired chain, which cannot be simulated without mutating the machine trust store. The pinned `tls: failed to verify certificate` umbrella prefix (present in all 4 TLS transcripts; emitted by crypto/tls for every certificate-verify failure) covers that shape instead.
- gh's `error connecting to` wrapper NOT added: it never fired on the attestation-verify path (the live shape is the raw `Get "…": proxyconnect tcp: … no such host` url.Error, whose bytes already classify via the existing `no such host` / `dial tcp` / `proxyconnect` markers). The string exists in the gh binary but only for other subcommand paths; adding an empirically unreachable marker would violate the pinning rule.

## Tests (red-first)

`tests/scripts/test_openapi_workflow_contract.py::test_envelope_preflight_probe_names_transient_classes_before_marker_drift`:

- New dedicated TLS-trust section with both pinned fixtures (full live stderr bytes) asserting the distinct no-transience wording (`failed TLS certificate verification`, `persists until the runner trusts`, `"transient" not in reason`) — red first at each step (fell through to drift wording before the markers existed; showed network wording before the dedicated class existed), green after.
- New dedicated HTTP-403 section asserting the new wording and `"transient" not in reason` — red against the old wording, green after.
- Network loop unchanged for the genuinely transient shapes (verifier-init, connection-refused).
- Drift boundary now also pins the exact drift-sentence head/tail substrings so future rewording of the byte-unchanged branch is caught.

## VAL-CDG-012 protection

- All 12 selector tests byte-identical to `origin/main` (AST `get_source_segment` compare at head vs base): PASS.
- Exact contract `-k` selector run: `12 passed, 34 deselected`.

## Gates run at head `843d7bddb70ae8e717a92ae12f67ab9da9b9a072`

- `python3 -m pytest tests/scripts/test_openapi_workflow_contract.py -q` → 46 passed
- `make lint` → All checks passed; `ruff format --check aragora/ tests/ scripts/` → clean
- `bash scripts/preflight_mypy.sh --diff-base origin/main` → no issues in the 2 changed files
- `make test-smoke` (AWS-neutralized) → passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → ok
- Diff bound: 2 files, +111/−21 (132 changed lines ≤ 800)
