### PR TITLE
fix(tests): make TestConfigureFromEnv order-independent under xdist

### DIFF
--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 import pytest
 
+from aragora.config.settings import AuthSettings, get_settings
 from aragora.server.auth import AuthConfig, check_auth
 from aragora.storage.debate_storage import _escape_like_pattern, DebateStorage
 
@@ -643,8 +644,34 @@ class TestCheckAuthIntegration:
             auth_config.api_token = original_token
 
 
+def _auth_settings_env_names() -> tuple[str, ...]:
+    """Environment variable names AuthSettings reads (alias or prefix + field name)."""
+    prefix = str(AuthSettings.model_config.get("env_prefix") or "")
+    names = []
+    for field_name, field in AuthSettings.model_fields.items():
+        alias = field.validation_alias if isinstance(field.validation_alias, str) else field.alias
+        names.append(alias if isinstance(alias, str) else f"{prefix}{field_name}".upper())
+    return tuple(names)
+
+
 class TestConfigureFromEnv:
     """Test environment variable configuration."""
+
+    @pytest.fixture(autouse=True)
+    def _presettle_auth_settings(self, monkeypatch):
+        """Parse AuthSettings before the test body's env patches take effect.
+
+        AuthConfig.__init__ reads get_settings().auth lazily. A test that ran
+        earlier in the same worker may leave the lru-cached Settings cleared
+        (reset_settings()) or its auth block unparsed; AuthSettings would then
+        be parsed inside this class's patch.dict scope, where ARAGORA_TOKEN_TTL
+        deliberately violates the ge=60 int field and raises ValidationError
+        before configure_from_env() ever runs. Scrub AuthSettings' env inputs
+        and parse it here so the bodies exercise configure_from_env() alone.
+        """
+        for env_name in _auth_settings_env_names():
+            monkeypatch.delenv(env_name, raising=False)
+        _ = get_settings().auth
 
     def test_configure_from_env_token(self):
         """Should load token from environment."""


### PR DESCRIPTION
Part of #8257 (structural excellence). Feature: `misc-authsettings-env-pollution-test-isolation` (milestone `cdg-bootstrap-route-truth`).

Fixes the pre-existing pytest-xdist order-dependence flake proven LIVE during the PR #9822 settlement (run 33017349776 attempt 1): `tests/server/test_security.py::TestConfigureFromEnv::{test_configure_from_env_negative_ttl,test_configure_from_env_invalid_ttl}` fail on the REQUIRED `test-fast (server-rest)` shard when another test in the same worker leaks settings-cache state, while both pass in isolation.

## Root cause (proven, not guessed)

`AuthConfig.__init__` reads `get_settings().auth` lazily. The two victim tests construct `AuthConfig()` inside a `patch.dict` scope whose `ARAGORA_TOKEN_TTL` is deliberately invalid for `AuthSettings.token_ttl` (`int`, `ge=60`): `"-100"` and `"not_a_number"`. In isolation this is safe because `aragora/server/auth.py` warms the lru-cached `Settings` (including the lazy auth block) at import time, before any env patching.

Under xdist + pytest-randomly, any earlier test in the same worker that leaves the cache cleared or the auth block unparsed forces `AuthSettings` to parse **inside the victim's patched scope**, raising `ValidationError` at `AuthConfig()` construction, before `configure_from_env()` (the code under test) ever runs.

Polluters identified by deterministic bisection (both legitimate `reset_settings()` users; neither is modified):

- `tests/server/test_rate_limit.py::TestRedisRateLimiter::test_redis_config_in_settings` (and `test_get_redis_client_without_config`) call `reset_settings()`
- `tests/server/handler_registry/test_agent_bridge_feature_flag.py` autouse teardown calls `reset_settings()` after every test

A cleared settings cache is a legitimate post-test state (`reset_settings()` exists exactly so tests do not leak patched-env parses); the defect is the victim class's hidden dependency on a warm cache. The fix therefore hardens the victim class, per the feature's sanctioned strategy.

## Fix (zero assertion weakening)

Autouse fixture on `TestConfigureFromEnv` that, before each test body:

1. scrubs the env variables `AuthSettings` reads (names derived from `model_fields`, so the guard tracks future fields), and
2. pre-parses the lazy auth block (`get_settings().auth`) against that clean env.

The bodies then exercise `configure_from_env()` alone, exactly as in isolation mode. All five test bodies and every assertion are byte-identical; the diff is +27/-0 on `tests/server/test_security.py` only.

## Red-first proof (before fix)

```
$ pytest tests/server/test_security.py::TestConfigureFromEnv -p no:randomly -q
5 passed                                    # isolation, matches the 9822 settlement proof
$ pytest "tests/server/test_security.py::TestConfigureFromEnv::test_configure_from_env_negative_ttl" \
         "tests/server/test_security.py::TestConfigureFromEnv::test_configure_from_env_invalid_ttl" -p no:randomly -q
2 passed                                    # victims alone
$ pytest "tests/server/test_rate_limit.py::TestRedisRateLimiter::test_redis_config_in_settings" <victims> -p no:randomly -q
2 failed, 1 passed
  E pydantic_core.ValidationError: 1 validation error for AuthSettings
  E ARAGORA_TOKEN_TTL: Input should be greater than or equal to 60 [greater_than_equal, input_value='-100']
  E ARAGORA_TOKEN_TTL: unable to parse string as an integer [int_parsing, input_value='not_a_number']
$ pytest tests/server/handler_registry/test_agent_bridge_feature_flag.py <victims> -p no:randomly -q
2 failed, 2 passed                          # same signature — exact live-CI failure mode
```

## Green proof (after fix)

- Both polluter→victim orderings: all passed (3 passed / 4 passed)
- `TestConfigureFromEnv` alone: 5 passed (semantics unchanged)
- Seed sweep: `tests/server/test_security.py` × seeds {1, 42, 100, 2024, 12345} → 96 passed each; rate_limit + agent_bridge + security trio × seeds {7, 77, 777} → 151 passed each
- Full shard selection `tests/server --ignore=tests/server/handlers` with `-n 8`, randomized order: **10125 passed, 4 skipped**
- `make lint`, `ruff format --check`, `preflight_mypy` (committed state), `make test-smoke`, smoke tier (138 passed), `automation_pr_preflight`: all green

## Census

Path-freeze census at claim time: 78 open PRs, none owning `tests/server/test_security.py`, either polluter file, `tests/server/conftest.py`, `aragora/config/settings.py`, or `aragora/server/auth.py`. No PR at the 100-file pagination limit. V1 scope lock not implicated (tests-only diff).

## Status

Prepare-only per mission mandate: this PR stays **draft** with `operator-review-required`; evidence rounds run apply=False and are kept unposted; settlement packet in the mission library. No ready flip, no evidence posting, no settlement, no merge in this session.

Distinct from `misc-supabase-test-env-mock-isolation` (different polluter/victim pair).
