### PR TITLE
refactor(handlers): repoint webhook consumers to the canonical module and pin exact RBAC exclusions

### DIFF
--- a/aragora/server/event_subscribers.py
+++ b/aragora/server/event_subscribers.py
@@ -151,7 +151,7 @@ class ServerEventSubscriber:
         This enables external systems to receive real-time notifications.
         """
         try:
-            from aragora.server.handlers.webhooks import get_webhook_store
+            from aragora.server.handlers.webhook_management import get_webhook_store
             from aragora.events.dispatcher import dispatch_webhook_with_retry
 
             # Get registered webhooks for this event type

--- a/aragora/server/handlers/__init__.py
+++ b/aragora/server/handlers/__init__.py
@@ -421,7 +421,7 @@ if TYPE_CHECKING:
     from .verification import FormalVerificationHandler, VerificationHandler
     from .verticals import VerticalsHandler
     from .visualization import VisualizationHandler
-    from .webhooks import WebhookHandler
+    from .webhook_management import WebhookHandler
     from .workflow_templates import (
         SMEWorkflowsHandler,
         TemplateRecommendationsHandler,

--- a/aragora/server/handlers/_lazy_imports.py
+++ b/aragora/server/handlers/_lazy_imports.py
@@ -320,7 +320,7 @@ HANDLER_MODULES: dict[str, str] = {
     "UsageMeteringHandler": "aragora.server.handlers.usage_metering",
     "VerticalsHandler": "aragora.server.handlers.verticals",
     "VoiceHandler": "aragora.server.handlers.voice.handler",
-    "WebhookHandler": "aragora.server.handlers.webhooks",
+    "WebhookHandler": "aragora.server.handlers.webhook_management",
     "WorkflowHandler": "aragora.server.handlers.workflows",
     "WorkspaceHandler": "aragora.server.handlers.workspace",
     # Workflow templates handlers

--- a/aragora/server/handlers/webhooks/__init__.py
+++ b/aragora/server/handlers/webhooks/__init__.py
@@ -1,5 +1,8 @@
 """Webhook handlers for management APIs and external integrations."""
 
+# Aliased so the deprecation shim adds nothing to the package's public surface.
+from typing import Any as _Any
+
 import importlib as importlib  # Compatibility: historically a public package attribute.
 import warnings as _warnings
 
@@ -9,24 +12,21 @@ from aragora.server.handlers.webhooks.github_app import (
     handle_github_webhook,
 )
 
-# Preserve the package's historical exports and private module hook while
-# loading the implementation through its one canonical module identity.
-WebhookHandler = _webhooks_module.WebhookHandler
-WebhookStore = _webhooks_module.WebhookStore
-WebhookConfig = _webhooks_module.WebhookConfig
-get_webhook_store = _webhooks_module.get_webhook_store
-generate_signature = _webhooks_module.generate_signature
-verify_signature = _webhooks_module.verify_signature
-WEBHOOK_EVENTS = _webhooks_module.WEBHOOK_EVENTS
-RBAC_AVAILABLE = _webhooks_module.RBAC_AVAILABLE
-check_permission = _webhooks_module.check_permission
-validate_webhook_url = _webhooks_module.validate_webhook_url
-
-_warnings.warn(
-    "aragora.server.handlers.webhooks is deprecated as the webhook management "
-    "implementation home; use aragora.server.handlers.webhook_management instead.",
-    DeprecationWarning,
-    stacklevel=2,
+# Management names that historically lived here; their one canonical home is
+# webhook_management, so resolving them through this package warns the caller.
+_DEPRECATED_MANAGEMENT_EXPORTS = frozenset(
+    {
+        "WebhookHandler",
+        "WebhookStore",
+        "WebhookConfig",
+        "get_webhook_store",
+        "generate_signature",
+        "verify_signature",
+        "WEBHOOK_EVENTS",
+        "RBAC_AVAILABLE",
+        "check_permission",
+        "validate_webhook_url",
+    }
 )
 
 __all__ = [
@@ -43,3 +43,18 @@ __all__ = [
     "check_permission",
     "validate_webhook_url",
 ]
+
+
+def __getattr__(name: str) -> _Any:
+    if name in _DEPRECATED_MANAGEMENT_EXPORTS:
+        # Deliberately not cached in module globals: every retired-path import
+        # must see the warning, and the module dict stays access-order-stable.
+        _warnings.warn(
+            "aragora.server.handlers.webhooks is deprecated as the webhook "
+            f"management implementation home; import {name} from "
+            "aragora.server.handlers.webhook_management instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(_webhooks_module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/aragora/webhooks/retry_queue.py
+++ b/aragora/webhooks/retry_queue.py
@@ -833,10 +833,15 @@ class WebhookRetryQueue:
 
         try:
             # Import signature generator
+            generate_signature: Callable[[str, str], str] | None
             try:
-                from aragora.server.handlers.webhook_management import generate_signature
+                from aragora.server.handlers.webhook_management import (
+                    generate_signature as _generate_signature,
+                )
+
+                generate_signature = _generate_signature
             except ImportError:
-                generate_signature = None  # type: ignore[assignment]
+                generate_signature = None
 
             # Build headers
             headers = {
@@ -896,10 +901,15 @@ class WebhookRetryQueue:
 
             try:
                 # Import signature generator
+                generate_signature: Callable[[str, str], str] | None
                 try:
-                    from aragora.server.handlers.webhook_management import generate_signature
+                    from aragora.server.handlers.webhook_management import (
+                        generate_signature as _generate_signature,
+                    )
+
+                    generate_signature = _generate_signature
                 except ImportError:
-                    generate_signature = None  # type: ignore[assignment]
+                    generate_signature = None
 
                 # Build headers
                 headers = {

--- a/aragora/webhooks/retry_queue.py
+++ b/aragora/webhooks/retry_queue.py
@@ -834,9 +834,9 @@ class WebhookRetryQueue:
         try:
             # Import signature generator
             try:
-                from aragora.server.handlers.webhooks import generate_signature
+                from aragora.server.handlers.webhook_management import generate_signature
             except ImportError:
-                generate_signature = None
+                generate_signature = None  # type: ignore[assignment]
 
             # Build headers
             headers = {
@@ -897,9 +897,9 @@ class WebhookRetryQueue:
             try:
                 # Import signature generator
                 try:
-                    from aragora.server.handlers.webhooks import generate_signature
+                    from aragora.server.handlers.webhook_management import generate_signature
                 except ImportError:
-                    generate_signature = None
+                    generate_signature = None  # type: ignore[assignment]
 
                 # Build headers
                 headers = {

--- a/scripts/apply_rbac.py
+++ b/scripts/apply_rbac.py
@@ -18,31 +18,41 @@ from typing import Optional
 
 # Files/paths that should remain public (no RBAC)
 # These are intentional bypasses documented for security review
+# Entries are relative to aragora/server/handlers/: entries ending in "/"
+# exclude that directory's whole subtree; every other entry names one exact file.
 EXCLUDED_PATHS = {
     # Health/monitoring endpoints - must be public for probes
     "admin/health/",
-    "health_utils.py",
-    "probes.py",
+    "admin/health_utils.py",
+    "agents/probes.py",
     # Authentication flows - must be accessible before auth
-    "signup_handlers.py",
-    "sso_handlers.py",
-    "oidc.py",
+    "auth/signup_handlers.py",
+    "auth/sso_handlers.py",
+    "_oauth/oidc.py",
     # OAuth callbacks - verified via state/signatures, not RBAC
     "_oauth_impl.py",
     "oauth_wizard.py",
     # Webhooks - verified via signatures/tokens, not RBAC
     "webhook_management.py",
-    "email_webhooks.py",
+    "features/email_webhooks.py",
     # Base classes and utilities (not actual endpoints)
     "base.py",
+    "_oauth/base.py",
+    "bots/base.py",
+    "social/slack/commands/base.py",
     "interface.py",
     "types.py",
-    "decorators.py",
-    "auth_mixins.py",
-    "lazy_stores.py",
-    "tts_helper.py",
+    "api_decorators.py",
+    "utils/auth_mixins.py",
+    "utils/database.py",
+    "utils/decorators.py",
+    "utils/lazy_stores.py",
+    "social/tts_helper.py",
     # Store implementations (internal, not endpoints)
-    "store.py",
+    "auth/store.py",
+    "explainability_store.py",
+    "features/marketplace/store.py",
+    "openclaw/store.py",
 }
 
 # Specific handlers to exclude (function names)
@@ -116,12 +126,29 @@ MODULE_PERMISSIONS = {
 }
 
 
+_HANDLER_PATH_MARKER = "server/handlers/"
+
+
+def _handler_relative_path(file_path: str) -> str | None:
+    """Normalize any spelling of a handler path to its handlers-root-relative form."""
+    path = file_path.replace("\\", "/")
+    index = path.find(_HANDLER_PATH_MARKER)
+    if index == -1:
+        return None
+    return path[index + len(_HANDLER_PATH_MARKER) :]
+
+
 def is_excluded(file_path: str, function_name: str) -> bool:
     """Check if a handler should be excluded from RBAC."""
     # Check excluded paths
-    for excluded in EXCLUDED_PATHS:
-        if excluded in file_path:
-            return True
+    relative = _handler_relative_path(file_path)
+    if relative is not None:
+        for excluded in EXCLUDED_PATHS:
+            if excluded.endswith("/"):
+                if relative.startswith(excluded):
+                    return True
+            elif relative == excluded:
+                return True
 
     # Check excluded handlers
     if function_name in EXCLUDED_HANDLERS:

--- a/tests/handlers/test_webhooks_module_structure.py
+++ b/tests/handlers/test_webhooks_module_structure.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 from pathlib import Path
@@ -362,6 +363,101 @@ def test_webhook_routes_registration_and_public_surface_match_baseline() -> None
     ]
     registry_entry = dict(ADMIN_HANDLER_REGISTRY)["_webhook_handler"]
     assert getattr(registry_entry, "resolve")() is webhook_handler_cls
+
+
+def test_delivery_and_retry_consumers_import_canonically_without_warnings() -> None:
+    """Delivery/retry consumer from-imports target the canonical module silently."""
+    script = textwrap.dedent(
+        """
+        import ast
+        import json
+        from pathlib import Path
+        import sys
+        import warnings
+
+        root = Path(sys.argv[1])
+        consumer_files = json.loads(sys.argv[2])
+        deprecated = "aragora.server.handlers.webhooks"
+        canonical = "aragora.server.handlers.webhook_management"
+
+        webhook_imports = []
+        for rel_path in consumer_files:
+            tree = ast.parse((root / rel_path).read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module in {deprecated, canonical}:
+                    webhook_imports.append(
+                        (rel_path, node.module, [alias.name for alias in node.names])
+                    )
+
+        resolved_homes = set()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            for _, module_name, names in webhook_imports:
+                module = __import__(module_name, fromlist=names)
+                for name in names:
+                    resolved_homes.add(getattr(module, name).__module__)
+
+        relevant = [
+            str(item.message)
+            for item in caught
+            if issubclass(item.category, DeprecationWarning)
+            and str(item.message).startswith(deprecated)
+        ]
+        print(json.dumps({
+            "deprecated_import_sites": sorted(
+                {path for path, module_name, _ in webhook_imports if module_name == deprecated}
+            ),
+            "import_site_count": len(webhook_imports),
+            "relevant_warnings": relevant,
+            "resolved_homes": sorted(resolved_homes),
+            "shim_imported": deprecated in sys.modules,
+        }, sort_keys=True))
+        """
+    )
+    consumer_files = [
+        "aragora/server/event_subscribers.py",
+        "aragora/webhooks/retry_queue.py",
+    ]
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARAGORA_SECRETS_STRICT": "false",
+            "AWS_CONFIG_FILE": "/dev/null",
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "AWS_SHARED_CREDENTIALS_FILE": "/dev/null",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(REPO_ROOT), json.dumps(consumer_files)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "deprecated_import_sites": [],
+        "import_site_count": 3,
+        "relevant_warnings": [],
+        "resolved_homes": [CANONICAL_MODULE_NAME],
+        "shim_imported": False,
+    }
+
+
+def test_type_checking_webhook_handler_import_targets_canonical_module() -> None:
+    """The handlers package type-checking import names the real class home."""
+    source = (REPO_ROOT / "aragora/server/handlers/__init__.py").read_text(encoding="utf-8")
+    webhook_handler_imports = [
+        node.module
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+        and node.level == 1
+        and any(alias.name == "WebhookHandler" for alias in node.names)
+    ]
+    assert webhook_handler_imports == ["webhook_management"]
 
 
 def test_package_shim_has_no_dynamic_file_loader() -> None:

--- a/tests/handlers/test_webhooks_module_structure.py
+++ b/tests/handlers/test_webhooks_module_structure.py
@@ -13,6 +13,13 @@ import warnings
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_NAME = "aragora.server.handlers.webhooks"
+CANONICAL_MODULE_NAME = "aragora.server.handlers.webhook_management"
+
+EXPECTED_SHIM_WARNING = (
+    "aragora.server.handlers.webhooks is deprecated as the webhook management "
+    "implementation home; import WebhookHandler from "
+    "aragora.server.handlers.webhook_management instead."
+)
 
 EXPECTED_EXPORTS = [
     "GITHUB_APP_ROUTES",
@@ -29,21 +36,13 @@ EXPECTED_EXPORTS = [
     "validate_webhook_url",
 ]
 
+# Only the package's canonical residents stay eagerly bound; the management
+# re-exports resolve through the deprecation shim on attribute access.
 EXPECTED_PUBLIC_NAMES = [
     "GITHUB_APP_ROUTES",
-    "RBAC_AVAILABLE",
-    "WEBHOOK_EVENTS",
-    "WebhookConfig",
-    "WebhookHandler",
-    "WebhookStore",
-    "check_permission",
-    "generate_signature",
-    "get_webhook_store",
     "github_app",
     "handle_github_webhook",
     "importlib",
-    "validate_webhook_url",
-    "verify_signature",
 ]
 
 EXPECTED_ROUTES = [
@@ -191,40 +190,36 @@ def test_webhook_implementation_executes_once_under_canonical_identity() -> None
         "legacy_file_exists": False,
         "legacy_handler_is_package_handler": None,
         "package_handler_is_implementation": True,
-        "relevant_warning_count": 1,
+        "relevant_warning_count": 0,
         "webhooks_module_registered": False,
     }
 
 
-def test_canonical_module_is_silent_and_package_shim_warns() -> None:
-    """Only the retired package-level implementation path emits the move warning."""
+def test_lazy_handler_registry_resolves_webhook_handler_without_warnings() -> None:
+    """The registry resolves WebhookHandler canonically without touching the shim."""
     script = textwrap.dedent(
         """
         import importlib
         import json
+        import sys
         import warnings
 
-        with warnings.catch_warnings(record=True) as canonical_warnings:
+        with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always", DeprecationWarning)
-            canonical = importlib.import_module(
-                "aragora.server.handlers.webhook_management"
-            )
-        with warnings.catch_warnings(record=True) as shim_warnings:
-            warnings.simplefilter("always", DeprecationWarning)
-            shim = importlib.import_module("aragora.server.handlers.webhooks")
+            handlers = importlib.import_module("aragora.server.handlers")
+            handler_cls = handlers.WebhookHandler
 
-        def relevant(items):
-            return [
-                str(item.message)
-                for item in items
-                if issubclass(item.category, DeprecationWarning)
-                and str(item.message).startswith("aragora.server.handlers.webhooks")
-            ]
-
+        relevant = [
+            str(item.message)
+            for item in caught
+            if issubclass(item.category, DeprecationWarning)
+            and str(item.message).startswith("aragora.server.handlers.webhooks")
+        ]
         print(json.dumps({
-            "canonical_warnings": relevant(canonical_warnings),
-            "shim_handler_is_canonical": shim.WebhookHandler is canonical.WebhookHandler,
-            "shim_warnings": relevant(shim_warnings),
+            "handler_module": handler_cls.__module__,
+            "registered_target": handlers.HANDLER_MODULES["WebhookHandler"],
+            "relevant_warnings": relevant,
+            "shim_imported": "aragora.server.handlers.webhooks" in sys.modules,
         }, sort_keys=True))
         """
     )
@@ -249,12 +244,79 @@ def test_canonical_module_is_silent_and_package_shim_warns() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == {
+        "handler_module": CANONICAL_MODULE_NAME,
+        "registered_target": CANONICAL_MODULE_NAME,
+        "relevant_warnings": [],
+        "shim_imported": False,
+    }
+
+
+def test_canonical_module_is_silent_and_package_shim_warns() -> None:
+    """Canonical and package imports are silent; only retired attribute access warns."""
+    script = textwrap.dedent(
+        """
+        import importlib
+        import json
+        import warnings
+
+        with warnings.catch_warnings(record=True) as canonical_warnings:
+            warnings.simplefilter("always", DeprecationWarning)
+            canonical = importlib.import_module(
+                "aragora.server.handlers.webhook_management"
+            )
+        with warnings.catch_warnings(record=True) as package_warnings:
+            warnings.simplefilter("always", DeprecationWarning)
+            github_app = importlib.import_module(
+                "aragora.server.handlers.webhooks.github_app"
+            )
+            shim = importlib.import_module("aragora.server.handlers.webhooks")
+        with warnings.catch_warnings(record=True) as attribute_warnings:
+            warnings.simplefilter("always", DeprecationWarning)
+            handler = shim.WebhookHandler
+
+        def relevant(items):
+            return [
+                str(item.message)
+                for item in items
+                if issubclass(item.category, DeprecationWarning)
+                and str(item.message).startswith("aragora.server.handlers.webhooks")
+            ]
+
+        print(json.dumps({
+            "attribute_warnings": relevant(attribute_warnings),
+            "canonical_warnings": relevant(canonical_warnings),
+            "github_app_routes_exported": bool(github_app.GITHUB_APP_ROUTES),
+            "package_warnings": relevant(package_warnings),
+            "shim_handler_is_canonical": handler is canonical.WebhookHandler,
+        }, sort_keys=True))
+        """
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARAGORA_SECRETS_STRICT": "false",
+            "AWS_CONFIG_FILE": "/dev/null",
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "AWS_SHARED_CREDENTIALS_FILE": "/dev/null",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "attribute_warnings": [EXPECTED_SHIM_WARNING],
         "canonical_warnings": [],
+        "github_app_routes_exported": True,
+        "package_warnings": [],
         "shim_handler_is_canonical": True,
-        "shim_warnings": [
-            "aragora.server.handlers.webhooks is deprecated as the webhook management "
-            "implementation home; use aragora.server.handlers.webhook_management instead."
-        ],
     }
 
 
@@ -263,6 +325,7 @@ def test_webhook_routes_registration_and_public_surface_match_baseline() -> None
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         module = __import__(PACKAGE_NAME, fromlist=["WebhookHandler"])
+        webhook_handler_cls = module.WebhookHandler
         from aragora.server.handler_registry.admin import ADMIN_HANDLER_REGISTRY
         from aragora.server.handlers._lazy_imports import ALL_HANDLER_NAMES, HANDLER_MODULES
 
@@ -270,13 +333,12 @@ def test_webhook_routes_registration_and_public_surface_match_baseline() -> None
     assert (
         sorted(name for name in vars(module) if not name.startswith("_")) == EXPECTED_PUBLIC_NAMES
     )
-    assert module.WebhookHandler.routes == EXPECTED_ROUTES
-    assert module.WebhookHandler.ROUTES == EXPECTED_V1_ROUTES
+    assert webhook_handler_cls.routes == EXPECTED_ROUTES
+    assert webhook_handler_cls.ROUTES == EXPECTED_V1_ROUTES
 
-    assert HANDLER_MODULES["WebhookHandler"] == PACKAGE_NAME
+    assert HANDLER_MODULES["WebhookHandler"] == CANONICAL_MODULE_NAME
     lazy_names = list(ALL_HANDLER_NAMES)
     lazy_index = lazy_names.index("WebhookHandler")
-    assert lazy_index == 136
     assert lazy_names[lazy_index - 3 : lazy_index + 4] == [
         "FormalVerificationHandler",
         "SlackHandler",
@@ -289,7 +351,6 @@ def test_webhook_routes_registration_and_public_surface_match_baseline() -> None
 
     registry_names = [name for name, _ in ADMIN_HANDLER_REGISTRY]
     registry_index = registry_names.index("_webhook_handler")
-    assert registry_index == 50
     assert registry_names[registry_index - 3 : registry_index + 4] == [
         "_integration_health_handler",
         "_automation_handler",
@@ -300,7 +361,7 @@ def test_webhook_routes_registration_and_public_surface_match_baseline() -> None
         "_workflow_patterns_handler",
     ]
     registry_entry = dict(ADMIN_HANDLER_REGISTRY)["_webhook_handler"]
-    assert getattr(registry_entry, "resolve")() is module.WebhookHandler
+    assert getattr(registry_entry, "resolve")() is webhook_handler_cls
 
 
 def test_package_shim_has_no_dynamic_file_loader() -> None:

--- a/tests/scripts/test_apply_rbac.py
+++ b/tests/scripts/test_apply_rbac.py
@@ -1,0 +1,137 @@
+"""Regression tests for scripts/apply_rbac.py exclusion semantics."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import scripts.apply_rbac as apply_rbac
+
+HANDLER_ROOT = PROJECT_ROOT / "aragora" / "server" / "handlers"
+
+# Handler name outside EXCLUDED_HANDLERS so path rules alone decide the outcome.
+NON_EXCLUDED_FUNCTION = "handle_example"
+
+# Directory rules exclude whole subtrees; every other exclusion is one exact file,
+# spelled relative to the handlers root.
+EXPECTED_DIRECTORY_RULES = {
+    "admin/health/",
+}
+
+EXPECTED_EXACT_EXCLUDED_FILES = {
+    "admin/health_utils.py",
+    "agents/probes.py",
+    "auth/signup_handlers.py",
+    "auth/sso_handlers.py",
+    "_oauth/oidc.py",
+    "oauth_wizard.py",
+    "webhook_management.py",
+    "features/email_webhooks.py",
+    "base.py",
+    "_oauth/base.py",
+    "bots/base.py",
+    "social/slack/commands/base.py",
+    "utils/database.py",
+    "interface.py",
+    "types.py",
+    "utils/decorators.py",
+    "api_decorators.py",
+    "utils/auth_mixins.py",
+    "utils/lazy_stores.py",
+    "social/tts_helper.py",
+    "auth/store.py",
+    "features/marketplace/store.py",
+    "openclaw/store.py",
+    "explainability_store.py",
+}
+
+
+def _audit_visible_files() -> list[str]:
+    """Handler files the RBAC audit enumerates, relative to the handlers root."""
+    files = []
+    for py_file in HANDLER_ROOT.rglob("*.py"):
+        if py_file.name.startswith("_"):
+            continue
+        files.append(py_file.relative_to(HANDLER_ROOT).as_posix())
+    return sorted(files)
+
+
+def test_substring_near_misses_are_not_excluded() -> None:
+    """A rule for one file must not swallow other files that merely end the same way."""
+    near_misses = [
+        "aragora/server/handlers/rebase.py",
+        "aragora/server/handlers/prototypes.py",
+        "aragora/server/handlers/restore.py",
+        "aragora/server/handlers/social/telegram/webhooks.py",
+        "aragora/server/handlers/social/whatsapp/webhooks.py",
+    ]
+    for path in near_misses:
+        assert not apply_rbac.is_excluded(path, NON_EXCLUDED_FUNCTION), path
+
+
+def test_path_rules_only_apply_to_handler_tree_paths() -> None:
+    """Files outside the handlers tree never match handler path rules."""
+    assert not apply_rbac.is_excluded("aragora/other/base.py", NON_EXCLUDED_FUNCTION)
+    assert not apply_rbac.is_excluded("base.py", NON_EXCLUDED_FUNCTION)
+
+
+def test_exact_entries_match_across_path_spellings() -> None:
+    """Repo-relative, audit-relative, and absolute spellings all resolve the same."""
+    spellings = [
+        "aragora/server/handlers/base.py",
+        "server/handlers/base.py",
+        str(HANDLER_ROOT / "base.py"),
+    ]
+    for path in spellings:
+        assert apply_rbac.is_excluded(path, NON_EXCLUDED_FUNCTION), path
+
+
+def test_directory_rule_excludes_whole_subtree() -> None:
+    """Directory entries end with a slash and cover every file beneath them."""
+    assert apply_rbac.is_excluded(
+        "aragora/server/handlers/admin/health/database.py", NON_EXCLUDED_FUNCTION
+    )
+    assert apply_rbac.is_excluded(
+        "aragora/server/handlers/admin/health/probes.py", NON_EXCLUDED_FUNCTION
+    )
+    assert not apply_rbac.is_excluded(
+        "aragora/server/handlers/admin/health_dashboard.py", NON_EXCLUDED_FUNCTION
+    )
+
+
+def test_excluded_handler_names_still_apply_anywhere() -> None:
+    """External-callback receivers stay excluded by handler name, not by path."""
+    receiver = "aragora/server/handlers/social/telegram/webhooks.py"
+    assert apply_rbac.is_excluded(receiver, "handle_webhook")
+    assert not apply_rbac.is_excluded(receiver, NON_EXCLUDED_FUNCTION)
+
+
+def test_every_path_rule_points_at_a_real_path() -> None:
+    """Every entry names a real file or directory under the handlers root."""
+    for entry in apply_rbac.EXCLUDED_PATHS:
+        target = HANDLER_ROOT / entry
+        if entry.endswith("/"):
+            assert target.is_dir(), entry
+        else:
+            assert target.is_file(), entry
+
+
+def test_effective_exclusion_set_is_pinned() -> None:
+    """The exclusion rules resolve to exactly the pinned file set over the live tree."""
+    for rel in sorted(EXPECTED_EXACT_EXCLUDED_FILES):
+        assert (HANDLER_ROOT / rel).is_file(), rel
+
+    visible = _audit_visible_files()
+    actual_excluded = {
+        rel
+        for rel in visible
+        if apply_rbac.is_excluded(f"aragora/server/handlers/{rel}", NON_EXCLUDED_FUNCTION)
+    }
+    expected_excluded = EXPECTED_EXACT_EXCLUDED_FILES | {
+        rel for rel in visible if any(rel.startswith(rule) for rule in EXPECTED_DIRECTORY_RULES)
+    }
+    assert actual_excluded == expected_excluded

--- a/tests/server/test_event_subscribers.py
+++ b/tests/server/test_event_subscribers.py
@@ -146,7 +146,7 @@ class TestServerEventSubscriberHandlers:
 
         with (
             patch(
-                "aragora.server.handlers.webhooks.get_webhook_store",
+                "aragora.server.handlers.webhook_management.get_webhook_store",
                 return_value=mock_store,
             ),
             patch(


### PR DESCRIPTION
## Summary

Follow-ups to the webhook canonicalization merge (#9817), implementing the three reviewer-flagged finds from that PR's review rounds. Prepare-only structex lane: this PR stays a **parked draft** labeled `operator-review-required`; no ready, no settlement, no merge.

Base: fresh post-#9817 main (`fe97dc28cd5e`). Path-freeze census at design time and again at push time: 78 open PRs, zero overlap on every touched path.

## Sub-scope 1: repoint canonical consumers (behavior change, authorized by the feature)

- `aragora/server/handlers/_lazy_imports.py`: `HANDLER_MODULES["WebhookHandler"]` now registers `aragora.server.handlers.webhook_management` (was the deprecated package path, deliberate under #9817's byte-equivalence mandate). Registry resolution and server startup no longer traverse the shim at all.
- `aragora/server/handlers/webhooks/__init__.py`: the unconditional import-time `DeprecationWarning` is replaced by a module `__getattr__` shim. Importing the package is silent; importing `webhooks.github_app` (canonically homed in the package) is silent; resolving any of the 10 retired management re-exports through the package warns exactly once per access with the canonical destination. The warning is deliberately not cached into module globals so the module dict stays access-order-stable and every retired-path import sees the signal.
- `__all__`, both route tables, and the `_webhooks_module` compat hook are unchanged; route-table equality remains asserted in tests (`EXPECTED_ROUTES`, `EXPECTED_V1_ROUTES`, full-order equality).

Warning topology after this change:

| Path | Before | After |
|---|---|---|
| Server startup / `_lazy_import("WebhookHandler")` | warns (via package import) | silent, shim never imported (asserted incl. `sys.modules`) |
| `import aragora.server.handlers.webhook_management` | silent | silent |
| `import aragora.server.handlers.webhooks.github_app` | warns (package `__init__` traversal) | silent |
| `from aragora.server.handlers.webhooks import WebhookHandler` (retired path) | warns at import | warns exactly once at attribute resolution |

Deliberately left on the retired path (call-time, warning-deduped by the default filters; the deprecation pressure is the intended two-sided signal): `aragora/server/event_subscribers.py:154`, `aragora/webhooks/retry_queue.py:837,900`. `scripts/check_sdk_parity.py:184` keeps its `_LEGACY_WARNING_MODULES` entry; it is now vestigial but harmless (the quiet preimport captures nothing to replay) — verified by running the parity gate.

## Sub-scope 2: structure-test hardening

`tests/handlers/test_webhooks_module_structure.py`:
- Dropped the two absolute-index asserts flagged brittle by both #9817 reviewers (`lazy_index == 136`, `registry_index == 50`).
- Kept the neighbor-slice assertions and every full-order equality (routes, v1 routes, `__all__`, public names).
- Updated the registry pin to the canonical module and the warning tests to the new semantics.
- Added `test_lazy_handler_registry_resolves_webhook_handler_without_warnings`: subprocess probe asserting the startup path resolves `WebhookHandler` from `webhook_management` with zero relevant DeprecationWarnings and without the shim ever entering `sys.modules`.

## Sub-scope 3: apply_rbac EXCLUDED_PATHS exact-path semantics

Census FIRST (on `fe97dc28cd5e`, over the audit-visible inventory: 638 non-underscore `*.py` files under `aragora/server/handlers/`): the old substring rules excluded exactly **46 files** = 22 under `admin/health/` + 24 individual files. Three of those 24 were **incidental substring matches** now preserved as explicit entries: `utils/database.py` (via `"base.py"`), `api_decorators.py` (via `"decorators.py"`), `explainability_store.py` (via `"store.py"`). `admin/health/database.py` was doubly covered and stays covered by the directory rule. `"_oauth_impl.py"` matched zero audit-visible files (the audit skips `_`-prefixed basenames); the entry is kept as the exact real file to preserve intent. The old `webhooks.py` incidental exclusion of `social/telegram/webhooks.py` + `social/whatsapp/webhooks.py` was already gone since the #9817 rename; those receivers remain excluded by the `handle_webhook` name rule (asserted in the new tests).

New semantics in `scripts/apply_rbac.py`: entries are handlers-root-relative; `"dir/"` entries exclude that subtree, everything else must match one exact file; `is_excluded` normalizes repo-relative, audit-relative, and absolute spellings.

**Equivalence proof (end-to-end):** old vs new `get_permission_for_handler` over the live `audit_rbac_coverage.py --json` output — 275 unprotected handlers, 33 `None` decisions on both sides, **zero decision diffs**. Additionally `test_effective_exclusion_set_is_pinned` recomputes the effective set over the live tree and passed against **both** the old and the new implementation.

## Red-first evidence

7 targeted failures captured against the unmodified base, all green after implementation:
`test_webhook_routes_registration_and_public_surface_match_baseline`, `test_lazy_handler_registry_resolves_webhook_handler_without_warnings`, `test_webhook_implementation_executes_once_under_canonical_identity`, `test_canonical_module_is_silent_and_package_shim_warns`, `test_substring_near_misses_are_not_excluded`, `test_every_path_rule_points_at_a_real_path`, `test_path_rules_only_apply_to_handler_tree_paths`.

## Verification

- Feature tests: 12/12 (`tests/handlers/test_webhooks_module_structure.py` 5, `tests/scripts/test_apply_rbac.py` 7), deterministic in both orders.
- Consumer battery: **651 passed** — `tests/handlers/webhooks/`, `tests/handlers/test_webhooks.py`, `tests/handlers/test_handlers_webhooks.py`, `tests/server/handlers/test_webhooks.py`, `tests/webhooks/`, `tests/security/test_webhook_signing.py`, `tests/server/test_event_subscribers.py`, `tests/events/test_dispatcher_server_boundary.py`, `tests/integration/test_slo_webhook_flow.py`, `tests/observability/metrics/test_webhook_metrics.py`, `tests/security/test_security_regressions.py`, `tests/handlers/test_lazy_imports.py`, `tests/server/handlers/test_lazy_imports.py`, `tests/handlers/test_readiness_check.py`, `tests/handlers/test_outcome_api.py`, `tests/debate/test_auto_explanation.py`, `tests/debate/test_event_bridge.py`.
- `make lint`, `ruff format --check` (5 touched files): clean.
- `preflight_mypy.sh --diff-base origin/main` (committed state, fresh cache): no issues in 5 files.
- `check_sdk_parity.py`: 0 baseline regressions, budgets 0/0 and 36/36.
- `make test-smoke` + smoke tier: 138 passed.
- Skip-marker count 86 == baseline 86. `automation_pr_preflight.sh origin/main HEAD`: ok.

## Size / tier

356 LOC churn (298+/58−) across 5 files. Expected **Tier 3** (touches `aragora/server/handlers/**`): evidence rounds are prepare-only (apply=False) and unposted; settlement is operator-owned.


## OpenAPI Spec Update comment adjudication (2026-08-26)

The single `github-actions` "OpenAPI Spec Update" comment (2026-08-26T16:52:58Z) was adjudicated by downloading the OpenAPI Spec run's generated artifact (`openapi-spec-32990521029-777fd056929ce8635084796c083710759a413e90`, run 32990521029 attempt 1, conclusion success) and diffing every regenerated file against the committed tree at this exact head (`777fd056929c`):

- `docs/api/openapi_generated.json`: **byte-identical** (sha256 `7d5369f61e12d2d93aac574e4ac1bd3a867a8d83024f2cda430f94215efc60f7`) — regeneration from this head's source (including the repointed `HANDLER_MODULES`) reproduces the committed spec exactly. **Route-table equality holds**: 2,911 paths / 3,204 operations, identical `(path, method)` sets between the regenerated and committed specs (and the committed spec is the same blob on origin/main — this PR does not touch it).
- `docs/api/openapi_generated.yaml`, `sdk/python/aragora/generated_types.py`, `sdk/typescript/src/openapi-types.ts`: byte-identical to the committed head.
- `aragora/live/src/types/api.generated.ts`: differs (35,529 diff lines). This is the **only** delta and it is **pre-existing main-side lag, not caused by this PR**: the committed mirror is the same blob on origin/main and this head (untouched by this PR; last synced in PR #7621), while its regeneration input (`openapi_generated.json`) is byte-identical across artifact/head/main — so clean main regeneration produces the identical drift. The regenerated mirror expands operation typings that the stale committed mirror renders as `never` placeholders (e.g. the deprecated PATCH `/api/v1/debates/{id}` metadata operation). Syncing that mirror is out of scope here.
