### PR TITLE
fix(nomic): return empty debate context when the index has zero files

### DIFF
--- a/aragora/nomic/context_builder.py
+++ b/aragora/nomic/context_builder.py
@@ -1147,11 +1147,22 @@ class NomicContextBuilder:
         This provides a navigable map of the codebase that agents can
         reference during structured debate rounds. For TRUE RLM agents,
         this also registers the context for REPL queries.
+
+        Returns an empty string when the index contains no files (empty or
+        nonexistent root), so callers can truthiness-check the result
+        instead of receiving a header-only map.
         """
         if self._index is None:
             await self.build_index()
         if self._index is None:
             raise RuntimeError("Index not built - call build_index() first")
+
+        if self._index.total_files == 0:
+            logger.debug(
+                "Skipping debate context: no files indexed under %s",
+                self._index.root_path,
+            )
+            return ""
 
         sections = []
         sections.append(

--- a/tests/nomic/test_context_builder.py
+++ b/tests/nomic/test_context_builder.py
@@ -184,6 +184,18 @@ class TestNomicContextBuilder:
         assert index.total_bytes == 0
 
     @pytest.mark.asyncio
+    async def test_build_debate_context_empty_root_returns_empty(self, tmp_path):
+        builder = NomicContextBuilder(aragora_path=tmp_path, full_corpus=False)
+        context = await builder.build_debate_context()
+        assert context == ""
+
+    @pytest.mark.asyncio
+    async def test_build_debate_context_nonexistent_root_returns_empty(self, tmp_path):
+        builder = NomicContextBuilder(aragora_path=tmp_path / "does-not-exist", full_corpus=False)
+        context = await builder.build_debate_context()
+        assert context == ""
+
+    @pytest.mark.asyncio
     async def test_knowledge_mound_integration(self, sample_tree):
         mock_mound = AsyncMock()
         mock_mound.query_semantic = AsyncMock(return_value=[])


### PR DESCRIPTION
## Summary

Follow-up to #9827 (merge `368a8d2fd123`). `NomicContextBuilder.build_debate_context()` returned a header-only map, `# Aragora Codebase Context (0 files, ~0K tokens)` plus `Repo root:` / `Manifest:` lines, whenever the cached index reported zero files (empty or nonexistent root). #9827 added None-guards at the two debate emitters only, so every other consumer still received header-only maps for empty roots.

This PR normalizes the empty-root output to `""` at the source:

- `aragora/nomic/context_builder.py`: in `build_debate_context()`, return `""` when `self._index.total_files == 0`, before header/manifest emission. The docstring documents the contract so callers can truthiness-check the result.
- `tests/nomic/test_context_builder.py`: red-first tests for empty-dir and nonexistent roots (both previously returned the header string).

`CodebaseContextBuilder` (`aragora/rlm/codebase_context.py`) subclasses `NomicContextBuilder` and inherits the fix. `""` was chosen over `None` to preserve the `-> str` signature and match the dominant convention among consumers (`CodebaseContextProvider.build_context` and `build_static_inventory` both return `""` for nothing).

## Call-site audit (per-consumer empty-root disposition)

| # | Call site | Empty-root handling today | Effect of `""` |
|---|-----------|---------------------------|----------------|
| 1 | `aragora/debate/codebase_context.py:142` (`CodebaseContextProvider._build_fresh_context`) | caller pre-checks `path.exists()`; result cached | `""` flows to cache; `get_summary()` returns it; downstream guards skip injection |
| 2 | `aragora/debate/context_engineering.py:313` (`_build_base_map`) | pre-checks `repo_path.exists()`; header counts come from the index, not the string | tolerates `""` — audit-only, file owned by open PR #9064, not edited here |
| 3 | `aragora/debate/context_gatherer/gatherer.py:640` | **#9827-guarded emitter, untouched** | its `if not context: return None` fires before its `getattr(builder, "_index", None)` guard |
| 4 | `aragora/debate/context/processors.py:464` | **#9827-guarded emitter, untouched** | same pattern (guards at ~435/473-480) |
| 5 | `aragora/nomic/phases/context.py:212,231` (nomic loop) | both uses wrapped in `if rlm_context:` | `""` correctly skips insertion/replacement — audit-only, #9064 path, not edited here |
| 6 | `aragora/cli/commands/tools.py:465` (`--summary-out` / `--preview`) | writes/prints result as-is | empty file/preview for empty roots; index stats printed separately |
| 7 | `aragora/agents/codebase_agent.py:323` (`_get_rlm_context`) | result gated by `if rlm_context:` at :492 | `""` correctly skips the RLM section |
| 8 | `aragora/debate/phases/context_init.py` (`_inject_codebase_context`, via provider) | `if context and ...` guard | `""` skips injection |
| 9 | `aragora/memory/cross_debate_rlm.py:426,618` | different private method `_build_debate_context(result: DebateResult)`, not a consumer | n/a, listed for audit completeness |

Adjudication: no consumer relies on the header-only string, so the normalization lands at the source and no consumer edits are needed. Mock-based consumer tests stub the builder method and stay green (#9827's `getattr(_index)` technique remains intact at the emitters). The only test asserting the header, `tests/nomic/test_context_builder.py::test_build_debate_context`, uses a populated tree.

## Validation

- Red-first: both new tests failed on the old behavior (`AssertionError: assert '# Aragora Co...anifest.tsv\n' == ''`), green after the fix.
- `python3 -m pytest tests/nomic/test_context_builder.py` — 19 passed; repeated under `pytest-randomly` seeds 0/1/2/3/42, all green.
- Consumer sweep (`tests/debate/context_gatherer/test_gatherer.py`, `tests/debate/context/test_processors.py`, `tests/debate/test_codebase_context.py`, `tests/debate/test_context_engineering.py`, `tests/debate/test_context_gatherer.py`, `tests/rlm/test_codebase_context.py`, `tests/agents/test_codebase_agent.py`, `tests/nomic/test_phase3_wiring.py`, `tests/nomic/phases/test_context_phase.py`, `tests/nomic/test_context_pack.py`, `tests/handlers/test_rlm.py`, `tests/debate/test_strategic_priorities.py`, `tests/nomic/test_generic_meta_planner.py`) — 582 passed, including the #9827 target files.
- `python3 -m pytest tests/nomic` — 5792 passed.
- `make lint` and `ruff format --check` — clean.
- `bash scripts/preflight_mypy.sh --diff-base origin/main` — no issues in the 2 changed files.
- `make test-smoke` and `bash scripts/test_tiers.sh smoke` — 138 passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — ok.

Diff: +23/-0 across 2 files (`aragora/nomic/` + `tests/nomic/`). Path-freeze census at worktree time: write set clean; the only overlap with open PRs (#9064) is on audit-only files that this PR does not modify.
