### PR TITLE
fix(sdk-parity): route strict --json diagnostics to stderr and refresh the burndown doc

### DIFF
--- a/docs/status/SDK_PARITY_BURNDOWN.md
+++ b/docs/status/SDK_PARITY_BURNDOWN.md
@@ -1,40 +1,94 @@
 # SDK Parity Burndown
 
-Last updated: 2026-03-03
+Last updated: 2026-08-18
 
-This document tracks weekly debt reduction against the parity budget in
-`scripts/baselines/check_sdk_parity_budget.json`.
+This document describes the committed-ceiling budget contract that
+`scripts/check_sdk_parity.py` enforces against
+`scripts/baselines/check_sdk_parity_budget.json`. It replaces the retired
+weekly-decay contract this page described until March 2026: the budget no
+longer shrinks on a clock, and the wall-clock date can never change the
+gate's pass/fail result.
 
-## Current Baseline
+## Committed-ceiling contract
 
-- Public routes found: `1811`
-- Python SDK coverage: `99.9%`
-- TypeScript SDK coverage: `99.9%`
-- Missing from both SDKs: `0`
-- Stale Python SDK paths: `0`
-- Gate status:
-  - `python scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json` -> pass
-  - Budget status on 2026-03-03: `missing_from_both 0/22 | stale_python 0/20`
+The budget file carries schema `check-sdk-parity-committed-budget-v1` and
+exactly two enforced ceilings:
 
-## Week 2 Plan (2026-03-03 to 2026-03-09)
+| Key | Committed ceiling |
+|-----|-------------------|
+| `committed_max_missing_from_both_sdks` | `0` |
+| `committed_max_stale_python_sdk_paths` | `36` |
 
-### Missing-from-both wave
+- Strict mode (`--strict`) exits `1` when measured debt exceeds either
+  committed ceiling; debt at or under both ceilings passes.
+- Strict mode fails closed with exit `2` when the budget file is missing.
+  A legacy clock-derived budget (cadence keys without committed ceilings)
+  or a malformed budget fails closed with exit `2` in both strict and
+  non-strict runs.
+- `--today` is accepted but advisory-only: it shapes the non-enforcing
+  paydown target derived from the optional `advisory_cadence` block (the
+  retired cadence is preserved there purely as a reference), never the
+  exit status.
+- The `schema` field is an informational label. The loader intentionally
+  classifies the file by its keys (committed ceilings present, or retired
+  cadence keys only) rather than validating the label, so a future schema
+  revision can land without a lockstep checker update (forward-compat
+  behavior, not an oversight).
+- In `--json` mode stdout is always exactly one parseable JSON document
+  (the report, including the `budget` block); all human diagnostics go to
+  stderr.
 
-Target: maintain `0` (no regressions).
+## Banking progress with `--tighten`
 
-### Stale Python path wave
+Ceilings never decay on their own, and the checker never raises them.
+After a real paydown lands, someone must bank it:
 
-Completed in this wave: reduced stale Python paths to `0`.
+```bash
+python3 scripts/check_sdk_parity.py --tighten \
+  --budget scripts/baselines/check_sdk_parity_budget.json
+```
 
-Next target: maintain `0` stale paths while reducing one-sided handler gaps
-reported by the strict parity checker (for example, SlackHandler and
-UnifiedInboxHandler deltas where routes exist in only one SDK surface).
+- `--tighten` measures current debt and rewrites the ceilings down to the
+  measured values. It is idempotent: when the file is already tight it
+  reports so and performs no write.
+- It refuses to raise a ceiling: if measured debt exceeds a committed
+  ceiling it exits `1` and leaves the budget file byte-identical. Raising
+  a ceiling is a human-only decision made by hand-editing the budget file
+  in a reviewed change; the tool will never do it.
+- It bootstraps a missing or legacy budget file from measured debt
+  (preserving a legacy cadence as the non-enforcing `advisory_cadence`),
+  and exits `2` without writing when route extraction is unavailable or
+  the budget path is unwritable.
+- When current debt sits below the committed ceilings, the checker prints
+  an advisory reminder suggesting `--tighten` so the slack cannot be
+  silently consumed by a later regression. The advisory never affects the
+  exit status.
 
-## Weekly Loop
+## No automatic decay (operational consequences)
 
-1. Run parity report and save output:
-   - `python scripts/check_sdk_parity.py --json > /tmp/sdk_parity.json`
-2. Run strict gate with baseline + budget:
-   - `python scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json`
-3. Compare against this doc and budget file.
-4. Update this doc with achieved reductions and next wave.
+Under the retired weekly-decay contract the budget shrank every week, so
+the gate could turn red — or green again — with zero code change. The
+committed-ceiling contract removes both directions:
+
+- The gate turns red only when debt actually grows past a committed
+  ceiling. A red gate can never be fixed by waiting; someone must either
+  pay the debt down or (human-only) raise the ceiling in a reviewed edit.
+- Paydown does not tighten anything by itself. After real paydown someone
+  must run `--tighten`, or the freed headroom remains silently
+  consumable.
+
+## Current state (2026-08-18)
+
+- Missing from both SDKs: `0` (ceiling `0`)
+- Stale Python SDK paths: `36` (ceiling `36`)
+- Gate command and result:
+  - `python3 scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json` -> pass
+  - `Budget status (committed ceilings): missing_from_both 0/0 | stale_python 36/36`
+
+## Paydown loop
+
+1. Report: `python3 scripts/check_sdk_parity.py --json > /tmp/sdk_parity.json`
+2. Gate: `python3 scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json`
+3. Pay down stale paths or missing routes for real.
+4. Bank it: run `--tighten` and commit the lowered ceilings in the same
+   change, so the ratchet holds the new floor.

--- a/scripts/check_sdk_parity.py
+++ b/scripts/check_sdk_parity.py
@@ -1012,6 +1012,19 @@ def main() -> int:
                         f"{advisory_target['missing_from_both_sdks_max']} | stale_python<="
                         f"{advisory_target['stale_python_sdk_paths_max']}"
                     )
+                if budget_passing and (
+                    current_missing < committed.max_missing_from_both
+                    or current_stale < committed.max_stale_python
+                ):
+                    # Ceilings never decay on their own, so unbanked slack after a
+                    # real paydown stays silently consumable until someone tightens.
+                    print(
+                        "Advisory: current debt is below the committed ceilings "
+                        f"(missing_from_both {current_missing}/"
+                        f"{committed.max_missing_from_both} "
+                        f"| stale_python {current_stale}/{committed.max_stale_python}); "
+                        "run --tighten to bank this progress as the new ceilings."
+                    )
         else:
             budget_block["skipped"] = "handler routes unavailable in this environment"
             if not args.json:
@@ -1025,43 +1038,55 @@ def main() -> int:
     if args.json:
         print(json.dumps(report, indent=2))
 
+    # In --json mode stdout must stay exactly one parseable JSON document
+    # (sdk-parity.yml redirects it into an artifact), so every human
+    # diagnostic below is routed to stderr instead.
+    diagnostics = sys.stderr if args.json else sys.stdout
+
     if budget_failure_rc is not None:
         if budget_failure_msg:
-            print(f"\n{budget_failure_msg}", file=sys.stderr if args.json else sys.stdout)
+            print(f"\n{budget_failure_msg}", file=diagnostics)
         return budget_failure_rc
 
     # Strict mode: fail if gaps exceed threshold
     if args.strict:
         if not handler_result.available:
             print(
-                "\nSKIP: Handler route extraction unavailable; strict parity enforcement skipped."
+                "\nSKIP: Handler route extraction unavailable; strict parity enforcement skipped.",
+                file=diagnostics,
             )
             return 0
         py_cov = report["summary"]["python_sdk_coverage_pct"]
         ts_cov = report["summary"]["typescript_sdk_coverage_pct"]
         if py_cov < args.threshold or ts_cov < args.threshold:
-            print(f"\nFAIL: Coverage below threshold ({args.threshold}%)")
+            print(f"\nFAIL: Coverage below threshold ({args.threshold}%)", file=diagnostics)
             return 1
         missing = report["summary"]["routes_missing_from_both_sdks"]
         if len(new_missing) > 0 and not args.allow_missing:
             print(
                 f"\nFAIL: {len(new_missing)} new routes lack SDK coverage "
-                f"(total missing: {missing})."
+                f"(total missing: {missing}).",
+                file=diagnostics,
             )
-            print("Run with --allow-missing only as a temporary migration override.")
+            print(
+                "Run with --allow-missing only as a temporary migration override.",
+                file=diagnostics,
+            )
             return 1
         if committed is not None and budget_passing is False:
             current = budget_block["current_missing_from_both_sdks"]
             if current > committed.max_missing_from_both:
                 print(
                     "\nFAIL: Missing-from-both debt exceeds committed ceiling "
-                    f"({current} > {committed.max_missing_from_both})."
+                    f"({current} > {committed.max_missing_from_both}).",
+                    file=diagnostics,
                 )
                 return 1
             stale = budget_block["current_stale_python_sdk_paths"]
             print(
                 "\nFAIL: Stale Python SDK debt exceeds committed ceiling "
-                f"({stale} > {committed.max_stale_python})."
+                f"({stale} > {committed.max_stale_python}).",
+                file=diagnostics,
             )
             return 1
 

--- a/tests/scripts/test_check_sdk_parity.py
+++ b/tests/scripts/test_check_sdk_parity.py
@@ -645,3 +645,160 @@ def test_tighten_refuses_malformed_budget_without_writing(monkeypatch, tmp_path)
     monkeypatch.setattr(sys, "argv", _tighten_argv(budget))
     assert check_sdk_parity.main() == 2
     assert budget.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# --json stdout purity (diagnostics on stderr)
+# ---------------------------------------------------------------------------
+
+
+def test_json_stdout_is_parseable_when_extraction_unavailable_strict(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0)
+    monkeypatch.setattr(
+        check_sdk_parity,
+        "extract_handler_routes_with_status",
+        lambda: check_sdk_parity.HandlerRouteExtractionResult(
+            routes={}, available=False, error="handlers unavailable"
+        ),
+    )
+    budget = _write_committed_budget(tmp_path / "budget.json")
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget, "--json"))
+    assert check_sdk_parity.main() == 0
+    captured = capsys.readouterr()
+    json.loads(captured.out)
+    assert "SKIP: Handler route extraction unavailable" in captured.err
+    assert "SKIP" not in captured.out
+
+
+def test_json_stdout_is_parseable_on_threshold_failure(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, py_cov=75.0, ts_cov=88.0)
+    budget = _write_committed_budget(tmp_path / "budget.json")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_sdk_parity.py",
+            "--strict",
+            "--threshold",
+            "90",
+            "--json",
+            "--budget",
+            str(budget),
+        ],
+    )
+    assert check_sdk_parity.main() == 1
+    captured = capsys.readouterr()
+    json.loads(captured.out)
+    assert "FAIL: Coverage below threshold (90.0%)" in captured.err
+    assert "FAIL" not in captured.out
+
+
+def test_json_stdout_is_parseable_on_new_missing_routes_failure(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=3)
+    budget = _write_committed_budget(tmp_path / "budget.json")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_sdk_parity.py", "--strict", "--json", "--budget", str(budget)],
+    )
+    assert check_sdk_parity.main() == 1
+    captured = capsys.readouterr()
+    json.loads(captured.out)
+    assert "new routes lack SDK coverage" in captured.err
+    assert "Run with --allow-missing only as a temporary migration override." in captured.err
+    assert "FAIL" not in captured.out
+
+
+def test_json_stdout_is_parseable_on_missing_ceiling_failure(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=3, stale_python=0)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=2, max_stale=10)
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget, "--json"))
+    assert check_sdk_parity.main() == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["budget"]["passing"] is False
+    assert "FAIL: Missing-from-both debt exceeds committed ceiling (3 > 2)." in captured.err
+    assert "FAIL" not in captured.out
+
+
+def test_json_stdout_is_parseable_on_stale_ceiling_failure(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, stale_python=5)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=4)
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget, "--json"))
+    assert check_sdk_parity.main() == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["budget"]["passing"] is False
+    assert "FAIL: Stale Python SDK debt exceeds committed ceiling (5 > 4)." in captured.err
+    assert "FAIL" not in captured.out
+
+
+def test_non_json_diagnostics_remain_on_stdout(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, py_cov=75.0, ts_cov=88.0)
+    budget = _write_committed_budget(tmp_path / "budget.json")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_sdk_parity.py", "--strict", "--threshold", "90", "--budget", str(budget)],
+    )
+    assert check_sdk_parity.main() == 1
+    captured = capsys.readouterr()
+    assert "FAIL: Coverage below threshold (90.0%)" in captured.out
+    assert captured.err == ""
+
+    _patch_report(monkeypatch, missing=0, stale_python=5)
+    over_budget = _write_committed_budget(tmp_path / "budget2.json", max_missing=0, max_stale=4)
+    monkeypatch.setattr(sys, "argv", _strict_argv(over_budget))
+    assert check_sdk_parity.main() == 1
+    captured = capsys.readouterr()
+    assert "FAIL: Stale Python SDK debt exceeds committed ceiling (5 > 4)." in captured.out
+    assert captured.err == ""
+
+
+# ---------------------------------------------------------------------------
+# Below-ceiling --tighten advisory (output-only)
+# ---------------------------------------------------------------------------
+
+
+def test_below_ceiling_advisory_suggests_tighten(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=10)
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget))
+    assert check_sdk_parity.main() == 0
+    captured = capsys.readouterr()
+    assert (
+        "Advisory: current debt is below the committed ceilings "
+        "(missing_from_both 0/0 | stale_python 3/10); "
+        "run --tighten to bank this progress" in captured.out
+    )
+    assert captured.err == ""
+
+
+def test_no_advisory_at_exact_committed_ceiling(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, stale_python=10)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=10)
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget))
+    assert check_sdk_parity.main() == 0
+    captured = capsys.readouterr()
+    assert "run --tighten to bank this progress" not in captured.out
+    assert captured.err == ""
+
+
+def test_no_advisory_when_over_ceiling(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, stale_python=11)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=10)
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget))
+    assert check_sdk_parity.main() == 1
+    captured = capsys.readouterr()
+    assert "run --tighten to bank this progress" not in captured.out
+
+
+def test_advisory_is_absent_from_json_mode_output(monkeypatch, tmp_path, capsys):
+    _patch_report(monkeypatch, missing=0, stale_python=3)
+    budget = _write_committed_budget(tmp_path / "budget.json", max_missing=0, max_stale=10)
+    monkeypatch.setattr(sys, "argv", _strict_argv(budget, "--json"))
+    assert check_sdk_parity.main() == 0
+    captured = capsys.readouterr()
+    json.loads(captured.out)
+    assert "run --tighten to bank this progress" not in captured.out
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

Bounded follow-up batch for the merged PR #9790 committed-ceiling SDK-parity gate, closing the recorded round-1 advisories and handoff discoveries. Three deliverables, exactly three files, one commit.

1. **`--json` stdout purity (`scripts/check_sdk_parity.py`)** — the remaining pre-existing non-budget FAIL/SKIP diagnostics (strict SKIP line, threshold FAIL, new-missing-routes FAIL + `--allow-missing` hint, and both committed-ceiling FAILs) are now routed to stderr in `--json` mode, so stdout is always exactly one parseable JSON document on every failure class. `sdk-parity.yml` redirects stdout into `parity-report.json`, which these diagnostics previously corrupted. Exit statuses unchanged; non-JSON-mode output byte-unchanged (test-guarded).
2. **Below-ceiling advisory (output-only)** — when the budget passes and current debt sits strictly below either committed ceiling, non-JSON mode prints one advisory line suggesting `--tighten` to bank the progress. Never affects exit status; absent in `--json` mode, at exact ceiling, and over ceiling.
3. **`docs/status/SDK_PARITY_BURNDOWN.md` rewrite** — replaces the retired weekly-decay description (stale since 2026-03-03) with the live committed-ceiling contract: schema `check-sdk-parity-committed-budget-v1`, ceilings 0 missing / 36 stale, strict exit semantics (1 over-ceiling, 2 missing/legacy/malformed), `--today` advisory-only, `--tighten` banking workflow (idempotent, refuses raises with exit 1, human-only raises), no-automatic-decay consequences, and the documented forward-compat non-validation of the `schema` field (intentional; NOT changed by this PR).

## Red-first tests

10 new tests in `tests/scripts/test_check_sdk_parity.py` (38 → 48):

- At base head `cc77845e`: **6 failed / 42 passed** — the five `--json`-purity tests fail with `json.decoder.JSONDecodeError: Extra data` (one per failure class: SKIP, threshold, new-missing-routes, missing-ceiling, stale-ceiling) and the below-ceiling advisory test fails on the absent line. The remaining 4 new tests are regression guards that pass at base by design (non-JSON diagnostics stay on stdout with empty stderr; no advisory at exact/over ceiling; no advisory contamination of `--json` stdout).
- After the fix: **48 passed**, plus a 5-seed randomized sweep of the file (48 passed × seeds 0-4).

## Live proofs (real handler extraction, worktree at `cc77845e`)

1. Production strict argv → rc=0, `missing_from_both 0/0 | stale_python 36/36`, no advisory (at exact ceiling).
2. Strict `--json` → rc=0, stdout parses as JSON, `budget.passing=true`.
3. Legacy cadence budget with `--json --strict` → rc=2, stdout parses (`budget.error="legacy"`), FAIL text on stderr only.
4. Slack budget (ceilings 1/40) → rc=0 with the new advisory line on stdout; stderr free of FAIL text.
5. `--tighten` on a scratch copy of the real budget → rc=0, `Budget already tight ... (no write)`, copy byte-identical (doc claim verified live).

## Scope and constraints

- Files: `scripts/check_sdk_parity.py`, `tests/scripts/test_check_sdk_parity.py`, `docs/status/SDK_PARITY_BURNDOWN.md`. **`scripts/baselines/check_sdk_parity_budget.json` was NOT edited** (no fixture required it).
- All five production caller argvs preserved (`sdk-parity.yml`, `release.yml`, `Makefile`, `pre_release_check.py`, `pristine_main_health.py`); no workflow files touched.
- The intentional non-validation of the budget `schema` field on load is documented as forward-compat behavior, not changed.
- Path-freeze census (92 open PRs): sole overlap is #9675 on the three code paths, tolerated-in-census and UNTOUCHED per the 2026-08-18 single-use "SDK-Parity Ceiling-Followups Overlap Lift" Decision (AGENTS.md + library/operator-approvals.md); the burndown doc is freeze-clean.
- Measured diff: 270 insertions / 34 deletions (304 changed lines) across 3 files.

## Status

Parked draft, `operator-review-required`. Fresh exact-head claude+openai evidence is collected prepare-only (`apply=False`) after draft checks; no ready, no evidence posting, no settlement, no merge under this feature's authority.
