### PR TITLE
docs(testing): refresh the skip-audit inventory and correct stale skip-count claims

### DIFF
--- a/docs/status/TEST_SKIP_BURNDOWN.md
+++ b/docs/status/TEST_SKIP_BURNDOWN.md
@@ -1,39 +1,44 @@
 # Test Skip Burndown
 
-Last updated: 2026-04-06
+Last updated: 2026-08-19
 
 This file tracks intentional test-skip debt reduction so `tests/.skip_baseline`
 stays actionable and does not hide regressions.
 
 ## Current Baseline
 
-- Total skip markers: `57`
+- Total skip markers: `86`
 - Source command: `python scripts/audit_test_skips.py --json`
-- CI baseline file: `tests/.skip_baseline` = `57`
+- CI baseline file: `tests/.skip_baseline` = `86`
 - Marker types:
-  - `skipif`: `34`
-  - `pytest.skip`: `18`
+  - `pytest.skip`: `40`
+  - `skipif`: `39`
+  - `pytest.importorskip`: `5`
   - `skip`: `2`
+
+> Provenance: re-measured 2026-08-19 via `python3 scripts/audit_test_skips.py --json` on main `6955ab420e` (baseline settled at 86 by PR #9795).
 
 ### Category Snapshot
 
 | Category | Count | Weekly target |
 |---|---:|---:|
-| `missing_feature` | 12 | -2 |
 | `integration_dependency` | 29 | hold |
+| `uncategorized` | 20 | — |
+| `missing_feature` | 17 | -2 |
+| `optional_dependency` | 9 | -1 |
 | `platform_specific` | 6 | hold |
-| `optional_dependency` | 4 | -1 |
-| `performance` | 3 | hold |
+| `performance` | 4 | hold |
+| `known_bug` | 1 | — |
 
 ## Highest-Skip Files
 
 | File | Count |
 |---|---:|
 | `tests/integration/test_knowledge_visibility_sharing.py` | 6 |
-| `tests/test_plugin_sandbox.py` | 4 |
+| `tests/swarm/test_quorum_evidence.py` | 4 |
+| `tests/plugins/test_plugin_sandbox.py` | 4 |
 | `tests/debate/test_voting_engine.py` | 3 |
-| `tests/test_proofs.py` | 2 |
-| `tests/test_broadcast_audio.py` | 2 |
+| `tests/ranking/test_calibration_engine.py` | 2 |
 
 ## Execution Rules
 

--- a/docs/testing/TEST_SKIP_POLICY.md
+++ b/docs/testing/TEST_SKIP_POLICY.md
@@ -6,7 +6,9 @@ This document defines the policy for using `@pytest.mark.skip` markers in the Ar
 
 Skip markers are essential for maintaining a green CI pipeline while allowing tests that depend on optional components. However, excessive or stale skips reduce test coverage confidence.
 
-**Current baseline:** ~370 skip markers (tracked in `tests/.skip_baseline`)
+**Current baseline:** 86 skip markers (tracked in `tests/.skip_baseline`)
+
+> Provenance: re-measured 2026-08-19 via `python3 scripts/audit_test_skips.py --count-only` on main `6955ab420e` (baseline settled at 86 by PR #9795).
 
 ## Categories
 
@@ -106,17 +108,17 @@ Target: Maintain skip count within 10% of baseline.
 
 ## Current Distribution
 
-As of 2026-02:
+As of 2026-08-19:
 
 | Category | Count | Status |
 |----------|-------|--------|
-| optional_dependency | ~173 | Valid (environment-based) |
-| missing_feature | ~130 | Valid (roadmap items) |
-| integration_dependency | ~26 | Valid (external services) |
-| uncategorized | ~16 | Needs review |
-| known_bug | ~11 | Actionable tech debt |
-| platform_specific | ~10 | Valid (OS compatibility) |
-| performance | ~3 | Valid (resource limits) |
+| optional_dependency | 9 | Valid (environment-based) |
+| missing_feature | 17 | Valid (roadmap items) |
+| integration_dependency | 29 | Valid (external services) |
+| uncategorized | 20 | Needs review |
+| known_bug | 1 | Actionable tech debt |
+| platform_specific | 6 | Valid (OS compatibility) |
+| performance | 4 | Valid (resource limits) |
 
 ## Related Files
 

--- a/scripts/audit_test_skips.py
+++ b/scripts/audit_test_skips.py
@@ -663,9 +663,9 @@ def main():
         markdown = generate_markdown(report)
         docs_path.write_text(markdown)
 
-        # Update baseline
+        # Update baseline (single integer plus LF, matching the committed convention)
         baseline_path = tests_dir / ".skip_baseline"
-        baseline_path.write_text(str(report["total"]))
+        baseline_path.write_text(f"{report['total']}\n")
         _emit_output(
             "\n".join(
                 [

--- a/tests/SKIP_AUDIT.md
+++ b/tests/SKIP_AUDIT.md
@@ -1,7 +1,7 @@
 # Test Skip Marker Audit
 
-**Generated**: 2026-07-23
-**Total Skip Markers**: 83
+**Generated**: 2026-08-19
+**Total Skip Markers**: 86
 
 ---
 
@@ -9,20 +9,20 @@
 
 | Category | Count | Percentage |
 |----------|-------|------------|
-| integration_dependency | 29 | 34.9% |
-| missing_feature | 17 | 20.5% |
-| uncategorized | 17 | 20.5% |
-| optional_dependency | 9 | 10.8% |
-| platform_specific | 6 | 7.2% |
-| performance | 4 | 4.8% |
+| integration_dependency | 29 | 33.7% |
+| uncategorized | 20 | 23.3% |
+| missing_feature | 17 | 19.8% |
+| optional_dependency | 9 | 10.5% |
+| platform_specific | 6 | 7.0% |
+| performance | 4 | 4.7% |
 | known_bug | 1 | 1.2% |
 
 ## Summary by Marker Type
 
 | Type | Count |
 |------|-------|
-| `pytest.skip` | 39 |
-| `skipif` | 37 |
+| `pytest.skip` | 40 |
+| `skipif` | 39 |
 | `pytest.importorskip` | 5 |
 | `skip` | 2 |
 
@@ -36,10 +36,10 @@
 | `tests/debate/test_voting_engine.py` | 3 |
 | `tests/ranking/test_calibration_engine.py` | 2 |
 | `tests/inbox/test_inbox_receipt_convergence.py` | 2 |
+| `tests/server/middleware/rate_limit/test_distributed_integration.py` | 2 |
+| `tests/server/startup/test_validation.py` | 2 |
 | `tests/triage/test_auto_handle_calibration.py` | 2 |
 | `tests/storage/test_integration_store.py` | 2 |
-| `tests/verification/test_proofs_root.py` | 2 |
-| `tests/performance/test_load.py` | 2 |
 
 ---
 
@@ -71,10 +71,7 @@
 
 ## Skip Count Baseline
 
-Current baseline: **83** skips
-
-This regeneration lowers the baseline from 84 to 83 after replacing the
-vacuous provider-config catalog skip with a fail-closed coverage assertion.
+Current baseline: **86** skips
 
 CI will warn if skip count exceeds this baseline.
 Update `tests/.skip_baseline` when intentionally adding skips.

--- a/tests/scripts/test_audit_test_skips.py
+++ b/tests/scripts/test_audit_test_skips.py
@@ -105,3 +105,39 @@ def test_main_default_summary_uses_pipe_safe_emitter(
     assert "Total skip markers: 2" in emitted[0]
     assert "known_bug: 1" in emitted[0]
     assert "tests/test_example.py: 2" in emitted[0]
+
+
+def test_main_update_docs_writes_baseline_with_trailing_newline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["audit_test_skips.py", "--update-docs", "--tests-dir", str(tests_dir)],
+    )
+    monkeypatch.setattr(audit_test_skips, "audit_skips", lambda _tests_dir: [])
+    monkeypatch.setattr(
+        audit_test_skips,
+        "generate_report",
+        lambda _markers: {
+            "total": 7,
+            "by_category": {},
+            "by_type": {},
+            "by_file": {},
+            "high_skip_files": [],
+            "markers": [],
+            "generated_at": "2026-06-13T00:00:00",
+        },
+    )
+    monkeypatch.setattr(audit_test_skips, "generate_markdown", lambda _report: "# stub\n")
+    monkeypatch.setattr(audit_test_skips, "_emit_output", lambda _output: None)
+
+    audit_test_skips.main()
+
+    assert (tests_dir / "SKIP_AUDIT.md").read_text() == "# stub\n"
+    # The committed tests/.skip_baseline convention is a single integer plus LF.
+    assert (tests_dir / ".skip_baseline").read_text() == "7\n"


### PR DESCRIPTION
## Summary

Docs-plus-hygiene sweep for the stale skip-audit documentation discovered during the `misc-test-skip-audit-baseline-refresh` prep. All counts are machine-measured on main `6955ab420e` (live count settled at 86 by PR #9795).

| File | +/− | Change |
|---|---|---|
| `tests/SKIP_AUDIT.md` | +13/−16 | Regenerated via the script's documented regen path (`python3 scripts/audit_test_skips.py --update-docs`): Generated 2026-08-19, Total 86 (was stuck at 2026-07-23 / 83) |
| `docs/status/TEST_SKIP_BURNDOWN.md` | +16/−11 | Corrected stale baseline claim 57 → 86 plus the same doc's stale marker-type/category/high-skip tables to measured values; one-line provenance note |
| `docs/testing/TEST_SKIP_POLICY.md` | +11/−9 | Corrected stale "~370 skip markers" claim → 86 and the tied "Current Distribution" table to measured values; one-line provenance note |
| `scripts/audit_test_skips.py` | +2/−2 | ONE bounded hygiene alignment: `--update-docs` baseline writer now emits `<total>\n` (was `write_text(str(total))` without LF) matching the committed single-integer-plus-LF convention (`tests/.skip_baseline` is `86\n`). Red-first tested |
| `tests/scripts/test_audit_test_skips.py` | +36/−0 | New red-first test `test_main_update_docs_writes_baseline_with_trailing_newline`; captured red on the pre-fix writer: `AssertionError: assert '7' == '7\n'` |

**116 changed LOC total (78+/38−).**

## Measured values (2026-08-19, main `6955ab420e`)

- Total: **86** (`--count-only`), equal to committed `tests/.skip_baseline` (`86\n`, byte-identical, **not modified by this PR**)
- By type: `pytest.skip` 40, `skipif` 39, `pytest.importorskip` 5, `skip` 2
- By category: integration_dependency 29, uncategorized 20, missing_feature 17, optional_dependency 9, platform_specific 6, performance 4, known_bug 1

## Authority and freeze posture

- `tests/SKIP_AUDIT.md` is #9556-frozen. This PR proceeds under the operator's **2026-08-19 single-use path-freeze lift over exactly that one path**, recorded in both authority files (mission AGENTS.md section "Skip-Audit-Docs #9556 Path-Freeze Lift" and the matching Decision in `library/operator-approvals.md`). PR #9556 (head `520ab0aeca03`) stays OPEN and untouched; re-verified unchanged immediately before this push.
- Fresh overlap census over every touched path at prep and again pre-push (93 open PRs, none ≥100 files): zero foreign owners; only the tolerated #9556 on `tests/SKIP_AUDIT.md` / `tests/.skip_baseline`.
- `tests/.skip_baseline` is NOT lifted and is not edited: after the LF fix, regen writes `86\n` over the identical committed bytes, so the path is absent from this diff (verified via `git status` and `xxd`).
- No threshold, baseline-value, or workflow edits. CI consumes only `tests/.skip_baseline`, so this PR is docs-plus-hygiene only.

## Verification

- `make lint`: pass; `ruff format --check aragora/ tests/ scripts/`: pass (10814 files already formatted)
- `python3 -m pytest tests/scripts/test_audit_test_skips.py -q`: 4 passed; 5-run seed sweep (PYTHONHASHSEED 101/202/303/404/505): 4 passed each
- Red-first: new test failed pre-fix with `AssertionError: assert '7' == '7\n'`, green post-fix
- `python3 scripts/ci/check_docs_links.py`: OK; `python3 scripts/check_docs_consistency.py`: PASS, no findings
- AWS-neutralized `make test-smoke`: "Smoke tests passed!"
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: preflight ok
- `bash scripts/preflight_mypy.sh --diff-base origin/main`: exit 1 with 5 errors, **all pre-existing at identical lines in the origin/main versions of both touched Python files** (verified by running the same mypy env against the origin/main blobs: `scripts/audit_test_skips.py:331,381,543`, `tests/scripts/test_audit_test_skips.py:44,78`). Zero new errors introduced; annotations left untouched for scope discipline.

## Known residual (intentionally out of scope)

`docs/testing/TEST_SKIP_POLICY.md` "CI Enforcement" still describes "Warns 1-5 / Fails >5"; the actual lane fails iff CURRENT − BASELINE > 2 with no warn band. Not one of the two named stale claims for this feature ("change NOTHING else"), so it is disclosed here rather than edited.

## Status

Parked draft, `operator-review-required`. Prepare-only feature: all evidence rounds run with apply=False, evidence stays unposted, and no ready/settle/merge action is taken. Mission feature: `misc-skip-audit-docs-refresh` (milestone `cdg-bootstrap-route-truth`).
