### PR TITLE
fix(ci): keep draft PR current-head runs alive in stale-run GC

### DIFF
--- a/scripts/pr_stale_run_gc.py
+++ b/scripts/pr_stale_run_gc.py
@@ -2,10 +2,12 @@
 """Cancel stale PR workflow runs to reduce CI queue pressure.
 
 Stale runs are queued/in-progress PR runs where:
-- the run branch has no open active PR (closed branch), or
+- the run branch has no open PR at all (closed branch), or
 - the run SHA is not the latest head SHA for that open PR branch.
 
-By default, draft PR branches are treated as inactive.
+Open PR heads count as active whether or not the PR is a draft, so a draft
+PR's current-head runs always survive. ``--keep-draft-runs`` additionally
+keeps superseded-head runs on draft PR branches.
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ import argparse
 import json
 import os
 import sys
+from collections.abc import Set as AbstractSet
 from typing import Any
 from urllib import error, parse, request
 
@@ -141,16 +144,15 @@ class GitHubClient:
             return False, message
 
 
-def compute_active_head_map(
-    open_pulls: list[dict[str, Any]],
-    *,
-    keep_draft_runs: bool,
-) -> dict[str, str]:
-    """Return branch -> head_sha for active PR heads."""
+def compute_active_head_map(open_pulls: list[dict[str, Any]]) -> dict[str, str]:
+    """Return branch -> head_sha for every open PR head, draft or not.
+
+    Draft heads must stay in this map: excluding them made scheduled GC
+    cancel every in-flight current-head run on parked draft branches as
+    ``no-active-pr-head``.
+    """
     active: dict[str, str] = {}
     for pr in open_pulls:
-        if bool(pr.get("draft")) and not keep_draft_runs:
-            continue
         head = pr.get("head", {})
         branch = str(head.get("ref", "")).strip()
         sha = str(head.get("sha", "")).strip()
@@ -159,13 +161,30 @@ def compute_active_head_map(
     return active
 
 
+def compute_draft_branches(open_pulls: list[dict[str, Any]]) -> set[str]:
+    """Return the head branch names of open draft PRs."""
+    branches: set[str] = set()
+    for pr in open_pulls:
+        if not bool(pr.get("draft")):
+            continue
+        branch = str(pr.get("head", {}).get("ref", "")).strip()
+        if branch:
+            branches.add(branch)
+    return branches
+
+
 def compute_stale_runs(
     runs: list[dict[str, Any]],
     *,
     active_heads: dict[str, str],
     cancel_events: set[str],
+    keep_stale_sha_branches: AbstractSet[str] = frozenset(),
 ) -> list[dict[str, Any]]:
-    """Determine which runs are stale and should be cancelled."""
+    """Determine which runs are stale and should be cancelled.
+
+    ``keep_stale_sha_branches`` exempts those branches (the draft PR heads
+    when ``--keep-draft-runs`` is set) from superseded-head cancellation.
+    """
     stale: list[dict[str, Any]] = []
     for run in runs:
         event_name = str(run.get("event", "")).strip()
@@ -196,6 +215,8 @@ def compute_stale_runs(
             )
             continue
         if active_sha != sha:
+            if branch in keep_stale_sha_branches:
+                continue
             stale.append(
                 {
                     "run_id": run_id,
@@ -224,7 +245,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--keep-draft-runs",
         action="store_true",
-        help="Treat draft PR branches as active and keep their runs",
+        help=(
+            "Also keep superseded-head runs on draft PR branches "
+            "(current-head runs of open PRs, draft or not, are always kept)"
+        ),
     )
     parser.add_argument(
         "--events",
@@ -255,12 +279,16 @@ def main(argv: list[str] | None = None) -> int:
     try:
         client = GitHubClient(repo=args.repo, token=token)
         open_pulls = client.list_open_pulls()
-        active_heads = compute_active_head_map(
-            open_pulls, keep_draft_runs=bool(args.keep_draft_runs)
+        active_heads = compute_active_head_map(open_pulls)
+        keep_stale_sha_branches: AbstractSet[str] = (
+            compute_draft_branches(open_pulls) if args.keep_draft_runs else frozenset()
         )
         runs = client.list_recent_workflow_runs(max_runs=args.max_runs)
         stale_runs = compute_stale_runs(
-            runs, active_heads=active_heads, cancel_events=cancel_events
+            runs,
+            active_heads=active_heads,
+            cancel_events=cancel_events,
+            keep_stale_sha_branches=keep_stale_sha_branches,
         )
 
         cancelled = 0

--- a/tests/scripts/test_pr_stale_run_gc.py
+++ b/tests/scripts/test_pr_stale_run_gc.py
@@ -1,24 +1,148 @@
 from __future__ import annotations
 
-from scripts.pr_stale_run_gc import compute_active_head_map, compute_stale_runs
+from typing import Any
+
+from scripts.pr_stale_run_gc import (
+    compute_active_head_map,
+    compute_draft_branches,
+    compute_stale_runs,
+    parse_args,
+)
+
+PR_EVENTS = {"pull_request", "pull_request_target"}
 
 
-def test_compute_active_head_map_excludes_drafts_by_default() -> None:
+def _default_schedule_stale(
+    pulls: list[dict[str, Any]], runs: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Mirror the scheduled GC invocation, which passes no --keep-draft-runs."""
+    return compute_stale_runs(
+        runs,
+        active_heads=compute_active_head_map(pulls),
+        cancel_events=set(PR_EVENTS),
+    )
+
+
+def test_compute_active_head_map_includes_draft_heads() -> None:
     pulls = [
         {"draft": False, "head": {"ref": "feat/a", "sha": "sha-a"}},
         {"draft": True, "head": {"ref": "feat/b", "sha": "sha-b"}},
     ]
-    active = compute_active_head_map(pulls, keep_draft_runs=False)
-    assert active == {"feat/a": "sha-a"}
-
-
-def test_compute_active_head_map_can_keep_drafts() -> None:
-    pulls = [
-        {"draft": False, "head": {"ref": "feat/a", "sha": "sha-a"}},
-        {"draft": True, "head": {"ref": "feat/b", "sha": "sha-b"}},
-    ]
-    active = compute_active_head_map(pulls, keep_draft_runs=True)
+    active = compute_active_head_map(pulls)
     assert active == {"feat/a": "sha-a", "feat/b": "sha-b"}
+
+
+def test_compute_draft_branches_returns_only_draft_refs() -> None:
+    pulls = [
+        {"draft": False, "head": {"ref": "feat/a", "sha": "sha-a"}},
+        {"draft": True, "head": {"ref": "feat/b", "sha": "sha-b"}},
+        {"draft": True, "head": {"ref": "", "sha": "sha-c"}},
+    ]
+    assert compute_draft_branches(pulls) == {"feat/b"}
+
+
+def test_draft_pr_current_head_run_survives_default_gc() -> None:
+    pulls = [{"draft": True, "head": {"ref": "feat/draft", "sha": "sha-cur"}}]
+    runs = [
+        {
+            "id": 10,
+            "event": "pull_request",
+            "status": "in_progress",
+            "head_branch": "feat/draft",
+            "head_sha": "sha-cur",
+        }
+    ]
+    assert _default_schedule_stale(pulls, runs) == []
+
+
+def test_draft_pr_superseded_head_run_still_cancelled() -> None:
+    pulls = [{"draft": True, "head": {"ref": "feat/draft", "sha": "sha-new"}}]
+    runs = [
+        {
+            "id": 11,
+            "event": "pull_request",
+            "status": "queued",
+            "head_branch": "feat/draft",
+            "head_sha": "sha-old",
+        }
+    ]
+    stale = _default_schedule_stale(pulls, runs)
+    assert [(item["run_id"], item["reason"]) for item in stale] == [(11, "stale-sha")]
+    assert stale[0]["active_sha"] == "sha-new"
+
+
+def test_branch_without_open_pr_still_cancelled() -> None:
+    pulls = [{"draft": True, "head": {"ref": "feat/draft", "sha": "sha-cur"}}]
+    runs = [
+        {
+            "id": 12,
+            "event": "pull_request",
+            "status": "queued",
+            "head_branch": "feat/closed",
+            "head_sha": "sha-z",
+        }
+    ]
+    stale = _default_schedule_stale(pulls, runs)
+    assert [(item["run_id"], item["reason"]) for item in stale] == [(12, "no-active-pr-head")]
+
+
+def test_non_draft_behavior_unchanged_by_default() -> None:
+    pulls = [{"draft": False, "head": {"ref": "feat/a", "sha": "sha-a"}}]
+    runs = [
+        {
+            "id": 20,
+            "event": "pull_request",
+            "status": "in_progress",
+            "head_branch": "feat/a",
+            "head_sha": "sha-a",
+        },
+        {
+            "id": 21,
+            "event": "pull_request",
+            "status": "queued",
+            "head_branch": "feat/a",
+            "head_sha": "sha-old",
+        },
+        {
+            "id": 22,
+            "event": "push",
+            "status": "queued",
+            "head_branch": "feat/a",
+            "head_sha": "sha-old",
+        },
+    ]
+    stale = _default_schedule_stale(pulls, runs)
+    assert [(item["run_id"], item["reason"]) for item in stale] == [(21, "stale-sha")]
+
+
+def test_keep_draft_runs_also_keeps_superseded_draft_heads() -> None:
+    pulls = [
+        {"draft": True, "head": {"ref": "feat/draft", "sha": "sha-new"}},
+        {"draft": False, "head": {"ref": "feat/a", "sha": "sha-a"}},
+    ]
+    runs = [
+        {
+            "id": 30,
+            "event": "pull_request",
+            "status": "queued",
+            "head_branch": "feat/draft",
+            "head_sha": "sha-old",
+        },
+        {
+            "id": 31,
+            "event": "pull_request",
+            "status": "queued",
+            "head_branch": "feat/a",
+            "head_sha": "sha-old",
+        },
+    ]
+    stale = compute_stale_runs(
+        runs,
+        active_heads=compute_active_head_map(pulls),
+        cancel_events=set(PR_EVENTS),
+        keep_stale_sha_branches=compute_draft_branches(pulls),
+    )
+    assert [(item["run_id"], item["reason"]) for item in stale] == [(31, "stale-sha")]
 
 
 def test_compute_stale_runs_flags_missing_branch_and_stale_sha() -> None:
@@ -56,3 +180,8 @@ def test_compute_stale_runs_flags_missing_branch_and_stale_sha() -> None:
     assert by_id[1]["reason"] == "stale-sha"
     assert by_id[2]["reason"] == "no-active-pr-head"
     assert 3 not in by_id
+
+
+def test_parse_args_keep_draft_runs_flag() -> None:
+    assert parse_args(["--repo", "o/r"]).keep_draft_runs is False
+    assert parse_args(["--repo", "o/r", "--keep-draft-runs"]).keep_draft_runs is True


### PR DESCRIPTION
## Summary

Script-side fix (no `.github/workflows` file touched) for the scheduled stale-run GC cancelling every in-flight/queued PR-event run on draft-PR branches.

- `compute_active_head_map` now includes every open PR head, draft or not, so a draft PR's **current-head** runs survive the scheduled tick (which passes no `--keep-draft-runs`).
- Superseded-head (`stale-sha`) cancellation on draft branches is PRESERVED by default.
- `no-active-pr-head` cancellation for branches with no open PR at all is PRESERVED.
- `--keep-draft-runs` is redefined coherently: it now additionally exempts draft-PR branches from superseded-head (`stale-sha`) cancellation (new `keep_stale_sha_branches` parameter on `compute_stale_runs`, populated via the new `compute_draft_branches`). The flag name is preserved, so the untouched workflow's `workflow_dispatch` input keeps working.

## Source adjudication (falsified premise -> re-scoped fix)

This PR replaces the falsified feature `misc-openapi-workflow-concurrency-fix` (adjudication: worker 3be885a6 handoff, 2026-08-26). Evidence re-fetched read-only 2026-08-26:

| Claim under adjudication | Evidence (read-only re-fetch) | Verdict |
|---|---|---|
| The `openapi.yml` concurrency group (`openapi-sync-<PR#>`, cancel-in-progress) cancelled PR #9817's in-flight opened-event run | Victim run 32774277173 ("OpenAPI Spec", branch `structex/misc-webhooks-package-dedup-v2`) attempt 1 annotation: "The run was canceled by @github-actions[bot]." - the explicit API-cancel message, not the concurrency-supersession message | FALSIFIED |
| Scheduled `pr-stale-run-gc.yml` (cron `*/10`) is the cancelling actor | GC run 32774460034 (event=schedule, success, 2026-08-24T20:32:25Z) log: `stale_runs_found=1 cancelled=1 reasons={"no-active-pr-head": 1}`; the single victim is run 32774277173, cancelled 2026-08-24T20:33:07Z inside the GC tick | PROVEN |
| Draft PRs are the exposure | Same GC log: `open_prs_total=78, active_heads_total=48` -> 30 draft-PR heads excluded from the active-head map (schedule path passes no `--keep-draft-runs`), so every current-head run on a draft branch classifies `no-active-pr-head` | ROOT CAUSE (fixed here) |

**Do not conflate:** there is a separate, pre-existing, cosmetic-only cancellation class inside the `openapi-sync-<PR#>` concurrency group: when a PR flips opened -> ready_for_review (or opened -> labeled at creation), the later same-head event run supersedes the earlier one. The replacement run covers the same head SHA, so no coverage is lost. That class is unrelated to the GC mechanism fixed here and is intentionally left untouched.

## Behavior matrix (red-first tests in `tests/scripts/test_pr_stale_run_gc.py`)

| Class | Before | After |
|---|---|---|
| Draft PR, current head, in-flight/queued | CANCELLED (`no-active-pr-head`) | KEPT |
| Draft PR, superseded head | CANCELLED (`stale-sha`) | CANCELLED (`stale-sha`), unchanged |
| Branch with no open PR | CANCELLED (`no-active-pr-head`) | CANCELLED, unchanged |
| Non-draft PR (current / superseded head) | kept / CANCELLED (`stale-sha`) | unchanged |
| Draft PR, superseded head, `--keep-draft-runs` | kept (branch treated active) | KEPT (`stale-sha` exemption) |

## Validation

- Red-first: the new tests failed on the pre-fix code (collection ImportError on `compute_draft_branches`; behavioral demo showed the current-head draft run classified `no-active-pr-head` with an empty active-head map under schedule defaults).
- `python3 -m pytest tests/scripts/test_pr_stale_run_gc.py -q` -> 9 passed; 5-seed randomized sweep (1, 42, 1337, 20260826, 987654) all green.
- `make lint` and `ruff format --check aragora/ tests/ scripts/` -> green.
- `bash scripts/preflight_mypy.sh --diff-base origin/main` -> only the 2 pre-existing `.mypy-baseline` entries for `scripts/pr_stale_run_gc.py` (`arg-type`, `name-defined`), byte-identical on origin/main's copy; zero new errors.
- `make test-smoke` and smoke tier (`scripts/test_tiers.sh smoke`) -> green (138 passed).
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok.

## Risks

- Bounded to `scripts/pr_stale_run_gc.py` + its tests; no workflow file touched (schedule and dispatch invocations keep working; `--keep-draft-runs` flag name preserved with coherent, documented semantics).
- Only other consumer of this module is `scripts/benchmark_publication_run_followup.py` (imports `GitHubApiError`/`GitHubClient` only, both untouched).
- Queue-pressure protection retained: draft branches keep at most their current-head runs; superseded heads are still cancelled.

## Irony guard

This PR itself parks as a draft and is subject to the same GC collateral until the fix merges. If its own check rows show "canceled by @github-actions[bot]", the repair is `gh run rerun` on the unchanged head (recorded in the settlement packet); do not re-diagnose.

## Mission

Feature `misc-pr-stale-run-gc-draft-head-fix` (structex, prepare-only): ONE draft PR labeled `operator-review-required`, evidence rounds prepare-only/UNPOSTED, settlement packet written, PR parked. No ready, posting, settlement, or merge in this session.
