### PR TITLE
chore(tiers): regenerate module_tiers.yaml to clear ambient Module Tier Drift red

### DIFF
--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -25,8 +25,8 @@ thresholds:
 
 summary:
   core: 21
-  integrated: 92
-  experimental: 29
+  integrated: 93
+  experimental: 28
   deprecated: 3
   total: 145
 
@@ -46,8 +46,8 @@ modules:
   - name: cli
     tier: core
     py_files: 124
-    importer_count: 9
-    test_file_count: 155
+    importer_count: 10
+    test_file_count: 158
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
@@ -64,7 +64,7 @@ modules:
     tier: core
     py_files: 19
     importer_count: 206
-    test_file_count: 196
+    test_file_count: 197
     override_reason: "root type hierarchy + Agent base class"
   - name: db
     tier: core
@@ -87,7 +87,7 @@ modules:
     tier: core
     py_files: 40
     importer_count: 68
-    test_file_count: 120
+    test_file_count: 122
   - name: knowledge
     tier: core
     py_files: 179
@@ -101,9 +101,9 @@ modules:
     override_reason: "ContinuumMemory + CritiqueStore — persistent state"
   - name: nomic
     tier: core
-    py_files: 165
+    py_files: 166
     importer_count: 89
-    test_file_count: 228
+    test_file_count: 230
   - name: observability
     tier: core
     py_files: 92
@@ -137,18 +137,18 @@ modules:
     test_file_count: 97
   - name: server
     tier: core
-    py_files: 1123
+    py_files: 1126
     importer_count: 150
-    test_file_count: 1897
+    test_file_count: 1902
     override_reason: "FastAPI server + 3K+ API operations"
   - name: storage
     tier: core
     py_files: 109
     importer_count: 235
-    test_file_count: 168
+    test_file_count: 169
     override_reason: "persistence layer"
 
-  # --- integrated (92) ---
+  # --- integrated (93) ---
   - name: analysis
     tier: integrated
     py_files: 29
@@ -413,8 +413,8 @@ modules:
   - name: models
     tier: integrated
     py_files: 3
-    importer_count: 8
-    test_file_count: 5
+    importer_count: 16
+    test_file_count: 6
   - name: modes
     tier: integrated
     py_files: 20
@@ -480,6 +480,11 @@ modules:
     py_files: 7
     importer_count: 10
     test_file_count: 8
+  - name: receipts
+    tier: integrated
+    py_files: 3
+    importer_count: 5
+    test_file_count: 5
   - name: replay
     tier: integrated
     py_files: 6
@@ -611,7 +616,7 @@ modules:
     importer_count: 16
     test_file_count: 11
 
-  # --- experimental (29) ---
+  # --- experimental (28) ---
   - name: advocates
     tier: experimental
     py_files: 2
@@ -687,11 +692,6 @@ modules:
     py_files: 2
     importer_count: 0
     test_file_count: 3
-  - name: receipts
-    tier: experimental
-    py_files: 3
-    importer_count: 5
-    test_file_count: 4
   - name: reports
     tier: experimental
     py_files: 2


### PR DESCRIPTION
## What

Byte-exact regeneration of `aragora/module_tiers.yaml` via the documented regen path (`python3 scripts/regenerate_module_tiers.py`) so the non-required **Module Tier Drift** lane stops failing on clean main itself. Single-file diff, 20 insertions / 20 deletions (machine numstat). No script-logic, threshold, or workflow changes.

Mission feature: `misc-module-tiers-drift-refresh` (milestone `cdg-bootstrap-route-truth`). Ambient red discovered during PR #9794 settlement attempt 2: every fresh PR evaluation showed a pre-existing drift red that settlement workers had to repeatedly re-prove ambient.

## Red-first proof (same fresh-main worktree, base `6955ab420ed959dcce9cece4120b298453adc9c3`)

**Before regen** — `python3 scripts/regenerate_module_tiers.py --check` → **exit 1**:

```
Module tier drift detected:
  TIER CHANGE: receipts 'experimental' -> 'integrated' (imports 5 -> 5, tests 4 -> 5)

Run `python scripts/regenerate_module_tiers.py` to refresh aragora/module_tiers.yaml and commit the result.
```

**Regen** — `python3 scripts/regenerate_module_tiers.py` → `Wrote aragora/module_tiers.yaml with 145 modules.`

**After regen** — `python3 scripts/regenerate_module_tiers.py --check` → **exit 0**: `No tier drift.`

## Full machine diff disclosure (mandatory, 123 lines)

The regen output is committed byte-exact, never hand-trimmed. Beyond the receipts tier move it also refreshes tier-neutral importer/test counts on 7 modules (cli, core, gauntlet, nomic, server, storage, models) and the summary block (integrated 92→93, experimental 29→28):

```diff
diff --git a/aragora/module_tiers.yaml b/aragora/module_tiers.yaml
index 4a9d58cb05..d3dbeeb4b6 100644
--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -25,8 +25,8 @@ thresholds:
 
 summary:
   core: 21
-  integrated: 92
-  experimental: 29
+  integrated: 93
+  experimental: 28
   deprecated: 3
   total: 145
 
@@ -46,8 +46,8 @@ modules:
   - name: cli
     tier: core
     py_files: 124
-    importer_count: 9
-    test_file_count: 155
+    importer_count: 10
+    test_file_count: 158
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
@@ -64,7 +64,7 @@ modules:
     tier: core
     py_files: 19
     importer_count: 206
-    test_file_count: 196
+    test_file_count: 197
     override_reason: "root type hierarchy + Agent base class"
   - name: db
     tier: core
@@ -87,7 +87,7 @@ modules:
     tier: core
     py_files: 40
     importer_count: 68
-    test_file_count: 120
+    test_file_count: 122
   - name: knowledge
     tier: core
     py_files: 179
@@ -101,9 +101,9 @@ modules:
     override_reason: "ContinuumMemory + CritiqueStore — persistent state"
   - name: nomic
     tier: core
-    py_files: 165
+    py_files: 166
     importer_count: 89
-    test_file_count: 228
+    test_file_count: 230
   - name: observability
     tier: core
     py_files: 92
@@ -137,18 +137,18 @@ modules:
     test_file_count: 97
   - name: server
     tier: core
-    py_files: 1123
+    py_files: 1126
     importer_count: 150
-    test_file_count: 1897
+    test_file_count: 1902
     override_reason: "FastAPI server + 3K+ API operations"
   - name: storage
     tier: core
     py_files: 109
     importer_count: 235
-    test_file_count: 168
+    test_file_count: 169
     override_reason: "persistence layer"
 
-  # --- integrated (92) ---
+  # --- integrated (93) ---
   - name: analysis
     tier: integrated
     py_files: 29
@@ -413,8 +413,8 @@ modules:
   - name: models
     tier: integrated
     py_files: 3
-    importer_count: 8
-    test_file_count: 5
+    importer_count: 16
+    test_file_count: 6
   - name: modes
     tier: integrated
     py_files: 20
@@ -480,6 +480,11 @@ modules:
     py_files: 7
     importer_count: 10
     test_file_count: 8
+  - name: receipts
+    tier: integrated
+    py_files: 3
+    importer_count: 5
+    test_file_count: 5
   - name: replay
     tier: integrated
     py_files: 6
@@ -611,7 +616,7 @@ modules:
     importer_count: 16
     test_file_count: 11
 
-  # --- experimental (29) ---
+  # --- experimental (28) ---
   - name: advocates
     tier: experimental
     py_files: 2
@@ -687,11 +692,6 @@ modules:
     py_files: 2
     importer_count: 0
     test_file_count: 3
-  - name: receipts
-    tier: experimental
-    py_files: 3
-    importer_count: 5
-    test_file_count: 4
   - name: reports
     tier: experimental
     py_files: 2
```

## Overlap census (fresh, 2026-08-19)

- 95 open PRs enumerated via `gh pr list --state open --limit 100 --json files`; **no PR at the 100-file pagination cap**, so the file lists are complete.
- **Zero overlap** on `aragora/module_tiers.yaml` and on all 8 consumers checked: `scripts/regenerate_module_tiers.py`, `.github/workflows/module-tier-drift.yml`, `tests/scripts/test_regenerate_module_tiers.py`, `scripts/ci/check_import_contracts.py`, `scripts/baselines/import_contracts_baseline.json`, `.importlinter`, `aragora/swarm/pr_value.py`, `tests/scripts/test_pr_value_classifier.py`.

### PR #8519 pin-movement disclosure (mandatory)

The operator's single-use census lift (AGENTS.md "Module-Tiers #8519 Overlap Lift" + 2026-08-19 Decision in `library/operator-approvals.md`) tolerated foreign PR #8519's ownership of `aragora/module_tiers.yaml` at pin `3bdd1e281e7c87a7d60474f6a37230082936e2bb`, with "pin change = fail fast".

The live #8519 head has **moved off the pin**: now `5fca28107c39efaf127d09f6a57a524491dec165` (updated 2026-08-19T14:11Z), rebased onto current main (`6955ab420e`) and narrowed to **5 files, all `aragora/prediction/**` + `tests/prediction/**`**. Its stale `module_tiers.yaml` regen hunk is **gone**, so the overlap the lift tolerated no longer exists. This PR proceeds on the plain census result (zero overlap); the lift went **unused**, and #8519 remains untouched (no adoption, comment, label, review, or branch mutation). The pin-change fail-fast guarded the census tolerance, which was not needed or relied on; this disclosure substitutes for the tolerance path.

Forward note: when #8519 merges it adds a new top-level `aragora/prediction/` module, which will produce a new one-module drift (`NEW module: prediction`) on main until the next regen. That is the known recurring property of this generated last-writer-wins file, not a defect of this refresh.

## Lane expectation on this draft

`.github/workflows/module-tier-drift.yml` skips draft PRs (`if: github.event_name != 'pull_request' || !github.event.pull_request.draft`), so this parked DRAFT shows the Module Tier Drift lane **skipped-neutral**. The authoritative in-scope evidence is the local merge-state `--check` proof above (exit 1 before / exit 0 after on the same fresh-main worktree). The lane greens on the first non-draft evaluation after the operator's ready flip.

## Validation

| Gate | Result |
| --- | --- |
| `python3 scripts/regenerate_module_tiers.py --check` (before / after, same worktree) | exit 1 → exit 0 |
| `make lint` (ruff check aragora/ tests/) | pass |
| `ruff format --check aragora/ tests/ scripts/` | pass (10814 files already formatted) |
| `bash scripts/preflight_mypy.sh --diff-base origin/main` | skipped (no python changes), exit 0 |
| `python3 -m pytest tests/scripts/test_regenerate_module_tiers.py -q` | 8 passed |
| `python3 -m pytest tests/scripts/test_pr_value_classifier.py -q` | 53 passed |
| `make test-smoke` (AWS-neutralized) | pass |
| `bash scripts/automation_pr_preflight.sh origin/main HEAD` | ok, exit 0 |

No focused-test update is included because no existing test pins the receipts tier or the summary counts (`tests/scripts/test_regenerate_module_tiers.py` holds deliberately loose invariants only; `tests/packaging/test_tiers.py` covers pyproject dependency groups, unrelated to this yaml).

## Parked draft — operator-review-required

This PR is parked as a DRAFT per the mission's prepare-only mandate: **no ready flip, no evidence posting, no settlement, no merge** is authorized from this lane. Fresh unposted exact-head model evidence and the settlement packet are prepared out-of-band for the operator.
