### PR TITLE
fix(knowledge): contain weaviate's global warning-filter mutation at import

### DIFF
--- a/aragora/documents/indexing/weaviate_store.py
+++ b/aragora/documents/indexing/weaviate_store.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, cast
 from collections.abc import Callable
@@ -33,10 +34,14 @@ from aragora.documents.models import DocumentChunk
 logger = logging.getLogger(__name__)
 
 try:
-    import weaviate
-    from weaviate.classes.config import Configure, Property, DataType
-    from weaviate.classes.query import MetadataQuery, Filter
-    from weaviate.classes.data import DataObject  # noqa: F401
+    # weaviate's package __init__ calls a bare warnings.simplefilter("default")
+    # (and its transitive imports register more filters), globally rewriting the
+    # ambient warning policy; the scoped guard confines that to this import.
+    with warnings.catch_warnings():
+        import weaviate
+        from weaviate.classes.config import Configure, Property, DataType
+        from weaviate.classes.query import MetadataQuery, Filter
+        from weaviate.classes.data import DataObject  # noqa: F401
 
     WEAVIATE_AVAILABLE = True
 except ImportError:

--- a/aragora/knowledge/embeddings.py
+++ b/aragora/knowledge/embeddings.py
@@ -8,6 +8,7 @@ using Weaviate as the vector database.
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -19,10 +20,14 @@ logger = logging.getLogger(__name__)
 WeaviateConnectionError: type[Exception]
 
 try:
-    import weaviate
-    from weaviate.classes.config import Configure, Property, DataType
-    from weaviate.classes.query import MetadataQuery, Filter
-    from weaviate.exceptions import WeaviateConnectionError as _WeaviateConnectionError
+    # weaviate's package __init__ calls a bare warnings.simplefilter("default")
+    # (and its transitive imports register more filters), globally rewriting the
+    # ambient warning policy; the scoped guard confines that to this import.
+    with warnings.catch_warnings():
+        import weaviate
+        from weaviate.classes.config import Configure, Property, DataType
+        from weaviate.classes.query import MetadataQuery, Filter
+        from weaviate.exceptions import WeaviateConnectionError as _WeaviateConnectionError
 
     WeaviateConnectionError = _WeaviateConnectionError
     WEAVIATE_AVAILABLE = True

--- a/aragora/knowledge/embeddings.py
+++ b/aragora/knowledge/embeddings.py
@@ -33,7 +33,7 @@ try:
     WEAVIATE_AVAILABLE = True
 except ImportError:
     WEAVIATE_AVAILABLE = False
-    weaviate = None
+    weaviate = None  # type: ignore[assignment]
 
     class _FallbackWeaviateConnectionError(Exception):
         """Fallback exception when Weaviate is not available."""

--- a/aragora/knowledge/mound/vector_abstraction/weaviate.py
+++ b/aragora/knowledge/mound/vector_abstraction/weaviate.py
@@ -11,6 +11,7 @@ Requirements:
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any, cast
 from collections.abc import Sequence
 
@@ -25,10 +26,14 @@ logger = logging.getLogger(__name__)
 
 # Check for weaviate library
 try:
-    import weaviate
-    from weaviate.classes.config import Configure, DataType, Property
-    from weaviate.classes.data import DataObject  # noqa: F401
-    from weaviate.classes.query import Filter, MetadataQuery
+    # weaviate's package __init__ calls a bare warnings.simplefilter("default")
+    # (and its transitive imports register more filters), globally rewriting the
+    # ambient warning policy; the scoped guard confines that to this import.
+    with warnings.catch_warnings():
+        import weaviate
+        from weaviate.classes.config import Configure, DataType, Property
+        from weaviate.classes.data import DataObject  # noqa: F401
+        from weaviate.classes.query import Filter, MetadataQuery
 
     WEAVIATE_AVAILABLE = True
 except ImportError:

--- a/aragora/knowledge/mound/vector_abstraction/weaviate.py
+++ b/aragora/knowledge/mound/vector_abstraction/weaviate.py
@@ -61,6 +61,10 @@ class WeaviateVectorStore(BaseVectorStore):
         await store.connect()
     """
 
+    # Initialized by BaseVectorStore.__init__; annotated here because the
+    # changed-file mypy hook runs with --follow-imports=skip and cannot see it.
+    _connected: bool
+
     def __init__(self, config: VectorStoreConfig):
         """Initialize Weaviate store."""
         if not WEAVIATE_AVAILABLE:
@@ -262,7 +266,9 @@ class WeaviateVectorStore(BaseVectorStore):
                 )
                 ids.append(item_id)
 
-        return ids
+        # Items without an explicit "id" append None here; preserved as-is, the
+        # cast only records the declared contract.
+        return cast("list[str]", ids)
 
     async def delete(
         self,

--- a/aragora/knowledge/vector_store.py
+++ b/aragora/knowledge/vector_store.py
@@ -120,7 +120,9 @@ class KnowledgeVectorConfig:
             api_key=os.getenv("WEAVIATE_API_KEY"),
             collection_name=os.getenv("WEAVIATE_KNOWLEDGE_COLLECTION", "KnowledgeNodes"),
             embedding_model=os.getenv("EMBEDDING_MODEL", "text-embedding-3-small"),
-            default_workspace=workspace_id or os.getenv("ARAGORA_WORKSPACE", "default"),
+            default_workspace=(
+                workspace_id if workspace_id else os.getenv("ARAGORA_WORKSPACE", "default")
+            ),
         )
 
 
@@ -150,7 +152,9 @@ class KnowledgeVectorStore:
         self.config = config or KnowledgeVectorConfig.from_env(workspace_id)
         self.workspace_id = workspace_id or self.config.default_workspace
         self._client: Any | None = None
-        self._collection: Any | None = None
+        # Typed Any (not Any | None): connect() must run before use, and the
+        # unconnected AttributeError is part of the existing error contract.
+        self._collection: Any = None
         self._connected = False
 
     @property

--- a/aragora/knowledge/vector_store.py
+++ b/aragora/knowledge/vector_store.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 from collections.abc import Callable
@@ -40,10 +41,14 @@ logger = logging.getLogger(__name__)
 
 # Check for weaviate library
 try:
-    import weaviate  # noqa: F401
-    from weaviate.classes.config import Configure, DataType, Property  # noqa: F401
-    from weaviate.classes.data import DataObject  # noqa: F401
-    from weaviate.classes.query import Filter, MetadataQuery  # noqa: F401
+    # weaviate's package __init__ calls a bare warnings.simplefilter("default")
+    # (and its transitive imports register more filters), globally rewriting the
+    # ambient warning policy; the scoped guard confines that to this import.
+    with warnings.catch_warnings():
+        import weaviate  # noqa: F401
+        from weaviate.classes.config import Configure, DataType, Property  # noqa: F401
+        from weaviate.classes.data import DataObject  # noqa: F401
+        from weaviate.classes.query import Filter, MetadataQuery  # noqa: F401
 
     WEAVIATE_AVAILABLE = True
 except ImportError:

--- a/tests/knowledge/test_weaviate_warning_filter_containment.py
+++ b/tests/knowledge/test_weaviate_warning_filter_containment.py
@@ -1,0 +1,136 @@
+"""Aragora's weaviate import sites must not mutate process-global warning filters.
+
+weaviate-client's package ``__init__`` calls a bare ``warnings.simplefilter("default")``
+(and its transitive imports register further filters), globally rewriting the ambient
+warning policy of any process that imports it. Every aragora import site of weaviate
+wraps the import in a scoped ``warnings.catch_warnings`` guard so that mutation is
+confined to the import itself. These tests pin that invariant per import site.
+
+Each check runs in a fresh subprocess because a package ``__init__`` executes only
+once per process. The subprocess first loads the target module with weaviate blocked
+(caching every non-weaviate prerequisite import and its own filter side effects),
+then re-executes the module body with weaviate importable, so the measured filters
+delta is exactly the weaviate-attributable contribution.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+WEAVIATE_IMPORT_SITES = [
+    "aragora.documents.indexing.weaviate_store",
+    "aragora.knowledge.embeddings",
+    "aragora.knowledge.vector_store",
+    "aragora.knowledge.mound.vector_abstraction.weaviate",
+]
+
+_SITE_SCRIPT = """\
+import importlib
+import importlib.util
+import sys
+import warnings
+
+mod_name = {mod!r}
+spec_available = importlib.util.find_spec("weaviate") is not None
+
+# Phase A: load the module with weaviate blocked so every non-weaviate
+# prerequisite import (and any filter side effect it carries) is cached first.
+sys.modules["weaviate"] = None
+module = importlib.import_module(mod_name)
+assert module.WEAVIATE_AVAILABLE is False, "weaviate import block did not take"
+del sys.modules["weaviate"]
+del sys.modules[mod_name]
+
+# Phase B: re-execute the module body; the only fresh imports are weaviate and
+# its transitive dependencies, so any filters delta is weaviate-attributable.
+before = list(warnings.filters)
+before_repr = repr(warnings.filters)
+module = importlib.import_module(mod_name)
+after = list(warnings.filters)
+after_repr = repr(warnings.filters)
+
+if spec_available and not module.WEAVIATE_AVAILABLE:
+    print("AVAILABILITY_BROKEN")
+    raise SystemExit(4)
+if not spec_available:
+    print("WEAVIATE_UNAVAILABLE")
+    raise SystemExit(0)
+if before == after and before_repr == after_repr:
+    print("FILTERS_UNCHANGED")
+    raise SystemExit(0)
+print("FILTERS_MUTATED")
+for entry in after:
+    if entry not in before:
+        print("leaked:", entry)
+raise SystemExit(3)
+"""
+
+_BARE_IMPORT_SCRIPT = """\
+import warnings
+
+before = list(warnings.filters)
+try:
+    import weaviate  # noqa: F401
+except ImportError:
+    print("WEAVIATE_UNAVAILABLE")
+    raise SystemExit(0)
+after = list(warnings.filters)
+if before == after:
+    print("UPSTREAM_FIXED")
+    raise SystemExit(0)
+print("FILTERS_MUTATED")
+raise SystemExit(3)
+"""
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONPATH": str(REPO_ROOT),
+            # Importing aragora.server.* without AWS neutralization can trigger
+            # botocore credential prompts on some machines.
+            "AWS_CONFIG_FILE": "/dev/null",
+            "AWS_SHARED_CREDENTIALS_FILE": "/dev/null",
+            "AWS_EC2_METADATA_DISABLED": "true",
+        }
+    )
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+        cwd=REPO_ROOT,
+    )
+
+
+@pytest.mark.parametrize("site", WEAVIATE_IMPORT_SITES)
+def test_import_site_leaves_global_warning_filters_byte_identical(site: str) -> None:
+    """Importing an aragora weaviate module leaves warnings.filters untouched."""
+    proc = _run_isolated(_SITE_SCRIPT.format(mod=site))
+    assert proc.returncode == 0, (
+        f"{site} leaked warning-filter mutations (exit {proc.returncode}):\n"
+        f"{proc.stdout}{proc.stderr}"
+    )
+    assert ("FILTERS_UNCHANGED" in proc.stdout) or ("WEAVIATE_UNAVAILABLE" in proc.stdout), (
+        f"unexpected subprocess output for {site}:\n{proc.stdout}{proc.stderr}"
+    )
+
+
+def test_bare_weaviate_import_mutates_filters_upstream_control() -> None:
+    """Positive control pinning the upstream side effect the guards contain."""
+    proc = _run_isolated(_BARE_IMPORT_SCRIPT)
+    if "WEAVIATE_UNAVAILABLE" in proc.stdout or "UPSTREAM_FIXED" in proc.stdout:
+        # Nothing to contain in this environment; the site guards are inert.
+        return
+    assert proc.returncode == 3 and "FILTERS_MUTATED" in proc.stdout, (
+        f"unexpected bare-import behavior:\n{proc.stdout}{proc.stderr}"
+    )


### PR DESCRIPTION
## Source

Structural-excellence feature `misc-weaviate-warning-filter-containment` (milestone `cdg-bootstrap-route-truth`): root-cause containment of the side effect discovered during PR #9797 prep. weaviate-client's package `__init__` mutates the process-global `warnings.filters` of ANY importing process; #9797 contained it for the parity checker only. This PR contains it at every aragora import site.

## Upstream pin (offending line)

- **weaviate-client 4.19.2** (installed at `weaviate/__init__.py`)
- `weaviate/__init__.py:41`: `from warnings import simplefilter`
- `weaviate/__init__.py:43`: `simplefilter("default")` — a bare global filter mutation at import time
- Measured leak on bare `import weaviate` (fresh main): `warnings.filters` grows 5 → 8; the 3 weaviate-attributable entries are `('default', None, Warning, None, 0)`, a protobuf `runtime_version` `ignore` filter, and an authlib `AuthlibDeprecationWarning` `always` filter (the latter two registered by weaviate's transitive imports during the same import).

## Behavior summary

- Complete inventory (measure-first, fresh main `605a6f6131`): exactly **4 static import sites** of weaviate in `aragora/`, all in module-top `try/except ImportError` blocks; **zero** dynamic/importlib/string imports. The bm25/embeddings prerequisite chain reaches weaviate through `aragora.knowledge.embeddings` (one of the 4), so guarding all 4 closes every aragora vector.
  - `aragora/documents/indexing/weaviate_store.py`
  - `aragora/knowledge/embeddings.py`
  - `aragora/knowledge/vector_store.py`
  - `aragora/knowledge/mound/vector_abstraction/weaviate.py`
- Each site's weaviate import block is now wrapped in a scoped `with warnings.catch_warnings():` guard, restoring the pre-import filter state byte-identically. No global policy change, no package-`__init__` change, no change to weaviate usage; `WEAVIATE_AVAILABLE` semantics preserved (assignments stay outside the guard).
- Red-first test `tests/knowledge/test_weaviate_warning_filter_containment.py` pins the invariant per site via subprocess two-phase isolation (phase A: load the module with weaviate blocked so all non-weaviate prereqs cache; phase B: re-execute the module body so the only fresh imports are weaviate's — the measured delta is exactly the weaviate-attributable contribution). Includes an upstream positive control (bare `import weaviate` still mutates) and an availability check (guard must not break `WEAVIATE_AVAILABLE=True`).
- Rider (gate-required): pays down the 12 pre-existing mypy errors these 4 files carried (identical on origin/main), behavior-preservingly — idiomatic `type: ignore[assignment]` on the optional-import fallback, a truthy-conditional mypy narrows honestly, `Any` for the connect-before-use collection handle, a `cast` recording `upsert_batch`'s declared contract, and a `_connected: bool` annotation for the changed-file hook's `--follow-imports=skip` mode.

## Validation

- RED (before fix, `set -o pipefail`): `python3 -m pytest tests/knowledge/test_weaviate_warning_filter_containment.py -v` → **4 failed** (all 4 sites leak the 3-entry weaviate delta), 1 passed (upstream control), exit 1.
- GREEN: same command → **5 passed**.
- Affected adapter/store suites: `tests/documents/test_indexing.py tests/knowledge/test_vector_store.py tests/knowledge/mound/vector_abstraction/test_weaviate.py tests/knowledge/mound/vector_abstraction/test_vector_adapters.py tests/knowledge/mound/test_vector_stores.py` → **288 passed**.
- Remaining weaviate-touching suites (`test_knowledge_pipeline.py`, `test_knowledge_integration.py`, `mound/test_core.py`, `server/startup/test_knowledge_mound.py`, `cli/test_knowledge.py`, `integration/test_knowledge_vector_stores.py`, `integration/test_knowledge_pipeline.py`) → **242 passed, 9 skipped** (pre-existing skips).
- 5-seed randomized sweep on the new test file (seeds 1, 42, 100, 2024, 12345) → 5 × **5 passed**.
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (committed state): stage-1 commit exit 1 (12 pre-existing errors), final head **exit 0** (no issues in 5 source files).
- `make lint`, `ruff format --check aragora/ tests/ scripts/`: pass.
- `make test-smoke` (AWS-neutralized): pass. `bash scripts/test_tiers.sh smoke`: **138 passed**.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok.

## Risks

- Low. The guard only scopes filter mutations during the import statement itself; weaviate's own modules import fully and `WEAVIATE_AVAILABLE` stays `True` (pinned by the availability check in phase B).
- Weaviate registers its protobuf/authlib filters for its own runtime benefit; containing them restores aragora's ambient policy. Any weaviate-internal warning that those filters would have surfaced/hidden now follows aragora's ambient policy instead — that is the intended behavior change boundary (aragora owns its process's warning policy).
- The upsert_batch `cast` records the declared `list[str]` contract without changing the pre-existing runtime behavior (items without an explicit `"id"` still append `None`); flagged as a latent upstream-of-contract issue in the mission handoff.

Measured LOC: **+186 / −20 (206 changed lines) across 5 files** (well under the 800 cap).
