### PR TITLE
fix(debate): return no codebase map for nonexistent or 0-file roots

### DIFF
--- a/aragora/debate/context/processors.py
+++ b/aragora/debate/context/processors.py
@@ -432,6 +432,13 @@ class ContentProcessor:
         if not use_codebase:
             return None
 
+        if not self._project_root.is_dir():
+            logger.debug(
+                "Codebase context skipped: project root %s is not a directory",
+                self._project_root,
+            )
+            return None
+
         try:
             from aragora.rlm.codebase_context import CodebaseContextBuilder
         except (ImportError, OSError) as exc:
@@ -465,6 +472,13 @@ class ContentProcessor:
             return None
 
         if not context:
+            return None
+
+        # An index with zero files means the root had nothing to map; a
+        # header-only codebase map would be misleading, so emit nothing.
+        index = getattr(self._codebase_context_builder, "_index", None)
+        if index is not None and getattr(index, "total_files", None) == 0:
+            logger.debug("Codebase context skipped: no files indexed")
             return None
 
         return "## ARAGORA CODEBASE MAP\n" + context

--- a/aragora/debate/context/processors.py
+++ b/aragora/debate/context/processors.py
@@ -583,13 +583,11 @@ class ContentProcessor:
                 return "", [], {}
 
             # Track retrieved memory IDs and tiers for outcome updates and analytics
-            retrieved_ids = [
-                getattr(mem, "id", None) for mem in all_memories if getattr(mem, "id", None)
-            ]
+            retrieved_ids = [mem_id for mem in all_memories if (mem_id := getattr(mem, "id", None))]
             retrieved_tiers = {
-                getattr(mem, "id", None): getattr(mem, "tier", None)
+                mem_id: tier
                 for mem in all_memories
-                if getattr(mem, "id", None) and getattr(mem, "tier", None)
+                if (mem_id := getattr(mem, "id", None)) and (tier := getattr(mem, "tier", None))
             }
 
             # Format memories with confidence markers based on consolidation

--- a/aragora/debate/context_gatherer/gatherer.py
+++ b/aragora/debate/context_gatherer/gatherer.py
@@ -605,6 +605,13 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
         if not get_use_codebase():
             return None
 
+        if not self._project_root.is_dir():
+            logger.debug(
+                "Codebase context skipped: project root %s is not a directory",
+                self._project_root,
+            )
+            return None
+
         try:
             from aragora.rlm.codebase_context import CodebaseContextBuilder
         except (ImportError, ModuleNotFoundError) as exc:
@@ -641,6 +648,13 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
             return None
 
         if not context:
+            return None
+
+        # An index with zero files means the root had nothing to map; a
+        # header-only codebase map would be misleading, so emit nothing.
+        index = getattr(self._codebase_context_builder, "_index", None)
+        if index is not None and getattr(index, "total_files", None) == 0:
+            logger.debug("Codebase context skipped: no files indexed")
             return None
 
         return "## ARAGORA CODEBASE MAP\n" + context


### PR DESCRIPTION
## Summary

Fixes the pre-existing DETERMINISTIC red on the non-required `test-fast(debate-1)` shard: 10 failures in `tests/debate/test_context_gatherer.py` + `tests/debate/test_context_gatherer_root.py` on pristine origin/main. `gather_aragora_context` for a nonexistent/empty project root (e.g. `/nonexistent`) emitted an `## ARAGORA CODEBASE MAP` section wrapping a header-only 0-file context, so the gatherer returned a non-None `## ARAGORA PROJECT CONTEXT` block where the documented contract (and 10 tests) require `None`.

Landing this removes the standing ambient advisory red that flips `test-fast(debate-1)` on every lane (tolerated at the #9824 settlement via the #9807 non-required advisory carve-out; ledgered in the mission library environment notes, 2026-08-27 merge census line).

## Mechanism verification (red-first)

- **Red-first proof at base `68368943e9` (origin/main tip):** `pytest tests/debate/test_context_gatherer.py tests/debate/test_context_gatherer_root.py` → **10 failed, 178 passed**. All 10 failures assert `result is None` but receive the `## ARAGORA PROJECT CONTEXT ...` block.
- **Root cause:** both `_gather_codebase_context` emitters call `CodebaseContextBuilder.build_debate_context()` (`aragora/nomic/context_builder.py::NomicContextBuilder`), which builds an index even for a nonexistent root and unconditionally returns a non-empty `# Aragora Codebase Context (0 files, ~0K tokens)` header string. The emitters wrap it as `## ARAGORA CODEBASE MAP\n...`, making `aragora_context_parts` non-empty. Codebase context defaults on (`get_use_codebase()` → True; processors.py has an inline equivalent, also default True).
- **Suspect-commit adjudication (`083aa6d4b5` "feat(debate): skip empty sidecars for simple tasks"):** that commit only added `skip_empty_sidecars` handling in `gather_all()` and never touched `gather_aragora_context` / `_gather_codebase_context` (the aragora-context region was already structurally identical at that commit: same lines 514/646). Pickaxe confirms the `## ARAGORA CODEBASE MAP` emitter string predates it and no `docs_dir.exists`-style guard ever existed in these files. Conclusion: the commit did **not** deliberately change the None-for-nonexistent-root contract, so per the feature mandate the code-fix path applies (restore the short-circuit), not the test-update path.

## Fix

Restore the None/empty short-circuit at BOTH emitter sites, kept byte-identical:

- `aragora/debate/context_gatherer/gatherer.py::_gather_codebase_context`
- `aragora/debate/context/processors.py::_gather_codebase_context`

Each emitter now:
1. returns `None` when `self._project_root` is not a directory (nonexistent root), and
2. drops the map when the builder's built index reports `total_files == 0` (existing-but-empty root).

The zero-file check reads the builder's cached index defensively via `getattr` so the existing green mock-based tests (`AsyncMock`/`MagicMock` builders in `tests/debate/test_context_gatherer.py`, `tests/debate/context_gatherer/test_gatherer.py`, `tests/debate/context/test_processors.py`) keep their current behavior (a Mock `total_files` never compares equal to 0). No behavior change for non-empty roots.

Also includes one bounded type-narrowing fix surfaced by `scripts/preflight_mypy.sh` (which type-checks every touched file): the continuum id/tier comprehensions in `processors.py` inferred `list[Any | None]` against the declared `tuple[str, list[str], dict[str, Any]]`; binding each `getattr` once via walrus preserves identical truthy-filter semantics and satisfies the annotation. This error was latent on main and blocked preflight for any PR touching the file.

## Validation

- Red-first at base: 10 failed / 178 passed (exact 10 target tests).
- After fix: `pytest tests/debate/test_context_gatherer.py tests/debate/test_context_gatherer_root.py` → **188 passed**.
- Adjacent suites: `pytest tests/debate/context_gatherer/test_gatherer.py tests/debate/context/test_processors.py tests/debate/test_context_engineering.py tests/rlm/test_codebase_context.py tests/handlers/test_rlm.py` → **262 passed**.
- `make lint` (ruff check aragora/ tests/) → pass; `ruff format --check aragora/ tests/ scripts/` → all formatted.
- `bash scripts/preflight_mypy.sh --diff-base origin/main` → no issues in the 2 touched files.
- AWS-neutralized `make test-smoke` → pass.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → ok (source-without-test-changes advisory satisfied by this section: the 10 pre-existing failing tests are the red-first TDD; no test edits were needed).
- Full `tests/debate` local sweep running in parallel at time of draft; CI shards at head are authoritative and will be green before ready-for-review.

## Path-freeze census

Re-run at push time via GraphQL: 78 open PRs, none with >100 files (no pagination risk), **zero overlaps** with the 2 changed files. Authoring-time census (2026-08-27) was also clean (0/78).

## Scope

+31/-5 lines across 2 files. No API changes, no new dependencies, no behavior change for non-empty roots.
