### PR TITLE
fix(governance): bind the successor rule-suite plane to the implementation push [Tier 4]

### DIFF
--- a/docs/governance/PR9320_SUCCESSOR_BACKFILL_RUNBOOK.md
+++ b/docs/governance/PR9320_SUCCESSOR_BACKFILL_RUNBOOK.md
@@ -135,7 +135,9 @@ Build the final input document with:
 - current exact-ref authority, dependency, inventory, public-symbol, route-boundary, category,
   original-ID, projection-schema, SDK-provenance, and SDK/core/extended partition digests;
 - all `655` projection memberships and all `666` method-specific edges;
-- a new passing rule-suite record for `refs/heads/main`;
+- the passing `refs/heads/main` rule-suite record of the implementation push, with
+  `rule_suite.after_sha == authority_source_sha == IMPLEMENTATION_SHA` and `repository_name`
+  normalized to `synaptent/aragora`;
 - stable attestation identity claims for `actions/attest@v4`;
 - non-precedential `historical_nonconforming` disposition;
 - explicit supersession of release `363450207`.
@@ -188,7 +190,12 @@ the later delegation, passing `source_digest=<merged implementation SHA>`. Requi
 - exact subject SHA-256 values for the three frozen assets.
 
 Run `gh attestation verify` twice per asset. Capture the passing rule-suite ID/result immediately
-and require its repository, `refs/heads/main`, and `after_sha` to match the payload.
+and require `refs/heads/main`, `result=pass`, and `after_sha` equal to the exact merged
+implementation SHA bound by the payload as `authority_source_sha` — never the historical squash
+merge SHA, whose push predates the repository's rule-suite ledger and therefore has no record.
+The raw rule-suites API returns the bare repository name (`aragora`, `repository_id 1126097105`);
+normalize it to `synaptent/aragora` before comparing against the payload while persisting the raw
+bytes unmodified.
 
 ## Finalization checkpoint P6: negative probes
 
@@ -309,3 +316,30 @@ uses `--config-env`, so the exact historical-receipt patch argv remains accepted
 Behavior is proven by `test_read_only_git_guard_rejects_config_env_joined_form` and
 `test_read_only_git_guard_rejects_config_env_separate_form` in
 `tests/scripts/test_check_contract_drift_ratchet.py`.
+
+## Rule-suite binding: implementation push identity (fail-closed)
+
+`validate_payload` previously required `rule_suite.after_sha` to equal the historical squash
+merge SHA `0b28f68b…`. That plane was unsatisfiable: the repository's rule-suite ledger did not
+exist at the 2026-07-16 historical merge (ruleset `20156862` `cdg-boundary-main-evaluation` was
+created `2026-07-31T23:08:36Z`, and the first `refs/heads/main` rule-suite record ever is
+`3525237532` on `2026-08-01`), so no passing record with that `after_sha` ever existed or can
+exist. Only the synthetic fixture record, which reused the merge SHA, masked the defect.
+
+The rule-suite plane now binds the implementation push identity, symmetric with the attestation
+plane: `rule_suite.after_sha` must equal `authority_source_sha` — the exact merged implementation
+SHA whose `refs/heads/main` push produced the passing record — with `ref == refs/heads/main` and
+`result == pass`, fail-closed on any mismatch. The capsule schema documents the same binding on
+`rule_suite.after_sha`. The live implementation push
+`057407297d7c7991bddb4cf16185ee3626100dd2` has passing record ID `3821290531`
+(`before_sha 80671081ec1558aaf63460f39980b43601a7c44d`, `result pass`).
+
+Repository-name normalization is explicit: the raw GitHub rule-suites API returns the bare
+repository name (`"repository_name": "aragora"`, `repository_id 1126097105`), while the builder
+validates the normalized `synaptent/aragora` form. Input construction normalizes the name to the
+`owner/name` form (the preparation fixture does the same); the boundary-capsule precedent
+persists raw API bytes bare and validates fields separately.
+
+Behavior is proven by the rule-suite binding tests in
+`tests/scripts/test_build_contract_drift_historical_backfill.py` and the schema region test in
+`tests/scripts/test_contract_drift_historical_backfill_schema.py`.

--- a/scripts/build_contract_drift_historical_backfill.py
+++ b/scripts/build_contract_drift_historical_backfill.py
@@ -1293,7 +1293,14 @@ def validate_payload(payload: Any) -> dict[str, Any]:
         repository=repository,
         source_sha=authority["source_sha"],
     )
-    _validate_rule_suite(document.get("rule_suite"), repository=repository, source_sha=merge_sha)
+    # The repository's rule-suite ledger postdates the historical squash merge, so
+    # no passing record for merge_sha can exist; the rule-suite plane binds the
+    # implementation push identity, symmetric with the attestation plane.
+    _validate_rule_suite(
+        document.get("rule_suite"),
+        repository=repository,
+        source_sha=authority["source_sha"],
+    )
 
     supersedes = _require_exact_fields(
         document.get("supersedes"),

--- a/scripts/schemas/contract-drift-historical-backfill-capsule-v2.schema.json
+++ b/scripts/schemas/contract-drift-historical-backfill-capsule-v2.schema.json
@@ -268,7 +268,11 @@
     "rule_suite": {
       "additionalProperties": false,
       "properties": {
-        "after_sha": {"pattern": "^[0-9a-f]{40}$", "type": "string"},
+        "after_sha": {
+          "description": "Exact merged implementation SHA whose refs/heads/main push produced the passing rule-suite record; distinct from the historical squash merge SHA, which predates the repository's rule-suite ledger.",
+          "pattern": "^[0-9a-f]{40}$",
+          "type": "string"
+        },
         "id": {"minimum": 1, "type": "integer"},
         "ref": {"const": "refs/heads/main"},
         "repository_id": {"minimum": 1, "type": "integer"},

--- a/tests/scripts/test_build_contract_drift_historical_backfill.py
+++ b/tests/scripts/test_build_contract_drift_historical_backfill.py
@@ -22,6 +22,8 @@ FIRST_PARENT_SHA = "e448b840dad03ee28accd218c14a27fa8b87c7b4"
 HEAD_TREE_SHA = "e5c6c3d07a918cf43fffed6d4a9f472bc10a674a"
 MERGE_TREE_SHA = "79c1c374eed261c42468dc526d837e726e73425a"
 PATCH_SHA256 = "7c53f6c8b9bd17847cdb4ecc5dfa1c7aa1699105faabc47439a4437709a175b4"
+IMPLEMENTATION_PUSH_SHA = "057407297d7c7991bddb4cf16185ee3626100dd2"
+IMPLEMENTATION_RULE_SUITE_ID = 3821290531
 OLD_RELEASE_ID = 363450207
 SYNTHETIC_RELEASE_ID = 990000001
 SYNTHETIC_RULE_SUITE_ID = 990000002
@@ -929,6 +931,65 @@ def test_rule_suite_and_projection_edges_are_fail_closed(payload: dict[str, Any]
     missing_edge["projection"]["records"][0]["operation_edges"].clear()
     with pytest.raises(ValueError, match="no method-specific edges"):
         backfill.validate_payload(missing_edge)
+
+
+def test_rule_suite_after_sha_bound_to_historical_merge_fails_closed(
+    payload: dict[str, Any],
+) -> None:
+    # The repository's rule-suite ledger began after the 2026-07-16 historical
+    # squash merge, so no passing record with after_sha == merge_sha ever
+    # existed or can exist; a payload claiming one must be rejected.
+    candidate = copy.deepcopy(payload)
+    candidate["rule_suite"]["after_sha"] = MERGE_SHA
+    with pytest.raises(ValueError, match="rule-suite after SHA mismatch"):
+        backfill.validate_payload(candidate)
+
+
+def test_rule_suite_after_sha_bound_to_implementation_source_validates(
+    payload: dict[str, Any],
+) -> None:
+    candidate = copy.deepcopy(payload)
+    candidate["rule_suite"]["after_sha"] = SOURCE_SHA
+    validated = backfill.validate_payload(candidate)
+    assert validated["rule_suite"]["after_sha"] == validated["authority"]["source_sha"]
+
+
+def test_live_rule_suite_record_normalizes_bare_repository_name() -> None:
+    # Field values from the live passing record for the merged implementation
+    # push (rule-suite ID 3821290531). The raw rule-suites API returns the bare
+    # repository name ("aragora"), so input construction must normalize it to
+    # the owner/name form before validation; raw persisted bytes stay bare.
+    record = {
+        "after_sha": IMPLEMENTATION_PUSH_SHA,
+        "id": IMPLEMENTATION_RULE_SUITE_ID,
+        "ref": "refs/heads/main",
+        "repository_id": 1126097105,
+        "repository_name": "synaptent/aragora",
+        "result": "pass",
+        "schema": backfill.RULE_SUITE_SCHEMA,
+    }
+    validated = backfill._validate_rule_suite(
+        dict(record),
+        repository="synaptent/aragora",
+        source_sha=IMPLEMENTATION_PUSH_SHA,
+    )
+    assert validated == record
+
+    bare = {**record, "repository_name": "aragora"}
+    with pytest.raises(ValueError, match="rule-suite repository mismatch"):
+        backfill._validate_rule_suite(
+            bare,
+            repository="synaptent/aragora",
+            source_sha=IMPLEMENTATION_PUSH_SHA,
+        )
+
+    before_push = {**record, "after_sha": "80671081ec1558aaf63460f39980b43601a7c44d"}
+    with pytest.raises(ValueError, match="rule-suite after SHA mismatch"):
+        backfill._validate_rule_suite(
+            before_push,
+            repository="synaptent/aragora",
+            source_sha=IMPLEMENTATION_PUSH_SHA,
+        )
 
 
 def test_movement_is_fail_closed() -> None:

--- a/tests/scripts/test_build_contract_drift_historical_backfill.py
+++ b/tests/scripts/test_build_contract_drift_historical_backfill.py
@@ -207,7 +207,7 @@ def _input_document() -> dict[str, Any]:
         },
         "repository": "synaptent/aragora",
         "rule_suite": {
-            "after_sha": MERGE_SHA,
+            "after_sha": SOURCE_SHA,
             "id": SYNTHETIC_RULE_SUITE_ID,
             "ref": "refs/heads/main",
             "repository_id": 1126097105,
@@ -293,6 +293,7 @@ def test_fixture_binds_all_semantic_planes(payload: dict[str, Any]) -> None:
     assert payload["release"]["exact_full_sha_tag"] == MERGE_SHA
     assert payload["release"]["tag_target_sha"] == SOURCE_SHA
     assert payload["attestation"]["source_digest"] == SOURCE_SHA
+    assert payload["rule_suite"]["after_sha"] == SOURCE_SHA
     assert (
         payload["historical_pull_request"]["changed_files"]
         == _input_document()["historical_pull_request"]["changed_files"]

--- a/tests/scripts/test_contract_drift_historical_backfill_schema.py
+++ b/tests/scripts/test_contract_drift_historical_backfill_schema.py
@@ -74,6 +74,15 @@ def test_schema_binds_successor_release_attestation_and_disposition() -> None:
     assert disposition["authoritative_for_future_admission"]["const"] is False
 
 
+def test_schema_rule_suite_region_binds_implementation_push_identity() -> None:
+    rule_suite = SCHEMA["properties"]["rule_suite"]["properties"]
+    assert "merged implementation SHA" in rule_suite["after_sha"]["description"]
+    assert rule_suite["after_sha"]["pattern"] == "^[0-9a-f]{40}$"
+    assert rule_suite["ref"]["const"] == "refs/heads/main"
+    assert rule_suite["result"]["const"] == "pass"
+    assert rule_suite["schema"]["const"] == "contract-drift-historical-backfill-rule-suite-v1"
+
+
 def test_schema_requires_complete_method_specific_projection_edges() -> None:
     record = SCHEMA["properties"]["projection"]["properties"]["records"]["items"]
     edge = record["properties"]["operation_edges"]["items"]


### PR DESCRIPTION
## Tier-4 prepare-only: cure the successor capsule's unsatisfiable rule_suite plane

**Authority:** operator "Ruling: rule-suite plane cure option A + cure-first sequencing (2026-08-26)" — prepare-only feature `cdg-capsule-rule-suite-plane-cure`. Parked draft; NO ready/posting/settlement/merge in this session.

### Defect

`validate_payload` bound `rule_suite.after_sha` to the frozen historical squash merge `0b28f68b9f4d204ae14814169093723ea84c1364` (the call site passed `source_sha=merge_sha`). The repository's rule-suite ledger postdates that 2026-07-16 merge: ruleset `20156862` (`cdg-boundary-main-evaluation`) was created `2026-07-31T23:08:36Z`, and the first `refs/heads/main` rule-suite record ever is `3525237532` on 2026-08-01. No passing record with that `after_sha` ever existed or can exist, so the plane was unsatisfiable by any real capsule. The test fixture's synthetic record reused the merge SHA, which masked the defect.

### Cure (symmetric with the attestation plane)

- Builder call site now binds `source_sha=authority["source_sha"]` (the merged implementation push identity); `ref == refs/heads/main` and `result == pass` remain fail-closed. The `_validate_rule_suite` body is unchanged — it already enforced exact fields and equality; only the bound identity was wrong.
- Fixture rule-suite record rebinds `after_sha` to the fixture authority source SHA (`ee989c88…`), eliminating the masking; the synthetic numeric ID stays fixture-only.
- v2 schema documents the implementation-SHA binding on `rule_suite.after_sha` (description mirroring `attestation.source_digest` / `release.tag_target_sha`).
- Runbook P3 bullet + P5 capture requirement updated, plus a dedicated "Rule-suite binding: implementation push identity (fail-closed)" section.

### repository_name normalization (explicit)

The raw rule-suites API returns the BARE repository name (`"repository_name": "aragora"`, `repository_id 1126097105`) while the builder validates the normalized `synaptent/aragora` form. Input construction normalizes to `owner/name` (the fixture does the same); the boundary-capsule precedent persists raw API bytes bare and validates fields separately. Locked by `test_live_rule_suite_record_normalizes_bare_repository_name` using field values from live record `3821290531` — the passing record of implementation push `057407297d7c7991bddb4cf16185ee3626100dd2` (`before_sha 80671081ec…`, `result pass`).

### Red-first proof (commit b834ddf1a7)

Targeted RED run: 3 failed / 2 passed exactly as designed:

- `test_rule_suite_after_sha_bound_to_historical_merge_fails_closed` — DID NOT RAISE (the current builder demands the impossible historical record)
- `test_rule_suite_after_sha_bound_to_implementation_source_validates` — `ValueError: historical rule-suite after SHA mismatch` (the current builder rejects the only satisfiable identity)
- `test_schema_rule_suite_region_binds_implementation_push_identity` — `KeyError: 'description'`
- green: existing `test_rule_suite_and_projection_edges_are_fail_closed` + the new live-record normalization vector

### Verification (cure commit 9dbf15edbb)

- Builder + schema suites: **153 passed** (`tests/scripts/test_build_contract_drift_historical_backfill.py`, `tests/scripts/test_contract_drift_historical_backfill_schema.py`, `python3 -B`)
- Adjacent: **1356 passed, 1 skipped** (pre-existing `ARAGORA_RUN_LIVE_CDG_WORKFLOW_TEST` gate; zero new skips) across `test_check_contract_drift_ratchet.py`, `test_contract_drift_measurement_authority_tier.py`, `test_contract_drift_workflow.py`, `test_generate_contract_drift_inventory.py`; no analyzer-bundle digest rebind needed (the builder is not a bundle member)
- `make lint`, `ruff format --check` (3 touched Python files), `preflight_mypy.sh --diff-base origin/main`, AWS-neutral `make test-smoke`, `automation_pr_preflight.sh origin/main HEAD`: all green
- Fixture double build byte-identical across two fully independent builds; NEW pinned digests (byte lengths unchanged vs the superseded table, digests rotated):
  - `manifest.json` 457 B `5ad2630d4669bc998dfbb80deb3a61383055a09627fba59e0afdc359cf048d42`
  - `payload.json` 1122038 B `567b6c26b51aee0b07609ca5fb18e4f638a1a2d713edfd6048e632fa1574eb1b`
  - `checksums.txt` 159 B `cd54b0f9ba62bac5fb2c08678e6d5a74d894ae7260a3dd7862121919688eb614`

### Bounds

5 files, +121/−5 (126 LOC, cap 800). Zero releases/tags/workflow-dispatch mutations; releases 363450207/367396047/372111033 untouched. Evidence rounds are prepare-only (apply=False, UNPOSTED, claude+openai).
