### PR TITLE
feat(swarm): add hard never-post control to the quorum evidence collector

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -256,6 +256,27 @@ def advisory_dissent_settle_enabled(env: dict[str, str] | None = None) -> bool:
     )
 
 
+# Hard "never post" control for prepare-only missions. When active — via the
+# ``never_post`` kwarg (threaded from the ``--never-post`` CLI flag) or via this
+# environment variable (which also covers the ``review-queue collect-evidence``
+# path without a CLI change) — :func:`decide_action` forces ``"prepare"`` at
+# EVERY tier, including Tier 0-2 runs invoked with ``apply=True``, so a
+# prepare-only mission no longer depends on every worker remembering to omit
+# ``--apply``. The control is monotonic: an explicit ``never_post=False`` cannot
+# switch the environment variable back off. Combining the control with an
+# explicit ``--apply`` is a loud error rather than a silent override, so a
+# contradictory invocation fails fast instead of quietly preparing.
+_NEVER_POST_ENV = "ARAGORA_EVIDENCE_NEVER_POST"
+_NEVER_POST_TRUE = frozenset(("1", "true", "yes", "on"))
+
+
+def never_post_enabled(env: dict[str, str] | None = None) -> bool:
+    """Whether the hard never-post control is active via the environment.
+    Default OFF; see :data:`_NEVER_POST_ENV`."""
+    source = os.environ if env is None else env
+    return str(source.get(_NEVER_POST_ENV, "")).strip().lower() in _NEVER_POST_TRUE
+
+
 def _coerce_relaxed_flag(value: Any) -> bool:
     """Coerce a serialized gate-regime flag (``severity_gated`` / ``tiered_gate``) to
     bool, fail-closed. A real bool passes through; a string counts as relaxed ONLY for
@@ -1324,14 +1345,21 @@ def load_prepared_outcome(path: Path) -> CollectOutcome:
     return collect_outcome_from_dict(json.loads(path.read_text(encoding="utf-8")))
 
 
-def decide_action(tier: int | None, apply: bool) -> tuple[str, str]:
+def decide_action(tier: int | None, apply: bool, *, never_post: bool = False) -> tuple[str, str]:
     """Return ``(action, reason)`` where action is ``"post"`` or ``"prepare"``.
 
     Tier 3+ (and unknown tier) always ``prepare`` — high-tier merge authority is
     only ever settled by an operator on the exact head, so this collector refuses
     to post there regardless of ``apply``. Tier 0-2 posts only when ``apply`` is
-    set; otherwise it is a dry run.
+    set; otherwise it is a dry run. The never-post control (``never_post=True``
+    or :data:`_NEVER_POST_ENV`) dominates everything: it forces ``prepare`` at
+    every tier, and the environment variable cannot be switched off per-call.
     """
+    if never_post or never_post_enabled():
+        return (
+            "prepare",
+            "never-post control active; preparing evidence only at every tier",
+        )
     if tier is None or tier < 0:
         return ("prepare", "tier unknown; preparing evidence only (fail-safe)")
     if tier >= SETTLEMENT_TIER_FLOOR:
@@ -2963,6 +2991,7 @@ def collect_evidence(
     families: Sequence[str],
     author: str,
     apply: bool,
+    never_post: bool = False,
     context_fetcher: Callable[[str, int], dict[str, Any]] = merge_quorum_io.fetch_pr_context,
     tier_fetcher: Callable[[str, int], int | None] = merge_quorum_io.fetch_pr_tier,
     prompt_builder: Callable[[str, int, dict[str, Any]], str] = default_prompt_builder,
@@ -2984,7 +3013,7 @@ def collect_evidence(
         raise ValueError(f"could not resolve head SHA for PR #{pr} in {repo}")
 
     tier = tier_fetcher(repo, pr)
-    action, action_reason = decide_action(tier, apply)
+    action, action_reason = decide_action(tier, apply, never_post=never_post)
 
     outcome = CollectOutcome(
         repo=repo,
@@ -3141,7 +3170,7 @@ def collect_evidence(
             )
             _record_review_adjudication_if_applicable(outcome)
             return outcome
-        recheck_action, recheck_reason = decide_action(recheck_tier, apply)
+        recheck_action, recheck_reason = decide_action(recheck_tier, apply, never_post=never_post)
         if recheck_head != head_sha or recheck_action != "post":
             outcome.action = "prepare"
             outcome.action_reason = (
@@ -3610,6 +3639,7 @@ def apply_prepared_evidence(
     prepared_json: Path,
     author: str,
     apply: bool,
+    never_post: bool = False,
     families: Sequence[str] | None = None,
     context_fetcher: Callable[[str, int], dict[str, Any]] = merge_quorum_io.fetch_pr_context,
     tier_fetcher: Callable[[str, int], int | None] = merge_quorum_io.fetch_pr_tier,
@@ -3674,7 +3704,7 @@ def apply_prepared_evidence(
     live_severity_gated = severity_gated_dissent_enabled()
 
     tier = tier_fetcher(repo, pr)
-    action, action_reason = decide_action(tier, apply)
+    action, action_reason = decide_action(tier, apply, never_post=never_post)
     outcome = CollectOutcome(
         repo=repo,
         pr=pr,
@@ -3769,7 +3799,7 @@ def apply_prepared_evidence(
         )
         _record_review_adjudication_if_applicable(outcome)
         return outcome
-    recheck_action, recheck_reason = decide_action(recheck_tier, apply)
+    recheck_action, recheck_reason = decide_action(recheck_tier, apply, never_post=never_post)
     recheck_stability_problem = _settlement_stability_problem(recheck_context)
     if recheck_head != head_sha or recheck_action != "post" or recheck_stability_problem:
         outcome.action = "prepare"
@@ -3895,6 +3925,7 @@ def run_collect_cli(
     author: str | None,
     apply: bool,
     json_output: bool,
+    never_post: bool = False,
     prepared_json: Path | None = None,
     reviewer_timeout_seconds: float | None = None,
     overall_timeout_seconds: float | None = None,
@@ -3912,10 +3943,20 @@ def run_collect_cli(
     still exit 2 (quorum is enforced as N-of-M elsewhere). Inspect
     ``posted_families`` in the JSON output rather than treating a non-zero exit
     as "nothing posted".
+
+    ``never_post`` (or :data:`_NEVER_POST_ENV`) is the hard prepare-only
+    control: it forces ``action=prepare`` / ``posted_families=[]`` at every
+    tier and conflicts loudly with ``apply`` instead of silently overriding it.
     """
     fams = tuple(families) if families else DEFAULT_FAMILIES
     resolved_author = author or resolve_author()
     try:
+        if apply and (never_post or never_post_enabled()):
+            raise ValueError(
+                f"--never-post (or {_NEVER_POST_ENV}=1) conflicts with --apply: the "
+                "never-post control forbids posting at any tier; drop --apply or "
+                "clear the control"
+            )
         overall_timeout_seconds = _positive_timeout_seconds(
             overall_timeout_seconds, "overall_timeout_seconds"
         )
@@ -3930,6 +3971,7 @@ def run_collect_cli(
                     families=fams,
                     author=resolved_author,
                     apply=apply,
+                    never_post=never_post,
                     env=merge_quorum_io.aragora_env(),
                     quorum_reconciler=default_quorum_reconciler if apply else None,
                     overall_timeout_seconds=overall_timeout_seconds,
@@ -3941,6 +3983,7 @@ def run_collect_cli(
                     prepared_json=prepared_json,
                     author=resolved_author,
                     apply=apply,
+                    never_post=never_post,
                     families=fams,
                     env=merge_quorum_io.aragora_env(),
                     quorum_reconciler=default_quorum_reconciler if apply else None,

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -13,7 +13,9 @@ Two safety invariants (enforced in :mod:`aragora.swarm.quorum_evidence`):
   ``--apply``); Tier 3-4 (and unknown tier) always prepare evidence for an
   operator and never post.
 
-Defaults to a dry run (prepares + lints, prints, posts nothing).
+Defaults to a dry run (prepares + lints, prints, posts nothing). ``--never-post``
+(or ``ARAGORA_EVIDENCE_NEVER_POST=1``) is a hard prepare-only control on top of
+that: it forces prepare at every tier and conflicts loudly with ``--apply``.
 
 Examples
 --------
@@ -86,6 +88,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Post evidence for Tier 0-2 PRs (Tier 3-4 always prepare-only).",
     )
     parser.add_argument(
+        "--never-post",
+        dest="never_post",
+        action="store_true",
+        help=(
+            "Hard prepare-only control: force action=prepare at every tier and never "
+            "post (also enabled via ARAGORA_EVIDENCE_NEVER_POST=1). Conflicts with "
+            "--apply."
+        ),
+    )
+    parser.add_argument(
         "--reviewer-timeout",
         dest="reviewer_timeout",
         type=float,
@@ -110,6 +122,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--json", dest="json_output", action="store_true", help="Output as JSON")
     args = parser.parse_args(argv)
+    if args.apply and args.never_post:
+        parser.error(
+            "--never-post conflicts with --apply: the never-post control forbids "
+            "posting at any tier"
+        )
 
     return run_collect_cli(
         repo=args.repo,
@@ -118,6 +135,7 @@ def main(argv: list[str] | None = None) -> int:
         author=args.author,
         apply=args.apply,
         json_output=args.json_output,
+        never_post=args.never_post,
         prepared_json=args.prepared_json,
         reviewer_timeout_seconds=args.reviewer_timeout,
         overall_timeout_seconds=args.overall_timeout,

--- a/tests/swarm/test_quorum_evidence_never_post.py
+++ b/tests/swarm/test_quorum_evidence_never_post.py
@@ -1,0 +1,458 @@
+"""Tests for the collector-side hard never-post control.
+
+The control forces ``action="prepare"`` / ``posted_families=[]`` at EVERY tier,
+including Tier 0-2 runs that would otherwise auto-post under ``apply=True``.
+It has three surfaces:
+
+* the ``never_post`` kwarg on :func:`decide_action`, :func:`collect_evidence`,
+  :func:`apply_prepared_evidence`, and :func:`run_collect_cli`;
+* the ``--never-post`` flag on ``scripts/collect_quorum_evidence.py``;
+* the ``ARAGORA_EVIDENCE_NEVER_POST`` environment variable, which also covers
+  the ``review-queue collect-evidence`` path without any CLI change.
+
+Combining the control with ``--apply`` is a loud error rather than a silent
+override, and the default behavior without the control stays byte-identical
+to the pre-control decision matrix.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm import quorum_evidence as qe
+from aragora.swarm.quorum_evidence import (
+    CollectOutcome,
+    EvidenceItem,
+    ReviewerResult,
+    collect_evidence,
+    decide_action,
+)
+
+HEAD = "49a979d587f910aaad4fb0f0bed708dd48c97c35"
+COMMITTED = "2026-06-04T09:57:49-05:00"
+# The env var name is part of the feature contract (prepare-only missions pin
+# it in runbooks), so tests spell it out instead of importing the constant.
+NEVER_POST_ENV = "ARAGORA_EVIDENCE_NEVER_POST"
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "collect_quorum_evidence.py"
+
+
+@pytest.fixture(autouse=True)
+def _clear_never_post_env(monkeypatch):
+    # Every test states its own control state explicitly; start from the
+    # documented default (control absent) regardless of the ambient shell env.
+    monkeypatch.delenv(NEVER_POST_ENV, raising=False)
+
+
+# --- decide_action: the single choke point ----------------------------------
+
+# The exact pre-control decision matrix. Frozen byte-for-byte so the control's
+# default-off path provably changes nothing.
+_DEFAULT_MATRIX: dict[tuple[int | None, bool], tuple[str, str]] = {
+    (None, False): ("prepare", "tier unknown; preparing evidence only (fail-safe)"),
+    (None, True): ("prepare", "tier unknown; preparing evidence only (fail-safe)"),
+    (-1, True): ("prepare", "tier unknown; preparing evidence only (fail-safe)"),
+    (0, False): ("prepare", "dry-run; re-run with --apply to post"),
+    (1, False): ("prepare", "dry-run; re-run with --apply to post"),
+    (2, False): ("prepare", "dry-run; re-run with --apply to post"),
+    (0, True): ("post", "tier 0 is auto-postable"),
+    (1, True): ("post", "tier 1 is auto-postable"),
+    (2, True): ("post", "tier 2 is auto-postable"),
+    (3, False): (
+        "prepare",
+        "tier 3 requires exact-head operator settlement; preparing evidence only",
+    ),
+    (3, True): (
+        "prepare",
+        "tier 3 requires exact-head operator settlement; preparing evidence only",
+    ),
+    (4, True): (
+        "prepare",
+        "tier 4 requires exact-head operator settlement; preparing evidence only",
+    ),
+}
+
+
+def test_decide_action_default_matrix_byte_identical_without_control() -> None:
+    for (tier, apply), expected in _DEFAULT_MATRIX.items():
+        assert decide_action(tier, apply) == expected
+
+
+def test_decide_action_explicit_false_matches_default_matrix() -> None:
+    for (tier, apply), expected in _DEFAULT_MATRIX.items():
+        assert decide_action(tier, apply, never_post=False) == expected
+
+
+@pytest.mark.parametrize("apply", [False, True])
+@pytest.mark.parametrize("tier", [None, -1, 0, 1, 2, 3, 4])
+def test_decide_action_never_post_kwarg_forces_prepare_at_every_tier(
+    tier: int | None, apply: bool
+) -> None:
+    action, reason = decide_action(tier, apply, never_post=True)
+    assert action == "prepare"
+    assert "never-post" in reason
+
+
+@pytest.mark.parametrize("tier", [0, 1, 2])
+def test_decide_action_env_forces_prepare_at_auto_post_tiers(tier: int, monkeypatch) -> None:
+    monkeypatch.setenv(NEVER_POST_ENV, "1")
+    action, reason = decide_action(tier, apply=True)
+    assert action == "prepare"
+    assert "never-post" in reason
+
+
+def test_decide_action_env_cannot_be_disabled_per_call(monkeypatch) -> None:
+    # The env var is a hard control: an explicit never_post=False must not
+    # switch it back off. The control is monotonic — it can only force prepare.
+    monkeypatch.setenv(NEVER_POST_ENV, "1")
+    action, reason = decide_action(0, apply=True, never_post=False)
+    assert action == "prepare"
+    assert "never-post" in reason
+
+
+# --- collect_evidence orchestration (fully offline via injected callables) ---
+
+
+def _fakes(*, tier: int):
+    posted: list[tuple[str, str]] = []
+
+    def context_fetcher(repo: str, pr: int) -> dict:
+        return {"head_sha": HEAD, "head_committed_at": COMMITTED}
+
+    def tier_fetcher(repo: str, pr: int):
+        return tier
+
+    def prompt_builder(repo: str, pr: int, ctx: dict) -> str:
+        return "review prompt"
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    def linter(pr, head_sha, head_committed_at, author, body, env) -> dict:
+        return {
+            "would_count": True,
+            "counted_reviewer_ids": [body.split()[1].lower()],
+            "problems": [],
+        }
+
+    def poster(repo: str, pr: int, body: str) -> None:
+        posted.append((repo, body))
+
+    return dict(
+        context_fetcher=context_fetcher,
+        tier_fetcher=tier_fetcher,
+        prompt_builder=prompt_builder,
+        reviewer_runner=reviewer_runner,
+        linter=linter,
+        poster=poster,
+    ), posted
+
+
+def test_collect_low_tier_apply_posts_without_control() -> None:
+    # Baseline: without the control this exact fixture auto-posts, which is
+    # what makes the suppression assertions below meaningful.
+    fakes, posted = _fakes(tier=1)
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=True, **fakes
+    )
+    assert outcome.action == "post"
+    assert sorted(outcome.posted) == ["claude", "grok"]
+    assert len(posted) == 2
+
+
+@pytest.mark.parametrize("tier", [0, 1, 2])
+def test_collect_env_never_post_suppresses_low_tier_posting(tier: int, monkeypatch) -> None:
+    monkeypatch.setenv(NEVER_POST_ENV, "1")
+    fakes, posted = _fakes(tier=tier)
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=True, **fakes
+    )
+    assert outcome.action == "prepare"
+    assert "never-post" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+    assert outcome.to_dict()["posted_families"] == []
+
+
+def test_collect_never_post_kwarg_beats_apply() -> None:
+    fakes, posted = _fakes(tier=0)
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        never_post=True,
+        **fakes,
+    )
+    assert outcome.action == "prepare"
+    assert "never-post" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+
+
+def test_collect_never_post_reason_dominates_dry_run_reason() -> None:
+    fakes, posted = _fakes(tier=1)
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=False,
+        never_post=True,
+        **fakes,
+    )
+    assert outcome.action == "prepare"
+    # The rendered outcome must tell the truth: re-running with --apply is NOT
+    # a way out while the control is active, so the ordinary dry-run reason
+    # ("re-run with --apply to post") must not surface.
+    assert "never-post" in outcome.action_reason
+    assert "--apply" not in outcome.action_reason
+    assert posted == []
+
+
+# --- apply_prepared_evidence (prepared-artifact path) ------------------------
+
+
+def _prepared_body(family: str) -> str:
+    return f"Verdict: PASS\n\n{family} body\n"
+
+
+def _prepared_outcome_file(tmp_path) -> Path:
+    outcome = CollectOutcome(
+        repo="o/r",
+        pr=1,
+        head_sha=HEAD,
+        head_committed_at=COMMITTED,
+        tier=1,
+        action="prepare",
+        action_reason="dry-run; re-run with --apply to post",
+        items=[
+            EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass"),
+            EvidenceItem("grok", _prepared_body("grok"), True, ["grok"], [], "pass"),
+        ],
+    )
+    path = tmp_path / "prepared.json"
+    path.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
+    return path
+
+
+def _prepared_linter(pr, head_sha, head_committed_at, author, body, env) -> dict:
+    family = "claude" if "claude body" in body else "grok"
+    return {"would_count": True, "counted_reviewer_ids": [family], "problems": []}
+
+
+def _apply_prepared(
+    prepared: Path, posted: list[tuple[str, str]], *, never_post: bool = False
+) -> CollectOutcome:
+    return qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        never_post=never_post,
+        families=["claude", "grok"],
+        context_fetcher=lambda repo, pr: {"head_sha": HEAD, "head_committed_at": COMMITTED},
+        tier_fetcher=lambda repo, pr: 1,
+        linter=_prepared_linter,
+        poster=lambda repo, pr, body: posted.append((repo, body)),
+    )
+
+
+def test_apply_prepared_posts_without_control(tmp_path) -> None:
+    posted: list[tuple[str, str]] = []
+    outcome = _apply_prepared(_prepared_outcome_file(tmp_path), posted)
+    assert outcome.action == "post"
+    assert outcome.posted == ["claude", "grok"]
+    assert len(posted) == 2
+
+
+def test_apply_prepared_env_never_post_suppresses_posting(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv(NEVER_POST_ENV, "1")
+    posted: list[tuple[str, str]] = []
+    outcome = _apply_prepared(_prepared_outcome_file(tmp_path), posted)
+    assert outcome.action == "prepare"
+    assert "never-post" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+    assert outcome.to_dict()["posted_families"] == []
+
+
+def test_apply_prepared_never_post_kwarg_suppresses_posting(tmp_path) -> None:
+    posted: list[tuple[str, str]] = []
+    outcome = _apply_prepared(_prepared_outcome_file(tmp_path), posted, never_post=True)
+    assert outcome.action == "prepare"
+    assert "never-post" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+
+
+# --- run_collect_cli: conflict error + threading -----------------------------
+
+
+def test_run_collect_cli_flag_apply_conflict_is_loud(monkeypatch) -> None:
+    calls: list[tuple[str, int]] = []
+
+    def boom(repo, pr, context_fetcher):
+        calls.append((repo, pr))
+        raise RuntimeError("collection started despite the conflict")
+
+    monkeypatch.setattr(qe, "_fetch_preflight_context", boom)
+    lines: list[str] = []
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=("claude",),
+        author="me",
+        apply=True,
+        json_output=False,
+        never_post=True,
+        printer=lines.append,
+    )
+    assert rc == 1
+    output = "\n".join(lines)
+    assert "error:" in output
+    assert "never-post" in output
+    assert "--apply" in output
+    assert calls == []
+
+
+def test_run_collect_cli_env_apply_conflict_is_loud(monkeypatch) -> None:
+    monkeypatch.setenv(NEVER_POST_ENV, "1")
+    calls: list[tuple[str, int]] = []
+
+    def boom(repo, pr, context_fetcher):
+        calls.append((repo, pr))
+        raise RuntimeError("collection started despite the conflict")
+
+    monkeypatch.setattr(qe, "_fetch_preflight_context", boom)
+    lines: list[str] = []
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=("claude",),
+        author="me",
+        apply=True,
+        json_output=True,
+        printer=lines.append,
+    )
+    assert rc == 1
+    payload = json.loads(lines[-1])
+    assert "never-post" in payload["error"]
+    assert calls == []
+
+
+def _prepare_only_outcome() -> CollectOutcome:
+    return CollectOutcome(
+        repo="o/r",
+        pr=1,
+        head_sha=HEAD,
+        head_committed_at=COMMITTED,
+        tier=1,
+        action="prepare",
+        action_reason="never-post control active",
+    )
+
+
+def test_run_collect_cli_threads_never_post_into_collection(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_collect_evidence(**kwargs):
+        captured.update(kwargs)
+        return _prepare_only_outcome()
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect_evidence)
+    lines: list[str] = []
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=("claude", "grok"),
+        author="me",
+        apply=False,
+        json_output=True,
+        never_post=True,
+        printer=lines.append,
+    )
+    # Empty outcome -> documented non-zero exit; the JSON stays the authority.
+    assert rc == 1
+    assert captured["never_post"] is True
+    assert captured["apply"] is False
+
+
+def test_run_collect_cli_threads_never_post_into_prepared_apply(monkeypatch, tmp_path) -> None:
+    captured: dict = {}
+
+    def fake_apply_prepared(**kwargs):
+        captured.update(kwargs)
+        return _prepare_only_outcome()
+
+    monkeypatch.setattr(qe, "apply_prepared_evidence", fake_apply_prepared)
+    lines: list[str] = []
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=("claude",),
+        author="me",
+        apply=False,
+        json_output=True,
+        prepared_json=tmp_path / "prepared.json",
+        never_post=True,
+        printer=lines.append,
+    )
+    assert rc == 1
+    assert captured["never_post"] is True
+    assert captured["apply"] is False
+
+
+# --- scripts/collect_quorum_evidence.py flag parsing -------------------------
+
+
+def _load_script(monkeypatch):
+    spec = importlib.util.spec_from_file_location(
+        "collect_quorum_evidence_under_test", _SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # Secrets hydration is startup plumbing, not parsing behavior under test.
+    monkeypatch.setattr(module, "_hydrate_provider_secrets", lambda: None)
+    return module
+
+
+def test_cli_never_post_flag_parses_and_threads(monkeypatch) -> None:
+    module = _load_script(monkeypatch)
+    captured: dict = {}
+    monkeypatch.setattr(qe, "run_collect_cli", lambda **kwargs: captured.update(kwargs) or 0)
+    rc = module.main(["--repo", "o/r", "--pr", "1", "--never-post"])
+    assert rc == 0
+    assert captured["never_post"] is True
+    assert captured["apply"] is False
+
+
+def test_cli_default_threads_control_off(monkeypatch) -> None:
+    module = _load_script(monkeypatch)
+    captured: dict = {}
+    monkeypatch.setattr(qe, "run_collect_cli", lambda **kwargs: captured.update(kwargs) or 0)
+    rc = module.main(["--repo", "o/r", "--pr", "1"])
+    assert rc == 0
+    assert captured["never_post"] is False
+
+
+def test_cli_apply_conflicts_with_never_post_flag(monkeypatch, capsys) -> None:
+    module = _load_script(monkeypatch)
+    monkeypatch.setattr(
+        qe,
+        "run_collect_cli",
+        lambda **kwargs: pytest.fail("run_collect_cli must not run on a conflicting invocation"),
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        module.main(["--repo", "o/r", "--pr", "1", "--apply", "--never-post"])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "--never-post" in err
+    assert "conflicts with --apply" in err


### PR DESCRIPTION
## Source

Mission feature `misc-quorum-collector-never-post-flag` (aragora Structural Excellence, epic #8257): the quorum evidence collector auto-posts at tier <= 2 when `--apply` is passed, so prepare-only missions depend on every worker remembering to omit `--apply` (recurring trap; latest instance: PR #9823 prep, 2026-08-27).

## Behavior

Adds a collector-side hard "never post" control with three surfaces:

- `--never-post` flag on `scripts/collect_quorum_evidence.py`;
- `never_post` kwarg on `run_collect_cli` / `collect_evidence` / `apply_prepared_evidence` / `decide_action`;
- `ARAGORA_EVIDENCE_NEVER_POST=1` environment variable, which also covers the `review-queue collect-evidence` path without any change to `aragora/cli/commands/review_queue.py`.

Under the control, `decide_action` short-circuits to `("prepare", "never-post control active; preparing evidence only at every tier")` ahead of every other branch, at all four call sites (initial decision + pre-post recheck on both the live-collection and prepared-artifact paths), so `action=prepare` / `posted_families=[]` is forced regardless of tier. The control is monotonic: an explicit `never_post=False` cannot switch the environment variable back off.

Combining the control with `--apply` errors loudly instead of silently overriding:

- `--apply --never-post` at the script parser: argparse error, exit 2, before any collection work;
- `apply=True` + control (kwarg or env) inside `run_collect_cli`: `error: --never-post (or ARAGORA_EVIDENCE_NEVER_POST=1) conflicts with --apply: ...`, exit 1, before any preflight fetch.

Default behavior without the control is byte-identical: the new tests pin the exact pre-control `decide_action` matrix (actions and reason strings) plus the tier-1 auto-post baselines on both collection paths, and the existing 380-test `tests/swarm/test_quorum_evidence.py` battery passes unchanged.

## Validation

- `python3 -m pytest tests/swarm/test_quorum_evidence_never_post.py -q --timeout=120` -> 36 passed (red-first: 33 failed on the unmodified tree, 3 byte-identical baseline guards passed).
- `python3 -m pytest tests/swarm/test_quorum_evidence.py -q --timeout=300` -> 380 passed (frozen battery, untouched).
- `make lint` + `ruff format --check aragora/ tests/ scripts/` -> clean.
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (committed state) -> `Success: no issues found in 3 source files`.
- `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke` -> passed.
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed.
- File-scoped randomized sweep, seeds 1/42/100/2024/12345 -> 36 passed on every seed.
- Live CLI check: `--apply --never-post` -> exit 2 with the conflict on stderr.

Measured LOC: +526/-7 = 533 changed lines (`git diff --numstat origin/main...HEAD`).

## Tier and process

`aragora/swarm/quorum_evidence.py` is a `TIER_4_PREFIXES` member, so this PR computes tier 4: it stays a parked draft labeled `operator-review-required` with prepare-only (UNPOSTED) model evidence and a settlement packet; no ready flip, no evidence posting, no settlement, no merge without a later exact-head operator delegation.

Census disclosure (operator overlap ratification recorded 2026-08-27 in mission `AGENTS.md` + `library/operator-approvals.md`, pinned): tolerated foreign owners of the touched production files are #9147 `eded2273`, #9081 `622d158e`, #8879 `89d17eb9`, #8756 `af4e82eb`, #8406 `ac8d65f1` (both files: #8756 only for `scripts/collect_quorum_evidence.py`), plus #9064 `defdde14` on the frozen `tests/swarm/test_quorum_evidence.py` (not touched here). All six re-verified OPEN at exactly those heads immediately before push; all new tests live in the census-clean new file `tests/swarm/test_quorum_evidence_never_post.py`.

## Risks

- Additive, default-off control; the default path is proven byte-identical by pinned-matrix tests and the untouched 380-test battery.
- The six tolerated foreign PRs carry their own `quorum_evidence.py` hunks; whichever side merges second must rebase/regenerate (disclosed above, per the standing ratification).
