### PR TITLE
refactor(scripts): align audit_rbac_coverage exclusions with exact handler paths

### DIFF
--- a/scripts/audit_rbac_coverage.py
+++ b/scripts/audit_rbac_coverage.py
@@ -21,6 +21,83 @@ from pathlib import Path
 from typing import Optional
 
 
+# Handler files whose functions are data/storage utilities rather than HTTP
+# endpoints; name-detected functions in them are not audited as handlers.
+# Entries are relative to aragora/server/handlers/: entries ending in "/"
+# exclude that directory's whole subtree; every other entry names one exact file.
+STORAGE_EXCLUDED_PATHS = frozenset(
+    {
+        "_oauth/utils.py",
+        "admin/health/database_utils.py",
+        "admin/health/diagnostics.py",
+        "admin/health/probes.py",
+        "admin/health/stores.py",
+        "agents/probes.py",
+        "auth/store.py",
+        "codebase/security/storage.py",
+        "debates/diagnostics.py",
+        "email/categorization.py",
+        "email/storage.py",
+        "features/marketplace/store.py",
+        "gauntlet/storage.py",
+        "openclaw/store.py",
+        "shared_inbox/storage.py",
+        "utils/params.py",
+    }
+)
+
+# Handler files that establish authentication (login, signup, SSO, OAuth);
+# their endpoints run pre-auth, so the audit classifies them as protection
+# type "auth_flow" instead of unprotected. Same path semantics as above.
+AUTH_FLOW_PATHS = frozenset(
+    {
+        "_oauth/oidc.py",
+        "auth/login.py",
+        "auth/password.py",
+        "auth/signup_handlers.py",
+        "auth/sso_handlers.py",
+        "bots/slack/oauth.py",
+        "bots/teams/oauth.py",
+        "email/oauth.py",
+    }
+)
+
+_HANDLER_PATH_MARKER = "server/handlers/"
+
+
+def _handler_relative_path(file_path: str) -> str | None:
+    """Normalize any spelling of a handler path to its handlers-root-relative form."""
+    path = file_path.replace("\\", "/")
+    index = path.find(_HANDLER_PATH_MARKER)
+    if index == -1:
+        return None
+    return path[index + len(_HANDLER_PATH_MARKER) :]
+
+
+def _matches_exclusion_rules(file_path: str, rules: frozenset[str]) -> bool:
+    """Match a handler path against exact-file / directory-prefix exclusion rules."""
+    relative = _handler_relative_path(file_path)
+    if relative is None:
+        return False
+    for rule in rules:
+        if rule.endswith("/"):
+            if relative.startswith(rule):
+                return True
+        elif relative == rule:
+            return True
+    return False
+
+
+def is_storage_path(file_path: str) -> bool:
+    """Check if a handler file holds storage/data utilities rather than endpoints."""
+    return _matches_exclusion_rules(file_path, STORAGE_EXCLUDED_PATHS)
+
+
+def is_auth_flow_path(file_path: str) -> bool:
+    """Check if a handler file implements pre-auth authentication flows."""
+    return _matches_exclusion_rules(file_path, AUTH_FLOW_PATHS)
+
+
 @dataclass
 class HandlerInfo:
     """Information about a handler function."""
@@ -91,35 +168,8 @@ def find_handlers(handler_dir: Path) -> list[HandlerInfo]:
             file_path = str(py_file)
             # Exclude files that are clearly not HTTP handlers
             # Also exclude auth flow endpoints (they establish auth, can't require it)
-            is_storage_file = any(
-                p in file_path
-                for p in (
-                    "/store.py",
-                    "/stores.py",
-                    "/params.py",
-                    "/utils.py",
-                    "/probes.py",
-                    "/diagnostics.py",
-                    "/database_utils.py",
-                    "/storage.py",
-                    "/categorization.py",  # Data access utilities
-                )
-            )
-            is_auth_flow_file = any(
-                p in file_path
-                for p in (
-                    "/oidc.py",
-                    "/sso_handlers.py",
-                    "/saml.py",
-                    "/oauth.py",
-                    "/login.py",
-                    "/auth_flow.py",
-                    "/callback.py",
-                    "/oauth_providers/",
-                    "/signup_handlers.py",
-                    "/password.py",
-                )
-            )
+            is_storage_file = is_storage_path(file_path)
+            is_auth_flow_file = is_auth_flow_path(file_path)
 
             i = 0
             while i < len(lines):
@@ -315,7 +365,7 @@ def generate_report(handlers: list[HandlerInfo], output_format: str = "text") ->
     coverage = (protected / total * 100) if total > 0 else 0
 
     # Count by protection type
-    by_type = defaultdict(int)
+    by_type: defaultdict[str, int] = defaultdict(int)
     for h in handlers:
         if h.protection_type:
             by_type[h.protection_type] += 1

--- a/tests/scripts/test_audit_rbac_coverage.py
+++ b/tests/scripts/test_audit_rbac_coverage.py
@@ -1,0 +1,160 @@
+"""Regression tests for scripts/audit_rbac_coverage.py exclusion semantics."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import scripts.audit_rbac_coverage as audit_rbac_coverage
+
+HANDLER_ROOT = PROJECT_ROOT / "aragora" / "server" / "handlers"
+
+# The effective exclusion sets the substring-era rules resolved to over the
+# live tree, now pinned as exact handlers-root-relative paths. The four
+# substring rules that matched nothing (/saml.py, /auth_flow.py, /callback.py,
+# /oauth_providers/) were dropped: every remaining entry must name a real path.
+EXPECTED_STORAGE_EXCLUDED_FILES = {
+    "_oauth/utils.py",
+    "admin/health/database_utils.py",
+    "admin/health/diagnostics.py",
+    "admin/health/probes.py",
+    "admin/health/stores.py",
+    "agents/probes.py",
+    "auth/store.py",
+    "codebase/security/storage.py",
+    "debates/diagnostics.py",
+    "email/categorization.py",
+    "email/storage.py",
+    "features/marketplace/store.py",
+    "gauntlet/storage.py",
+    "openclaw/store.py",
+    "shared_inbox/storage.py",
+    "utils/params.py",
+}
+
+EXPECTED_AUTH_FLOW_FILES = {
+    "_oauth/oidc.py",
+    "auth/login.py",
+    "auth/password.py",
+    "auth/signup_handlers.py",
+    "auth/sso_handlers.py",
+    "bots/slack/oauth.py",
+    "bots/teams/oauth.py",
+    "email/oauth.py",
+}
+
+
+def _audit_visible_files() -> list[str]:
+    """Handler files the RBAC audit enumerates, relative to the handlers root."""
+    files = []
+    for py_file in HANDLER_ROOT.rglob("*.py"):
+        if py_file.name.startswith("_"):
+            continue
+        files.append(py_file.relative_to(HANDLER_ROOT).as_posix())
+    return sorted(files)
+
+
+def test_substring_near_misses_are_not_excluded() -> None:
+    """A rule for one file must not swallow same-named files elsewhere in the tree."""
+    near_misses = [
+        # Basename matches at un-pinned locations: substring-era rules
+        # excluded these anywhere; exact-path rules must not.
+        "aragora/server/handlers/newfeature/store.py",
+        "aragora/server/handlers/inbox/storage.py",
+        "aragora/server/handlers/social/probes.py",
+        # Suffix near-miss: ends the same way but is a different file.
+        "aragora/server/handlers/auth/backing_store.py",
+    ]
+    for path in near_misses:
+        assert not audit_rbac_coverage.is_storage_path(path), path
+
+    auth_near_misses = [
+        "aragora/server/handlers/social/oauth.py",
+        "aragora/server/handlers/features/login.py",
+        # Dropped zero-match rules must not resurrect by name anywhere.
+        "aragora/server/handlers/auth/callback.py",
+        "aragora/server/handlers/auth/saml.py",
+    ]
+    for path in auth_near_misses:
+        assert not audit_rbac_coverage.is_auth_flow_path(path), path
+
+
+def test_path_rules_only_apply_to_handler_tree_paths() -> None:
+    """Files outside the handlers tree never match handler path rules."""
+    assert not audit_rbac_coverage.is_storage_path("aragora/other/auth/store.py")
+    assert not audit_rbac_coverage.is_storage_path("store.py")
+    assert not audit_rbac_coverage.is_auth_flow_path("aragora/other/auth/login.py")
+    assert not audit_rbac_coverage.is_auth_flow_path("login.py")
+
+
+def test_exact_entries_match_across_path_spellings() -> None:
+    """Repo-relative, audit-relative, and absolute spellings all resolve the same."""
+    storage_spellings = [
+        "aragora/server/handlers/auth/store.py",
+        "server/handlers/auth/store.py",
+        str(HANDLER_ROOT / "auth" / "store.py"),
+    ]
+    for path in storage_spellings:
+        assert audit_rbac_coverage.is_storage_path(path), path
+
+    auth_spellings = [
+        "aragora/server/handlers/auth/login.py",
+        "server/handlers/auth/login.py",
+        str(HANDLER_ROOT / "auth" / "login.py"),
+    ]
+    for path in auth_spellings:
+        assert audit_rbac_coverage.is_auth_flow_path(path), path
+
+
+def test_directory_rules_exclude_whole_subtree() -> None:
+    """Slash-terminated entries cover every file beneath them; siblings stay out."""
+    rules = frozenset({"admin/health/"})
+    assert audit_rbac_coverage._matches_exclusion_rules(
+        "aragora/server/handlers/admin/health/database.py", rules
+    )
+    assert audit_rbac_coverage._matches_exclusion_rules(
+        "aragora/server/handlers/admin/health/nested/deep.py", rules
+    )
+    assert not audit_rbac_coverage._matches_exclusion_rules(
+        "aragora/server/handlers/admin/health_dashboard.py", rules
+    )
+
+
+def test_every_path_rule_points_at_a_real_path() -> None:
+    """Every entry names a real file or directory under the handlers root."""
+    for entry in audit_rbac_coverage.STORAGE_EXCLUDED_PATHS | audit_rbac_coverage.AUTH_FLOW_PATHS:
+        target = HANDLER_ROOT / entry
+        if entry.endswith("/"):
+            assert target.is_dir(), entry
+        else:
+            assert target.is_file(), entry
+
+
+def test_storage_and_auth_flow_groups_are_disjoint() -> None:
+    """One file cannot be both denominator-excluded and auth-flow-protected."""
+    overlap = audit_rbac_coverage.STORAGE_EXCLUDED_PATHS & audit_rbac_coverage.AUTH_FLOW_PATHS
+    assert overlap == frozenset()
+
+
+def test_effective_exclusion_sets_are_pinned() -> None:
+    """The rules resolve to exactly the pinned file sets over the live tree."""
+    for rel in sorted(EXPECTED_STORAGE_EXCLUDED_FILES | EXPECTED_AUTH_FLOW_FILES):
+        assert (HANDLER_ROOT / rel).is_file(), rel
+
+    visible = _audit_visible_files()
+    actual_storage = {
+        rel
+        for rel in visible
+        if audit_rbac_coverage.is_storage_path(f"aragora/server/handlers/{rel}")
+    }
+    actual_auth_flow = {
+        rel
+        for rel in visible
+        if audit_rbac_coverage.is_auth_flow_path(f"aragora/server/handlers/{rel}")
+    }
+    assert actual_storage == EXPECTED_STORAGE_EXCLUDED_FILES
+    assert actual_auth_flow == EXPECTED_AUTH_FLOW_FILES


### PR DESCRIPTION
## Summary

Aligns `scripts/audit_rbac_coverage.py` with the exact-path `EXCLUDED_PATHS` semantics PR #9822 introduced in `scripts/apply_rbac.py`. The audit script kept its own substring-style storage/auth-flow exclusion lists (`p in file_path`), a pre-existing divergence flagged as a claude P3 finding in #9822's evidence round (recorded in the mission settlement packet for #9822). Hard gate satisfied: #9822 is terminally MERGED (`7b267f56435c`).

Both groups now use handlers-root-relative rules with apply_rbac's semantics: entries ending in `/` exclude that directory's subtree; every other entry names one exact file. Shared helpers (`_handler_relative_path`, `_matches_exclusion_rules`) mirror `apply_rbac.is_excluded`, and module-level `is_storage_path` / `is_auth_flow_path` replace the inline tuples in `find_handlers()`.

## Census (effective exclusions on main @ 368a8d2fd123, 638 audit-visible files)

Storage rules (9 substring rules -> 16 exact files, all preserved):

| Substring rule | Resolved exact entries |
|---|---|
| `/store.py` | `auth/store.py`, `features/marketplace/store.py`, `openclaw/store.py` |
| `/stores.py` | `admin/health/stores.py` |
| `/params.py` | `utils/params.py` |
| `/utils.py` | `_oauth/utils.py` |
| `/probes.py` | `admin/health/probes.py`, `agents/probes.py` |
| `/diagnostics.py` | `admin/health/diagnostics.py`, `debates/diagnostics.py` |
| `/database_utils.py` | `admin/health/database_utils.py` |
| `/storage.py` | `codebase/security/storage.py`, `email/storage.py`, `gauntlet/storage.py`, `shared_inbox/storage.py` |
| `/categorization.py` | `email/categorization.py` |

Auth-flow rules (10 substring rules -> 8 exact files preserved, 4 zero-match rules dropped):

| Substring rule | Resolved exact entries |
|---|---|
| `/oidc.py` | `_oauth/oidc.py` |
| `/sso_handlers.py` | `auth/sso_handlers.py` |
| `/oauth.py` | `bots/slack/oauth.py`, `bots/teams/oauth.py`, `email/oauth.py` |
| `/login.py` | `auth/login.py` |
| `/signup_handlers.py` | `auth/signup_handlers.py` |
| `/password.py` | `auth/password.py` |
| `/saml.py`, `/auth_flow.py`, `/callback.py`, `/oauth_providers/` | **zero matches on main -> deliberately dropped** (documented correction; the real-path test forbids phantom entries, mirroring #9822) |

Groups are disjoint (test-enforced). No `oauth_providers/` directory exists anywhere under handlers.

## Equivalence proof

- Full `--json` audit output before vs after: **byte-identical** (519,087 bytes, `cmp` clean).
- `--summary --min-coverage 55`: unchanged `837/1112 handlers protected (75.3%)`, exit 0 (CI floor 55%).
- Consumers unaffected: `apply_rbac.py --json` subprocess, `test.yml` bare run, `security.yml` / pre-commit `--summary --min-coverage 55`.

## Tests (red-first, mirroring #9822's test_apply_rbac.py)

`tests/scripts/test_audit_rbac_coverage.py`, 7 cases: substring near-miss rejection for both groups (including dropped-rule names not resurrecting), handlers-tree scoping, cross-spelling normalization, directory-rule subtree semantics, real-path requirement for every entry, group disjointness, pinned effective-set equality over the live tree. Red run pre-implementation: 7 failed (missing exact-path surface); green after: 14 passed together with `test_apply_rbac.py`, stable across 5 random-order seeds.

## Disclosed bounded latent-debt fix

`by_type: defaultdict[str, int]` annotation (line ~370) clears the file's single pre-existing mypy error, required because `preflight_mypy.sh` type-checks whole touched files without baseline filtering.

## Validation

- `python3 -m pytest tests/scripts/test_audit_rbac_coverage.py tests/scripts/test_apply_rbac.py -q` -> 14 passed (plus 5-seed random-order sweep)
- `cmp` old vs new full `--json` -> byte-identical; `--summary --min-coverage 55` -> exit 0, 75.3%
- `make lint`, `ruff format --check aragora/ tests/ scripts/` -> clean
- `bash scripts/preflight_mypy.sh --diff-base origin/main` -> no issues in 2 source files (hook-variant mypy also clean)
- AWS-neutralized `make test-smoke` -> pass; `python3 scripts/report_code_quality.py --check` -> PASS
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

LOC delta: 240 insertions / 30 deletions. Census: no open PR touches `audit_rbac*` / `apply_rbac*` paths.
