### PR TITLE
fix(scripts): disclose uncommitted python edits in mypy preflight

### DIFF
--- a/docs/dev/MYPY_PREFLIGHT.md
+++ b/docs/dev/MYPY_PREFLIGHT.md
@@ -26,6 +26,10 @@ The script:
 3. Otherwise runs `mypy --pretty <files...>` using the repo's existing config
    and exits with mypy's exit code (plus a short remediation hint on failure).
 
+The gate evaluates **committed state only** — staged, unstaged, or untracked
+python edits are never type-checked (the script prints a stderr warning naming
+them), so run it after committing.
+
 ## Integration suggestion
 
 Call it from Phase 2 (verification) of any lane that touches Python:

--- a/docs/dev/MYPY_PREFLIGHT.md
+++ b/docs/dev/MYPY_PREFLIGHT.md
@@ -26,9 +26,9 @@ The script:
 3. Otherwise runs `mypy --pretty <files...>` using the repo's existing config
    and exits with mypy's exit code (plus a short remediation hint on failure).
 
-The gate evaluates **committed state only** — staged, unstaged, or untracked
-python edits are never type-checked (the script prints a stderr warning naming
-them), so run it after committing.
+The gate selects files from **committed state only** — python edits outside
+the committed diff (staged, unstaged, or untracked) are never type-checked
+(the script prints a stderr warning naming them), so run it after committing.
 
 ## Integration suggestion
 

--- a/scripts/preflight_mypy.sh
+++ b/scripts/preflight_mypy.sh
@@ -92,15 +92,18 @@ ${CHANGED_FILES_RAW}
 EOF
 fi
 
-# The three-dot diff above reads committed state only, so a pre-commit run
-# with real python edits would silently skip them — surface those paths as a
-# stderr advisory without touching stdout, mypy argv, or exit codes.
+# The three-dot diff above selects files from committed state only, so a
+# pre-commit run with python edits outside that diff silently skips them.
+# Files inside the committed diff ARE handed to mypy (which reads their
+# working-tree content), so only dirty paths outside the diff are unchecked —
+# surface those as a stderr advisory without touching stdout, mypy argv, or
+# exit codes.
 UNCOMMITTED_PY="$(
     {
         git diff --name-only --cached -- '*.py' || true
         git diff --name-only -- '*.py' || true
         git ls-files --others --exclude-standard -- '*.py' || true
-    } | sort -u
+    } | sort -u | comm -23 - <(printf '%s\n' "${CHANGED_FILES}" | sort)
 )"
 if [ -n "${UNCOMMITTED_PY}" ]; then
     {

--- a/scripts/preflight_mypy.sh
+++ b/scripts/preflight_mypy.sh
@@ -92,6 +92,24 @@ ${CHANGED_FILES_RAW}
 EOF
 fi
 
+# The three-dot diff above reads committed state only, so a pre-commit run
+# with real python edits would silently skip them — surface those paths as a
+# stderr advisory without touching stdout, mypy argv, or exit codes.
+UNCOMMITTED_PY="$(
+    {
+        git diff --name-only --cached -- '*.py' || true
+        git diff --name-only -- '*.py' || true
+        git ls-files --others --exclude-standard -- '*.py' || true
+    } | sort -u
+)"
+if [ -n "${UNCOMMITTED_PY}" ]; then
+    {
+        echo "preflight_mypy: WARNING: uncommitted python changes are NOT checked by this committed-state gate (${DIFF_BASE}...HEAD):"
+        echo "${UNCOMMITTED_PY}" | sed 's/^/  /'
+        echo "preflight_mypy: commit them and re-run scripts/preflight_mypy.sh to type-check them."
+    } >&2
+fi
+
 if [ -z "${CHANGED_FILES}" ]; then
     echo "no python changes; mypy preflight skipped"
     exit 0

--- a/tests/scripts/test_preflight_mypy.py
+++ b/tests/scripts/test_preflight_mypy.py
@@ -1,10 +1,12 @@
 """Focused tests for scripts/preflight_mypy.sh.
 
-The gate reads COMMITTED state only (a three-dot ``<base>...HEAD`` diff), so
-staged, unstaged, or untracked python edits are never type-checked. These
-tests pin the committed-diff behavior byte-for-byte (stdout, exit codes, and
-the exact mypy argv captured via a PATH shim) and prove the advisory stderr
-disclosure for uncommitted python changes never alters that behavior.
+The gate selects files from COMMITTED state only (a three-dot
+``<base>...HEAD`` diff), so python edits outside that diff (staged, unstaged,
+or untracked) are never type-checked; files inside the diff are passed to
+mypy, which reads their working-tree content. These tests pin the
+committed-diff behavior byte-for-byte (stdout, exit codes, and the exact mypy
+argv captured via a PATH shim) and prove the advisory stderr disclosure for
+uncommitted python changes never alters that behavior.
 """
 
 from __future__ import annotations
@@ -182,6 +184,33 @@ def test_non_python_dirty_files_do_not_disclose(tmp_path: Path) -> None:
     assert proc.stdout == SKIP_STDOUT
     assert proc.stderr == ""
     assert not argv_out.exists()
+
+
+def test_dirty_file_inside_committed_diff_is_not_named_in_disclosure(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit_python_pair(repo)
+    env, argv_out = _shim_env(tmp_path)
+    # scripts/foo.py is selected by the committed diff and mypy reads its
+    # working-tree content, so it IS checked (dirty edits included) and must
+    # not be reported as unchecked; only pkg.py is genuinely outside the gate.
+    (repo / "scripts" / "foo.py").write_text("y = 2\ny2 = 5\n", encoding="utf-8")
+    (repo / "pkg.py").write_text("x = 1\nx5 = 5\n", encoding="utf-8")
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 0
+    assert proc.stdout == (
+        "preflight_mypy: origin/main...HEAD changed python files:\n"
+        "  scripts/foo.py\n"
+        "  tests/test_foo.py\n"
+        "\n"
+    )
+    assert proc.stderr == DISCLOSURE_HEADER + "  pkg.py\n" + DISCLOSURE_FOOTER
+    assert argv_out.read_text(encoding="utf-8").splitlines() == [
+        "--pretty",
+        "scripts/foo.py",
+        "tests/test_foo.py",
+    ]
 
 
 def test_committed_diff_with_dirty_tree_keeps_committed_behavior_identical(

--- a/tests/scripts/test_preflight_mypy.py
+++ b/tests/scripts/test_preflight_mypy.py
@@ -1,0 +1,205 @@
+"""Focused tests for scripts/preflight_mypy.sh.
+
+The gate reads COMMITTED state only (a three-dot ``<base>...HEAD`` diff), so
+staged, unstaged, or untracked python edits are never type-checked. These
+tests pin the committed-diff behavior byte-for-byte (stdout, exit codes, and
+the exact mypy argv captured via a PATH shim) and prove the advisory stderr
+disclosure for uncommitted python changes never alters that behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "preflight_mypy.sh"
+
+SKIP_STDOUT = "no python changes; mypy preflight skipped\n"
+DISCLOSURE_HEADER = (
+    "preflight_mypy: WARNING: uncommitted python changes are NOT checked "
+    "by this committed-state gate (origin/main...HEAD):\n"
+)
+DISCLOSURE_FOOTER = (
+    "preflight_mypy: commit them and re-run scripts/preflight_mypy.sh to type-check them.\n"
+)
+
+
+def _run(
+    args: list[str], *, cwd: Path, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False, env=env)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-b", "main"], cwd=repo)
+    _run(["git", "config", "user.name", "Test User"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    (repo / "pkg.py").write_text("x = 1\n", encoding="utf-8")
+    _run(["git", "add", "README.md", "pkg.py"], cwd=repo)
+    _run(["git", "commit", "-m", "init"], cwd=repo)
+    _run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=repo)
+    return repo
+
+
+def _shim_env(tmp_path: Path, *, exit_code: int = 0) -> tuple[dict[str, str], Path]:
+    """Build a PATH shim for mypy that records its argv and never type-checks.
+
+    Keeps the tests hermetic (no real mypy run, no mypy install requirement)
+    while proving exactly which argv the script would hand to mypy.
+    """
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    argv_out = shim_dir / "argv.txt"
+    shim = shim_dir / "mypy"
+    shim.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "${MYPY_ARGV_OUT:?}"\n' + f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env['PATH']}"
+    env["MYPY_ARGV_OUT"] = str(argv_out)
+    return env, argv_out
+
+
+def _preflight(repo: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return _run(["bash", str(SCRIPT), "--diff-base", "origin/main"], cwd=repo, env=env)
+
+
+def _commit_python_pair(repo: Path) -> None:
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "foo.py").write_text("y = 2\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_foo.py").write_text("z = 3\n", encoding="utf-8")
+    _run(["git", "add", "scripts/foo.py", "tests/test_foo.py"], cwd=repo)
+    _run(["git", "commit", "-m", "feat: add python pair"], cwd=repo)
+
+
+def test_clean_tree_skips_with_no_disclosure(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    env, argv_out = _shim_env(tmp_path)
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 0
+    assert proc.stdout == SKIP_STDOUT
+    assert proc.stderr == ""
+    assert not argv_out.exists()
+
+
+def test_committed_python_diff_runs_mypy_on_exactly_changed_files(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit_python_pair(repo)
+    env, argv_out = _shim_env(tmp_path)
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 0
+    assert proc.stdout == (
+        "preflight_mypy: origin/main...HEAD changed python files:\n"
+        "  scripts/foo.py\n"
+        "  tests/test_foo.py\n"
+        "\n"
+    )
+    assert proc.stderr == ""
+    assert argv_out.read_text(encoding="utf-8").splitlines() == [
+        "--pretty",
+        "scripts/foo.py",
+        "tests/test_foo.py",
+    ]
+
+
+def test_committed_diff_mypy_exit_code_passthrough_and_hint(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit_python_pair(repo)
+    env, argv_out = _shim_env(tmp_path, exit_code=7)
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 7
+    assert "preflight_mypy: mypy reported issues (exit 7)." in proc.stderr
+    assert "uncommitted python changes" not in proc.stderr
+    assert argv_out.read_text(encoding="utf-8").splitlines() == [
+        "--pretty",
+        "scripts/foo.py",
+        "tests/test_foo.py",
+    ]
+
+
+def test_unstaged_python_edit_discloses_on_stderr(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    env, argv_out = _shim_env(tmp_path)
+    (repo / "pkg.py").write_text("x = 1\nx2 = 2\n", encoding="utf-8")
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 0
+    assert proc.stdout == SKIP_STDOUT
+    assert proc.stderr == DISCLOSURE_HEADER + "  pkg.py\n" + DISCLOSURE_FOOTER
+    assert not argv_out.exists()
+
+
+def test_staged_python_edit_discloses_on_stderr(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    env, argv_out = _shim_env(tmp_path)
+    (repo / "pkg.py").write_text("x = 1\nx3 = 3\n", encoding="utf-8")
+    _run(["git", "add", "pkg.py"], cwd=repo)
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 0
+    assert proc.stdout == SKIP_STDOUT
+    assert proc.stderr == DISCLOSURE_HEADER + "  pkg.py\n" + DISCLOSURE_FOOTER
+    assert not argv_out.exists()
+
+
+def test_untracked_python_file_discloses_on_stderr(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    env, argv_out = _shim_env(tmp_path)
+    (repo / "new_tool.py").write_text("t = 4\n", encoding="utf-8")
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 0
+    assert proc.stdout == SKIP_STDOUT
+    assert proc.stderr == DISCLOSURE_HEADER + "  new_tool.py\n" + DISCLOSURE_FOOTER
+    assert not argv_out.exists()
+
+
+def test_non_python_dirty_files_do_not_disclose(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    env, argv_out = _shim_env(tmp_path)
+    (repo / "README.md").write_text("base\nedited\n", encoding="utf-8")
+
+    proc = _preflight(repo, env)
+
+    assert proc.returncode == 0
+    assert proc.stdout == SKIP_STDOUT
+    assert proc.stderr == ""
+    assert not argv_out.exists()
+
+
+def test_committed_diff_with_dirty_tree_keeps_committed_behavior_identical(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _commit_python_pair(repo)
+    env, argv_out = _shim_env(tmp_path)
+
+    control = _preflight(repo, env)
+    control_argv = argv_out.read_text(encoding="utf-8")
+    argv_out.unlink()
+
+    (repo / "pkg.py").write_text("x = 1\nx4 = 4\n", encoding="utf-8")
+    dirty = _preflight(repo, env)
+
+    assert dirty.returncode == control.returncode == 0
+    assert dirty.stdout == control.stdout
+    assert argv_out.read_text(encoding="utf-8") == control_argv
+    assert control.stderr == ""
+    assert dirty.stderr == DISCLOSURE_HEADER + "  pkg.py\n" + DISCLOSURE_FOOTER


### PR DESCRIPTION
## What

`scripts/preflight_mypy.sh` selects files from committed state only (`<base>...HEAD` three-dot diff). When the only python edits are outside that diff (dirty-tree / pre-commit run), it silently printed `no python changes; mypy preflight skipped` — a proven foot-gun that generated a false defect report (predecessor feature `misc-preflight-mypy-scripts-scope`, premise falsified on fresh main `6955ab420e`).

This PR makes the script emit a loud stderr advisory naming the uncommitted `*.py` paths (staged + unstaged + untracked, `sort -u`) that are NOT checked by this committed-state gate, while keeping every existing behavior byte-unchanged:

- identical mypy argv on committed diffs
- identical exit codes (advisory only — never fails the gate, never type-checks uncommitted files)
- identical stdout for genuinely clean trees and committed diffs

Precision (round-1 review finding, adjudicated genuine and fixed in `c6531d575f`): files selected by the committed diff are handed to mypy, which reads their working-tree content — so a dirty file that is ALSO in the committed diff IS checked and is excluded from the advisory (`comm -23`). Only dirty paths outside the committed diff are reported.

Also adds the single clarifying sentence to `docs/dev/MYPY_PREFLIGHT.md`: the gate selects files from committed state only — run it after committing.

## Red-first proof

New test file `tests/scripts/test_preflight_mypy.py` (9 hermetic tests: tmp git repo fixture + argv-capturing mypy PATH shim, no real mypy dependency).

Round 1 (head `5844d18a92`), run against the UNMODIFIED script first:

- RED — 4 failed, proving the disclosure was absent (stderr was `''`): `test_unstaged_python_edit_discloses_on_stderr`, `test_staged_python_edit_discloses_on_stderr`, `test_untracked_python_file_discloses_on_stderr`, `test_committed_diff_with_dirty_tree_keeps_committed_behavior_identical`
- 4 passed, byte-pinning current behavior: `test_clean_tree_skips_with_no_disclosure`, `test_committed_python_diff_runs_mypy_on_exactly_changed_files` (argv-exact `--pretty scripts/foo.py tests/test_foo.py`), `test_committed_diff_mypy_exit_code_passthrough_and_hint` (exit 7), `test_non_python_dirty_files_do_not_disclose`
- GREEN after the change: 8/8.

Round 2 amendment (head `c6531d575f`), red-first again: `test_dirty_file_inside_committed_diff_is_not_named_in_disclosure` failed against the round-1 advisory (it named an in-diff dirty file as unchecked), passes after the `comm -23` filter; all byte-pinning tests unchanged. Final: 9/9.

The byte-pinning tests passing on both the old and new script is the committed-behavior invariance proof.

## Byte-unchanged proof (direct A/B)

`git show origin/main:scripts/preflight_mypy.sh` vs the new script on the same committed-pair fixture with a clean tree (re-run after the amendment): `cmp` reports STDOUT_IDENTICAL, ARGV_IDENTICAL, STDERR_IDENTICAL, rc 0 == 0.

## Verification (at head `c6531d575f`)

| Gate | Result |
|---|---|
| `python3 -m pytest tests/scripts/test_preflight_mypy.py` (9 tests) | 9 passed |
| `bash -n scripts/preflight_mypy.sh` | ok |
| `make lint` + `ruff format --check` | clean |
| `python3 -m mypy --pretty tests/scripts/test_preflight_mypy.py` | Success: no issues |
| `make test-smoke` (AWS-neutralized) | passed |
| `bash scripts/test_tiers.sh smoke` (at `5844d18a92`; delta since is shell+doc+1 test fn) | 138 passed |
| `bash scripts/preflight_mypy.sh --diff-base origin/main` (committed state, dogfood) | rc=0, type-checked `tests/scripts/test_preflight_mypy.py` |
| `bash scripts/automation_pr_preflight.sh origin/main HEAD` | preflight: ok |
| Draft-lane CI (lint, typecheck, sdk-parity, Generate & Validate, TS SDK Type Check) | 5/5 success at `c6531d575f` |

## Numstat (machine-derived, `git diff --numstat origin/main...HEAD`)

```
4	0	docs/dev/MYPY_PREFLIGHT.md
21	0	scripts/preflight_mypy.sh
234	0	tests/scripts/test_preflight_mypy.py
```

## Evidence (prepare-only, UNPOSTED)

Tier read from collector JSON: **2**; action: **prepare** (no `--apply`; nothing posted, all items `posted: None`).

- Round 1, head `5844d18a92`: claude PASS (countable) + openai CHANGES-REQUESTED ([P2], severity-gated advisory) — adjudicated GENUINE and fixed by `c6531d575f`.
- Round 2, head `c6531d575f` (exact current head): claude PASS + openai PASS, 2/2 counting families, zero dissent, zero timeouts.

## Scope / process

- Feature: `misc-preflight-mypy-dirty-tree-disclosure` (milestone `cdg-bootstrap-route-truth`)
- Fresh-main reauthentication performed first at `f2dfbf8fca`: committed scripts+tests pair ran mypy with exact argv; dirty-tree-only python edits skipped silently with 0-byte stderr (foot-gun reproduced)
- Caller census re-verified: NO CI workflow or Makefile caller of `preflight_mypy.sh` (docs-only references)
- Overlap census at each push: zero overlap on all three touched paths, no PR ≥100 files
- PARKED DRAFT: labeled `operator-review-required`; no ready-flip, posting, settlement, or merge is authorized in this session.
