### PR TITLE
fix(tests): scope supabase env mocking to SUPABASE_* keys

### DIFF
--- a/tests/persistence/test_supabase_client.py
+++ b/tests/persistence/test_supabase_client.py
@@ -139,11 +139,18 @@ class TestSupabaseClientInitialization:
 
     def test_init_without_credentials(self):
         """Client should initialize with client=None if no credentials."""
-        with patch.dict(os.environ, {}, clear=True):
-            with patch.object(os.environ, "get", return_value=None):
-                client = SupabaseClient(url=None, key=None)
-                # Either client is None or is_configured is False
-                assert not client.is_configured or client.client is None
+        # Remove only SUPABASE_* keys rather than stubbing os.environ.get:
+        # constructing the client triggers the lazy supabase -> websockets
+        # import, and websockets.frames evaluates
+        # int(os.environ.get("WEBSOCKETS_MAX_LOG_SIZE", "75")) at import time,
+        # which raises TypeError if get() is forced to return None globally.
+        env_without_supabase = {
+            k: v for k, v in os.environ.items() if not k.startswith("SUPABASE_")
+        }
+        with patch.dict(os.environ, env_without_supabase, clear=True):
+            client = SupabaseClient(url=None, key=None)
+            # Either client is None or is_configured is False
+            assert not client.is_configured or client.client is None
 
     def test_init_with_env_vars(self, mock_supabase_client):
         """Client should use environment variables."""


### PR DESCRIPTION
## Summary

Fixes a pre-existing test-isolation defect in `tests/persistence/test_supabase_client.py::TestSupabaseClientInitialization::test_init_without_credentials` that flips the non-required test-fast (storage) shard red on unrelated PRs.

**Root cause:** the test stubbed `os.environ.get` globally via `patch.object(os.environ, "get", return_value=None)`. Constructing `SupabaseClient` triggers the lazy `supabase -> realtime -> websockets` import chain, and `websockets/frames.py:150` evaluates `MAX_LOG_SIZE = int(os.environ.get("WEBSOCKETS_MAX_LOG_SIZE", "75"))` at import time. With the stub active, `get()` returns `None` for every key, so the import raises `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`. The failure fires whenever pytest-randomly orders this test as the process's FIRST websockets importer (reproduced on clean main with CI seed 348725080; first proven during PR #9817 settlement, worker d4c2232d, 2026-08-25).

**Fix (zero weakening):** replace the global `get()` stub with a single `patch.dict(os.environ, env_without_supabase, clear=True)` where `env_without_supabase = {k: v for k, v in os.environ.items() if not k.startswith("SUPABASE_")}`. This removes only `SUPABASE_*` keys, guaranteeing credential absence while preserving real `os.environ.get` default semantics for the import chain. The credential-absence assertion is unchanged verbatim.

Tests-only diff: 1 file, +12/-5.

## Red-first evidence (unfixed tree at worktree base = fresh main `ef3d09c557`)

All commands from the repo root with `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true ARAGORA_SECRETS_STRICT=false`.

| Proof | Command | Result |
|---|---|---|
| R1 | `python3 -m pytest "tests/persistence/test_supabase_client.py::TestSupabaseClientInitialization::test_init_without_credentials" -q -p no:randomly --timeout=120` | FAILED (TypeError int(None)), exit 1 |
| R2 | `python3 -m pytest tests/persistence/test_supabase_client.py -q -p randomly --randomly-seed=348725080 --timeout=120` | 1 failed, 40 passed, exit 1 |
| R3 | R1 command + `--tb=long` | Traceback pinned to `websockets/frames.py:150` (`MAX_LOG_SIZE = int(os.environ.get("WEBSOCKETS_MAX_LOG_SIZE", "75"))`) raising `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` |

R1 is the deterministic first-importer harness: single-test invocation makes this test the process's first websockets importer without needing a particular seed.

## Green evidence (fix head)

| Proof | Command | Result |
|---|---|---|
| G1 | `python3 -m pytest "tests/persistence/test_supabase_client.py::TestSupabaseClientInitialization::test_init_without_credentials" -q -p no:randomly --timeout=120` | 1 passed, exit 0 |
| G2 | `python3 -m pytest tests/persistence/test_supabase_client.py -q -p randomly --randomly-seed=<SEED> --timeout=120` for SEED in 348725080, 1, 42, 100, 2024 | 41 passed, exit 0 for every seed |
| G3 | `python3 -m pytest tests/persistence/test_supabase_client.py -q -p no:randomly --timeout=120` | 41 passed, exit 0 |

## Local gates

- `make lint` - pass; `ruff format --check aragora/ tests/ scripts/` - pass (10824 files already formatted)
- `make test-smoke` - pass (AWS-neutralized)
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` - 138 passed, exit 0
- `bash scripts/preflight_mypy.sh --diff-base origin/main` - Success: no issues found in 1 source file
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` - preflight: ok

## Census

- Path-freeze census (session start, 2026-08-27): 78 open PRs, none touch `tests/persistence/test_supabase_client.py`. Feature precondition satisfied.
- Sibling-pattern census: `rg 'patch\.object\(os\.environ'` across `tests/` matches only this one occurrence repo-wide; sibling tests in this file use plain `patch.dict` plus a patched `SUPABASE_AVAILABLE` and never trigger the lazy import chain. No sibling fixes needed.

## Process

Standard structex prepare-only flow: this draft stays parked with `operator-review-required`. Evidence rounds run apply=False and remain unposted; the settlement packet lives in the mission library. No ready, posting, settlement, or merge in this session.
