### PR TITLE
refactor(scripts): make the RBAC audit handlers-root marker contract explicit

### DIFF
--- a/scripts/audit_rbac_coverage.py
+++ b/scripts/audit_rbac_coverage.py
@@ -16,6 +16,7 @@ import json
 import re
 import sys
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
@@ -62,6 +63,11 @@ AUTH_FLOW_PATHS = frozenset(
     }
 )
 
+# Exclusion rules anchor on this literal marker: a path without it normalizes to
+# None in _handler_relative_path and matches no rule, so auditing a handlers tree
+# copied to a path lacking the marker disables every exclusion. The fail direction
+# is safe (files are audited rather than silently skipped); find_handlers warns
+# on stderr when its root is spelled without the marker.
 _HANDLER_PATH_MARKER = "server/handlers/"
 
 
@@ -114,9 +120,27 @@ class HandlerInfo:
     protection_type: str | None = None  # 'decorator', 'admin_secure', 'manual_check'
 
 
+def iter_handler_files(handler_dir: Path) -> Iterator[Path]:
+    """Yield the Python files under ``handler_dir`` that the audit enumerates."""
+    for py_file in handler_dir.rglob("*.py"):
+        if py_file.name.startswith("_"):
+            continue
+        yield py_file
+
+
 def find_handlers(handler_dir: Path) -> list[HandlerInfo]:
     """Find all handler functions and their RBAC decorators."""
     handlers = []
+
+    # The trailing slash lets the root itself (".../server/handlers") satisfy the
+    # same literal-substring rule _handler_relative_path applies to each file.
+    if _HANDLER_PATH_MARKER not in handler_dir.as_posix() + "/":
+        print(
+            f"WARNING: {handler_dir} does not contain '{_HANDLER_PATH_MARKER}'; "
+            "storage/auth-flow exclusions are disabled and every enumerated file "
+            "will be audited.",
+            file=sys.stderr,
+        )
 
     # Decorator patterns
     func_pattern = re.compile(r"^(?:async\s+)?def\s+(\w+)\s*\(")
@@ -155,10 +179,7 @@ def find_handlers(handler_dir: Path) -> list[HandlerInfo]:
     # Pattern for SecureHandler inheritance
     secure_handler_pattern = re.compile(r"class\s+\w+\s*\([^)]*SecureHandler[^)]*\)\s*:")
 
-    for py_file in handler_dir.rglob("*.py"):
-        if py_file.name.startswith("_"):
-            continue
-
+    for py_file in iter_handler_files(handler_dir):
         try:
             content = py_file.read_text()
             lines = content.split("\n")

--- a/tests/scripts/test_audit_rbac_coverage.py
+++ b/tests/scripts/test_audit_rbac_coverage.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -50,12 +52,10 @@ EXPECTED_AUTH_FLOW_FILES = {
 
 def _audit_visible_files() -> list[str]:
     """Handler files the RBAC audit enumerates, relative to the handlers root."""
-    files = []
-    for py_file in HANDLER_ROOT.rglob("*.py"):
-        if py_file.name.startswith("_"):
-            continue
-        files.append(py_file.relative_to(HANDLER_ROOT).as_posix())
-    return sorted(files)
+    return sorted(
+        py_file.relative_to(HANDLER_ROOT).as_posix()
+        for py_file in audit_rbac_coverage.iter_handler_files(HANDLER_ROOT)
+    )
 
 
 def test_substring_near_misses_are_not_excluded() -> None:
@@ -158,3 +158,34 @@ def test_effective_exclusion_sets_are_pinned() -> None:
     }
     assert actual_storage == EXPECTED_STORAGE_EXCLUDED_FILES
     assert actual_auth_flow == EXPECTED_AUTH_FLOW_FILES
+
+
+def test_marker_less_tree_is_audited_with_exclusions_disabled(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A tree whose path lacks the handlers-root marker audits fail-open, and says so."""
+    copy_root = tmp_path / "handlers_copy"
+    (copy_root / "auth").mkdir(parents=True)
+    (copy_root / "auth" / "store.py").write_text("def get_data():\n    return None\n")
+
+    handlers = audit_rbac_coverage.find_handlers(copy_root)
+
+    captured = capsys.readouterr()
+    assert audit_rbac_coverage._HANDLER_PATH_MARKER in captured.err
+    # Exclusions are disabled, so the storage file is audited rather than skipped.
+    assert [handler.function for handler in handlers] == ["get_data"]
+
+
+def test_marker_bearing_tree_keeps_exclusions_active(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The same file under a marker-bearing root stays excluded, with no warning."""
+    handlers_root = tmp_path / "server" / "handlers"
+    (handlers_root / "auth").mkdir(parents=True)
+    (handlers_root / "auth" / "store.py").write_text("def get_data():\n    return None\n")
+
+    handlers = audit_rbac_coverage.find_handlers(handlers_root)
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert handlers == []


### PR DESCRIPTION
## Summary

Bounded follow-ups from PR #9828's evidence round (two claude [P3] advisories, non-counted), both scoped to `scripts/audit_rbac_coverage.py` + `tests/scripts/test_audit_rbac_coverage.py`:

1. **Handlers-root marker contract made explicit.** The exclusion rules anchor on the literal `server/handlers/` marker inside each file path; auditing a copied handlers tree whose path lacks the marker silently disables every exclusion (fail direction is safe: files get audited, not skipped). `find_handlers` now emits a single stderr warning when its root's path lacks the marker, and the contract is documented at `_HANDLER_PATH_MARKER`. No matching behavior changed, and the warning cannot fire for any current caller (all invoke against the real `aragora/server/handlers` tree; caller census: `security.yml`, `test.yml`, pre-commit, `apply_rbac.py`, docs).
2. **Shared enumeration helper.** New `iter_handler_files()` is the single source of the enumeration rule (`rglob("*.py")`, skip underscore-prefixed names); `find_handlers` consumes it, and the test helper `_audit_visible_files` now derives from it instead of re-implementing the rule (no silent divergence path). The 16-file storage / 8-file auth-flow live-tree pins are unchanged.

## Red-first pins

- `test_marker_less_tree_is_audited_with_exclusions_disabled`: marker-less tmp tree -> stderr warning containing `server/handlers/` + the storage-named file is audited fail-open.
- `test_marker_bearing_tree_keeps_exclusions_active`: same file under a marker-bearing tmp root -> excluded, no warning.
- Red run captured before implementation: 2 failed (missing warning; missing `iter_handler_files`), 7 existing pins passed.

## Equivalence proof (behavior-neutral on the live tree)

- `--json` output byte-identical pre/post: `cmp` clean, sha256 `ea27489804af8ab5fe49b02d52db270d393d3088ed8df81913ce3398355f016b`, 519087 bytes (deterministic across runs); stderr empty post-change.
- `--summary` unchanged: `837/1112 handlers protected (75.3%)` (>= CI floor 55 in `security.yml`).

## Verification

- `python3 -m pytest tests/scripts/test_audit_rbac_coverage.py tests/scripts/test_apply_rbac.py -q --timeout=120`: 16 passed (was 14 pre-feature; +2 new pins).
- 5-seed randomized sweep of both files: 16 passed on every seed (1, 7, 42, 1337, 20260827).
- `make lint`, `ruff format --check aragora/ tests/ scripts/`, `bash scripts/preflight_mypy.sh --diff-base origin/main` (both touched files, no issues): clean.
- AWS-neutralized `make test-smoke`: pass. `scripts/test_tiers.sh smoke`: 138 passed.

LOC: +62/-10 across 2 files (cap 800). No workflow/.github, protection, release, or publication surfaces touched.
