### PR TITLE
test(server): preserve empty-string env restores and harden the auth presettle fixture

### DIFF
--- a/tests/server/test_rate_limit.py
+++ b/tests/server/test_rate_limit.py
@@ -565,8 +565,8 @@ class TestRedisRateLimiter:
             # May return None or may connect to localhost depending on environment
             # Just ensure it doesn't crash
         finally:
-            # Restore original
-            if original:
+            # Restore original (an empty string is a real value; skip only when unset)
+            if original is not None:
                 os.environ["ARAGORA_REDIS_URL"] = original
             reset_redis_client()
 

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 import pytest
 
-from aragora.config.settings import AuthSettings, get_settings
+from aragora.config.settings import AuthSettings, get_settings, reset_settings
 from aragora.server.auth import AuthConfig, check_auth
 from aragora.storage.debate_storage import _escape_like_pattern, DebateStorage
 
@@ -644,14 +644,21 @@ class TestCheckAuthIntegration:
             auth_config.api_token = original_token
 
 
-def _auth_settings_env_names() -> tuple[str, ...]:
-    """Environment variable names AuthSettings reads (alias or prefix + field name)."""
+def _auth_settings_env_names() -> set[str]:
+    """Environment variable names AuthSettings reads (aliases plus prefix + field name)."""
     prefix = str(AuthSettings.model_config.get("env_prefix") or "")
-    names = []
+    names: set[str] = set()
     for field_name, field in AuthSettings.model_fields.items():
-        alias = field.validation_alias if isinstance(field.validation_alias, str) else field.alias
-        names.append(alias if isinstance(alias, str) else f"{prefix}{field_name}".upper())
-    return tuple(names)
+        for alias in (field.validation_alias, field.alias):
+            if isinstance(alias, str):
+                names.add(alias)
+            else:
+                # AliasChoices exposes .choices; AliasPath entries are not env names.
+                for choice in getattr(alias, "choices", None) or ():
+                    if isinstance(choice, str):
+                        names.add(choice)
+        names.add(f"{prefix}{field_name}".upper())
+    return names
 
 
 class TestConfigureFromEnv:
@@ -669,9 +676,23 @@ class TestConfigureFromEnv:
         before configure_from_env() ever runs. Scrub AuthSettings' env inputs
         and parse it here so the bodies exercise configure_from_env() alone.
         """
-        for env_name in _auth_settings_env_names():
-            monkeypatch.delenv(env_name, raising=False)
+        # pydantic-settings matches env names case-insensitively, so scrub every
+        # case variant of each name, not just the exact alias spelling.
+        targets = {name.casefold() for name in _auth_settings_env_names()}
+        for env_name in list(os.environ):
+            if env_name.casefold() in targets:
+                monkeypatch.delenv(env_name, raising=False)
+        # On a cold cache get_settings() re-hydrates os.environ from Secrets
+        # Manager with overwrite=True, which would undo the scrub above.
+        monkeypatch.setattr(
+            "aragora.config.secrets.hydrate_env_from_secrets",
+            lambda *args, **kwargs: {},
+        )
         _ = get_settings().auth
+        yield
+        # Drop the scrubbed-defaults Settings parsed above so it cannot serve
+        # later tests that run after monkeypatch restores the real env.
+        reset_settings()
 
     def test_configure_from_env_token(self):
         """Should load token from environment."""


### PR DESCRIPTION
## Source

Mission feature `misc-rate-limit-env-restore-empty-string` (structex, milestone cdg-bootstrap-route-truth): tests-hygiene fix discovered during `misc-authsettings-env-pollution-test-isolation` (#9826), plus the EXTENDED SCOPE hardening of the just-merged `_presettle_auth_settings` fixture per the three claude [P3] advisories from the #9826 settlement evidence (comment 5435440040).

## What changed (tests-only, zero assertion changes)

**`tests/server/test_rate_limit.py`** — `TestRedisRateLimiter::test_get_redis_client_without_config` restored `ARAGORA_REDIS_URL` only under `if original:`, silently dropping an originally-EMPTY-STRING value. Restore now keys on `is not None`. Sweep confirmed this is the file's only env save/restore occurrence. Disclosure: the bug is latent under pytest today because the unconditional autouse `reset_supabase_env` fixture (tests/fixtures/autouse.py) monkeypatch-delenv's `ARAGORA_REDIS_URL` around every test and restores the pre-test value at teardown; the broken restore is observable when the test body's own logic runs outside that safety net (direct invocation), and the fix keeps the test's own restore correct regardless of the fixture chain.

**`tests/server/test_security.py`** — hardened `_presettle_auth_settings` per the three [P3] advisories:
- (a) **teardown**: `reset_settings()` after each body so the scrubbed-defaults `Settings` parsed by the fixture cannot leak into later same-worker tests once monkeypatch restores the real env;
- (b) **hydration guard**: `aragora.config.secrets.hydrate_env_from_secrets` is monkeypatched to a no-op within fixture scope, because a cold-cache `get_settings()` re-hydrates `os.environ` with `overwrite=True` AFTER the fixture's delenv (TOCTOU);
- (c) **robust scrub**: `_auth_settings_env_names()` now enumerates non-str aliases (`AliasChoices.choices`) and both `validation_alias`/`alias`, and the fixture delenv's every case variant of each name (pydantic-settings matches env vars case-insensitively; exact-case delenv missed e.g. `aragora_token_ttl`).

## Red-first repro (all four mechanisms, pre-fix fail → post-fix pass)

| Repro | Pre-fix | Post-fix |
|---|---|---|
| A: direct call with `ARAGORA_REDIS_URL=''` | `RESTORE-DROPPED` (var unset after test) | `RESTORE-PRESERVED` (`''` intact) |
| B: cold-cache-per-test suite run with `ARAGORA_TOKEN_TTL=7200` | `CACHE-LEAK` (post-suite `token_ttl=3600`) | `CACHE-HERMETIC` (`7200`) |
| C: hydration stub injecting `ARAGORA_TOKEN_TTL=-100` on cold-cache fixture parse | `HYDRATION-DEFEATS-SCRUB` (5 errors, ValidationError) | `SCRUB-HOLDS` (5 passed) |
| D: lowercase `aragora_token_ttl=-100` pre-set | `CASE-VARIANT-ESCAPES-SCRUB` (5 errors, ValidationError) | `SCRUB-HOLDS` (5 passed) |

Repros B–D reproduce the documented same-worker scenario (an earlier test leaves the settings cache cleared, e.g. the known `reset_settings()` polluter in this same rate-limit test) via a plugin clearing the cache before each test's fixtures.

## Validation

- `python3 -m pytest -q -p no:randomly tests/server/test_rate_limit.py tests/server/test_security.py` → **149 passed**
- Polluter→victim chain (`test_get_redis_client_without_config` then `TestConfigureFromEnv`) → 6 passed
- Multi-seed sweep (pytest-randomly seeds 0, 1, 2, 42, 1337, 20260827; file-scoped) → 149 passed on every seed
- `make lint` + `ruff format --check aragora/ tests/ scripts/` → clean
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (post-commit) → no issues in 2 source files
- `make test-smoke` (AWS-neutralized) → passed; `bash scripts/test_tiers.sh smoke` → **138 passed**

## Risks

Tests-only; no production code touched. The fixture now leaves the settings cache cold after each `TestConfigureFromEnv` test (later readers re-parse the real env on demand — the conservative state). Measured diff: +32/−11 across the two test files.
