### PR TITLE
fix(types): pay down 25 pre-existing mypy errors in webhooks, salesforce, and slack command handlers

### DIFF
--- a/aragora/connectors/enterprise/crm/salesforce.py
+++ b/aragora/connectors/enterprise/crm/salesforce.py
@@ -431,7 +431,7 @@ class SalesforceConnector(EnterpriseConnector):
         password = await self.credentials.get_credential("SALESFORCE_PASSWORD")
         security_token = await self.credentials.get_credential("SALESFORCE_SECURITY_TOKEN")
 
-        if all([client_id, client_secret, username, password]):
+        if client_id and client_secret and username and password:
             return await self._password_auth(
                 client_id, client_secret, username, password, security_token
             )
@@ -553,7 +553,7 @@ class SalesforceConnector(EnterpriseConnector):
         import urllib.parse
 
         encoded_query = urllib.parse.quote(soql)
-        endpoint = f"/query/?q={encoded_query}"
+        endpoint: str | None = f"/query/?q={encoded_query}"
 
         while endpoint:
             data = await self._api_request(endpoint)

--- a/aragora/connectors/enterprise/crm/salesforce.py
+++ b/aragora/connectors/enterprise/crm/salesforce.py
@@ -423,7 +423,7 @@ class SalesforceConnector(EnterpriseConnector):
         refresh_token = await self.credentials.get_credential("SALESFORCE_REFRESH_TOKEN")
 
         # Try OAuth2 refresh first
-        if all([client_id, client_secret, refresh_token]):
+        if client_id and client_secret and refresh_token:
             return await self._refresh_oauth_token(client_id, client_secret, refresh_token)
 
         # Fall back to username/password flow

--- a/aragora/server/handlers/social/_slack_impl/commands.py
+++ b/aragora/server/handlers/social/_slack_impl/commands.py
@@ -20,7 +20,7 @@ from aragora.utils.public_urls import public_receipt_url
 try:
     from aragora.server.storage import get_debates_db
 except ImportError:  # pragma: no cover - optional dependency for tests
-    get_debates_db = None
+    get_debates_db = None  # type: ignore[assignment]
 
 from .config import (
     ARAGORA_API_BASE_URL,

--- a/aragora/server/handlers/social/_slack_impl/commands.py
+++ b/aragora/server/handlers/social/_slack_impl/commands.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import logging
 import time
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs
 
 from aragora.config import DEFAULT_ROUNDS
@@ -482,7 +482,7 @@ Reply in thread to add suggestions to ongoing debates
         try:
             # Call the debate engine directly instead of HTTP self-call.
             # Self-calls hit auth middleware which rejects the API token format.
-            from aragora.agents.base import create_agent
+            from aragora.agents.base import AgentType, create_agent
             from aragora.core import Environment
             from aragora.debate.orchestrator import Arena, DebateProtocol
             from aragora.cli.commands.quickstart import _detect_agents
@@ -506,7 +506,7 @@ Reply in thread to add suggestions to ongoing debates
             for i, (agent_type, model) in enumerate(detected[:3]):
                 agents.append(
                     create_agent(
-                        agent_type,
+                        cast(AgentType, agent_type),
                         name=f"agent-{i}",
                         role=roles[i % len(roles)],
                         model=model,

--- a/aragora/server/handlers/social/_slack_impl/commands.py
+++ b/aragora/server/handlers/social/_slack_impl/commands.py
@@ -11,11 +11,14 @@ import asyncio
 import json
 import logging
 import time
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs
 
 from aragora.config import DEFAULT_ROUNDS
 from aragora.utils.public_urls import public_receipt_url
+
+if TYPE_CHECKING:
+    from aragora.agents.base import AgentType
 
 try:
     from aragora.server.storage import get_debates_db
@@ -482,7 +485,7 @@ Reply in thread to add suggestions to ongoing debates
         try:
             # Call the debate engine directly instead of HTTP self-call.
             # Self-calls hit auth middleware which rejects the API token format.
-            from aragora.agents.base import AgentType, create_agent
+            from aragora.agents.base import create_agent
             from aragora.core import Environment
             from aragora.debate.orchestrator import Arena, DebateProtocol
             from aragora.cli.commands.quickstart import _detect_agents
@@ -506,7 +509,7 @@ Reply in thread to add suggestions to ongoing debates
             for i, (agent_type, model) in enumerate(detected[:3]):
                 agents.append(
                     create_agent(
-                        cast(AgentType, agent_type),
+                        cast("AgentType", agent_type),
                         name=f"agent-{i}",
                         role=roles[i % len(roles)],
                         model=model,

--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -22,7 +22,7 @@ import hmac
 import logging
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from aragora.security.webhook_signing import generate_signature as _generate_signature
 from aragora.server.handlers.base import (
@@ -405,7 +405,7 @@ class WebhookHandler(SecureHandler):
             delivery_id, err = self.extract_path_param(path, 5, "delivery_id", SAFE_ID_PATTERN)
             if err:
                 return err
-            return await self._handle_get_dead_letter(delivery_id, handler)
+            return await self._handle_get_dead_letter(cast(str, delivery_id), handler)
 
         # GET /api/webhooks/queue/stats - get queue statistics
         if path == "/api/v1/webhooks/queue/stats":
@@ -416,7 +416,7 @@ class WebhookHandler(SecureHandler):
             webhook_id, err = self.extract_path_param(path, 4, "webhook_id", SAFE_ID_PATTERN)
             if err:
                 return err
-            return self._handle_get_webhook(webhook_id, handler)
+            return self._handle_get_webhook(cast(str, webhook_id), handler)
 
         # GET /api/webhooks - list all webhooks
         if path == "/api/v1/webhooks":
@@ -510,21 +510,21 @@ The webhook secret is only returned once on creation - save it securely.""",
             delivery_id, err = self.extract_path_param(path, 5, "delivery_id", SAFE_ID_PATTERN)
             if err:
                 return err
-            return await self._handle_retry_dead_letter(delivery_id, handler)
+            return await self._handle_retry_dead_letter(cast(str, delivery_id), handler)
 
         # POST /api/v1/webhooks/:id/test
         if path.endswith("/test") and path.count("/") == 5:
             webhook_id, err = self.extract_path_param(path, 4, "webhook_id", SAFE_ID_PATTERN)
             if err:
                 return err
-            return self._handle_test_webhook(webhook_id, handler)
+            return self._handle_test_webhook(cast(str, webhook_id), handler)
 
         # POST /api/webhooks - register new webhook
         if path == "/api/v1/webhooks":
             body, err = self.read_json_body_validated(handler)
             if err:
                 return err
-            return self._handle_register_webhook(body, handler)
+            return self._handle_register_webhook(cast(dict[str, Any], body), handler)
 
         return None
 
@@ -569,14 +569,14 @@ The webhook secret is only returned once on creation - save it securely.""",
             delivery_id, err = self.extract_path_param(path, 5, "delivery_id", SAFE_ID_PATTERN)
             if err:
                 return err
-            return await self._handle_delete_dead_letter(delivery_id, handler)
+            return await self._handle_delete_dead_letter(cast(str, delivery_id), handler)
 
         # DELETE /api/webhooks/:id
         if path.startswith("/api/v1/webhooks/") and path.count("/") == 4:
             webhook_id, err = self.extract_path_param(path, 4, "webhook_id", SAFE_ID_PATTERN)
             if err:
                 return err
-            return self._handle_delete_webhook(webhook_id, handler)
+            return self._handle_delete_webhook(cast(str, webhook_id), handler)
 
         return None
 
@@ -593,7 +593,9 @@ The webhook secret is only returned once on creation - save it securely.""",
             body, err = self.read_json_body_validated(handler)
             if err:
                 return err
-            return self._handle_update_webhook(webhook_id, body, handler)
+            return self._handle_update_webhook(
+                cast(str, webhook_id), cast(dict[str, Any], body), handler
+            )
 
         return None
 
@@ -801,7 +803,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Audit log: webhook deleted
         if AUDIT_AVAILABLE and audit_data:
             audit_data(
-                user_id=user.user_id if user else "anonymous",
+                user_id=cast(str, user.user_id) if user else "anonymous",
                 resource_type="webhook",
                 resource_id=webhook_id,
                 action="delete",
@@ -882,13 +884,15 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Audit log: webhook updated
         if AUDIT_AVAILABLE and audit_data:
             audit_data(
-                user_id=user.user_id if user else "anonymous",
+                user_id=cast(str, user.user_id) if user else "anonymous",
                 resource_type="webhook",
                 resource_id=webhook_id,
                 action="update",
             )
 
-        return json_response({"webhook": updated.to_dict(include_secret=False)})
+        return json_response(
+            {"webhook": cast(WebhookConfig, updated).to_dict(include_secret=False)}
+        )
 
     def _handle_test_webhook(self, webhook_id: str, handler: Any) -> HandlerResult:
         """Handle POST /api/webhooks/:id/test - send test event."""
@@ -1142,7 +1146,7 @@ The webhook secret is only returned once on creation - save it securely.""",
             user = self.get_current_user(handler)
             if AUDIT_AVAILABLE and audit_data:
                 audit_data(
-                    user_id=user.user_id if user else "anonymous",
+                    user_id=cast(str, user.user_id) if user else "anonymous",
                     resource_type="webhook_delivery",
                     resource_id=delivery_id,
                     action="retry",
@@ -1182,7 +1186,7 @@ The webhook secret is only returned once on creation - save it securely.""",
             user = self.get_current_user(handler)
             if AUDIT_AVAILABLE and audit_data:
                 audit_data(
-                    user_id=user.user_id if user else "anonymous",
+                    user_id=cast(str, user.user_id) if user else "anonymous",
                     resource_type="webhook_delivery",
                     resource_id=delivery_id,
                     action="delete",

--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -74,7 +74,7 @@ try:
     AUDIT_AVAILABLE = True
 except ImportError:
     AUDIT_AVAILABLE = False
-    audit_data = None
+    audit_data = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Pays down the 25 pre-existing mypy errors discovered during PR #9797 prep (worker ce75eb14) under the repo changed-file gate (`bash scripts/preflight_mypy.sh --diff-base origin/main`), concentrated in exactly three files. Type-annotation/narrowing fixes only, zero behavior change: no public handler signature changes, no runtime semantics changes.

Mission feature: `misc-handler-mypy-debt-paydown` (milestone `cdg-bootstrap-route-truth`).

## Before/after mypy inventory (per file)

Reauthenticated on clean `origin/main` = `605a6f61318d47d069faf0b6b83935e0bad162d8` (fresh `MYPY_CACHE_DIR`, repo pyproject config): **25 errors, exit 1**. On this branch: **0 errors, exit 0**.

| File | Before | After | Error classes fixed |
|---|---|---|---|
| `aragora/server/handlers/webhooks.py` | 15 | 0 | L77 `audit_data = None` import-fallback `[assignment]`; 7× `str \| None` path-param + 2× `dict \| None` body `[arg-type]` at dispatch call sites (L408/419/513/520/527/572/579/596); 4× `user.user_id` audit `[arg-type]` (L804/885/1145/1185); 1× `updated.to_dict` `[union-attr]` (L891) |
| `aragora/connectors/enterprise/crm/salesforce.py` | 8 | 0 | 3× + 4× `[arg-type]` from non-narrowing `all([...])` credential guards (L427/L436); 1× `endpoint = None` `[assignment]` in `_query` pagination (L570) |
| `aragora/server/handlers/social/_slack_impl/commands.py` | 2 | 0 | L23 `get_debates_db = None` import-fallback `[assignment]`; L509 `create_agent` str-vs-`AgentType` Literal `[arg-type]` |

## Fix techniques (all runtime-neutral)

- `cast(...)` at call sites where control flow already guarantees non-None (`extract_path_param` / `read_json_body_validated` contract: value is non-None iff err is None; `store.update` after existence check; `user.user_id` under `if user`). `typing.cast` is a runtime no-op.
- `all([a, b, c])` → `a and b and c` in the two Salesforce credential guards: identical truthiness for the `if`, but mypy narrows each operand. Operands are pure locals, no side effects.
- `endpoint: str | None` annotation at first assignment (function-local annotations are never evaluated at runtime).
- `# type: ignore[assignment]` on the two `except ImportError` fallback reassignments (sanctioned repo idiom, used in `handlers/base.py`, `typed_handlers.py`, etc.).
- `AgentType` imported under `TYPE_CHECKING` only, with a string cast, so the runtime import surface of `aragora.agents.base` is byte-identical to base (tests stub that module with only `create_agent`).

## Red-first proof (committed states)

- Base inventory: `mypy --pretty` over the three files on clean `origin/main` → `Found 25 errors in 3 files`, exit 1.
- RED at commit `592cfe3f5e` (committed diff includes all three files): `bash scripts/preflight_mypy.sh --diff-base origin/main` → `Found 5 errors in 3 files`, **exit 1**.
- GREEN at head: same command → `Success: no issues found in 3 source files`, **exit 0**.

## Validation (exact test files next to every count)

| Command | Result |
|---|---|
| `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh `MYPY_CACHE_DIR`) | exit 0, `Success: no issues found in 3 source files` |
| `python3 -m pytest tests/server/handlers/test_webhooks.py -q --timeout=120` | **53 passed** |
| `python3 -m pytest tests/server/handlers/test_webhooks.py tests/server/handlers/test_webhooks_handler.py tests/handlers/test_webhooks.py tests/handlers/test_handlers_webhooks.py tests/security/test_webhook_signing.py -q -p no:randomly` | **3 failed, 228 passed** — byte-identical to clean `origin/main` (same 3 test IDs: `tests/handlers/test_webhooks.py::TestWebhookHandlerRegister::test_register_webhook_success`, `::TestWebhookHandlerTest::test_test_webhook_success`, `::TestWebhookHandlerTest::test_test_webhook_failure`; all `assert 429`). Pre-existing cross-file rate-limiter pollution (module-level `_register_limiter`/`_test_limiter` shared across files in one process); reproduced identically at base SHA `605a6f6131` in a scratch worktree. |
| `python3 -m pytest tests/connectors/enterprise/crm/test_salesforce.py -q --timeout=120` | **28 passed** |
| `python3 -m pytest tests/handlers/social/_slack_impl/ tests/handlers/social/test_slack_commands.py -q --timeout=120` | **841 passed** |
| `python3 -m pytest tests/events/test_dispatcher_server_boundary.py tests/integration/test_slo_webhook_flow.py tests/observability/metrics/test_webhook_metrics.py tests/server/test_event_subscribers.py tests/security/test_security_regressions.py tests/server/handlers/webhooks/ tests/handlers/webhooks/ -q --timeout=120` | **210 passed** |
| `make lint` + `ruff format --check aragora/ tests/ scripts/` | All checks passed; 10816 files already formatted |
| `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke` | Smoke tests passed |
| `bash scripts/automation_pr_preflight.sh origin/main HEAD` | preflight: ok |

## Machine-derived numstat (`git diff --numstat origin/main...HEAD`)

```
3	3	aragora/connectors/enterprise/crm/salesforce.py
6	3	aragora/server/handlers/social/_slack_impl/commands.py
19	15	aragora/server/handlers/webhooks.py
```

Total: +28/−21 = 49 changed lines (≤800 cap).

## Census / freeze disclosures

- Fresh pre-push census (73 open PRs, none ≥100 files): **zero open-PR overlap** on the three touched paths.
- Deferred optional extension NOT included: migrating the http_client_pool/storage/webhooks deprecated imports and shrinking `scripts/check_sdk_parity.py::_LEGACY_WARNING_MODULES` remains blocked — PR #9797 has merged, but the checker path `scripts/check_sdk_parity.py` is still frozen by open foreign PR #9675 at census time and no lift was granted. Follow-up required once #9675 resolves.

## Risks

- Low: all edits are typing-plane (casts, annotations, coded ignores) or truthiness-equivalent guard rewrites. The one runtime-visible hazard found during testing (runtime `AgentType` import breaking sys.modules-stubbed tests) was caught by the battery and eliminated via a TYPE_CHECKING-only import.

## Gate status

Tier read from the collector JSON; all evidence rounds run **prepare-only (apply=False)**, unposted. Parked draft labeled `operator-review-required`. No ready, posting, settlement, or merge is authorized for this PR in this session.
