### PR TITLE
fix(governance): split the Sigstore verifier-init probe class from the transient network wording

### DIFF
--- a/scripts/openapi_release_envelope.py
+++ b/scripts/openapi_release_envelope.py
@@ -74,13 +74,11 @@ NO_ATTESTATIONS_MARKER = "no attestations"
 ATTESTATIONS_API_PATH_MARKER = "/attestations/sha256:"
 BLOCKED_MARKER_PROBE_NAME = "blocked-marker-probe.bin"
 # Transient transport shapes for `_probe_transient_class` (observed live on
-# gh 2.96.0, 2026-08-18): before verifier initialization a dead network
-# surfaces as the Sigstore verifier-init failure, after it as Go net
-# dial/lookup text. Message-only classification; never an exit-class input.
-# The verifier-init marker also matches a stale or corrupt local TUF cache,
-# so `network` can name a cache state; every class stays blocked either way.
+# gh 2.96.0, 2026-08-18): after verifier initialization a dead network
+# surfaces as Go net dial/lookup text on the attestations-API read, so a
+# connectivity retry genuinely clears this class. Message-only
+# classification; never an exit-class input.
 PROBE_NETWORK_STDERR_MARKERS = (
-    "no valid sigstore verifiers could be initialized",
     "dial tcp",
     "proxyconnect",
     "no such host",
@@ -91,6 +89,14 @@ PROBE_NETWORK_STDERR_MARKERS = (
     "context deadline exceeded",
     "temporary failure in name resolution",
 )
+# A dead Sigstore verifier initialization, pinned live 2026-08-19 with the
+# byte-exact production argv (gh 2.96.0): gh swallows the underlying cause,
+# so unreachable TUF surfaces, TLS interception toward them, and a stale or
+# corrupt local TUF cache (`~/.cache/gh/.sigstore`) all emit this same bare
+# line. The corrupt-cache case reproduces it even with full connectivity
+# (gh never re-bootstraps the cache), so unlike the network class this
+# wording must never promise that a connectivity retry clears it.
+PROBE_VERIFIER_INIT_STDERR_MARKERS = ("no valid sigstore verifiers could be initialized",)
 # Corporate-MITM trust failures on the attestations-API read, pinned live
 # 2026-08-18 with the byte-exact production argv (gh 2.96.0). The crypto/tls
 # umbrella prefix is load-bearing: an untrusted interceptor reports unknown
@@ -468,16 +474,22 @@ def _is_absent_attestation_stderr(stderr: str, marker: str) -> bool:
 
 def _probe_transient_class(stderr: str) -> str | None:
     """Message-only hint for a probe stderr that matched no absent-attestation
-    shape: an HTTP 403 answer, a TLS certificate-verification failure, or a
-    network/Sigstore transport death never carried a verification verdict,
-    so attributing it to marker drift would misdirect the operator. Anything
-    unrecognized is genuine drift, and the caller's fail-closed blocked exit
-    is identical for every class."""
+    shape: an HTTP 403 answer, a TLS certificate-verification failure, a dead
+    Sigstore verifier initialization, or a network transport death never
+    carried a verification verdict, so attributing it to marker drift would
+    misdirect the operator. Anything unrecognized is genuine drift, and the
+    caller's fail-closed blocked exit is identical for every class."""
     lowered = stderr.lower()
     if "http 403" in lowered:
         return "http-403"
     if any(marker in lowered for marker in PROBE_TLS_TRUST_STDERR_MARKERS):
         return "tls-trust"
+    # Before the network markers: gh currently swallows the verifier-init
+    # cause, but a gh that starts appending it (dial/TLS text) must keep the
+    # no-transience classification instead of degrading to the network
+    # class's retry-on-connectivity promise.
+    if any(marker in lowered for marker in PROBE_VERIFIER_INIT_STDERR_MARKERS):
+        return "verifier-init"
     if any(marker in lowered for marker in PROBE_NETWORK_STDERR_MARKERS):
         return "network"
     return None
@@ -951,6 +963,16 @@ def cmd_preflight(args: argparse.Namespace) -> int:
                     f"expired chain); this persists until the runner trusts "
                     f"the presented chain, so repair the runner trust store or "
                     f"proxy configuration; observed: {probe_stderr[:300]}"
+                )
+            if transient == "verifier-init":
+                raise Blocked(
+                    f"blocked-marker probe could not initialize the Sigstore "
+                    f"verifier; gh swallows the underlying cause, and a stale "
+                    f"or corrupt local TUF cache reproduces this even with "
+                    f"full connectivity, so clear or repair the runner's "
+                    f"Sigstore TUF cache or restore its TUF reachability "
+                    f"instead of waiting on a connectivity retry; "
+                    f"observed: {probe_stderr[:300]}"
                 )
             if transient == "network":
                 raise Blocked(

--- a/tests/scripts/test_openapi_workflow_contract.py
+++ b/tests/scripts/test_openapi_workflow_contract.py
@@ -1877,11 +1877,12 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
     monkeypatch, tmp_path, capsys
 ):
     """A probe answered by HTTP 403, failed by TLS certificate
-    verification, or killed in the network/Sigstore transport never
-    observed a verification verdict, so the blocked report must name the
-    observed cause instead of claiming marker drift: network shapes as the
-    transient infrastructure class, TLS-trust and HTTP 403 shapes without
-    any transience promise (a corporate-MITM trust failure and a
+    verification, dead at Sigstore verifier initialization, or killed in
+    the network transport never observed a verification verdict, so the
+    blocked report must name the observed cause instead of claiming marker
+    drift: network shapes as the transient infrastructure class, TLS-trust,
+    verifier-init, and HTTP 403 shapes without any transience promise (a
+    corporate-MITM trust failure, a stale or corrupt local TUF cache, and a
     token-permission 403 persist until the runner/token configuration
     changes). The exit class is message-only cosmetics: every class stays
     blocked pre-publication with the observed stderr embedded and no
@@ -1893,12 +1894,9 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
     monkeypatch.setattr(module, "_sleep", lambda _delay: None)
     monkeypatch.setattr(module, "_gh_api_json", _live_api_stub(module, identity, head, []))
     transient_shapes = {
-        # Live network shapes (gh 2.96.0, observed 2026-08-18): transport
-        # death before verifier initialization, and a post-init API dial
-        # failure whose stderr carries the attestations path but no HTTP 404.
-        "no valid Sigstore verifiers could be initialized": (
-            b"error creating Sigstore verifier: no valid Sigstore verifiers could be initialized"
-        ),
+        # Live network shape (gh 2.96.0, observed 2026-08-18): a post-init
+        # API dial failure whose stderr carries the attestations path but
+        # no HTTP 404. A connectivity retry genuinely clears this class.
         "connection refused": (
             b'Error: Get "https://api.github.com/repos/synaptent/aragora/'
             b'attestations/sha256:ab12?per_page=30": proxyconnect tcp: '
@@ -1917,6 +1915,32 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
         assert observed in report["reason"], observed
         assert state["probe_calls"] == 1, observed
         assert state["asset_attempts"] == {}, observed
+    # Sigstore verifier-init death, pinned live 2026-08-19 with the
+    # byte-exact production argv (gh 2.96.0): dead TUF surfaces, TLS
+    # interception toward them, and a stale or corrupt local TUF cache all
+    # emit this same bare line, and the corrupt-cache case reproduces it
+    # with FULL connectivity (gh never self-heals the cache), so this
+    # wording must not promise that a connectivity retry clears it.
+    observed = "no valid Sigstore verifiers could be initialized"
+    fake_run, state = _preflight_gh_stub(
+        module,
+        probe_stderr=(
+            b"error creating Sigstore verifier: no valid Sigstore verifiers could be initialized"
+        ),
+    )
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+    assert "could not initialize the Sigstore verifier" in report["reason"]
+    assert "stale or corrupt local TUF cache" in report["reason"]
+    assert "even with full connectivity" in report["reason"]
+    assert "transient" not in report["reason"]
+    assert "neither the" not in report["reason"]
+    assert "observed:" in report["reason"]
+    assert observed in report["reason"]
+    assert state["probe_calls"] == 1
+    assert state["asset_attempts"] == {}
     # TLS-trust failures (corporate-MITM interception, untrusted or expired
     # chains), pinned live 2026-08-18 against the byte-exact production argv
     # (gh 2.96.0): an untrusted interceptor reports unknown authority even
@@ -1950,6 +1974,32 @@ def test_envelope_preflight_probe_names_transient_classes_before_marker_drift(
         assert observed in report["reason"], observed
         assert state["probe_calls"] == 1, observed
         assert state["asset_attempts"] == {}, observed
+    # Precedence guard: one stderr carrying BOTH a TLS-trust marker and
+    # network markers (an untrusted HTTPS proxy fails exactly this way:
+    # proxyconnect plus the crypto/tls umbrella text in one line) must keep
+    # classifying as the persistent TLS-trust runner state, never as the
+    # transient network class, so a `_probe_transient_class` reorder that
+    # checks the network markers first fails here instead of shipping.
+    combined = "tls-trust must win over network"
+    fake_run, state = _preflight_gh_stub(
+        module,
+        probe_stderr=(
+            b'Error: Get "https://api.github.com/repos/synaptent/aragora/'
+            b'attestations/sha256:ab12?per_page=30": proxyconnect tcp: '
+            b"tls: failed to verify certificate: x509: certificate signed "
+            b"by unknown authority"
+        ),
+    )
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+    assert module.cmd_preflight(args) == module.EXIT_BLOCKED, combined
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked", combined
+    assert "failed TLS certificate verification" in report["reason"], combined
+    assert "persists until the runner trusts" in report["reason"], combined
+    assert "transient" not in report["reason"], combined
+    assert "observed:" in report["reason"], combined
+    assert state["probe_calls"] == 1, combined
+    assert state["asset_attempts"] == {}, combined
     # HTTP 403 is named without any transience promise: a rate-limited read
     # clears on retry, but a token-permission 403 persists until the token
     # can read the attestations API, and calling it transient would


### PR DESCRIPTION
## Source

Bounded follow-up micro-batch closing the PR #9793 round-2 claude [P3] advisories recorded in `library/misc-envelope-probe-marker-followups-settlement.md` (mission feature `misc-envelope-probe-tls-precedence-followups`). Branched from post-merge main (`6955ab420e`, after #9793's squash `cc77845e3c`).

## Behavior

1. **Verifier-init split (advisory 2).** `"no valid sigstore verifiers could be initialized"` moves out of `PROBE_NETWORK_STDERR_MARKERS` into its own `PROBE_VERIFIER_INIT_STDERR_MARKERS` class with a no-transience Blocked wording. The old network wording promised "retry when the runner has connectivity"; live pinning (below) proves a stale/corrupt local TUF cache reproduces the identical stderr **even with full connectivity**, so that promise was false for this marker. All nine remaining network markers keep their byte-unchanged transient wording; drift/tls-trust/http-403 wordings and all exit classes are byte-unchanged (every class still exits `EXIT_BLOCKED`).
2. **Precedence fixture (advisory 1).** One combined-stderr fixture (TLS-trust + network markers in a single stderr: `proxyconnect tcp: tls: failed to verify certificate: x509: certificate signed by unknown authority`) asserts the tls-trust classification wins. Mutation-verified: reordering `_probe_transient_class` to check network first fails the fixture with `AssertionError: tls-trust must win over network`.
3. **Bare `certificate has expired` literal (advisory 3): NOT adopted, with pinning evidence.** The `gh attestation` command set was introduced in gh v2.49.0 (published 2024-04-30, official release notes read live via `gh api repos/cli/cli/releases/tags/v2.49.0`), seven months after Go 1.19 (the last toolchain emitting the bare literal) reached EOL on 2023-09-06. No gh build that accepts the production argv was ever built on Go <1.20, so the bare literal is unpinnable live by construction; the local gh 2.96.0 is built with go1.26.4 (`go version -m`). The Go >=1.20 umbrella `tls: failed to verify certificate` already covers trusted-but-expired chains.

## Live pinning (byte-exact production argv, gh 2.96.0, 2026-08-19)

Argv built by importing `attestation_verify_argv` from this branch's script (`gh attestation verify <probe> -R synaptent/aragora --signer-workflow synaptent/aragora/.github/workflows/openapi.yml --source-digest 6955ab420ed959dcce9cece4120b298453adc9c3 --format json`), run in scratch `$HOME`s with loopback-only proxy environments (no trust-store or real-cache mutation):

| run | environment | rc | stderr |
|---|---|---|---|
| control | healthy network, cold cache | 1 | `Error: HTTP 404: Not Found (https://api.github.com/repos/synaptent/aragora/attestations/sha256:...)` |
| dead proxy, all traffic | `HTTPS_PROXY=http://127.0.0.1:9`, cold cache | 1 | `error creating Sigstore verifier: no valid Sigstore verifiers could be initialized` |
| dead proxy, TUF only | same + `NO_PROXY=api.github.com` | 1 | same bare verifier-init line |
| corrupt TUF cache, offline | 12 cache files garbaged + dead proxy | 1 | same bare verifier-init line |
| **corrupt TUF cache, healthy network** | 12 cache files garbaged, no proxy | 1 | **same bare verifier-init line — gh does not self-heal; retry-on-connectivity is empirically false** |
| MITM CONNECT proxy toward TUF | self-signed cert; proxy log shows 3x `CONNECT tuf-repo-cdn.sigstore.dev:443` + 3x `CONNECT tuf-repo.github.com:443`, all client-aborted on bad certificate | 1 | same bare verifier-init line — TLS cause swallowed, no tls-trust markers surface |

The cache location is `$HOME/.cache/gh/.sigstore/root/` (two TUF repos: `tuf-repo.github.com`, `tuf-repo-cdn.sigstore.dev`). Because gh swallows every underlying cause into the same bare line, the verifier-init check sits between tls-trust and network in `_probe_transient_class`: today's live shape carries no other markers, and a future gh that appends the swallowed cause must not degrade to the network class's false transience promise.

## Validation

- Red-first: `python3 -m pytest tests/scripts/test_openapi_workflow_contract.py::test_envelope_preflight_probe_names_transient_classes_before_marker_drift -q` FAILED pre-implementation (`AssertionError: assert 'could not initialize the Sigstore verifier' in 'blo...'`), passes post-implementation.
- Full file: `python3 -m pytest tests/scripts/test_openapi_workflow_contract.py -q` -> `46 passed`.
- VAL-CDG-012 selector (12 tests): `12 passed, 34 deselected`; AST `get_source_segment` compare vs `origin/main` shows the ONLY changed function in the test file is the probe test — all 12 selector tests byte-identical.
- `make lint` PASS; `ruff format --check aragora/ tests/ scripts/` PASS (10814 files); `bash scripts/preflight_mypy.sh --diff-base origin/main` PASS (2 source files, no issues); AWS-neutralized `make test-smoke` PASS; `bash scripts/automation_pr_preflight.sh origin/main HEAD` PASS.
- Measured LOC: `git diff --numstat origin/main...HEAD` = scripts/openapi_release_envelope.py +33/-11, tests/scripts/test_openapi_workflow_contract.py +61/-11; total +94/-22 = 116 changed lines (<=800).

## Risks

- Message-only classification change: no exit-class, retry-ladder, or marker-drift fall-through behavior changes; the new class still exits `EXIT_BLOCKED` with the observed stderr embedded.
- The verifier-init wording steers operators to cache repair/TUF reachability instead of a connectivity retry; for the genuinely-transient dead-TUF-surface case the message still names reachability restoration, so no repair path is hidden.

## Status

Parked draft per feature mandate (`operator-review-required`): no ready, no evidence posting, no settlement, no merge. Fresh unposted exact-head claude+openai evidence and the settlement packet accompany this PR in the mission library.
