### PR TITLE
refactor(handlers): canonicalize webhook module identity

### DIFF
--- a/aragora/server/handlers/webhook_management.py
+++ b/aragora/server/handlers/webhook_management.py
@@ -78,13 +78,6 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-warnings.warn(
-    "aragora.server.handlers.webhooks.generate_signature is deprecated; "
-    "use aragora.security.webhook_signing.generate_signature instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
 # Rate limits for webhook operations
 WEBHOOK_REGISTER_RPM = 10  # Max 10 webhook registrations per minute
 WEBHOOK_TEST_RPM = 5  # Max 5 test deliveries per minute

--- a/aragora/server/handlers/webhooks/__init__.py
+++ b/aragora/server/handlers/webhooks/__init__.py
@@ -1,38 +1,37 @@
-"""Webhook handlers for external integrations."""
+"""Webhook handlers for management APIs and external integrations."""
 
+import importlib as importlib  # Compatibility: historically a public package attribute.
+import warnings as _warnings
+
+from aragora.server.handlers import webhook_management as _webhooks_module
 from aragora.server.handlers.webhooks.github_app import (
     GITHUB_APP_ROUTES,
     handle_github_webhook,
 )
 
-# Re-export WebhookHandler from the sibling webhooks.py module
-# This resolves the naming conflict between webhooks/ directory and webhooks.py file
-import importlib.util
-import os as _os
+# Preserve the package's historical exports and private module hook while
+# loading the implementation through its one canonical module identity.
+WebhookHandler = _webhooks_module.WebhookHandler
+WebhookStore = _webhooks_module.WebhookStore
+WebhookConfig = _webhooks_module.WebhookConfig
+get_webhook_store = _webhooks_module.get_webhook_store
+generate_signature = _webhooks_module.generate_signature
+verify_signature = _webhooks_module.verify_signature
+WEBHOOK_EVENTS = _webhooks_module.WEBHOOK_EVENTS
+RBAC_AVAILABLE = _webhooks_module.RBAC_AVAILABLE
+check_permission = _webhooks_module.check_permission
+validate_webhook_url = _webhooks_module.validate_webhook_url
 
-_webhooks_file = _os.path.join(_os.path.dirname(__file__), "..", "webhooks.py")
-_spec = importlib.util.spec_from_file_location("webhooks_module", _webhooks_file)
-if _spec and _spec.loader:
-    _webhooks_module = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_webhooks_module)
-    WebhookHandler = _webhooks_module.WebhookHandler
-    WebhookStore = _webhooks_module.WebhookStore
-    WebhookConfig = _webhooks_module.WebhookConfig
-    get_webhook_store = _webhooks_module.get_webhook_store
-    generate_signature = _webhooks_module.generate_signature
-    verify_signature = _webhooks_module.verify_signature
-    WEBHOOK_EVENTS = _webhooks_module.WEBHOOK_EVENTS
-    # RBAC exports
-    RBAC_AVAILABLE = _webhooks_module.RBAC_AVAILABLE
-    check_permission = _webhooks_module.check_permission
-    validate_webhook_url = _webhooks_module.validate_webhook_url
-else:
-    raise ImportError("Could not load webhooks.py module")
+_warnings.warn(
+    "aragora.server.handlers.webhooks is deprecated as the webhook management "
+    "implementation home; use aragora.server.handlers.webhook_management instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "GITHUB_APP_ROUTES",
     "handle_github_webhook",
-    # Re-exports from webhooks.py
     "WebhookHandler",
     "WebhookStore",
     "WebhookConfig",
@@ -40,7 +39,6 @@ __all__ = [
     "generate_signature",
     "verify_signature",
     "WEBHOOK_EVENTS",
-    # RBAC exports
     "RBAC_AVAILABLE",
     "check_permission",
     "validate_webhook_url",

--- a/aragora/storage/webhook_registry.py
+++ b/aragora/storage/webhook_registry.py
@@ -2,7 +2,7 @@
 Webhook Registration Storage.
 
 Provides durable storage for webhook registrations, replacing the in-memory
-dict in handlers/webhooks.py. Survives server restarts.
+dict in handlers/webhook_management.py. Survives server restarts.
 
 Backends:
 - SQLiteWebhookRegistry: Persisted, single-instance (default)
@@ -76,7 +76,7 @@ class SQLiteWebhookRegistry:
     SQLite-backed webhook registration store.
 
     Provides durable storage for webhook configurations with the same
-    interface as the in-memory WebhookStore in handlers/webhooks.py.
+    interface as the in-memory WebhookStore in handlers/webhook_management.py.
     """
 
     SCHEMA_VERSION = 1

--- a/docs-site/docs/contributing/handlers.md
+++ b/docs-site/docs/contributing/handlers.md
@@ -33,8 +33,9 @@ handlers/
 ├── decision.py         # Unified decision router
 ├── deliberations.py    # Vetted decisionmaking dashboard endpoints (deliberations API)
 ├── gauntlet.py         # Gauntlet stress-test API
+├── webhook_management.py # Outbound webhook management
 ├── workflows.py        # Workflow execution endpoints
-└── webhooks.py         # Outbound webhook management
+└── webhooks/           # Webhook integrations + compatibility exports
 ```
 
 ---
@@ -338,7 +339,7 @@ POST /api/formal/prove          - Generate formal proof
 | `reviews.py` | `/api/reviews/*` | Debate reviews |
 | `tournaments.py` | `/api/tournaments/*` | Tournament management |
 | `training.py` | `/api/training/*` | Training data export |
-| `webhooks.py` | `/api/webhooks/*` | Webhook management |
+| `webhook_management.py` | `/api/webhooks/*` | Webhook management |
 | `connectors.py` | `/api/connectors/*` | Data connector management |
 | `control_plane.py` | `/api/control-plane/*` | Enterprise control plane |
 | `routing.py` | `/api/routing/*` | Agent routing & team selection |

--- a/docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md
+++ b/docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md
@@ -774,7 +774,7 @@ domain/application/interface home packages + their tests) unless noted. LOC is a
 estimate of code touched (moved + edited + repointed + tests); a couple sit near the
 cap and carry a noted split point. **`events.dispatcher`/`async_dispatcher` ->
 `server` (webhook signing + tracing) is OUT OF SCOPE** here - that is Batch 1b-sweep
-+ Batch 2c (2c is Tier-3, `aragora/server/handlers/webhooks.py`).
++ Batch 2c (2c is Tier-3, `aragora/server/handlers/webhook_management.py`).
 
 ### Events (supersedes cancelled Batch 2a)
 

--- a/docs/architecture/P4A_LAYERING_DISPOSITION.md
+++ b/docs/architecture/P4A_LAYERING_DISPOSITION.md
@@ -336,11 +336,11 @@ Reclassify/relocate (or invert via registry) the application-layer subscribers
 and workers mislocated in infra `events` and `queue`:
 - **2a events subscribers**: relocate `events.cross_subscribers` + `events.subscribers` (+ `security_events`, `security_dispatcher`, `arena_bridge`) to an application home, OR invert via the EventBus registry. Clears `events -> {agents, debate, knowledge, memory, nomic, ranking, reasoning, workflow}` and the subscriber-side `events -> server` imports (`server.stream.state_manager`, `server.stream.emitter`, remaining `server.prometheus_cross_pollination`/`server.handlers.webhooks.get_webhook_store`).
 - **2b queue workers**: relocate `queue.worker` + `queue/workers/*` to an application home, OR invert via a job-handler registry. Clears `queue -> {agents, debate, gauntlet, integrations, memory, nomic, ranking}` and the worker-side `queue -> server` imports (`server.stream.gauntlet_emitter`, `server.debate_origin`).
-- **2c events dispatcher webhook signing** (Tier-3-flagged): extract the HMAC `generate_signature` helper out of `server/handlers/webhooks.py` (a Tier-3 path) down to foundation/security so `events.dispatcher`/`async_dispatcher` stop importing `server.handlers.webhooks`. Coordinate file boundaries with `p4b-handlers-*` (section 6).
+- **2c events dispatcher webhook signing** (Tier-3-flagged): extract the HMAC `generate_signature` helper out of `server/handlers/webhook_management.py` (a Tier-3 path) down to foundation/security so `events.dispatcher`/`async_dispatcher` stop importing `server.handlers.webhooks`. Coordinate file boundaries with `p4b-handlers-*` (section 6).
 
 Tier: 2a/2b Tier 1-2 (events/, queue/ are infra). 2c touches
 `aragora/server/handlers/` -> Tier 3 (operator settlement), or fold into the
-P4b handlers batch that owns `webhooks.py`.
+P4b handlers batch that owns `webhook_management.py`.
 
 ### Batch 3 - observability + billing connectors / integrations / knowledge
 
@@ -410,11 +410,12 @@ File-boundary rule (utilities vs handlers = different files):
   non-`handlers/` files; moving them down is Tier 1-2.
 - **P4b owns the `server/handlers/*` decomposition** (Tier-3 batches). The only
   overlap is the HMAC `generate_signature` helper in
-  `server/handlers/webhooks.py` (Batch 2c) and the `get_webhook_store` /
+  `server/handlers/webhook_management.py` (Batch 2c) and the `get_webhook_store` /
   `server.stream.gauntlet_emitter` / `server.debate_origin` server surfaces that
   events/queue subscribers reach into. Coordinate so the handler file is edited by
   exactly one thread: extract the foundation-level helper (signature) in the P4a
-  events thread OR fold it into the P4b batch that owns `webhooks.py`, never both.
+  events thread OR fold it into the P4b batch that owns `webhook_management.py`,
+  never both.
 
 VAL-P4B-004's conditional `tests/architecture/test_layering_baseline.py` clause
 is vacuous today (the file does not exist on `origin/main`); if a P4b/P0 PR adds

--- a/docs/enterprise/RBAC_AUDIT_REPORT.md
+++ b/docs/enterprise/RBAC_AUDIT_REPORT.md
@@ -217,7 +217,7 @@ aragora/server/handlers/sso.py
 aragora/server/handlers/verification/formal_verification.py
 aragora/server/handlers/verticals.py
 aragora/server/handlers/voice/handler.py
-aragora/server/handlers/webhooks.py
+aragora/server/handlers/webhook_management.py
 aragora/server/handlers/workflows.py
 aragora/server/handlers/workspace.py
 ```

--- a/docs/reference/HANDLERS.md
+++ b/docs/reference/HANDLERS.md
@@ -28,8 +28,9 @@ handlers/
 ├── decision.py         # Unified decision router
 ├── deliberations.py    # Vetted decisionmaking dashboard endpoints (deliberations API)
 ├── gauntlet.py         # Gauntlet stress-test API
+├── webhook_management.py # Outbound webhook management
 ├── workflows.py        # Workflow execution endpoints
-└── webhooks.py         # Outbound webhook management
+└── webhooks/           # Webhook integrations + compatibility exports
 ```
 
 ---
@@ -333,7 +334,7 @@ POST /api/formal/prove          - Generate formal proof
 | `reviews.py` | `/api/reviews/*` | Debate reviews |
 | `tournaments.py` | `/api/tournaments/*` | Tournament management |
 | `training.py` | `/api/training/*` | Training data export |
-| `webhooks.py` | `/api/webhooks/*` | Webhook management |
+| `webhook_management.py` | `/api/webhooks/*` | Webhook management |
 | `connectors.py` | `/api/connectors/*` | Data connector management |
 | `control_plane.py` | `/api/control-plane/*` | Enterprise control plane |
 | `routing.py` | `/api/routing/*` | Agent routing & team selection |

--- a/scripts/apply_rbac.py
+++ b/scripts/apply_rbac.py
@@ -31,7 +31,7 @@ EXCLUDED_PATHS = {
     "_oauth_impl.py",
     "oauth_wizard.py",
     # Webhooks - verified via signatures/tokens, not RBAC
-    "webhooks.py",
+    "webhook_management.py",
     "email_webhooks.py",
     # Base classes and utilities (not actual endpoints)
     "base.py",

--- a/tests/handlers/test_handlers_webhooks.py
+++ b/tests/handlers/test_handlers_webhooks.py
@@ -68,20 +68,15 @@ def _bypass_webhook_rbac(monkeypatch):
 @pytest.fixture(autouse=True)
 def _reset_rate_limiters():
     """Reset webhook rate limiters before each test to prevent cross-test exhaustion."""
-    import aragora.server.handlers.webhooks as webhooks_pkg
+    from aragora.server.handlers import webhook_management
 
-    webhooks_mod = getattr(webhooks_pkg, "_webhooks_module", None)
-    if webhooks_mod is not None:
-        for attr in ("_register_limiter", "_test_limiter", "_list_limiter"):
-            lim = getattr(webhooks_mod, attr, None)
-            if lim is not None:
-                lim.clear()
+    for attr in ("_register_limiter", "_test_limiter", "_list_limiter"):
+        limiter = getattr(webhook_management, attr)
+        limiter.clear()
     yield
-    if webhooks_mod is not None:
-        for attr in ("_register_limiter", "_test_limiter", "_list_limiter"):
-            lim = getattr(webhooks_mod, attr, None)
-            if lim is not None:
-                lim.clear()
+    for attr in ("_register_limiter", "_test_limiter", "_list_limiter"):
+        limiter = getattr(webhook_management, attr)
+        limiter.clear()
 
 
 @pytest.fixture
@@ -925,11 +920,11 @@ class TestGlobalWebhookStore:
     @pytest.fixture(autouse=True)
     def _reset_webhook_store_singleton(self):
         """Reset webhook store singleton before/after each test."""
-        import aragora.server.handlers.webhooks as webhooks_module
+        from aragora.storage.webhook_config_store import reset_webhook_config_store
 
-        webhooks_module._webhook_store = None
+        reset_webhook_config_store()
         yield
-        webhooks_module._webhook_store = None
+        reset_webhook_config_store()
 
     def test_get_webhook_store_singleton(self):
         """Test that get_webhook_store returns the same instance."""

--- a/tests/handlers/test_webhooks_module_structure.py
+++ b/tests/handlers/test_webhooks_module_structure.py
@@ -300,7 +300,7 @@ def test_webhook_routes_registration_and_public_surface_match_baseline() -> None
         "_workflow_patterns_handler",
     ]
     registry_entry = dict(ADMIN_HANDLER_REGISTRY)["_webhook_handler"]
-    assert registry_entry.resolve() is module.WebhookHandler
+    assert getattr(registry_entry, "resolve")() is module.WebhookHandler
 
 
 def test_package_shim_has_no_dynamic_file_loader() -> None:
@@ -309,7 +309,9 @@ def test_package_shim_has_no_dynamic_file_loader() -> None:
         warnings.simplefilter("ignore", DeprecationWarning)
         package = __import__(PACKAGE_NAME, fromlist=["_webhooks_module"])
 
-    source = Path(package.__file__).read_text(encoding="utf-8")
+    module_file = package.__file__
+    assert module_file is not None
+    source = Path(module_file).read_text(encoding="utf-8")
     assert "spec_from_file_location" not in source
     assert "module_from_spec" not in source
     assert "exec_module" not in source

--- a/tests/handlers/test_webhooks_module_structure.py
+++ b/tests/handlers/test_webhooks_module_structure.py
@@ -1,0 +1,316 @@
+"""Structural regression tests for the webhook handler package."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import warnings
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_NAME = "aragora.server.handlers.webhooks"
+
+EXPECTED_EXPORTS = [
+    "GITHUB_APP_ROUTES",
+    "handle_github_webhook",
+    "WebhookHandler",
+    "WebhookStore",
+    "WebhookConfig",
+    "get_webhook_store",
+    "generate_signature",
+    "verify_signature",
+    "WEBHOOK_EVENTS",
+    "RBAC_AVAILABLE",
+    "check_permission",
+    "validate_webhook_url",
+]
+
+EXPECTED_PUBLIC_NAMES = [
+    "GITHUB_APP_ROUTES",
+    "RBAC_AVAILABLE",
+    "WEBHOOK_EVENTS",
+    "WebhookConfig",
+    "WebhookHandler",
+    "WebhookStore",
+    "check_permission",
+    "generate_signature",
+    "get_webhook_store",
+    "github_app",
+    "handle_github_webhook",
+    "importlib",
+    "validate_webhook_url",
+    "verify_signature",
+]
+
+EXPECTED_ROUTES = [
+    "POST /api/webhooks",
+    "GET /api/webhooks",
+    "GET /api/webhooks/events",
+    "GET /api/webhooks/slo/status",
+    "POST /api/webhooks/slo/test",
+    "GET /api/webhooks/:id",
+    "DELETE /api/webhooks/:id",
+    "PATCH /api/webhooks/:id",
+    "POST /api/webhooks/:id/test",
+    "GET /api/webhooks/dead-letter",
+    "GET /api/webhooks/dead-letter/:id",
+    "POST /api/webhooks/dead-letter/:id/retry",
+    "DELETE /api/webhooks/dead-letter/:id",
+    "GET /api/webhooks/queue/stats",
+]
+
+EXPECTED_V1_ROUTES = [
+    "/api/v1/webhooks",
+    "/api/v1/webhooks/events",
+    "/api/v1/webhooks/events/categories",
+    "/api/v1/webhooks/slo/status",
+    "/api/v1/webhooks/slo/test",
+    "/api/v1/webhooks/dead-letter",
+    "/api/v1/webhooks/queue/stats",
+    "/api/v1/webhooks/bulk",
+    "/api/v1/webhooks/pause-all",
+    "/api/v1/webhooks/resume-all",
+]
+
+
+def _run_import_probe() -> dict[str, object]:
+    script = textwrap.dedent(
+        """
+        import importlib
+        import importlib.machinery
+        import importlib.util
+        import json
+        from pathlib import Path
+        import sys
+        import warnings
+
+        root = Path(sys.argv[1])
+        legacy_file = root / "aragora/server/handlers/webhooks.py"
+        canonical_file = root / "aragora/server/handlers/webhook_management.py"
+        implementation_paths = {
+            path.resolve() for path in (legacy_file, canonical_file) if path.exists()
+        }
+        execution_count = 0
+        original_exec_module = importlib.machinery.SourceFileLoader.exec_module
+
+        def counted_exec_module(loader, module):
+            global execution_count
+            if Path(loader.path).resolve() in implementation_paths:
+                execution_count += 1
+            return original_exec_module(loader, module)
+
+        importlib.machinery.SourceFileLoader.exec_module = counted_exec_module
+        legacy_module = None
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always", DeprecationWarning)
+                if legacy_file.exists():
+                    spec = importlib.util.spec_from_file_location(
+                        "aragora.server.handlers.webhooks",
+                        legacy_file,
+                    )
+                    assert spec is not None and spec.loader is not None
+                    legacy_module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(legacy_module)
+
+                package = importlib.import_module("aragora.server.handlers.webhooks")
+                try:
+                    implementation = importlib.import_module(
+                        "aragora.server.handlers.webhook_management"
+                    )
+                except ModuleNotFoundError:
+                    implementation = package._webhooks_module
+        finally:
+            importlib.machinery.SourceFileLoader.exec_module = original_exec_module
+
+        relevant_warnings = [
+            str(item.message)
+            for item in caught
+            if issubclass(item.category, DeprecationWarning)
+            and str(item.message).startswith(
+                "aragora.server.handlers.webhooks"
+            )
+        ]
+        print(json.dumps({
+            "execution_count": execution_count,
+            "handler_module": package.WebhookHandler.__module__,
+            "implementation_name": implementation.__name__,
+            "legacy_file_exists": legacy_file.exists(),
+            "legacy_handler_is_package_handler": (
+                None
+                if legacy_module is None
+                else legacy_module.WebhookHandler is package.WebhookHandler
+            ),
+            "package_handler_is_implementation": (
+                package.WebhookHandler is implementation.WebhookHandler
+            ),
+            "compat_module_alias_is_implementation": (
+                package._webhooks_module is implementation
+            ),
+            "relevant_warning_count": len(relevant_warnings),
+            "webhooks_module_registered": "webhooks_module" in sys.modules,
+        }, sort_keys=True))
+        """
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARAGORA_SECRETS_STRICT": "false",
+            "AWS_CONFIG_FILE": "/dev/null",
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "AWS_SHARED_CREDENTIALS_FILE": "/dev/null",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_webhook_implementation_executes_once_under_canonical_identity() -> None:
+    """The implementation has one source path, module identity, and class object."""
+    probe = _run_import_probe()
+
+    assert probe == {
+        "compat_module_alias_is_implementation": True,
+        "execution_count": 1,
+        "handler_module": "aragora.server.handlers.webhook_management",
+        "implementation_name": "aragora.server.handlers.webhook_management",
+        "legacy_file_exists": False,
+        "legacy_handler_is_package_handler": None,
+        "package_handler_is_implementation": True,
+        "relevant_warning_count": 1,
+        "webhooks_module_registered": False,
+    }
+
+
+def test_canonical_module_is_silent_and_package_shim_warns() -> None:
+    """Only the retired package-level implementation path emits the move warning."""
+    script = textwrap.dedent(
+        """
+        import importlib
+        import json
+        import warnings
+
+        with warnings.catch_warnings(record=True) as canonical_warnings:
+            warnings.simplefilter("always", DeprecationWarning)
+            canonical = importlib.import_module(
+                "aragora.server.handlers.webhook_management"
+            )
+        with warnings.catch_warnings(record=True) as shim_warnings:
+            warnings.simplefilter("always", DeprecationWarning)
+            shim = importlib.import_module("aragora.server.handlers.webhooks")
+
+        def relevant(items):
+            return [
+                str(item.message)
+                for item in items
+                if issubclass(item.category, DeprecationWarning)
+                and str(item.message).startswith("aragora.server.handlers.webhooks")
+            ]
+
+        print(json.dumps({
+            "canonical_warnings": relevant(canonical_warnings),
+            "shim_handler_is_canonical": shim.WebhookHandler is canonical.WebhookHandler,
+            "shim_warnings": relevant(shim_warnings),
+        }, sort_keys=True))
+        """
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARAGORA_SECRETS_STRICT": "false",
+            "AWS_CONFIG_FILE": "/dev/null",
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "AWS_SHARED_CREDENTIALS_FILE": "/dev/null",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "canonical_warnings": [],
+        "shim_handler_is_canonical": True,
+        "shim_warnings": [
+            "aragora.server.handlers.webhooks is deprecated as the webhook management "
+            "implementation home; use aragora.server.handlers.webhook_management instead."
+        ],
+    }
+
+
+def test_webhook_routes_registration_and_public_surface_match_baseline() -> None:
+    """The structural move preserves exports, route tables, and registration order."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        module = __import__(PACKAGE_NAME, fromlist=["WebhookHandler"])
+        from aragora.server.handler_registry.admin import ADMIN_HANDLER_REGISTRY
+        from aragora.server.handlers._lazy_imports import ALL_HANDLER_NAMES, HANDLER_MODULES
+
+    assert module.__all__ == EXPECTED_EXPORTS
+    assert (
+        sorted(name for name in vars(module) if not name.startswith("_")) == EXPECTED_PUBLIC_NAMES
+    )
+    assert module.WebhookHandler.routes == EXPECTED_ROUTES
+    assert module.WebhookHandler.ROUTES == EXPECTED_V1_ROUTES
+
+    assert HANDLER_MODULES["WebhookHandler"] == PACKAGE_NAME
+    lazy_names = list(ALL_HANDLER_NAMES)
+    lazy_index = lazy_names.index("WebhookHandler")
+    assert lazy_index == 136
+    assert lazy_names[lazy_index - 3 : lazy_index + 4] == [
+        "FormalVerificationHandler",
+        "SlackHandler",
+        "EvidenceHandler",
+        "WebhookHandler",
+        "CodebaseAuditHandler",
+        "AdminHandler",
+        "SecurityHandler",
+    ]
+
+    registry_names = [name for name, _ in ADMIN_HANDLER_REGISTRY]
+    registry_index = registry_names.index("_webhook_handler")
+    assert registry_index == 50
+    assert registry_names[registry_index - 3 : registry_index + 4] == [
+        "_integration_health_handler",
+        "_automation_handler",
+        "_workflow_handler",
+        "_webhook_handler",
+        "_queue_handler",
+        "_workflow_templates_handler",
+        "_workflow_patterns_handler",
+    ]
+    registry_entry = dict(ADMIN_HANDLER_REGISTRY)["_webhook_handler"]
+    assert registry_entry.resolve() is module.WebhookHandler
+
+
+def test_package_shim_has_no_dynamic_file_loader() -> None:
+    """The compatibility package uses a normal canonical import, not exec loading."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        package = __import__(PACKAGE_NAME, fromlist=["_webhooks_module"])
+
+    source = Path(package.__file__).read_text(encoding="utf-8")
+    assert "spec_from_file_location" not in source
+    assert "module_from_spec" not in source
+    assert "exec_module" not in source
+    assert package._webhooks_module.__name__ == "aragora.server.handlers.webhook_management"


### PR DESCRIPTION
## What

Structural dedup of the webhook handler module identity (feature `misc-webhooks-module-package-dedup`, milestone cdg-bootstrap-route-truth).

On main, `aragora/server/handlers/` contains BOTH `webhooks.py` and a `webhooks/` package whose `__init__` exec-loads the sibling FILE via `importlib.util.spec_from_file_location` under the ad-hoc module name `webhooks_module`. The implementation body therefore executes TWICE under two module identities, doubling import side effects (including its DeprecationWarning) and mis-attributing `WebhookHandler.__module__` to the bogus `webhooks_module`.

Measured red proof on base `e40805936f22` (== origin/main at branch): `{"execution_count": 2, "handler_module": "webhooks_module", "implementation_name": "webhooks_module", "legacy_handler_is_package_handler": false, "relevant_warning_count": 2}`.

## Fix (structural, zero behavior change)

- R100 rename `aragora/server/handlers/webhooks.py` -> `aragora/server/handlers/webhook_management.py` (similarity 99%; the only content change removes the module-level `generate_signature` DeprecationWarning, which remains at call time inside the function body, still exercised by `tests/security/test_webhook_signing.py`).
- `aragora/server/handlers/webhooks/__init__.py` drops the dynamic file loader entirely and imports the implementation normally (`from aragora.server.handlers import webhook_management as _webhooks_module`), re-exports the same 12 public symbols plus the historical `importlib` attribute, and emits one package-level DeprecationWarning naming old -> new path.
- Consumers keep working unrepointed: every dotted-path importer (production lazy imports in `event_subscribers.py` / `aragora/webhooks/retry_queue.py`, `_lazy_imports.py` string row, `handlers/__init__`, all test importers and patch targets) uses `aragora.server.handlers.webhooks`, which still re-exports everything. `check_sdk_parity.py`'s `_LEGACY_WARNING_MODULES` entry stays valid (the package still warns at import).
- Docs/path-list updates: `scripts/apply_rbac.py` EXCLUDED_PATHS, `aragora/storage/webhook_registry.py` docstring, `docs/reference/HANDLERS.md` + docs-site mirror (regen byte-exact), P4A architecture docs, RBAC audit report.
- New structural guard tests: `tests/handlers/test_webhooks_module_structure.py` (single-execution sentinel via subprocess probe, canonical-silent/shim-warns, route-table + `__all__` + lazy-row + admin-registry-order equality against pinned baselines, no dynamic loader in package source).

Green proof at head: `{"execution_count": 1, "handler_module": "aragora.server.handlers.webhook_management", "relevant_warning_count": 1}`.

Equality proof: behavior-surface dump (`__all__`, public names, `WebhookHandler.routes`/`ROUTES`, `HANDLER_MODULES` row, full lazy-name list, full admin-registry order, registry resolution identity) is byte-identical between base and head.

## Red-first discrimination

Committed structural test run against a clean base worktree: 3 failed (single-execution sentinel, no-dynamic-loader, shim-warning shape) / 1 passed (the route-table equality pin, by design green on both sides). At head: 4/4 pass.

## Verification (all at head, AWS-neutralized env)

- `tests/handlers/test_webhooks_module_structure.py` + `tests/handlers/test_handlers_webhooks.py`: 68 passed; 5-seed randomization sweep (101/202/303/404/505): 68 passed each.
- Full webhook consumer battery (`tests/server/handlers/test_webhooks.py`, `test_webhooks_handler.py`, `tests/security/test_webhook_signing.py`, `tests/server/test_event_subscribers.py`, `tests/handlers/test_webhooks.py`, `tests/storage/test_webhook_registry.py`, `tests/handlers/webhooks/`, `tests/webhooks/`): 405 passed.
- `make lint` PASS; `ruff format --check`: touched dirs already formatted.
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh cache): Success, no issues in 6 changed source files.
- AWS-neutralized `make test-smoke` PASS.
- `python3 scripts/check_sdk_parity.py`: 0 regressions, committed ceilings 0/0 and 36/36.
- OpenAPI regeneration guards (`tests/test_openapi_regeneration.py`, `tests/scripts/test_generate_openapi.py`): 22 passed.
- docs-site mirror regen (`node scripts/sync-docs.js`): byte-exact, tree clean; `tests/scripts/test_docs_site_sync_links.py`: 33 passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok.

## Census / sequencing

- Precondition gate: PR #9807 (mypy paydown owning `webhooks.py`) is terminal-merged (main `48888d05f9`); this branch bases on post-#9807 main `e40805936f22`.
- Fresh path-freeze census at push time: 77 open PRs, none >=100 files, ZERO overlap on all 12 touched paths and zero foreign PRs under `aragora/server/handlers/webhook*`.

Diff: 11 files, +368/-61 = 429 changed lines (machine `git diff --numstat` over `origin/main...HEAD`).

Shim ledger: `library/shims.md` appended for `aragora.server.handlers.webhooks` -> `aragora.server.handlers.webhook_management` (implementation home; old path keeps importing and warns).

## Status

Parked draft, label `operator-review-required`. Tier read from collector JSON (path-driven, `aragora/server/handlers/**` expected Tier 3). Evidence rounds run prepare-only with `apply=False`, UNPOSTED, bound to the exact head. No ready, posting, settlement, or merge is authorized for this session; settlement packet in the mission library.
