### PR TITLE
test(connectors): pin fail-closed error propagation in servicenow search/fetch tests

### DIFF
--- a/tests/connectors/enterprise/itsm/test_servicenow.py
+++ b/tests/connectors/enterprise/itsm/test_servicenow.py
@@ -1138,10 +1138,11 @@ class TestServiceNowErrorHandling:
 
     @pytest.mark.asyncio
     async def test_search_handles_api_errors(self, servicenow_connector):
-        """Test search gracefully handles API errors.
+        """Test search logs and propagates API errors (fail-closed).
 
-        Note: The implementation only catches specific exception types:
-        OSError, RuntimeError, ValueError, TypeError, KeyError.
+        Since #4781 search re-raises the caught exception types (OSError,
+        RuntimeError, ValueError, TypeError, KeyError) after logging, so
+        callers can distinguish a failure from an empty result set.
         """
         with patch.object(
             servicenow_connector,
@@ -1149,16 +1150,16 @@ class TestServiceNowErrorHandling:
             new_callable=AsyncMock,
             side_effect=OSError("API Error"),
         ):
-            results = await servicenow_connector.search("test query")
-            # Should return empty list, not raise
-            assert results == []
+            with pytest.raises(OSError, match="API Error"):
+                await servicenow_connector.search("test query")
 
     @pytest.mark.asyncio
     async def test_fetch_handles_api_errors(self, servicenow_connector):
-        """Test fetch gracefully handles API errors.
+        """Test fetch logs and propagates API errors (fail-closed).
 
-        Note: The implementation only catches specific exception types:
-        OSError, RuntimeError, ValueError, TypeError, KeyError.
+        Since #4781 fetch re-raises the caught exception types (OSError,
+        RuntimeError, ValueError, TypeError, KeyError) after logging;
+        ``None`` is reserved for legitimate "not found" responses.
         """
         with patch.object(
             servicenow_connector,
@@ -1166,8 +1167,8 @@ class TestServiceNowErrorHandling:
             new_callable=AsyncMock,
             side_effect=RuntimeError("Connection refused"),
         ):
-            result = await servicenow_connector.fetch("snow-incident-INC0001")
-            assert result is None
+            with pytest.raises(RuntimeError, match="Connection refused"):
+                await servicenow_connector.fetch("snow-incident-INC0001")
 
     @pytest.mark.asyncio
     async def test_comment_retrieval_error_handling(self, servicenow_connector):


### PR DESCRIPTION
## Source

Pre-existing test-health defect (mission feature `misc-servicenow-error-handling-test-health`), discovered during PR #9797 prep: two tests in `tests/connectors/enterprise/itsm/test_servicenow.py` fail identically on clean `origin/main`.

## Red-first proof (fresh origin/main `605a6f61318d47d069faf0b6b83935e0bad162d8`)

Command:

    python3 -m pytest "tests/connectors/enterprise/itsm/test_servicenow.py::TestServiceNowErrorHandling::test_fetch_handles_api_errors" "tests/connectors/enterprise/itsm/test_servicenow.py::TestServiceNowErrorHandling::test_search_handles_api_errors" -q

Result before this change: 2 failed —
- `FAILED tests/connectors/enterprise/itsm/test_servicenow.py::TestServiceNowErrorHandling::test_search_handles_api_errors - OSError: API Error`
- `FAILED tests/connectors/enterprise/itsm/test_servicenow.py::TestServiceNowErrorHandling::test_fetch_handles_api_errors - RuntimeError: Connection refused`

## Diagnosis: stale test expectations (fix at exactly ONE layer: tests)

The connector behavior is deliberate, not a defect. Commit `3bf1eb5bcf` ("fix: propagate errors in servicenow.py search/fetch/resolve_reference (#2992) (#4781)", 2026-04-11) intentionally changed `search`/`fetch`/`resolve_reference` to re-raise after logging "so callers fail closed", because swallowing made errors indistinguishable from legitimate "not found" responses. That commit changed only the source file (+3/-3) and never updated these two tests, which still pinned the pre-#4781 graceful contract (their stale docstring notes describe the old implementation).

The propagation contract also preserves the documented `None` = "not found" semantics of `fetch` (still pinned by `test_fetch_invalid_id_format` / `test_fetch_nonexistent_record`), and comment retrieval remains graceful by design (still pinned by `test_comment_retrieval_error_handling`). Sibling connectors (jira/confluence/gsheets) still swallow-and-return; ServiceNow was deliberately diverged from that pattern by #4781, so reverting the source here would undo a reasoned fix.

This PR therefore updates ONLY the two stale tests to pin the current intended contract (`pytest.raises` on the propagated exception). No connector source behavior changes.

## Validation (worktree at head `fe590c2a9b68aedfc4e01ef21eae7a10f5ad231f`)

- `python3 -m pytest tests/connectors/enterprise/itsm/test_servicenow.py -q --timeout=120` → **72 passed** (both target tests green)
- Seed sweep `-p randomly --randomly-seed={1,42,100,2024,12345}` on `tests/connectors/enterprise/itsm/test_servicenow.py` → 72 passed x 5
- `make lint` → All checks passed; `ruff format --check aragora/ tests/ scripts/` → 10816 files already formatted
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (committed state) → Success: no issues found in 1 source file
- `make test-smoke` → Smoke tests passed; `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` → 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → ok

## Scope / numstat (machine-derived)

`git diff --numstat origin/main...HEAD`:

    12	11	tests/connectors/enterprise/itsm/test_servicenow.py

1 file, +12/-11 = 23 changed lines. Tests-only; no source file touched; no other connector semantics change.

## Risks

Low. Tests-only. The two tests now assert the propagation contract live since #4781; a future revert to graceful degradation would be correctly flagged by these tests.

## Mission process note

Parked draft per feature spec: labeled `operator-review-required`; evidence collected prepare-only and unposted; no ready/posting/settlement/merge is authorized in this session.
