### PR TITLE
[AGT-02] Per-agent compute/cost metering stub for A2A consumer surface

### DIFF
--- a/aragora/protocols/a2a/metering.py
+++ b/aragora/protocols/a2a/metering.py
@@ -1,0 +1,208 @@
+"""Per-agent compute and cost metering for the A2A consumer surface (AGT-02).
+
+This module is the AGT-02 billing sub-deliverable.  It gives external software
+agents a canonical, machine-parseable record of the compute units, debate cost,
+and verifier cost billed to them for a single A2A session.  The record is
+content-addressed (SHA-256 of the canonical JSON) so downstream audit pipelines
+can detect tampering.
+
+See ``docs/plans/AGENT_CONSUMER_SURFACE.md`` §S3 (billing primitives) and
+``docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md`` (AGT-02).
+
+Activation: ``ARAGORA_AGENT_METERING_ENABLED`` (default off).  All
+computation is side-effect-free.  No costs are written to the billing stack
+automatically; server endpoints that emit metering records will land in a
+follow-up PR behind the same AGT-* "no live behavior change" rule from
+``docs/status/NEXT_STEPS_CANONICAL.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+METERING_SCHEMA_VERSION = "1.0"
+
+_METERING_FLAG = "ARAGORA_AGENT_METERING_ENABLED"
+_metering_enabled_override: bool | None = None
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+def agent_metering_enabled() -> bool:
+    """Return ``True`` when agent metering records may be created and emitted.
+
+    Checks the module-level override first, then the
+    ``ARAGORA_AGENT_METERING_ENABLED`` environment variable.  Default is
+    *False*; dataclass construction is always safe regardless.
+    """
+    if _metering_enabled_override is not None:
+        return _metering_enabled_override
+    raw = str(os.environ.get(_METERING_FLAG) or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_agent_metering() -> None:
+    """Enable agent metering for the current process.
+
+    Sets a module-level override rather than mutating ``os.environ``.
+    Call :func:`reset_agent_metering` to restore env-var-driven behaviour
+    (useful in test teardown).
+    """
+    global _metering_enabled_override
+    _metering_enabled_override = True
+
+
+def reset_agent_metering() -> None:
+    """Clear the module-level override, reverting to env-var-driven behaviour."""
+    global _metering_enabled_override
+    _metering_enabled_override = None
+
+
+# ---------------------------------------------------------------------------
+# Record type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentMeteringRecord:
+    """Immutable metering record for a single A2A agent session.
+
+    All monetary fields are in USD; ``compute_units`` is an abstract
+    platform unit (e.g., 1 unit ≈ 1 000 tokens processed).  Both default
+    to zero so callers can build records incrementally.
+
+    ``content_hash`` is set automatically by :func:`create_metering_record`
+    as the SHA-256 hex digest of the canonical JSON serialisation.
+    """
+
+    agent_id: str
+    session_id: str
+    compute_units: float = 0.0
+    debate_cost_usd: float = 0.0
+    verifier_cost_usd: float = 0.0
+    timestamp: str = field(default_factory=lambda: datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"))
+    schema_version: str = METERING_SCHEMA_VERSION
+    content_hash: str = ""
+
+    # ------------------------------------------------------------------
+    # Derived properties
+    # ------------------------------------------------------------------
+
+    @property
+    def total_cost_usd(self) -> float:
+        """Sum of debate and verifier costs in USD."""
+        return self.debate_cost_usd + self.verifier_cost_usd
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "agent_id": self.agent_id,
+            "session_id": self.session_id,
+            "compute_units": self.compute_units,
+            "debate_cost_usd": self.debate_cost_usd,
+            "verifier_cost_usd": self.verifier_cost_usd,
+            "total_cost_usd": self.total_cost_usd,
+            "timestamp": self.timestamp,
+            "content_hash": self.content_hash,
+        }
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, indent=indent)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def _canonical_payload(
+    agent_id: str,
+    session_id: str,
+    compute_units: float,
+    debate_cost_usd: float,
+    verifier_cost_usd: float,
+    timestamp: str,
+    schema_version: str,
+) -> str:
+    """Return the deterministic JSON string used for content-addressing."""
+    payload: dict[str, Any] = {
+        "agent_id": agent_id,
+        "compute_units": compute_units,
+        "debate_cost_usd": debate_cost_usd,
+        "schema_version": schema_version,
+        "session_id": session_id,
+        "timestamp": timestamp,
+        "verifier_cost_usd": verifier_cost_usd,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def create_metering_record(
+    *,
+    agent_id: str,
+    session_id: str,
+    compute_units: float = 0.0,
+    debate_cost_usd: float = 0.0,
+    verifier_cost_usd: float = 0.0,
+    timestamp: str | None = None,
+) -> AgentMeteringRecord:
+    """Create a content-addressed :class:`AgentMeteringRecord`.
+
+    Raises :exc:`RuntimeError` when ``ARAGORA_AGENT_METERING_ENABLED`` is not
+    set so metering records cannot be created accidentally in production paths
+    that haven't opted in.
+
+    Raises :exc:`ValueError` for invalid field values (negative costs, empty
+    identifiers).
+    """
+    if not agent_metering_enabled():
+        raise RuntimeError(
+            "ARAGORA_AGENT_METERING_ENABLED is not set; "
+            "metering records must not be created outside opted-in contexts."
+        )
+
+    if not agent_id or not agent_id.strip():
+        raise ValueError("agent_id must be a non-empty string")
+    if not session_id or not session_id.strip():
+        raise ValueError("session_id must be a non-empty string")
+    if compute_units < 0:
+        raise ValueError(f"compute_units must be >= 0, got {compute_units}")
+    if debate_cost_usd < 0:
+        raise ValueError(f"debate_cost_usd must be >= 0, got {debate_cost_usd}")
+    if verifier_cost_usd < 0:
+        raise ValueError(f"verifier_cost_usd must be >= 0, got {verifier_cost_usd}")
+
+    ts = timestamp or datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+    canonical = _canonical_payload(
+        agent_id=agent_id,
+        session_id=session_id,
+        compute_units=compute_units,
+        debate_cost_usd=debate_cost_usd,
+        verifier_cost_usd=verifier_cost_usd,
+        timestamp=ts,
+        schema_version=METERING_SCHEMA_VERSION,
+    )
+    content_hash = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    return AgentMeteringRecord(
+        agent_id=agent_id,
+        session_id=session_id,
+        compute_units=compute_units,
+        debate_cost_usd=debate_cost_usd,
+        verifier_cost_usd=verifier_cost_usd,
+        timestamp=ts,
+        schema_version=METERING_SCHEMA_VERSION,
+        content_hash=content_hash,
+    )

--- a/aragora/protocols/a2a/metering.py
+++ b/aragora/protocols/a2a/metering.py
@@ -88,7 +88,9 @@ class AgentMeteringRecord:
     compute_units: float = 0.0
     debate_cost_usd: float = 0.0
     verifier_cost_usd: float = 0.0
-    timestamp: str = field(default_factory=lambda: datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"))
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+    )
     schema_version: str = METERING_SCHEMA_VERSION
     content_hash: str = ""
 

--- a/tests/protocols/test_a2a_metering.py
+++ b/tests/protocols/test_a2a_metering.py
@@ -1,0 +1,257 @@
+"""Unit tests for aragora.protocols.a2a.metering (AGT-02).
+
+Verifies flag-gate semantics, record creation, content-addressing, and
+serialisation.  No network, no subprocess, no queue mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+import aragora.protocols.a2a.metering as _metering_module
+from aragora.protocols.a2a.metering import (
+    AgentMeteringRecord,
+    METERING_SCHEMA_VERSION,
+    agent_metering_enabled,
+    create_metering_record,
+    enable_agent_metering,
+    reset_agent_metering,
+)
+
+
+# ---------------------------------------------------------------------------
+# Autouse fixture: always restore module-level override after each test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_metering_override() -> pytest.IterableFixture:  # type: ignore[type-arg]
+    reset_agent_metering()
+    yield
+    reset_agent_metering()
+
+
+# ---------------------------------------------------------------------------
+# Flag-gate tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGate:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_AGENT_METERING_ENABLED", raising=False)
+        assert not agent_metering_enabled()
+
+    def test_enabled_via_env_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_AGENT_METERING_ENABLED", "1")
+        assert agent_metering_enabled()
+
+    def test_enabled_via_env_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_AGENT_METERING_ENABLED", "true")
+        assert agent_metering_enabled()
+
+    def test_enabled_via_env_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_AGENT_METERING_ENABLED", "yes")
+        assert agent_metering_enabled()
+
+    def test_enabled_via_env_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_AGENT_METERING_ENABLED", "on")
+        assert agent_metering_enabled()
+
+    def test_arbitrary_string_not_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_AGENT_METERING_ENABLED", "maybe")
+        assert not agent_metering_enabled()
+
+    def test_enable_helper_sets_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_AGENT_METERING_ENABLED", raising=False)
+        enable_agent_metering()
+        assert agent_metering_enabled()
+        assert _metering_module._metering_enabled_override is True  # noqa: SLF001
+
+    def test_enable_does_not_mutate_environ(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_AGENT_METERING_ENABLED", raising=False)
+        before = dict(os.environ)
+        enable_agent_metering()
+        assert os.environ == before
+
+    def test_reset_clears_override(self) -> None:
+        enable_agent_metering()
+        reset_agent_metering()
+        assert _metering_module._metering_enabled_override is None  # noqa: SLF001
+        assert not agent_metering_enabled()
+
+    def test_override_takes_priority_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_AGENT_METERING_ENABLED", raising=False)
+        enable_agent_metering()
+        assert agent_metering_enabled()
+
+    def test_create_raises_when_flag_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_AGENT_METERING_ENABLED", raising=False)
+        with pytest.raises(RuntimeError, match="ARAGORA_AGENT_METERING_ENABLED"):
+            create_metering_record(agent_id="ag-1", session_id="sess-1")
+
+
+# ---------------------------------------------------------------------------
+# Record creation tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMeteringRecord:
+    def test_basic_round_trip(self) -> None:
+        enable_agent_metering()
+        rec = create_metering_record(
+            agent_id="ag-123",
+            session_id="sess-abc",
+            compute_units=42.0,
+            debate_cost_usd=0.05,
+            verifier_cost_usd=0.01,
+            timestamp="2026-08-25T12:00:00Z",
+        )
+        assert rec.agent_id == "ag-123"
+        assert rec.session_id == "sess-abc"
+        assert rec.compute_units == 42.0
+        assert rec.debate_cost_usd == 0.05
+        assert rec.verifier_cost_usd == 0.01
+        assert rec.timestamp == "2026-08-25T12:00:00Z"
+        assert rec.schema_version == METERING_SCHEMA_VERSION
+
+    def test_defaults_to_zero_costs(self) -> None:
+        enable_agent_metering()
+        rec = create_metering_record(agent_id="ag-1", session_id="sess-1")
+        assert rec.compute_units == 0.0
+        assert rec.debate_cost_usd == 0.0
+        assert rec.verifier_cost_usd == 0.0
+
+    def test_content_hash_non_empty(self) -> None:
+        enable_agent_metering()
+        rec = create_metering_record(
+            agent_id="ag-1",
+            session_id="sess-1",
+            timestamp="2026-08-25T00:00:00Z",
+        )
+        assert len(rec.content_hash) == 64  # SHA-256 hex
+
+    def test_content_hash_deterministic(self) -> None:
+        enable_agent_metering()
+        kwargs = dict(
+            agent_id="ag-det",
+            session_id="sess-det",
+            compute_units=10.0,
+            debate_cost_usd=0.02,
+            verifier_cost_usd=0.005,
+            timestamp="2026-08-25T09:00:00Z",
+        )
+        r1 = create_metering_record(**kwargs)
+        r2 = create_metering_record(**kwargs)
+        assert r1.content_hash == r2.content_hash
+
+    def test_different_inputs_produce_different_hashes(self) -> None:
+        enable_agent_metering()
+        r1 = create_metering_record(
+            agent_id="ag-1", session_id="sess-1", compute_units=1.0,
+            timestamp="2026-08-25T00:00:00Z",
+        )
+        r2 = create_metering_record(
+            agent_id="ag-2", session_id="sess-1", compute_units=1.0,
+            timestamp="2026-08-25T00:00:00Z",
+        )
+        assert r1.content_hash != r2.content_hash
+
+    def test_timestamp_auto_generated_when_omitted(self) -> None:
+        enable_agent_metering()
+        rec = create_metering_record(agent_id="ag-1", session_id="sess-1")
+        assert rec.timestamp.endswith("Z")
+        assert "T" in rec.timestamp
+
+    def test_raises_on_empty_agent_id(self) -> None:
+        enable_agent_metering()
+        with pytest.raises(ValueError, match="agent_id"):
+            create_metering_record(agent_id="", session_id="sess-1")
+
+    def test_raises_on_whitespace_agent_id(self) -> None:
+        enable_agent_metering()
+        with pytest.raises(ValueError, match="agent_id"):
+            create_metering_record(agent_id="   ", session_id="sess-1")
+
+    def test_raises_on_empty_session_id(self) -> None:
+        enable_agent_metering()
+        with pytest.raises(ValueError, match="session_id"):
+            create_metering_record(agent_id="ag-1", session_id="")
+
+    def test_raises_on_negative_compute_units(self) -> None:
+        enable_agent_metering()
+        with pytest.raises(ValueError, match="compute_units"):
+            create_metering_record(agent_id="ag-1", session_id="s-1", compute_units=-1.0)
+
+    def test_raises_on_negative_debate_cost(self) -> None:
+        enable_agent_metering()
+        with pytest.raises(ValueError, match="debate_cost_usd"):
+            create_metering_record(agent_id="ag-1", session_id="s-1", debate_cost_usd=-0.01)
+
+    def test_raises_on_negative_verifier_cost(self) -> None:
+        enable_agent_metering()
+        with pytest.raises(ValueError, match="verifier_cost_usd"):
+            create_metering_record(agent_id="ag-1", session_id="s-1", verifier_cost_usd=-0.01)
+
+
+# ---------------------------------------------------------------------------
+# Property and serialisation tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentMeteringRecord:
+    def _make(self, **kwargs: object) -> AgentMeteringRecord:
+        enable_agent_metering()
+        defaults: dict = dict(
+            agent_id="ag-1",
+            session_id="sess-1",
+            timestamp="2026-08-25T00:00:00Z",
+        )
+        defaults.update(kwargs)
+        return create_metering_record(**defaults)
+
+    def test_total_cost_sums_debate_and_verifier(self) -> None:
+        rec = self._make(debate_cost_usd=0.10, verifier_cost_usd=0.03)
+        assert abs(rec.total_cost_usd - 0.13) < 1e-9
+
+    def test_total_cost_zero_when_both_zero(self) -> None:
+        rec = self._make()
+        assert rec.total_cost_usd == 0.0
+
+    def test_to_dict_has_required_keys(self) -> None:
+        d = self._make().to_dict()
+        required = {
+            "schema_version",
+            "agent_id",
+            "session_id",
+            "compute_units",
+            "debate_cost_usd",
+            "verifier_cost_usd",
+            "total_cost_usd",
+            "timestamp",
+            "content_hash",
+        }
+        assert required.issubset(d.keys())
+
+    def test_to_dict_total_cost_matches_property(self) -> None:
+        rec = self._make(debate_cost_usd=0.07, verifier_cost_usd=0.02)
+        d = rec.to_dict()
+        assert d["total_cost_usd"] == rec.total_cost_usd
+
+    def test_to_json_is_valid_json(self) -> None:
+        rec = self._make()
+        parsed = json.loads(rec.to_json())
+        assert parsed["agent_id"] == "ag-1"
+
+    def test_to_json_sorted_keys(self) -> None:
+        rec = self._make()
+        raw = rec.to_json()
+        keys = list(json.loads(raw).keys())
+        assert keys == sorted(keys)
+
+    def test_record_is_immutable(self) -> None:
+        rec = self._make()
+        with pytest.raises((AttributeError, TypeError)):
+            rec.compute_units = 999.0  # type: ignore[misc]

--- a/tests/protocols/test_a2a_metering.py
+++ b/tests/protocols/test_a2a_metering.py
@@ -150,11 +150,15 @@ class TestCreateMeteringRecord:
     def test_different_inputs_produce_different_hashes(self) -> None:
         enable_agent_metering()
         r1 = create_metering_record(
-            agent_id="ag-1", session_id="sess-1", compute_units=1.0,
+            agent_id="ag-1",
+            session_id="sess-1",
+            compute_units=1.0,
             timestamp="2026-08-25T00:00:00Z",
         )
         r2 = create_metering_record(
-            agent_id="ag-2", session_id="sess-1", compute_units=1.0,
+            agent_id="ag-2",
+            session_id="sess-1",
+            compute_units=1.0,
             timestamp="2026-08-25T00:00:00Z",
         )
         assert r1.content_hash != r2.content_hash


### PR DESCRIPTION
## Slice
Adds the billing sub-deliverable of AGT-02: an immutable `AgentMeteringRecord` dataclass that captures compute units, debate cost (USD), and verifier cost (USD) per agent session, content-addressed via SHA-256. A flag-gated factory `create_metering_record` is the only public constructor; it is guarded by `ARAGORA_AGENT_METERING_ENABLED` (default off) so no metering records can be created accidentally in production paths that haven't opted in.

## Gating
- Default: OFF (flag: `ARAGORA_AGENT_METERING_ENABLED`)
- Live queue effect: none — module is contract-only; no billing stack wired, no server endpoints emit records
- Advances issue: AGT-02 (A2A consumer surface — billing primitives sub-deliverable per `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` §AGT-02 and `docs/plans/AGENT_CONSUMER_SURFACE.md` §S3)

## Tests
- `TestFlagGate` (11 tests) — verifies default-off, env-var activation (`1`/`true`/`yes`/`on`), module-level override helpers, environ non-mutation, and that `create_metering_record` raises `RuntimeError` when flag is off
- `TestCreateMeteringRecord` (12 tests) — basic round-trip, zero-cost defaults, content-hash length and determinism, cross-input hash divergence, auto-timestamp, and validation errors for empty/negative fields
- `TestAgentMeteringRecord` (7 tests) — `total_cost_usd` property, `to_dict` key set, `to_json` validity and sorted-key guarantee, immutability

## Validation
- `pytest tests/protocols/test_a2a_metering.py --noconftest` — **30 passed** in 0.17 s
- `ruff check aragora/protocols/a2a/metering.py tests/protocols/test_a2a_metering.py` — clean
- `mypy aragora/protocols/a2a/metering.py --ignore-missing-imports` — clean

## Out of scope
- Server endpoints that emit `AgentMeteringRecord` (follow-up PR, same AGT-* gate)
- Persistence to the billing stack / ShiftLedger (AGT-06 VIAH dependency)
- Per-agent billing aggregation and quota enforcement (later AGT-02 slices)
- Reputation-delta linkage to metering records (AGT-05 dependency)

---
_Generated by [Claude Code](https://claude.ai/code/session_017L9h86juwb1rPTK7BcHAm7)_