### PR TITLE
refactor(webhooks): repoint retry-queue signing to the canonical signer

### DIFF
--- a/aragora/webhooks/retry_queue.py
+++ b/aragora/webhooks/retry_queue.py
@@ -835,7 +835,7 @@ class WebhookRetryQueue:
             # Import signature generator
             generate_signature: Callable[[str, str], str] | None
             try:
-                from aragora.server.handlers.webhook_management import (
+                from aragora.security.webhook_signing import (
                     generate_signature as _generate_signature,
                 )
 
@@ -903,7 +903,7 @@ class WebhookRetryQueue:
                 # Import signature generator
                 generate_signature: Callable[[str, str], str] | None
                 try:
-                    from aragora.server.handlers.webhook_management import (
+                    from aragora.security.webhook_signing import (
                         generate_signature as _generate_signature,
                     )
 

--- a/tests/handlers/test_webhooks_module_structure.py
+++ b/tests/handlers/test_webhooks_module_structure.py
@@ -438,9 +438,11 @@ def test_delivery_and_retry_consumers_import_canonically_without_warnings() -> N
         check=False,
     )
     assert result.returncode == 0, result.stderr
+    # The retry queue signs via aragora.security.webhook_signing (probed
+    # separately below), so only the event-subscriber store import remains.
     assert json.loads(result.stdout) == {
         "deprecated_import_sites": [],
-        "import_site_count": 3,
+        "import_site_count": 1,
         "relevant_warnings": [],
         "resolved_homes": [CANONICAL_MODULE_NAME],
         "shim_imported": False,
@@ -473,3 +475,123 @@ def test_package_shim_has_no_dynamic_file_loader() -> None:
     assert "module_from_spec" not in source
     assert "exec_module" not in source
     assert package._webhooks_module.__name__ == "aragora.server.handlers.webhook_management"
+
+
+def test_retry_queue_signs_via_security_layer_without_call_time_warnings() -> None:
+    """Retry-queue signing resolves AND CALLS the security-layer signer silently.
+
+    The webhook_management.generate_signature wrapper warns on every call, so a
+    delivery path that imports it stays noisy even when the import itself is
+    warning-free. This probe pins the retry queue's signer imports to the
+    security layer and proves the resolved callable is silent at call time.
+    """
+    script = textwrap.dedent(
+        """
+        import ast
+        import json
+        from pathlib import Path
+        import sys
+        import warnings
+
+        root = Path(sys.argv[1])
+        rel_path = "aragora/webhooks/retry_queue.py"
+        server_prefix = "aragora.server.handlers."
+
+        signer_imports = []
+        tree = ast.parse((root / rel_path).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and any(
+                alias.name == "generate_signature" for alias in node.names
+            ):
+                signer_imports.append(node.module)
+
+        expected_signature = (
+            "sha256=b82fcb791acec57859b989b430a826488ce2e479fdf92326bd0a2e8375a42ba4"
+        )
+        call_results = []
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            for module_name in signer_imports:
+                module = __import__(module_name, fromlist=["generate_signature"])
+                signer = getattr(module, "generate_signature")
+                call_results.append(signer("payload", "secret") == expected_signature)
+
+        relevant = [
+            str(item.message)
+            for item in caught
+            if issubclass(item.category, DeprecationWarning)
+        ]
+        print(json.dumps({
+            "call_results": call_results,
+            "call_time_warnings": relevant,
+            "server_modules_loaded": sorted(
+                name for name in sys.modules if name.startswith(server_prefix)
+            ),
+            "signer_import_modules": sorted(set(signer_imports)),
+            "signer_import_site_count": len(signer_imports),
+        }, sort_keys=True))
+        """
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARAGORA_SECRETS_STRICT": "false",
+            "AWS_CONFIG_FILE": "/dev/null",
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "AWS_SHARED_CREDENTIALS_FILE": "/dev/null",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "call_results": [True, True],
+        "call_time_warnings": [],
+        "server_modules_loaded": [],
+        "signer_import_modules": ["aragora.security.webhook_signing"],
+        "signer_import_site_count": 2,
+    }
+
+
+def test_webhook_suite_patch_targets_bypass_the_deprecation_shim() -> None:
+    """@patch targets in the handler test suite name the canonical module.
+
+    Patching the shim package attribute is a decoy: the implementation reads
+    its own module globals, so a shim-path patch never intercepts anything.
+    """
+    suite_path = REPO_ROOT / "tests/server/handlers/test_webhooks.py"
+    tree = ast.parse(suite_path.read_text(encoding="utf-8"))
+
+    patch_targets = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        func_name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if func_name != "patch":
+            continue
+        if (
+            node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            patch_targets.append(node.args[0].value)
+
+    shim_targets = [
+        target for target in patch_targets if target.startswith("aragora.server.handlers.webhooks.")
+    ]
+    canonical_targets = [
+        target
+        for target in patch_targets
+        if target.startswith("aragora.server.handlers.webhook_management.")
+    ]
+    assert shim_targets == []
+    assert len(canonical_targets) >= 8

--- a/tests/security/test_webhook_signing.py
+++ b/tests/security/test_webhook_signing.py
@@ -70,7 +70,21 @@ def test_events_verifier_reuses_canonical_signer() -> None:
 def test_event_dispatchers_do_not_import_server_signer(module_name: str) -> None:
     """Infrastructure dispatchers must not reach up into the server layer."""
     module = __import__(module_name, fromlist=["__file__"])
-    source = Path(module.__file__).read_text(encoding="utf-8")
+    module_file = module.__file__
+    assert module_file is not None
+    source = Path(module_file).read_text(encoding="utf-8")
 
     assert "from aragora.server.handlers.webhooks import generate_signature" not in source
     assert "from aragora.security.webhook_signing import generate_signature" in source
+
+
+def test_retry_queue_does_not_import_server_signer() -> None:
+    """The webhook retry queue signs through the security layer, not the server layer."""
+    module = __import__("aragora.webhooks.retry_queue", fromlist=["__file__"])
+    module_file = module.__file__
+    assert module_file is not None
+    source = Path(module_file).read_text(encoding="utf-8")
+
+    assert "from aragora.server.handlers.webhook_management import" not in source
+    assert "from aragora.server.handlers.webhooks import" not in source
+    assert "from aragora.security.webhook_signing import" in source

--- a/tests/server/handlers/test_webhooks.py
+++ b/tests/server/handlers/test_webhooks.py
@@ -414,7 +414,10 @@ class TestRegisterWebhook:
         handler_inst.read_json_body_validated = MagicMock(return_value=(body, None))
 
     @pytest.mark.asyncio
-    @patch("aragora.server.handlers.webhooks.validate_webhook_url", return_value=(True, ""))
+    @patch(
+        "aragora.server.handlers.webhook_management.validate_webhook_url",
+        return_value=(True, ""),
+    )
     async def test_register_webhook_success(self, mock_validate, handler):
         self._mock_body(
             handler,
@@ -447,7 +450,10 @@ class TestRegisterWebhook:
         assert status == 400
 
     @pytest.mark.asyncio
-    @patch("aragora.server.handlers.webhooks.validate_webhook_url", return_value=(True, ""))
+    @patch(
+        "aragora.server.handlers.webhook_management.validate_webhook_url",
+        return_value=(True, ""),
+    )
     async def test_register_webhook_missing_events(self, mock_validate, handler):
         self._mock_body(handler, {"url": "https://example.com/hook"})
         result = await handler.handle_post("/api/v1/webhooks", {}, _make_mock_http_handler())
@@ -455,7 +461,10 @@ class TestRegisterWebhook:
         assert status == 400
 
     @pytest.mark.asyncio
-    @patch("aragora.server.handlers.webhooks.validate_webhook_url", return_value=(True, ""))
+    @patch(
+        "aragora.server.handlers.webhook_management.validate_webhook_url",
+        return_value=(True, ""),
+    )
     async def test_register_webhook_invalid_event_type(self, mock_validate, handler):
         self._mock_body(
             handler,
@@ -470,7 +479,10 @@ class TestRegisterWebhook:
         assert "Invalid event types" in body.get("error", body.get("message", ""))
 
     @pytest.mark.asyncio
-    @patch("aragora.server.handlers.webhooks.validate_webhook_url", return_value=(True, ""))
+    @patch(
+        "aragora.server.handlers.webhook_management.validate_webhook_url",
+        return_value=(True, ""),
+    )
     async def test_register_webhook_wildcard_event(self, mock_validate, handler):
         self._mock_body(
             handler,
@@ -485,7 +497,7 @@ class TestRegisterWebhook:
 
     @pytest.mark.asyncio
     @patch(
-        "aragora.server.handlers.webhooks.validate_webhook_url",
+        "aragora.server.handlers.webhook_management.validate_webhook_url",
         return_value=(False, "URL resolves to private IP"),
     )
     async def test_register_webhook_ssrf_rejected(self, mock_validate, handler):
@@ -587,7 +599,10 @@ class TestUpdateWebhook:
     def _mock_body(self, handler_inst, body: dict):
         handler_inst.read_json_body_validated = MagicMock(return_value=(body, None))
 
-    @patch("aragora.server.handlers.webhooks.validate_webhook_url", return_value=(True, ""))
+    @patch(
+        "aragora.server.handlers.webhook_management.validate_webhook_url",
+        return_value=(True, ""),
+    )
     def test_update_webhook_url(self, mock_validate, handler):
         self._mock_body(handler, {"url": "https://new.example.com/hook"})
         result = handler.handle_patch("/api/v1/webhooks/wh-001", {}, _make_mock_http_handler())
@@ -623,7 +638,7 @@ class TestUpdateWebhook:
         assert "Invalid event types" in body.get("error", body.get("message", ""))
 
     @patch(
-        "aragora.server.handlers.webhooks.validate_webhook_url",
+        "aragora.server.handlers.webhook_management.validate_webhook_url",
         return_value=(False, "URL resolves to private IP"),
     )
     def test_update_webhook_ssrf_url_rejected(self, mock_validate, handler):
@@ -767,7 +782,7 @@ class TestSLOEndpoints:
 
     @pytest.mark.asyncio
     @patch(
-        "aragora.server.handlers.webhooks.WebhookHandler._handle_slo_status",
+        "aragora.server.handlers.webhook_management.WebhookHandler._handle_slo_status",
     )
     async def test_slo_status_route_dispatches(self, mock_slo, handler):
         """Verify the route dispatches to the SLO status handler."""


### PR DESCRIPTION
## Summary

Follow-up to #9822 (r2 evidence round, two pre-existing claude P3s recorded in the settlement packet). Two bounded sub-scopes:

1. **Runtime signer repoint.** `webhook_management.generate_signature` is a deprecated wrapper that emits a `DeprecationWarning` on every CALL and delegates to `aragora.security.webhook_signing`. The runtime-caller census on origin/main found exactly **2** wrapper call sites, both in `aragora/webhooks/retry_queue.py` (`_send_webhook` async path and `_sync_send` fallback). Both now import `aragora.security.webhook_signing` directly, so delivery/retry signing is warning-free at call time and no longer loads any `aragora.server.handlers.*` module at all.
2. **Decoy patch retarget.** `tests/server/handlers/test_webhooks.py` patched through the shim path, where `@patch("aragora.server.handlers.webhooks.validate_webhook_url", ...)` is a decoy: the implementation reads its own module globals in `webhook_management`, so the shim-attribute patch never intercepts. All shim-path patch targets now name `aragora.server.handlers.webhook_management.*`. Test assertions are unchanged.

## Census disclosures

- The feature brief said "5 decoy @patch targets"; the run-time census (mandated by the brief) found **8** shim-path targets: 7× `validate_webhook_url` (lines 417, 450, 458, 473, 487-489, 590, 625-627) + 1× `WebhookHandler._handle_slo_status` (769-771, functional via the shared class object but resolved through the shim's warning `__getattr__`). All 8 retargeted.
- Pre-existing shim **from-imports** in sibling test files (`tests/handlers/test_webhooks.py`, `tests/server/handlers/test_webhooks_handler.py`, and the module-level import at `tests/server/handlers/test_webhooks.py:32`) are intentional legacy-surface consumption coverage and out of this bounded scope; left untouched.
- By design retained: the deprecated wrapper itself and the shim's `generate_signature` export stay (public deprecation surface). Only call sites and patch targets moved.
- No test anywhere patches `generate_signature`/`webhook_management` as a mock seam, so the repoint breaks no interception (verified by repo-wide grep).

## Red-first evidence

Three new tests captured RED (3 failed, exit 1) against unmodified code, each for the designed reason, then GREEN after the repoint:

- `tests/handlers/test_webhooks_module_structure.py::test_retry_queue_signs_via_security_layer_without_call_time_warnings` — subprocess probe (extends #9822's pattern to CALL time): AST census pins 2 signer import sites to `aragora.security.webhook_signing`, calls each resolved signer on the known vector, asserts zero call-time DeprecationWarnings, byte-identical `sha256=` output, and **zero** `aragora.server.handlers.*` modules loaded.
- `tests/handlers/test_webhooks_module_structure.py::test_webhook_suite_patch_targets_bypass_the_deprecation_shim` — AST census of `patch(...)` string targets in the suite: zero shim-path targets, ≥8 canonical.
- `tests/security/test_webhook_signing.py::test_retry_queue_does_not_import_server_signer` — source-level layering assertion mirroring the dispatcher tests.

One #9822 guard evolved with the layering change: `test_delivery_and_retry_consumers_import_canonically_without_warnings` pinned retry_queue's signer home to `webhook_management` (canonical at the time); its site count moves 3→1 (event_subscribers' store import only) now that the retry-queue signer census is owned by the new call-time probe.

Also fixed 2 mypy `arg-type` errors on the `Path(module.__file__)` pattern in `tests/security/test_webhook_signing.py` (one pre-existing, surfaced by the diff; no `type: ignore` added — ratchet stays at 700/700).

## Verification

- RED: 3 failed (exit 1) pre-change; GREEN: full four-file battery 122 passed.
- Wider consumer battery: 885 passed (`tests/handlers/test_webhooks.py`, `tests/server/handlers/test_webhooks_handler.py`, `tests/server/test_event_subscribers.py`, `tests/events/`, `tests/integrations/test_webhooks.py`, `tests/resilience/test_webhooks.py`, `tests/notifications/test_retry_queue.py`).
- Smoke tier: 138 passed; `make test-smoke` green.
- Seed sweeps over the 3 touched test files: 5 seeds (1, 7, 42, 1337, 9822) × 70 passed.
- `ruff check` + `ruff format --check` clean; `preflight_mypy` (committed state) and hook-variant mypy clean.
- `report_code_quality.py --check`: PASS (noqa 2693/2800, type_ignore 700/700 unchanged).
- Skip audit: 0 skips in touched files, 0 added. LOC: 163 added / 12 deleted (175 total).
- Path freeze: 0 of 78 open PRs touch the 4 changed files.

Provenance: `library/misc-webhook-canonicalization-followups-settlement-packet-9822-e8ad6d5b37c5.md`; hard gate satisfied (#9822 MERGED at `7b267f56435c`).
