### PR TITLE
[DIC-20][DIC-21] epistemic pipeline helper: evaluate_and_quarantine()

### DIFF
--- a/aragora/epistemic/pipeline.py
+++ b/aragora/epistemic/pipeline.py
@@ -1,0 +1,139 @@
+"""DIC-20 → DIC-21 pipeline helper (epistemic decision pipeline).
+
+Chains :func:`~aragora.epistemic.decay_monitor.evaluate_unit` (DIC-20) with
+:func:`~aragora.epistemic.quarantine_policy.apply_quarantine_policy` (DIC-21)
+in a single call, returning both the :class:`DecaySignal` and the
+:class:`QuarantineDecision` together.
+
+This module adds no new logic; it is a convenience composition so callers
+don't have to import two modules and repeat the chaining boilerplate. Each
+constituent function may still be called independently.
+
+Flag gate
+---------
+``ARAGORA_EPISTEMIC_PIPELINE_ENABLED`` (default ``off``).
+:class:`EpistemicPipelineResult` construction is always importable, but
+:func:`evaluate_and_quarantine` raises :class:`RuntimeError` when the flag
+is not set so callers know the pipeline is not yet operational.
+
+Live queue effect
+-----------------
+None — read-only, no state mutation, no issue creation.
+
+Advances
+--------
+Issues #6031 (DIC-20) and #6032 (DIC-21).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .claim_verifier import ClaimResult
+    from .decay_monitor import DecaySignal
+    from .proof_unit import ProofCarryingCodeUnit
+    from .quarantine_policy import QuarantineDecision, QuarantinePolicy
+
+_FLAG = "ARAGORA_EPISTEMIC_PIPELINE_ENABLED"
+
+
+def epistemic_pipeline_enabled() -> bool:
+    """Return True when :func:`evaluate_and_quarantine` may be called.
+
+    Reads ``ARAGORA_EPISTEMIC_PIPELINE_ENABLED`` from the environment.
+    Default is ``False``; :class:`EpistemicPipelineResult` construction
+    is always safe regardless of this flag.
+    """
+    return os.environ.get(_FLAG, "").lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class EpistemicPipelineResult:
+    """Combined output of the DIC-20 → DIC-21 chain.
+
+    Both fields are set; neither is optional.  Callers should inspect
+    ``quarantine_decision.policy_action`` to decide whether to surface
+    the result to operators.
+    """
+
+    decay_signal: "DecaySignal"
+    quarantine_decision: "QuarantineDecision"
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable dict of both stages."""
+        return {
+            "decay_signal": self.decay_signal.to_dict(),
+            "quarantine_decision": self.quarantine_decision.to_dict(),
+        }
+
+
+def evaluate_and_quarantine(
+    unit: "ProofCarryingCodeUnit",
+    *,
+    claim_results: "dict[str, ClaimResult] | None" = None,
+    unresolved_crux_ids: "frozenset[str] | None" = None,
+    code_unit_class: str = "default",
+    policy: "QuarantinePolicy | None" = None,
+) -> EpistemicPipelineResult:
+    """Chain DIC-20 decay evaluation with DIC-21 quarantine policy in one call.
+
+    Parameters
+    ----------
+    unit:
+        The :class:`~aragora.epistemic.proof_unit.ProofCarryingCodeUnit` to
+        evaluate.  Should already have passed ``unit.validate()``.
+    claim_results:
+        Optional mapping of claim ID → :class:`~aragora.epistemic.claim_verifier.ClaimResult`.
+        Passed through to :func:`~aragora.epistemic.decay_monitor.evaluate_unit`.
+    unresolved_crux_ids:
+        Optional set of crux IDs whose resolution is still outstanding.
+        Passed through to :func:`~aragora.epistemic.decay_monitor.evaluate_unit`.
+    code_unit_class:
+        Selects the :class:`~aragora.epistemic.quarantine_policy.QuarantinePolicy`
+        from ``DEFAULT_POLICIES``.  Ignored when *policy* is provided explicitly.
+        Defaults to ``"default"``.
+    policy:
+        Override policy; when provided, *code_unit_class* is ignored.
+        Passed through to
+        :func:`~aragora.epistemic.quarantine_policy.apply_quarantine_policy`.
+
+    Returns
+    -------
+    EpistemicPipelineResult
+        Contains both the :class:`~aragora.epistemic.decay_monitor.DecaySignal`
+        and the :class:`~aragora.epistemic.quarantine_policy.QuarantineDecision`.
+
+    Raises
+    ------
+    RuntimeError
+        When ``ARAGORA_EPISTEMIC_PIPELINE_ENABLED`` is not set.
+    """
+    if not epistemic_pipeline_enabled():
+        raise RuntimeError(
+            f"{_FLAG} is not set; set it to '1' to enable the epistemic pipeline"
+        )
+
+    from .decay_monitor import evaluate_unit
+    from .quarantine_policy import apply_quarantine_policy
+
+    signal = evaluate_unit(
+        unit,
+        claim_results=claim_results,
+        unresolved_crux_ids=unresolved_crux_ids,
+    )
+    decision = apply_quarantine_policy(
+        signal,
+        policy=policy,
+        code_unit_class=code_unit_class,
+    )
+    return EpistemicPipelineResult(decay_signal=signal, quarantine_decision=decision)
+
+
+__all__ = [
+    "EpistemicPipelineResult",
+    "epistemic_pipeline_enabled",
+    "evaluate_and_quarantine",
+]

--- a/aragora/epistemic/pipeline.py
+++ b/aragora/epistemic/pipeline.py
@@ -112,9 +112,7 @@ def evaluate_and_quarantine(
         When ``ARAGORA_EPISTEMIC_PIPELINE_ENABLED`` is not set.
     """
     if not epistemic_pipeline_enabled():
-        raise RuntimeError(
-            f"{_FLAG} is not set; set it to '1' to enable the epistemic pipeline"
-        )
+        raise RuntimeError(f"{_FLAG} is not set; set it to '1' to enable the epistemic pipeline")
 
     from .decay_monitor import evaluate_unit
     from .quarantine_policy import apply_quarantine_policy

--- a/tests/epistemic/test_pipeline.py
+++ b/tests/epistemic/test_pipeline.py
@@ -1,0 +1,302 @@
+"""Tests for aragora.epistemic.pipeline (DIC-20 → DIC-21 chaining helper).
+
+All tests are hermetic — no network, no file I/O, no real claim verifiers.
+Claim results are injected directly via the ``claim_results`` parameter.
+
+Coverage:
+- Flag gate: disabled by default, enabled by truthy env value.
+- :class:`EpistemicPipelineResult`: to_dict, field access.
+- Healthy unit → report_only in both signal and decision.
+- Failed claim → decay propagates; live_dispatch class escalates.
+- Multiple failed claims → integrity below fail_closed threshold.
+- ``code_unit_class`` routing uses the correct DEFAULT_POLICIES entry.
+- ``unresolved_crux_ids`` propagate to the decay signal.
+- Explicit ``policy`` override bypasses class lookup.
+
+Advances: issues #6031 (DIC-20) and #6032 (DIC-21).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
+from aragora.epistemic.pipeline import (
+    _FLAG,
+    EpistemicPipelineResult,
+    epistemic_pipeline_enabled,
+    evaluate_and_quarantine,
+)
+from aragora.epistemic.proof_unit import DecayPolicy, FallbackPolicy, ProofCarryingCodeUnit
+from aragora.epistemic.quarantine_policy import EscalationMap, QuarantinePolicy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit(
+    claims: list[str] | None = None,
+    linked_crux_ids: list[str] | None = None,
+    decision_receipts: list[str] | None = None,
+    decay_policy: DecayPolicy | None = None,
+) -> ProofCarryingCodeUnit:
+    return ProofCarryingCodeUnit(
+        code_unit_id="unit.pipeline.test",
+        symbol="tests.fake.pipeline_fn",
+        source_path="tests/fake_pipeline.py",
+        owner="test-suite",
+        decision_receipts=decision_receipts if decision_receipts is not None else ["rcpt-001"],
+        claims=claims if claims is not None else ["claim.truth.rate"],
+        assumptions=["External service is stable."],
+        verifiers=[],
+        freshness_sla_hours=24,
+        decay_policy=decay_policy if decay_policy is not None else DecayPolicy(),
+        fallback_policy=FallbackPolicy(),
+        linked_crux_ids=linked_crux_ids if linked_crux_ids is not None else [],
+    )
+
+
+def _fail(claim_id: str) -> ClaimResult:
+    return ClaimResult(
+        claim_id=claim_id,
+        status=ClaimStatus.FAIL,
+        message="synthetic failure",
+        severity="error",
+        allowed_action="repair_required",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGate:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        assert not epistemic_pipeline_enabled()
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+    def test_truthy_values_enable(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv(_FLAG, val)
+        assert epistemic_pipeline_enabled()
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy_values_disable(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv(_FLAG, val)
+        assert not epistemic_pipeline_enabled()
+
+    def test_raises_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        with pytest.raises(RuntimeError, match=_FLAG):
+            evaluate_and_quarantine(_unit())
+
+
+# ---------------------------------------------------------------------------
+# Return type and structure
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineResult:
+    def test_returns_pipeline_result_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit())
+        assert isinstance(result, EpistemicPipelineResult)
+
+    def test_decay_signal_code_unit_id_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit())
+        assert result.decay_signal.code_unit_id == "unit.pipeline.test"
+
+    def test_quarantine_decision_code_unit_id_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit())
+        assert result.quarantine_decision.code_unit_id == "unit.pipeline.test"
+
+    def test_to_dict_contains_both_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        d = evaluate_and_quarantine(_unit()).to_dict()
+        assert "decay_signal" in d
+        assert "quarantine_decision" in d
+
+    def test_to_dict_decay_signal_has_integrity_score(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        d = evaluate_and_quarantine(_unit()).to_dict()
+        assert "integrity_score" in d["decay_signal"]
+
+    def test_to_dict_quarantine_decision_has_policy_action(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        d = evaluate_and_quarantine(_unit()).to_dict()
+        assert "policy_action" in d["quarantine_decision"]
+
+
+# ---------------------------------------------------------------------------
+# Healthy unit: no failures, full integrity
+# ---------------------------------------------------------------------------
+
+
+class TestHealthyUnit:
+    def test_healthy_unit_full_integrity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit())
+        assert result.decay_signal.integrity_score == pytest.approx(1.0)
+
+    def test_healthy_unit_report_only_signal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit())
+        assert result.decay_signal.recommended_action == "report_only"
+
+    def test_healthy_unit_report_only_decision(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit())
+        assert result.quarantine_decision.policy_action == "report_only"
+
+    def test_healthy_unit_not_fail_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit())
+        assert not result.quarantine_decision.fail_closed
+
+
+# ---------------------------------------------------------------------------
+# Failed claim escalation
+# ---------------------------------------------------------------------------
+
+
+class TestFailedClaim:
+    def test_failed_claim_reduces_integrity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(
+            _unit(claims=["claim.truth.rate"]),
+            claim_results={"claim.truth.rate": _fail("claim.truth.rate")},
+        )
+        assert result.decay_signal.integrity_score < 1.0
+
+    def test_failed_claim_produces_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(
+            _unit(claims=["claim.truth.rate"]),
+            claim_results={"claim.truth.rate": _fail("claim.truth.rate")},
+        )
+        reason_kinds = {r.kind for r in result.decay_signal.reasons}
+        assert "failed_claim" in reason_kinds
+
+    def test_live_dispatch_class_escalates_repair_to_quarantine(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(
+            _unit(claims=["claim.alpha"], decay_policy=DecayPolicy(failed_claim="repair_required")),
+            claim_results={"claim.alpha": _fail("claim.alpha")},
+            code_unit_class="live_dispatch",
+        )
+        # live_dispatch policy escalates repair_required → quarantine
+        assert result.quarantine_decision.policy_action in {"quarantine", "fail_closed"}
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed threshold
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosed:
+    def test_multiple_failures_drive_fail_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        claim_ids = [f"claim.{i}" for i in range(4)]
+        results = {cid: _fail(cid) for cid in claim_ids}
+        result = evaluate_and_quarantine(
+            _unit(claims=claim_ids),
+            claim_results=results,
+            code_unit_class="live_dispatch",
+        )
+        # live_dispatch fails closed at 0.6; 4 failed claims → integrity ≤ 0.4
+        assert result.quarantine_decision.fail_closed
+
+    def test_fail_closed_sets_live_swap_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        claim_ids = [f"claim.{i}" for i in range(4)]
+        results = {cid: _fail(cid) for cid in claim_ids}
+        result = evaluate_and_quarantine(
+            _unit(claims=claim_ids),
+            claim_results=results,
+            code_unit_class="live_dispatch",
+        )
+        assert result.quarantine_decision.live_swap_blocked
+
+
+# ---------------------------------------------------------------------------
+# code_unit_class routing
+# ---------------------------------------------------------------------------
+
+
+class TestCodeUnitClassRouting:
+    @pytest.mark.parametrize("cls", ["default", "demo", "report_surface", "live_dispatch"])
+    def test_healthy_unit_is_report_only_for_all_classes(
+        self, monkeypatch: pytest.MonkeyPatch, cls: str
+    ) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(_unit(), code_unit_class=cls)
+        assert result.quarantine_decision.policy_action == "report_only"
+
+    def test_demo_class_lower_fail_closed_threshold(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        claim_ids = ["claim.a", "claim.b"]
+        results = {cid: _fail(cid) for cid in claim_ids}
+        result = evaluate_and_quarantine(
+            _unit(claims=claim_ids),
+            claim_results=results,
+            code_unit_class="demo",
+        )
+        # demo threshold is 0.2; 2 failed claims → 0.4 deduction → score ≈ 0.6 → NOT fail_closed
+        # But integrity < 1.0 and decision should escalate beyond report_only
+        assert result.decay_signal.integrity_score < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Explicit policy override
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitPolicy:
+    def test_explicit_policy_overrides_class_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        strict_policy = QuarantinePolicy(
+            code_unit_class="custom_strict",
+            escalation_map=EscalationMap(
+                report_only="quarantine",
+                repair_required="fail_closed",
+            ),
+            fail_closed_threshold=0.9,
+        )
+        result = evaluate_and_quarantine(
+            _unit(),
+            policy=strict_policy,
+        )
+        # A healthy unit with a strict policy that maps report_only → quarantine
+        # integrity=1.0 ≥ 0.9 so not fail_closed; recommended_action=report_only → escalated
+        assert result.quarantine_decision.policy_action == "quarantine"
+
+
+# ---------------------------------------------------------------------------
+# Unresolved crux propagation
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolvedCrux:
+    def test_unresolved_crux_reduces_integrity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(
+            _unit(linked_crux_ids=["crux.b2.guard"]),
+            unresolved_crux_ids=frozenset({"crux.b2.guard"}),
+        )
+        assert result.decay_signal.integrity_score < 1.0
+
+    def test_unresolved_crux_produces_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        result = evaluate_and_quarantine(
+            _unit(linked_crux_ids=["crux.b2.guard"]),
+            unresolved_crux_ids=frozenset({"crux.b2.guard"}),
+        )
+        reason_kinds = {r.kind for r in result.decay_signal.reasons}
+        assert "unresolved_crux" in reason_kinds

--- a/tests/epistemic/test_pipeline.py
+++ b/tests/epistemic/test_pipeline.py
@@ -110,7 +110,9 @@ class TestPipelineResult:
         result = evaluate_and_quarantine(_unit())
         assert result.decay_signal.code_unit_id == "unit.pipeline.test"
 
-    def test_quarantine_decision_code_unit_id_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_quarantine_decision_code_unit_id_matches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv(_FLAG, "1")
         result = evaluate_and_quarantine(_unit())
         assert result.quarantine_decision.code_unit_id == "unit.pipeline.test"
@@ -121,12 +123,16 @@ class TestPipelineResult:
         assert "decay_signal" in d
         assert "quarantine_decision" in d
 
-    def test_to_dict_decay_signal_has_integrity_score(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_to_dict_decay_signal_has_integrity_score(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv(_FLAG, "1")
         d = evaluate_and_quarantine(_unit()).to_dict()
         assert "integrity_score" in d["decay_signal"]
 
-    def test_to_dict_quarantine_decision_has_policy_action(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_to_dict_quarantine_decision_has_policy_action(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv(_FLAG, "1")
         d = evaluate_and_quarantine(_unit()).to_dict()
         assert "policy_action" in d["quarantine_decision"]


### PR DESCRIPTION
## Summary

- Adds `aragora/epistemic/pipeline.py` — a thin composition module that chains `evaluate_unit()` (DIC-20 decay signal) with `apply_quarantine_policy()` (DIC-21 quarantine decision) in a single `evaluate_and_quarantine()` call.
- Returns `EpistemicPipelineResult(decay_signal, quarantine_decision)` — both fields always set, neither optional.
- No new logic; this is a convenience wrapper so callers avoid importing two modules and repeating chaining boilerplate.
- Gate: `ARAGORA_EPISTEMIC_PIPELINE_ENABLED` (default off). `EpistemicPipelineResult` construction is always importable; `evaluate_and_quarantine()` raises `RuntimeError` when the flag is unset.

**Advances issues #6031 (DIC-20) and #6032 (DIC-21).**

## Changed files

| File | Change |
|------|--------|
| `aragora/epistemic/pipeline.py` | New module (~90 LOC) |
| `tests/epistemic/test_pipeline.py` | New test module — 34 hermetic tests |

## Test coverage

All 34 tests are hermetic (no network, no file I/O, no real claim verifiers). Coverage:

- **Flag gate** — disabled by default, truthy/falsy env values, `RuntimeError` when unset
- **Result structure** — `EpistemicPipelineResult` fields, `to_dict()` shape
- **Healthy unit** — integrity 1.0, `report_only` in both signal and decision, `fail_closed=False`
- **Failed claim** — integrity reduced, `failed_claim` reason present, `live_dispatch` escalates to quarantine
- **Fail-closed threshold** — 4 failed claims → `fail_closed=True`, `live_swap_blocked=True`
- **`code_unit_class` routing** — healthy unit is `report_only` for all four built-in classes
- **Explicit policy override** — `QuarantinePolicy` passed directly bypasses class lookup
- **Unresolved crux propagation** — reduces integrity and emits `unresolved_crux` reason

## Checklist

- [x] Flag-gated (`ARAGORA_EPISTEMIC_PIPELINE_ENABLED`, default off)
- [x] 34 tests, all passing
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] No state mutation, no issue creation, no live-queue side effects
- [x] ≤300 LOC (combined ~260 LOC across both files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAaWqdA5Xwvjei3PGFBqey)_