### PR TITLE
test(governance): rename live rule-suite record test to reflect required normalization

### DIFF
--- a/tests/scripts/test_build_contract_drift_historical_backfill.py
+++ b/tests/scripts/test_build_contract_drift_historical_backfill.py
@@ -955,7 +955,7 @@ def test_rule_suite_after_sha_bound_to_implementation_source_validates(
     assert validated["rule_suite"]["after_sha"] == validated["authority"]["source_sha"]
 
 
-def test_live_rule_suite_record_normalizes_bare_repository_name() -> None:
+def test_live_rule_suite_record_requires_normalized_repository_name() -> None:
     # Field values from the live passing record for the merged implementation
     # push (rule-suite ID 3821290531). The raw rule-suites API returns the bare
     # repository name ("aragora"), so input construction must normalize it to


### PR DESCRIPTION
## Source

Post-merge follow-up to the rule-suite plane cure PR #9820 (merged as `fe97dc28cd5e`), executing claude review P3 finding #1 from the executed settlement packet (`library/cdg-capsule-rule-suite-plane-cure-settlement-packet.md`, mission Structural Excellence): the test name overstated builder behavior. P3 #2 and #3 were recorded no-action at settlement.

## Behavior summary

Pure test-function rename, no behavior change:

- `test_live_rule_suite_record_normalizes_bare_repository_name` -> `test_live_rule_suite_record_requires_normalized_repository_name`

The builder contains no repository_name normalization code (`_validate_rule_suite` copies the record verbatim and REJECTS the bare `aragora` form fail-closed); normalization to `synaptent/aragora` is the operator's manual input-construction step per the runbook (P3/P5). The new name states what the builder enforces. The test body and its inline comment (already accurate) are untouched.

## Validation

- `python3 -B -m pytest tests/scripts/test_build_contract_drift_historical_backfill.py tests/scripts/test_contract_drift_historical_backfill_schema.py -q` -> **153 passed** (packet-matching count)
- Randomized seed sweep, file-scoped, seeds 1/42/100/2024/12345 -> 146 passed each
- `make lint` PASS; `ruff format --check` PASS; `bash scripts/preflight_mypy.sh --diff-base origin/main` -> no issues in 1 source file
- AWS-neutral `make test-smoke` PASS; smoke tier -> 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok (exactly 1 file)
- Repo-wide reference scan: the old name appears ONLY at its definition site (no CI/workflow/docs/selector references)

## Risks

None identified. 1+/1- single-line rename in one test file; census over the file shows zero open-PR overlap.
