### PR TITLE
fix(scripts): keep check_sdk_parity stderr free of import-time DeprecationWarnings

### DIFF
--- a/aragora/connectors/enterprise/documents/gsheets.py
+++ b/aragora/connectors/enterprise/documents/gsheets.py
@@ -31,7 +31,7 @@ from aragora.connectors.enterprise.base import (
     SyncState,
 )
 from aragora.reasoning.provenance import SourceType
-from aragora.server.http_client_pool import get_http_pool
+from aragora.observability.http_client_pool import get_http_pool
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/connectors/enterprise/itsm/servicenow.py
+++ b/aragora/connectors/enterprise/itsm/servicenow.py
@@ -28,7 +28,7 @@ from aragora.connectors.enterprise.base import (
     SyncState,
 )
 from aragora.reasoning.provenance import SourceType
-from aragora.server.http_client_pool import get_http_pool
+from aragora.observability.http_client_pool import get_http_pool
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/debate/event_bus.py
+++ b/aragora/debate/event_bus.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 from typing import Any
 from collections.abc import Callable, Coroutine
 
-from aragora.server.middleware.tracing import get_span_id, get_trace_id
+from aragora.observability.middleware.tracing import get_span_id, get_trace_id
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/knowledge/mound/api/crud.py
+++ b/aragora/knowledge/mound/api/crud.py
@@ -54,7 +54,7 @@ def _mock_trace_context(
 # Pre-declare trace_context for optional import
 trace_context: Any = _mock_trace_context
 try:
-    from aragora.server.middleware.tracing import trace_context
+    from aragora.observability.middleware.tracing import trace_context  # type: ignore[no-redef]
 
     TRACING_AVAILABLE = True
 except ImportError:

--- a/aragora/knowledge/mound/api/query.py
+++ b/aragora/knowledge/mound/api/query.py
@@ -72,7 +72,7 @@ def _mock_trace_context(
 # Pre-declare trace_context for optional import
 trace_context: Any = _mock_trace_context
 try:
-    from aragora.server.middleware.tracing import trace_context  # type: ignore[no-redef]
+    from aragora.observability.middleware.tracing import trace_context  # type: ignore[no-redef]
 
     TRACING_AVAILABLE = True
 except ImportError:

--- a/aragora/server/handlers/debates/implementation.py
+++ b/aragora/server/handlers/debates/implementation.py
@@ -32,7 +32,7 @@ from aragora.pipeline.decision_integrity import (
     coerce_debate_result,
 )
 from aragora.pipeline.execution_mode import ExecutionMode as SafetyMode
-from aragora.server.decision_integrity_utils import (
+from aragora.pipeline.decision_integrity_utils import (
     ensure_decision_plan_backbone_run,
     execute_decision_plan_with_backbone,
     sync_decision_plan_backbone_receipt,

--- a/aragora/server/handlers/decisions/pipeline.py
+++ b/aragora/server/handlers/decisions/pipeline.py
@@ -32,7 +32,7 @@ from aragora.pipeline.backbone_errors import (
 from aragora.pipeline.decision_plan.factory import normalize_execution_mode
 from aragora.pipeline.execution_mode import ExecutionMode as SafetyMode
 from aragora.resilience import get_circuit_breaker
-from aragora.server.decision_integrity_utils import (
+from aragora.pipeline.decision_integrity_utils import (
     ensure_decision_plan_backbone_run,
     execute_decision_plan_with_backbone,
     sync_decision_plan_backbone_receipt,

--- a/aragora/server/middleware/auth.py
+++ b/aragora/server/middleware/auth.py
@@ -42,16 +42,6 @@ from collections.abc import Callable
 
 from aragora.utils.request_ip import extract_client_ip as _extract_client_ip
 
-try:
-    warnings.warn(
-        "aragora.server.middleware.auth.extract_client_ip is deprecated; "
-        "import aragora.utils.request_ip.extract_client_ip instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-except DeprecationWarning:
-    pass
-
 if TYPE_CHECKING:
     from aragora.rbac.models import AuthorizationContext
     from aragora.server.handlers.base import HandlerResult

--- a/aragora/server/middleware/user_auth.py
+++ b/aragora/server/middleware/user_auth.py
@@ -42,16 +42,6 @@ from collections.abc import Callable
 
 from aragora.utils.request_ip import extract_client_ip as _extract_client_ip
 
-try:
-    warnings.warn(
-        "aragora.server.middleware.user_auth.extract_client_ip is deprecated; "
-        "import aragora.utils.request_ip.extract_client_ip instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-except DeprecationWarning:
-    pass
-
 if TYPE_CHECKING:
     pass
 

--- a/scripts/check_sdk_parity.py
+++ b/scripts/check_sdk_parity.py
@@ -29,6 +29,7 @@ import os
 import re
 import sys
 import tempfile
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -165,8 +166,62 @@ def _collect_routes_from_handler_class(handler_cls: type[Any]) -> list[str]:
     return sorted(collected)
 
 
+# Modules the handler cascade still reaches transitively that emit a
+# module-level DeprecationWarning on first import: compatibility shims, plus
+# one handler module carrying a module-level notice for a single deprecated
+# function. Their remaining in-tree importers are migrated on separate
+# tracks, so this diagnostic script imports each module once under a locally
+# scoped filter instead. sys.modules caching guarantees the warning cannot
+# fire again during the cascade, and the filter list is restored on scope
+# exit, so no global warning state (and no package __init__) is ever touched.
+_LEGACY_WARNING_MODULES: tuple[str, ...] = (
+    "aragora.server.errors",
+    "aragora.debate.protocol",
+    "aragora.server.metrics",
+    "aragora.server.redis_config",
+    "aragora.server.storage",
+    "aragora.server.http_client_pool",
+    "aragora.server.handlers.webhooks",
+)
+
+
+def _preimport_legacy_warning_modules_quietly() -> None:
+    """Import the known modules, muting only their own DeprecationWarnings.
+
+    Capture-and-replay instead of an ignore filter: third-party imports deep
+    in these chains call ``warnings.simplefilter`` themselves, which would
+    front-run any filter installed here. ``record=True`` intercepts at the
+    ``showwarning`` level, which such filter mutations cannot bypass, and the
+    scope exit restores the pre-existing filter state so nothing leaks out.
+    """
+    for module_path in _LEGACY_WARNING_MODULES:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                importlib.import_module(module_path)
+            except (ImportError, AttributeError, ModuleNotFoundError):
+                # Same tolerance as the handler cascade below; a module that
+                # fails here fails identically there and is reported there.
+                continue
+        for captured in caught:
+            is_known_notice = issubclass(captured.category, DeprecationWarning) and str(
+                captured.message
+            ).startswith(_LEGACY_WARNING_MODULES)
+            if is_known_notice:
+                continue
+            # Replay everything else through the real (restored) filters so
+            # only the known notices above are actually silenced.
+            warnings.warn_explicit(
+                captured.message,
+                captured.category,
+                captured.filename,
+                captured.lineno,
+            )
+
+
 def extract_handler_routes_with_status() -> HandlerRouteExtractionResult:
     """Extract ROUTES from handler classes and report availability state."""
+    _preimport_legacy_warning_modules_quietly()
     try:
         from aragora.server.handlers._lazy_imports import ALL_HANDLER_NAMES, HANDLER_MODULES
     except (ImportError, ModuleNotFoundError) as exc:

--- a/tests/scripts/test_check_sdk_parity.py
+++ b/tests/scripts/test_check_sdk_parity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -802,3 +803,51 @@ def test_advisory_is_absent_from_json_mode_output(monkeypatch, tmp_path, capsys)
     json.loads(captured.out)
     assert "run --tighten to bank this progress" not in captured.out
     assert captured.err == ""
+
+
+# ---------------------------------------------------------------------------
+# Import-time DeprecationWarning hygiene on the stderr diagnostics stream
+# ---------------------------------------------------------------------------
+
+
+def test_representative_invocation_stderr_free_of_deprecation_warnings():
+    """The production argv must not leak import-time DeprecationWarnings.
+
+    The handler-import cascade only happens on a real run, so this drives the
+    script as a subprocess with the committed baseline/budget files. Only
+    DeprecationWarning lines are asserted; other stderr diagnostics remain
+    allowed.
+    """
+    script = PROJECT_ROOT / "scripts" / "check_sdk_parity.py"
+    baseline = PROJECT_ROOT / "scripts" / "baselines" / "check_sdk_parity.json"
+    budget = PROJECT_ROOT / "scripts" / "baselines" / "check_sdk_parity_budget.json"
+    # Neutralize ambient AWS credentials and warning overrides so the run is
+    # deterministic across dev machines and CI runners.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
+    env.pop("PYTHONWARNINGS", None)
+    env["AWS_EC2_METADATA_DISABLED"] = "true"
+    env.setdefault("ARAGORA_SECRETS_STRICT", "false")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--strict",
+            "--baseline",
+            str(baseline),
+            "--budget",
+            str(budget),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+        env=env,
+        timeout=600,
+        check=False,
+    )
+    # rc 0 (green) and rc 1 (budget breach) are both completed runs; anything
+    # else, or a traceback, means the checker itself broke.
+    assert proc.returncode in (0, 1), proc.stderr
+    assert "Traceback" not in proc.stderr, proc.stderr
+    assert proc.stdout.strip(), "checker produced no report on stdout"
+    deprecation_lines = [line for line in proc.stderr.splitlines() if "DeprecationWarning" in line]
+    assert deprecation_lines == [], "\n".join(deprecation_lines)


### PR DESCRIPTION
## Source

Mission feature `misc-handler-import-deprecation-cleanup` (milestone `cdg-bootstrap-route-truth`): bounded cleanup of the ~3.7KB of pre-existing import-time DeprecationWarnings that `scripts/check_sdk_parity.py` emits on stderr, polluting the diagnostics stream PR #9794 introduced. Discovered during #9794 prep; branched from post-#9794 main (`6955ab420e`).

**Prep-only Tier-4 parking per feature mandate:** this draft stays parked with label `operator-review-required`. All model-evidence rounds were run prepare-only (`apply=False`, nothing posted). No ready/settle/merge is authorized for this worker.

## Measure-first baseline (fresh main `6955ab420e`)

Representative invocation (the CI argv):

```
python3 scripts/check_sdk_parity.py --strict \
  --baseline scripts/baselines/check_sdk_parity.json \
  --budget scripts/baselines/check_sdk_parity_budget.json
```

- exit 0; stdout 1406 bytes (`missing_from_both 0/0 | stale_python 36/36`); `--json` variant stdout 61185 bytes
- stderr 3167 bytes containing exactly **11 DeprecationWarnings** (deterministic across runs)
- Display root cause: the handler cascade imports `weaviate`, whose `__init__` calls a bare `warnings.simplefilter("default")`, prepending a match-all filter above Python's ambient `ignore::DeprecationWarning`; every shim warn after that point displays.

## Per-warning disposition (all 11 baseline warnings)

| # | Baseline stderr attribution | Deprecated path | Disposition | Justification |
|---|---|---|---|---|
| 1 | `aragora/server/middleware/__init__.py:46` | `middleware.auth.extract_client_ip` notice | **Source fix**: removed spurious module-level warn in `auth.py` | The module-level warn fired on every import of the module, not on use of the deprecated function. The call-time warn inside the `extract_client_ip` wrapper is kept, so real deprecated *use* still warns. |
| 2 | `aragora/server/middleware/auth.py:138` | `middleware.user_auth.extract_client_ip` notice | **Source fix**: removed spurious module-level warn in `user_auth.py` | Same as #1; call-time wrapper warn kept. |
| 3 | `aragora/server/middleware/exception_handler.py:46` | `aragora.server.errors` shim | **Checker-scoped** | 18 eagerly-loaded in-tree importers reach this shim during the cascade; migrating all of them exceeds this feature's bounded scope (import-path migrations only, minimal module set). |
| 4 | `aragora/knowledge/mound/api/crud.py:57` | `aragora.server.middleware.tracing` shim | **Source fix**: migrated all 3 eagerly-loaded importers (`debate/event_bus.py`, `knowledge/mound/api/crud.py`, `knowledge/mound/api/query.py`) to `aragora.observability.middleware.tracing` | Bounded (3 files), and all are clean under the repo changed-file mypy gate after the touch (crud needed the same `# type: ignore[no-redef]` its sibling query.py already carries). |
| 5 | `aragora/knowledge/vector_store.py:30` | `aragora.server.metrics` shim | **Checker-scoped** | Its eager importers carry pre-existing mypy debt that the changed-file gate would surface on touch (`knowledge/vector_store.py` alone: 10 pre-existing errors on clean main). |
| 6 | `aragora/connectors/enterprise/documents/gsheets.py:34` | `aragora.server.http_client_pool` shim | **Source fix** for `gsheets.py` + `itsm/servicenow.py` (migrated to `aragora.observability.http_client_pool`); shim itself also **checker-scoped** | The third eager importer, `crm/salesforce.py`, carries 7 pre-existing mypy errors on clean main; touching it turns the changed-file gate red on inherited debt, so it stays unfixed here and the shim warn is silenced checker-side. |
| 7 | `aragora/debate/model_combinations.py:22` | `aragora.debate.protocol` shim | **Checker-scoped** | 23 eagerly-loaded in-tree importers; migration exceeds bounded scope. |
| 8 | `aragora/server/middleware/rate_limit/redis_limiter.py:95` | `aragora.server.redis_config` shim | **Checker-scoped** | The sole importer surfaced in the cascade (`redis_limiter.py`) is path-frozen by open PR #8939; editing it violates the open-PR path freeze. |
| 9 | `aragora/server/handlers/debates/implementation.py:35` | `aragora.server.decision_integrity_utils` shim | **Source fix**: migrated both eager importers (`handlers/debates/implementation.py`, `handlers/decisions/pipeline.py`) to `aragora.pipeline.decision_integrity_utils` | Bounded (2 files), mypy-clean after touch; all other tests already patch these names on the importer modules, so patch targets are unaffected. |
| 10 | `aragora/server/handlers/social/_slack_impl/commands.py:21` | `aragora.server.storage` shim | **Checker-scoped** | The sole runtime importer (`_slack_impl/commands.py`) carries 2 pre-existing mypy errors on clean main; the other importers are TYPE_CHECKING-only and never execute. |
| 11 | `aragora/server/handlers/webhooks/__init__.py:17` | module-level notice in `handlers/webhooks.py` for `generate_signature` | **Checker-scoped** | `webhooks.py` carries 15 pre-existing mypy errors on clean main, so the spurious module-level warn cannot be removed at source without tripping the changed-file gate on inherited debt. The call-time warn inside `generate_signature` is untouched, so deprecated *use* still warns. |

Pre-existing-debt counts above were verified on clean main: `python3 -m mypy --pretty` over the three debt files reports **25 errors on origin/main** (webhooks.py 15, salesforce.py 7 + 1 fixed-by-annotation candidate, commands.py 2) with zero of them on lines this PR would have authored.

## The checker-scoped mechanism (narrow, never global)

`scripts/check_sdk_parity.py` gains `_preimport_legacy_warning_modules_quietly()`, called only at the top of `extract_handler_routes_with_status()`:

- It imports each of the 7 listed modules once inside `warnings.catch_warnings(record=True)`. Capture-and-replay is used instead of an ignore filter because third-party imports deep in these chains (weaviate) call `simplefilter` themselves, which would front-run any filter installed here; `record=True` intercepts at the `showwarning` level, which in-chain filter mutations cannot bypass.
- Only DeprecationWarnings whose message starts with one of the 7 listed module paths are dropped; every other captured warning is replayed via `warnings.warn_explicit` through the restored ambient filters.
- The filter list and `showwarning` are restored on scope exit, so **no global warning state leaks** and nothing is touched in any package `__init__`. `sys.modules` caching guarantees the module-level warns cannot re-fire during the cascade.
- Import-failure tolerance mirrors the cascade's own `except (ImportError, AttributeError, ModuleNotFoundError)`.

This is deliberately scoped to the checker process's handler extraction only; library code, package `__init__`s, and global filters are untouched.

## Behavior preservation (byte-level)

- plain argv: exit 0 == 0; stdout **byte-identical** (1406 bytes, `cmp`)
- `--json` argv: exit 0 == 0; stdout **byte-identical** (61185 bytes, `cmp`)
- stderr: 3167 B / 11 DeprecationWarnings → **221 B / 0 DeprecationWarnings** (remaining stderr is the two benign auth/JWT log notices)
- No public API changes, no handler semantics changes; the 9 touched `aragora/` files change import sources or delete spurious module-level warns only.

## Validation

| Command | Result |
|---|---|
| `python3 -m pytest tests/scripts/test_check_sdk_parity.py -q --timeout=600` | 49 passed (new subprocess test `test_representative_invocation_stderr_free_of_deprecation_warnings` captured RED on baseline first: 1 failed listing the 11 warnings) |
| byte-parity harness (both argvs, fresh-main worktree vs this head) | stdout `cmp` identical, rc 0/0, DW 11→0 |
| `make lint` + `ruff format --check aragora/ tests/ scripts/` | pass (10814 files) |
| `bash scripts/preflight_mypy.sh --diff-base origin/main` | Success: no issues found in 11 source files |
| affected-area battery: `tests/handlers/debates/test_implementation.py`, `tests/handlers/decisions/test_pipeline.py`, `tests/debate/test_event_bus.py`, `tests/server/middleware/test_auth.py`, `tests/server/middleware/test_user_auth.py`, `tests/handlers/test_webhooks.py`, `tests/connectors/enterprise/itsm/test_servicenow.py`, `tests/connectors/enterprise/crm/test_salesforce.py`, `tests/connectors/enterprise/documents/test_gsheets.py`, `tests/scripts/test_check_sdk_parity.py` | 611 passed, 2 failed — both `TestServiceNowErrorHandling` failures reproduce identically on clean origin/main (pre-existing, untouched by this PR) |
| `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke` | Smoke tests passed |
| `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` | 138 passed |
| seed sweep `tests/scripts/test_check_sdk_parity.py` (seeds 1, 42, 100, 2024, 12345) | 49 passed × 5 |
| `bash scripts/automation_pr_preflight.sh origin/main HEAD` | preflight: ok |

## Overlap authority

- Fresh census (92 open PRs, none ≥100 files): all 9 touched `aragora/` paths CLEAN; `scripts/check_sdk_parity.py` + `tests/scripts/test_check_sdk_parity.py` overlap **only #9675** at exactly the tolerated pin `12ffb6f1ee1df161318af5bd9f5fbf04d0826a58` (OPEN, untouched), per the 2026-08-19 single-use operator overlap lift naming this feature id (recorded in mission AGENTS.md "Handler-Deprecation #9675 Overlap Lift" + `library/operator-approvals.md`).
- PR #8939's freeze on `rate_limit/redis_limiter.py` is respected (file untouched; its shim routed checker-side, row 8).

## Risks

- The checker now imports the 7 listed modules marginally earlier than the cascade would (same process, same modules); stdout/exit byte-parity above shows no observable effect.
- If a new eagerly-loaded importer of a *source-fixed* shim is added later, its warn would resurface on stderr; the new red-first subprocess test pins the invariant and will catch it.
- The dropped notices are module-level import-time warns only; all call-time deprecation warns (`extract_client_ip` wrappers, `generate_signature`) still fire on real deprecated use.

## Numstat (machine-derived, `git diff --numstat origin/main...HEAD`)

```
1   1   aragora/connectors/enterprise/documents/gsheets.py
1   1   aragora/connectors/enterprise/itsm/servicenow.py
1   1   aragora/debate/event_bus.py
1   1   aragora/knowledge/mound/api/crud.py
1   1   aragora/knowledge/mound/api/query.py
1   1   aragora/server/handlers/debates/implementation.py
1   1   aragora/server/handlers/decisions/pipeline.py
0   10  aragora/server/middleware/auth.py
0   10  aragora/server/middleware/user_auth.py
55  0   scripts/check_sdk_parity.py
49  0   tests/scripts/test_check_sdk_parity.py
TOTAL: 11 files, +111 -27 = 138 changed lines
```
