### PR TITLE
fix(server): implement POST /api/v1/quotas/request-increase handler branch

### DIFF
--- a/aragora/server/handlers/usage_metering.py
+++ b/aragora/server/handlers/usage_metering.py
@@ -13,6 +13,7 @@ Phase 4.3 Implementation.
 from __future__ import annotations
 
 import logging
+import math
 import uuid
 from datetime import datetime, timezone
 
@@ -738,11 +739,16 @@ class UsageMeteringHandler(SecureHandler):
         if not isinstance(resource, str) or not resource.strip():
             return error_response("Field 'resource' is required", 400)
         resource = resource.strip()
+        # The value feeds the audit log line below; control characters would
+        # allow forged log entries.
+        if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in resource):
+            return error_response("Field 'resource' contains invalid characters", 400)
 
         requested_limit = body.get("requested_limit")
         if requested_limit is not None and (
             isinstance(requested_limit, bool)
             or not isinstance(requested_limit, (int, float))
+            or not math.isfinite(requested_limit)
             or requested_limit <= 0
         ):
             return error_response("Field 'requested_limit' must be a positive number", 400)

--- a/aragora/server/handlers/usage_metering.py
+++ b/aragora/server/handlers/usage_metering.py
@@ -5,6 +5,7 @@ Provides billing usage endpoints for ENTERPRISE tier:
 - GET /api/v1/billing/usage - Current usage summary
 - GET /api/v1/billing/usage/breakdown - Detailed breakdown
 - GET /api/v1/billing/limits - Current limits and usage %
+- POST /api/v1/quotas/request-increase - Submit a quota increase request
 
 Phase 4.3 Implementation.
 """
@@ -12,6 +13,7 @@ Phase 4.3 Implementation.
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime, timezone
 
 from aragora.billing.models import SubscriptionTier
@@ -61,6 +63,7 @@ class UsageMeteringHandler(SecureHandler):
     ]
 
     _QUOTA_PREFIX = "/api/v1/quotas/"
+    _REQUEST_INCREASE_PATH = "/api/v1/quotas/request-increase"
 
     def can_handle(self, path: str) -> bool:
         """Check if this handler can process the given path."""
@@ -109,6 +112,14 @@ class UsageMeteringHandler(SecureHandler):
 
         if path == "/api/v1/quotas/usage" and method == "GET":
             return await self._get_quota_usage(handler, query_params)
+
+        # Action literal: must win over the /api/v1/quotas/{resource} branch
+        # below, otherwise GET would be mis-served as a lookup for the
+        # nonsense resource "request-increase".
+        if path == self._REQUEST_INCREASE_PATH:
+            if method == "POST":
+                return await self._request_quota_increase(handler)
+            return error_response("Method not allowed", 405)
 
         # Dynamic: /api/v1/quotas/{resource}
         if path.startswith(self._QUOTA_PREFIX) and path.count("/") == 4 and method == "GET":
@@ -671,6 +682,101 @@ class UsageMeteringHandler(SecureHandler):
                 "resets_at": status.period_resets_at.isoformat()
                 if status.period_resets_at
                 else None,
+            }
+        )
+
+    @handle_errors("request quota increase")
+    @require_permission("org:billing")
+    async def _request_quota_increase(
+        self,
+        handler,
+        user=None,
+    ) -> HandlerResult:
+        """
+        Submit a quota increase request for review.
+
+        Body Parameters:
+            resource: Resource type the increase applies to (required)
+            requested_limit: Desired new limit, positive number (optional)
+            reason: Why the increase is needed (optional; also accepted as
+                    'justification', the key the python SDK documents)
+
+        Returns:
+            JSON response with the submission receipt:
+            {
+                "request_id": "qir-...",
+                "status": "pending",
+                "resource": "debates",
+                "requested_limit": 500,
+                "reason": "scaling up",
+                "org_id": "org-001",
+                "submitted_by": "user-001",
+                "submitted_at": "2026-01-01T00:00:00+00:00"
+            }
+        """
+        user_store = self._get_user_store()
+        if not user_store:
+            return error_response("Service unavailable", 503)
+
+        db_user = user_store.get_user_by_id(user.user_id)
+        if not db_user:
+            return error_response("User not found", 404)
+
+        org = None
+        if db_user.org_id:
+            org = user_store.get_organization_by_id(db_user.org_id)
+        if not org:
+            return error_response("No organization found", 404)
+
+        body, err = self.read_json_object_or_error(handler)
+        if err:
+            return err
+        if body is None:  # pragma: no cover - read_json_object_or_error guarantees this
+            return error_response("Invalid JSON body", 400)
+
+        resource = body.get("resource")
+        if not isinstance(resource, str) or not resource.strip():
+            return error_response("Field 'resource' is required", 400)
+        resource = resource.strip()
+
+        requested_limit = body.get("requested_limit")
+        if requested_limit is not None and (
+            isinstance(requested_limit, bool)
+            or not isinstance(requested_limit, (int, float))
+            or requested_limit <= 0
+        ):
+            return error_response("Field 'requested_limit' must be a positive number", 400)
+
+        reason = body.get("reason")
+        if reason is None:
+            reason = body.get("justification")
+        if reason is not None and not isinstance(reason, str):
+            return error_response("Field 'reason' must be a string", 400)
+
+        request_id = f"qir-{uuid.uuid4().hex}"
+        submitted_at = datetime.now(timezone.utc).isoformat()
+
+        # No persistence layer exists for increase requests yet; the audit
+        # trail is this structured log line until a review workflow lands.
+        logger.info(
+            "Quota increase request %s submitted: org=%s resource=%s requested_limit=%s user=%s",
+            request_id,
+            org.id,
+            resource,
+            requested_limit,
+            user.user_id,
+        )
+
+        return json_response(
+            {
+                "request_id": request_id,
+                "status": "pending",
+                "resource": resource,
+                "requested_limit": requested_limit,
+                "reason": reason,
+                "org_id": org.id,
+                "submitted_by": user.user_id,
+                "submitted_at": submitted_at,
             }
         )
 

--- a/aragora/server/handlers/usage_metering.py
+++ b/aragora/server/handlers/usage_metering.py
@@ -739,16 +739,20 @@ class UsageMeteringHandler(SecureHandler):
         if not isinstance(resource, str) or not resource.strip():
             return error_response("Field 'resource' is required", 400)
         resource = resource.strip()
-        # The value feeds the audit log line below; control characters would
-        # allow forged log entries.
-        if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in resource):
+        # The value feeds the audit log line below; control characters and
+        # unicode line separators would allow forged log entries.
+        if any(ord(ch) < 0x20 or ord(ch) == 0x7F or ch in "\u0085\u2028\u2029" for ch in resource):
             return error_response("Field 'resource' contains invalid characters", 400)
+        if len(resource) > 256:
+            return error_response("Field 'resource' exceeds maximum length of 256", 400)
 
         requested_limit = body.get("requested_limit")
+        # isfinite only applies to floats: converting an arbitrary-precision
+        # JSON int to float raises OverflowError, and ints are always finite.
         if requested_limit is not None and (
             isinstance(requested_limit, bool)
             or not isinstance(requested_limit, (int, float))
-            or not math.isfinite(requested_limit)
+            or (isinstance(requested_limit, float) and not math.isfinite(requested_limit))
             or requested_limit <= 0
         ):
             return error_response("Field 'requested_limit' must be a positive number", 400)
@@ -758,6 +762,8 @@ class UsageMeteringHandler(SecureHandler):
             reason = body.get("justification")
         if reason is not None and not isinstance(reason, str):
             return error_response("Field 'reason' must be a string", 400)
+        if reason is not None and len(reason) > 2000:
+            return error_response("Field 'reason' exceeds maximum length of 2000", 400)
 
         request_id = f"qir-{uuid.uuid4().hex}"
         submitted_at = datetime.now(timezone.utc).isoformat()

--- a/tests/server/handlers/test_usage_metering.py
+++ b/tests/server/handlers/test_usage_metering.py
@@ -377,12 +377,14 @@ class TestQuotaIncreaseRequest:
             )
         assert result.status_code == 400
 
-    @pytest.mark.parametrize("bad_limit", ["lots", -5, 0, True])
+    @pytest.mark.parametrize(
+        "bad_limit", ["lots", -5, 0, True, float("nan"), float("inf"), float("-inf")]
+    )
     @pytest.mark.asyncio
     async def test_post_request_increase_rejects_invalid_requested_limit(
         self, metering_handler, mock_http_handler, bad_limit
     ):
-        """requested_limit must be a positive number when provided."""
+        """requested_limit must be a positive finite number when provided."""
         mock_http = mock_http_handler(
             method="POST", body={"resource": "debates", "requested_limit": bad_limit}
         )
@@ -394,6 +396,22 @@ class TestQuotaIncreaseRequest:
         assert result.status_code == 400
         body = parse_handler_response(result)
         assert "requested_limit" in body.get("error", "")
+
+    @pytest.mark.parametrize("bad_resource", ["debates\nfake-entry", "tok\rens", "a\x00b"])
+    @pytest.mark.asyncio
+    async def test_post_request_increase_rejects_control_chars_in_resource(
+        self, metering_handler, mock_http_handler, bad_resource
+    ):
+        """Control characters in 'resource' are rejected (it feeds the audit log)."""
+        mock_http = mock_http_handler(method="POST", body={"resource": bad_resource})
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 400
+        body = parse_handler_response(result)
+        assert "resource" in body.get("error", "").lower()
 
     @pytest.mark.asyncio
     async def test_post_request_increase_without_user_store_returns_503(self, mock_http_handler):

--- a/tests/server/handlers/test_usage_metering.py
+++ b/tests/server/handlers/test_usage_metering.py
@@ -277,3 +277,184 @@ class TestUsageMeteringRouting:
             mock_limiter.is_allowed.return_value = True
             result = await metering_handler.handle("/api/v1/billing/usage", {}, mock_http, "DELETE")
             assert result.status_code == 405
+
+
+class TestQuotaIncreaseRequest:
+    """Tests for POST /api/v1/quotas/request-increase and the literal-path guard.
+
+    The 'request-increase' literal is an action endpoint (POST-only per both
+    SDKs and the registered spec contract); it must never be served as a
+    /api/v1/quotas/{resource} lookup.
+    """
+
+    REQUEST_INCREASE_PATH = "/api/v1/quotas/request-increase"
+
+    @pytest.fixture
+    def metering_handler(self, mock_server_context):
+        """Create handler whose mocked user store resolves a user and an org."""
+        from aragora.server.handlers.usage_metering import UsageMeteringHandler
+
+        db_user = MagicMock()
+        db_user.org_id = "org-001"
+        org = MagicMock()
+        org.id = "org-001"
+        mock_server_context["user_store"].get_user_by_id.return_value = db_user
+        mock_server_context["user_store"].get_organization_by_id.return_value = org
+        return UsageMeteringHandler(server_context=mock_server_context)
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_returns_submission_receipt(
+        self, metering_handler, mock_http_handler
+    ):
+        """POST on the literal dispatches to a real implementation (no 405)."""
+        mock_http = mock_http_handler(
+            method="POST",
+            body={"resource": "debates", "requested_limit": 500, "reason": "scaling up"},
+        )
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 200
+        body = parse_handler_response(result)
+        assert isinstance(body["request_id"], str)
+        assert body["request_id"]
+        assert body["status"] == "pending"
+        assert body["resource"] == "debates"
+        assert body["requested_limit"] == 500
+        assert body["reason"] == "scaling up"
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_accepts_justification_alias(
+        self, metering_handler, mock_http_handler
+    ):
+        """The python SDK sends 'justification'; it is accepted as the reason."""
+        mock_http = mock_http_handler(
+            method="POST",
+            body={"resource": "tokens", "justification": "traffic spike"},
+        )
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 200
+        body = parse_handler_response(result)
+        assert body["reason"] == "traffic spike"
+        assert body["requested_limit"] is None
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_requires_resource(
+        self, metering_handler, mock_http_handler
+    ):
+        """A body without 'resource' is a 400, not a submission."""
+        mock_http = mock_http_handler(method="POST", body={"requested_limit": 100})
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 400
+        body = parse_handler_response(result)
+        assert "resource" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_rejects_invalid_json(self, metering_handler):
+        """A malformed JSON body is a 400."""
+        mock_http = MagicMock()
+        mock_http.command = "POST"
+        mock_http.client_address = ("127.0.0.1", 12345)
+        mock_http.body = None
+        mock_http.request = None
+        raw = b"{not-json"
+        mock_http.headers = {"Content-Length": str(len(raw))}
+        mock_http.rfile.read.return_value = raw
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 400
+
+    @pytest.mark.parametrize("bad_limit", ["lots", -5, 0, True])
+    @pytest.mark.asyncio
+    async def test_post_request_increase_rejects_invalid_requested_limit(
+        self, metering_handler, mock_http_handler, bad_limit
+    ):
+        """requested_limit must be a positive number when provided."""
+        mock_http = mock_http_handler(
+            method="POST", body={"resource": "debates", "requested_limit": bad_limit}
+        )
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 400
+        body = parse_handler_response(result)
+        assert "requested_limit" in body.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_without_user_store_returns_503(self, mock_http_handler):
+        """Missing user store keeps the sibling endpoints' 503 ladder."""
+        from aragora.server.handlers.usage_metering import UsageMeteringHandler
+
+        handler = UsageMeteringHandler(server_context={})
+        mock_http = mock_http_handler(method="POST", body={"resource": "debates"})
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await handler.handle(self.REQUEST_INCREASE_PATH, {}, mock_http, "POST")
+        assert result.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_get_request_increase_literal_is_not_a_resource_lookup(
+        self, metering_handler, mock_http_handler
+    ):
+        """GET on the literal returns 405 instead of a {resource} quota lookup."""
+        mock_http = mock_http_handler(method="GET")
+        with patch.object(
+            metering_handler, "_get_quota_for_resource", new=AsyncMock()
+        ) as mock_lookup:
+            with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+                mock_limiter.is_allowed.return_value = True
+                result = await metering_handler.handle(
+                    self.REQUEST_INCREASE_PATH, {}, mock_http, "GET"
+                )
+        assert result.status_code == 405
+        mock_lookup.assert_not_called()
+
+    @pytest.mark.parametrize("method", ["PUT", "DELETE", "PATCH"])
+    @pytest.mark.asyncio
+    async def test_other_methods_on_request_increase_literal_return_405(
+        self, metering_handler, mock_http_handler, method
+    ):
+        """Non-POST methods on the literal stay 405."""
+        mock_http = mock_http_handler(method=method)
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, method
+            )
+        assert result.status_code == 405
+
+    def test_can_handle_request_increase_literal(self, metering_handler):
+        """The literal remains claimed by can_handle (4-segment quotas path)."""
+        assert metering_handler.can_handle(self.REQUEST_INCREASE_PATH) is True
+
+    @pytest.mark.asyncio
+    async def test_dynamic_resource_lookup_still_dispatches(
+        self, metering_handler, mock_http_handler
+    ):
+        """Real resources (e.g. /api/v1/quotas/debates) still hit the lookup."""
+        mock_http = mock_http_handler(method="GET")
+        with patch.object(
+            metering_handler,
+            "_get_quota_for_resource",
+            new=AsyncMock(return_value=MagicMock(status_code=200)),
+        ) as mock_lookup:
+            with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+                mock_limiter.is_allowed.return_value = True
+                await metering_handler.handle("/api/v1/quotas/debates", {}, mock_http, "GET")
+        mock_lookup.assert_called_once()
+        assert mock_lookup.call_args.args[1] == "debates"

--- a/tests/server/handlers/test_usage_metering.py
+++ b/tests/server/handlers/test_usage_metering.py
@@ -397,12 +397,15 @@ class TestQuotaIncreaseRequest:
         body = parse_handler_response(result)
         assert "requested_limit" in body.get("error", "")
 
-    @pytest.mark.parametrize("bad_resource", ["debates\nfake-entry", "tok\rens", "a\x00b"])
+    @pytest.mark.parametrize(
+        "bad_resource",
+        ["debates\nfake-entry", "tok\rens", "a\x00b", "a\u0085b", "a\u2028b", "a\u2029b"],
+    )
     @pytest.mark.asyncio
     async def test_post_request_increase_rejects_control_chars_in_resource(
         self, metering_handler, mock_http_handler, bad_resource
     ):
-        """Control characters in 'resource' are rejected (it feeds the audit log)."""
+        """Control characters and line separators in 'resource' are rejected."""
         mock_http = mock_http_handler(method="POST", body={"resource": bad_resource})
         with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
             mock_limiter.is_allowed.return_value = True
@@ -412,6 +415,56 @@ class TestQuotaIncreaseRequest:
         assert result.status_code == 400
         body = parse_handler_response(result)
         assert "resource" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_accepts_huge_integer_limit(
+        self, metering_handler, mock_http_handler
+    ):
+        """Arbitrary-precision JSON ints are valid (ints are always finite, no 500)."""
+        huge = 10**400
+        mock_http = mock_http_handler(
+            method="POST", body={"resource": "debates", "requested_limit": huge}
+        )
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 200
+        body = parse_handler_response(result)
+        assert body["requested_limit"] == huge
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_rejects_overlong_resource(
+        self, metering_handler, mock_http_handler
+    ):
+        """resource is length-bounded well below the body-size cap."""
+        mock_http = mock_http_handler(method="POST", body={"resource": "r" * 257})
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 400
+        body = parse_handler_response(result)
+        assert "resource" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_rejects_overlong_reason(
+        self, metering_handler, mock_http_handler
+    ):
+        """reason is length-bounded well below the body-size cap."""
+        mock_http = mock_http_handler(
+            method="POST", body={"resource": "debates", "reason": "r" * 2001}
+        )
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 400
+        body = parse_handler_response(result)
+        assert "reason" in body.get("error", "").lower()
 
     @pytest.mark.asyncio
     async def test_post_request_increase_without_user_store_returns_503(self, mock_http_handler):


### PR DESCRIPTION
## Source

Mission feature `misc-quotas-request-increase-post-implementation` (route-truth follow-up to the #9838 registration; REPO TRUTH 405-gap facts in the mission library). Promoted to queue head by the 2026-08-28 operator adjudication (option b): this implementation moots the #9838 r3 dissent kernel (a 200-documented POST that 405s at runtime).

## Behavior

`UsageMeteringHandler.can_handle` claims `/api/v1/quotas/request-increase` via the 4-slash `/api/v1/quotas/{resource}` branch, but `handle()` dispatched only GET routes:

- **POST** (pinned stable in `aragora/server/openapi/stability_manifest.json`, exposed by BOTH SDKs: python `quotas.request_increase(resource, **kwargs)`, typescript `quotas.requestIncrease(resource, requestedLimit, reason?)`) returned **405** at runtime.
- **GET** on the literal was mis-served as a `{resource}` quota lookup for the nonsense resource `request-increase`.

This PR (handler + tests ONLY — zero spec-file changes; #9838's files stay untouched):

1. Adds a literal-path dispatch guard ahead of the dynamic `{resource}` branch: POST dispatches to the new `_request_quota_increase`; **every other method on the literal is an explicit 405** (chosen semantics: neither SDK issues GET on the literal — `get()` targets `{resource}` — so the action literal is POST-only, matching the registered spec contract entry `createQuotaIncreaseRequest`).
2. Implements `_request_quota_increase` following the sibling endpoints' conventions: `@handle_errors` + `@require_permission("org:billing")`, the user-store/org 503/404/404 ladder, `read_json_object_or_error` body parsing, validation (`resource` required non-empty string; `requested_limit` optional positive number; `reason` optional string with the python-SDK `justification` alias), and a 200 submission receipt matching the typescript SDK return shape `{request_id, status, resource, requested_limit}` plus `reason`, `org_id`, `submitted_by`, `submitted_at`. No persistence layer exists for increase requests yet; the audit trail is a structured log line until a review workflow lands (disclosed limitation).

## Validation

- Red-first at base `fbc7b39aab` (direct dispatch repro): `can_handle=True`, `POST -> 405 {"error": "Method not allowed"}`, `GET -> _get_quota_for_resource(..., 'request-increase')` mis-dispatch; new test battery 10 failed / 5 passed at base.
- After: `python3 -m pytest tests/server/handlers/test_usage_metering.py -q` -> **24 passed**; direct dispatch now `POST -> 401` unauthenticated (route exists, auth enforced), GET guard keeps `_get_quota_for_resource` uncalled.
- `python3 -m pytest tests/handlers/test_usage_metering.py -q` -> 96 passed (sibling battery).
- `make lint` + `ruff format --check` -> clean; `bash scripts/preflight_mypy.sh --diff-base origin/main` -> no issues (2 files).
- `make test-smoke` -> passed; `bash scripts/test_tiers.sh smoke` -> 138 passed.
- Seed sweep (file-scoped, seeds 1/42/100/2024/12345) -> 24 passed each.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok.

## Risks

- Behavior change on the literal only: GET `/api/v1/quotas/request-increase` moves from a nonsense resource-lookup response to an explicit 405. No test anywhere pinned the old behavior (repo-wide census), and no SDK calls GET there.
- Dynamic `{resource}` lookups are preserved (pinned by a new test).
- LOC: +287/-0 = 287 changed lines across 2 files.


---

## Update 2026-08-28 (review-evidence hardening, final head `6d61d8b19b`)

Two additive commits after prepare-only model-review rounds:

- `dd5e579320`: reject non-finite `requested_limit` (NaN/±Infinity) and C0/DEL control characters in `resource` (it feeds the audit log line).
- `6d61d8b19b`: scope `math.isfinite` to floats — an arbitrary-precision JSON int raised unmapped `OverflowError` (500 instead of the contractual 400, reproduced red-first); bound `resource` (256) and `reason` (2000) lengths below the body cap; also reject U+0085/U+2028/U+2029 line separators.

Final state: 36 handler tests green (5-seed sweep), sibling battery 96 green, smoke tiers 138 green, mypy/lint/format/preflight clean. Round-3 model evidence at this head: claude PASS + openai PASS (2/2, grounded, would-count; prepare-only, unposted per Tier 3). LOC now +370/−0 across 2 files. Tier 3 → parked draft with `operator-review-required`; settlement packet in the mission library pre-composes the operator completion runbook.
