### PR TITLE
ci(test): raise Baseline Determinism advisory job timeout 12m -> 18m [Tier 4]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,7 +285,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Baseline Determinism
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     needs: version-check
 
     steps:


### PR DESCRIPTION
## Tier 4 — PARKED DRAFT (operator-review-required)

One-line advisory-job budget raise: `.github/workflows/test.yml` line 288, job `baseline-determinism` (header line 284, `needs: version-check`), `timeout-minutes: 12 -> 18`. No other change; line 914 (`epistemic-settlement-gate`'s own `timeout-minutes: 12`, a dependent advisory lane) is intentionally untouched — same-signature risk recorded, separate feature only if a real incident ever implicates it.

### Source issue (confirmed premise — adjudication by worker ee0596ba, 2026-08-27; spot-checks re-verified this session)
- `Tests` run **32784061358** (PR #9811 ready-flip, head `deaf8d8296b898f37035f8d14cdda28ff02831e9`): attempts 1/2 jobs **97612536449** / **97616339413** each cancelled at **12m14s**, sole cancelled job among 28 with 13 green siblings, check-run annotation verbatim: **"The job has exceeded the maximum execution time of 12m0s"** = genuine job-level budget enforcement (re-read from both check runs this session).
- GC-collateral hypothesis FALSIFIED for these rows: covering GC ticks **32784775941** / **32785862755** logged `stale_runs_found=0 cancelled=0`.
- Passing attempt-3 job **97619819291**: success in **9m18s** (quiet queue, re-verified this session); ~11m16s observed loaded (worker 630330bf) → 18m gives >=60% headroom over worst observed nominal.
- Job verified NON-required: branch-protection required contexts re-read this session = `lint`, `typecheck`, `sdk-parity`, `Generate & Validate`, `TypeScript SDK Type Check`, `aragora-merge-quorum` ("Baseline Determinism" absent). Job stays non-required; semantics unchanged (only the budget moves).
- Full read-only adjudication: mission library `misc-baseline-determinism-mechanism-adjudication-20260826.md`.

### Scoped overlap lift disclosure (orchestrator, 2026-08-27 — this feature only)
The census overlap on `test.yml` from two stale dependabot PRs is LIFTED for this feature only; both hunk sets proven textually disjoint from the line-288 edit site (proof in the adjudication file):
- **#9690** "Bump actions/setup-node from 4 to 7": head `777ad33411dabace9e0eb887fa40aac89abb2a67`, test.yml hunks @85/@260/@2045/@2185 — re-verified unchanged at run time (25 files, OPEN).
- **#9688** "Bump codecov/codecov-action from 4 to 7": head `ec404d2c49e530dd8c6d2ead76ec51d4cb329d5d`, test.yml hunk @1796 — re-verified unchanged at run time (2 files, OPEN).
- Fresh census at run time: 78 open PRs, none >=100 files (pagination caveat satisfied), NO other open PR touches `.github/workflows/test.yml`. All lift-void conditions checked and absent.

Both dependabot PRs remain untouched by this feature.

### Validation
- `~/.local/bin/actionlint .github/workflows/test.yml` (v1.7.11) → clean, exit 0.
- `git diff --numstat origin/main...HEAD` → `1 1 .github/workflows/test.yml` (one-line diff; only line 288 changes).
- `sed -n '288p;914p' .github/workflows/test.yml` → line 288 `timeout-minutes: 18`; line 914 `timeout-minutes: 12` (untouched).
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → preflight ok.
- `make lint` → All checks passed.

### Risks
- Low: non-required advisory lane, budget-only change. Worst case a genuinely wedged run occupies a runner up to 6 extra minutes before cancellation.
- Dependent advisory lane `epistemic-settlement-gate` (`needs: baseline-determinism`) keeps its own 12m budget at line 914 — deliberately out of scope; same-signature risk recorded for a future feature only if a real incident implicates it.

Prepare-only flow per mission contract: parked draft, evidence rounds prepare-only (apply=False) UNPOSTED, settlement packet in the mission library. No ready, posting, settlement, or merge in this session.
