### PR TITLE
test(webhooks): confine shim-path consumption to the designated shim test

### DIFF
--- a/tests/handlers/test_handlers_webhooks.py
+++ b/tests/handlers/test_handlers_webhooks.py
@@ -24,7 +24,7 @@ import time
 import uuid
 from unittest.mock import Mock, MagicMock, patch
 
-from aragora.server.handlers.webhooks import (
+from aragora.server.handlers.webhook_management import (
     WebhookHandler,
     WebhookConfig,
     WebhookStore,

--- a/tests/handlers/test_webhooks.py
+++ b/tests/handlers/test_webhooks.py
@@ -21,7 +21,7 @@ class TestWebhookSignature:
 
     def test_generate_signature(self):
         """Test HMAC-SHA256 signature generation."""
-        from aragora.server.handlers.webhooks import generate_signature
+        from aragora.server.handlers.webhook_management import generate_signature
 
         payload = '{"event": "test", "data": {}}'
         secret = "test_secret_key"
@@ -33,7 +33,7 @@ class TestWebhookSignature:
 
     def test_generate_signature_deterministic(self):
         """Test signature is deterministic."""
-        from aragora.server.handlers.webhooks import generate_signature
+        from aragora.server.handlers.webhook_management import generate_signature
 
         payload = '{"event": "test"}'
         secret = "secret"
@@ -45,7 +45,7 @@ class TestWebhookSignature:
 
     def test_generate_signature_different_secrets(self):
         """Test different secrets produce different signatures."""
-        from aragora.server.handlers.webhooks import generate_signature
+        from aragora.server.handlers.webhook_management import generate_signature
 
         payload = '{"event": "test"}'
 
@@ -56,7 +56,7 @@ class TestWebhookSignature:
 
     def test_verify_signature_valid(self):
         """Test valid signature verification."""
-        from aragora.server.handlers.webhooks import (
+        from aragora.server.handlers.webhook_management import (
             generate_signature,
             verify_signature,
         )
@@ -69,7 +69,7 @@ class TestWebhookSignature:
 
     def test_verify_signature_invalid(self):
         """Test invalid signature verification."""
-        from aragora.server.handlers.webhooks import verify_signature
+        from aragora.server.handlers.webhook_management import verify_signature
 
         payload = '{"event": "test"}'
         secret = "my_secret"
@@ -79,7 +79,7 @@ class TestWebhookSignature:
 
     def test_verify_signature_wrong_secret(self):
         """Test signature with wrong secret fails."""
-        from aragora.server.handlers.webhooks import (
+        from aragora.server.handlers.webhook_management import (
             generate_signature,
             verify_signature,
         )
@@ -101,7 +101,7 @@ class TestWebhookHandler:
     @pytest.fixture
     def handler(self, mock_context):
         """Create WebhookHandler instance."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         return WebhookHandler(mock_context)
 
@@ -112,7 +112,7 @@ class TestWebhookHandler:
 
     def test_can_handle_webhooks_path(self):
         """Test can_handle for webhook paths."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         assert WebhookHandler.can_handle("/api/v1/webhooks") is True
         assert WebhookHandler.can_handle("/api/v1/webhooks/123") is True
@@ -126,7 +126,7 @@ class TestWebhookHandlerListEvents:
     @pytest.fixture
     def handler(self):
         """Create WebhookHandler instance."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         return WebhookHandler({})
 
@@ -157,7 +157,7 @@ class TestWebhookHandlerListWebhooks:
     @pytest.fixture
     def handler(self, mock_store):
         """Create WebhookHandler with mock store."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         ctx = {"webhook_store": mock_store}
         return WebhookHandler(ctx)
@@ -226,7 +226,7 @@ class TestWebhookHandlerGetWebhook:
     @pytest.fixture
     def handler(self, mock_store):
         """Create WebhookHandler with mock store."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         ctx = {"webhook_store": mock_store}
         return WebhookHandler(ctx)
@@ -310,7 +310,7 @@ class TestWebhookHandlerRegister:
     @pytest.fixture
     def handler(self, mock_store):
         """Create WebhookHandler with mock store."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         ctx = {"webhook_store": mock_store}
         h = WebhookHandler(ctx)
@@ -356,7 +356,7 @@ class TestWebhookHandlerRegister:
         handler.get_current_user = MagicMock(return_value=None)
 
         with patch(
-            "aragora.server.handlers.webhooks.validate_webhook_url",
+            "aragora.server.handlers.webhook_management.validate_webhook_url",
             return_value=(True, None),
         ):
             result = handler._handle_register_webhook(
@@ -383,7 +383,7 @@ class TestWebhookHandlerDelete:
     @pytest.fixture
     def handler(self, mock_store):
         """Create WebhookHandler with mock store."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         ctx = {"webhook_store": mock_store}
         h = WebhookHandler(ctx)
@@ -450,7 +450,7 @@ class TestWebhookHandlerUpdate:
     @pytest.fixture
     def handler(self, mock_store):
         """Create WebhookHandler with mock store."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         ctx = {"webhook_store": mock_store}
         h = WebhookHandler(ctx)
@@ -488,7 +488,7 @@ class TestWebhookHandlerUpdate:
         mock_store.get.return_value = webhook
 
         with patch(
-            "aragora.server.handlers.webhooks.validate_webhook_url",
+            "aragora.server.handlers.webhook_management.validate_webhook_url",
             return_value=(True, None),
         ):
             result = handler._handle_update_webhook(
@@ -533,7 +533,7 @@ class TestWebhookHandlerTest:
     @pytest.fixture
     def handler(self, mock_store):
         """Create WebhookHandler with mock store."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         ctx = {"webhook_store": mock_store}
         h = WebhookHandler(ctx)
@@ -608,7 +608,7 @@ class TestWebhookHandlerSLO:
     @pytest.fixture
     def handler(self):
         """Create WebhookHandler instance."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         return WebhookHandler({})
 
@@ -656,7 +656,7 @@ class TestWebhookHandlerRouting:
     @pytest.fixture
     def handler(self):
         """Create WebhookHandler instance."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         h = WebhookHandler({})
         h.get_current_user = MagicMock(return_value=None)

--- a/tests/handlers/test_webhooks_module_structure.py
+++ b/tests/handlers/test_webhooks_module_structure.py
@@ -595,3 +595,58 @@ def test_webhook_suite_patch_targets_bypass_the_deprecation_shim() -> None:
     ]
     assert shim_targets == []
     assert len(canonical_targets) >= 8
+
+
+def test_shim_path_consumption_is_confined_to_the_designated_shim_test() -> None:
+    """Test-tree shim consumption stays intentional and singular.
+
+    The deprecation shim exists for external callers; inside tests/ only this
+    file exercises the legacy path (the explicit warn-and-delegate probe in
+    test_canonical_module_is_silent_and_package_shim_warns), so any other
+    static shim-path import or shim-path patch target is drift, not coverage.
+    The github_app submodule is a canonical package resident, not shim surface.
+    """
+    deprecated = "aragora.server.handlers.webhooks"
+    native_submodule_prefix = deprecated + ".github_app"
+    designated_files = {"tests/handlers/test_webhooks_module_structure.py"}
+
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "tests").rglob("*.py")):
+        rel_path = path.relative_to(REPO_ROOT).as_posix()
+        if rel_path in designated_files:
+            continue
+        source = path.read_text(encoding="utf-8")
+        if deprecated not in source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            # An unparseable file cannot import anything.
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.level == 0 and node.module == deprecated:
+                    offenders.append(f"{rel_path}:{node.lineno} from-import")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == deprecated:
+                        offenders.append(f"{rel_path}:{node.lineno} import")
+            elif isinstance(node, ast.Call):
+                func = node.func
+                func_name = (
+                    func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+                )
+                if func_name != "patch":
+                    continue
+                if (
+                    node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)
+                ):
+                    target = node.args[0].value
+                    if target.startswith(deprecated + ".") and not target.startswith(
+                        native_submodule_prefix + "."
+                    ):
+                        offenders.append(f"{rel_path}:{node.lineno} patch-target {target}")
+
+    assert offenders == []

--- a/tests/integration/test_slo_webhook_flow.py
+++ b/tests/integration/test_slo_webhook_flow.py
@@ -248,7 +248,7 @@ class TestSLOWebhookIntegrationFlow:
 
     def test_webhook_handler_endpoints(self):
         """Test the webhook handler SLO endpoints."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         ctx: dict[str, Any] = {}
         handler = WebhookHandler(ctx)
@@ -275,7 +275,7 @@ class TestSLOWebhookIntegrationFlow:
             SLOWebhookConfig,
             init_slo_webhooks,
         )
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         notifications: list[dict[str, Any]] = []
 

--- a/tests/observability/metrics/test_webhook_metrics.py
+++ b/tests/observability/metrics/test_webhook_metrics.py
@@ -177,7 +177,7 @@ class TestDispatcherMetricsIntegration:
     def test_dispatcher_records_delivery_metrics(self):
         """Test that dispatcher records delivery metrics."""
         from aragora.events.dispatcher import dispatch_webhook_with_retry
-        from aragora.server.handlers.webhooks import WebhookConfig
+        from aragora.server.handlers.webhook_management import WebhookConfig
 
         # Create a test webhook
         webhook = WebhookConfig(
@@ -197,7 +197,7 @@ class TestDispatcherMetricsIntegration:
     def test_dispatcher_records_retry_metrics(self):
         """Test that dispatcher records retry metrics."""
         from aragora.events.dispatcher import dispatch_webhook_with_retry
-        from aragora.server.handlers.webhooks import WebhookConfig
+        from aragora.server.handlers.webhook_management import WebhookConfig
 
         webhook = WebhookConfig(
             id="test-456",

--- a/tests/security/test_security_regressions.py
+++ b/tests/security/test_security_regressions.py
@@ -136,7 +136,7 @@ class TestSecureHandlerInheritance:
 
     def test_webhook_handler_extends_secure_handler(self):
         """WebhookHandler must extend SecureHandler."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
         from aragora.server.handlers.secure import SecureHandler
 
         assert issubclass(WebhookHandler, SecureHandler), (

--- a/tests/security/test_webhook_signing.py
+++ b/tests/security/test_webhook_signing.py
@@ -38,7 +38,7 @@ def test_signature_output_is_byte_identical(payload: str, secret: str, expected:
 def test_legacy_handler_signature_warns_and_delegates() -> None:
     """The old server surface remains usable and points callers to the new home."""
     from aragora.security.webhook_signing import generate_signature as canonical
-    from aragora.server.handlers.webhooks import generate_signature as legacy
+    from aragora.server.handlers.webhook_management import generate_signature as legacy
 
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always")

--- a/tests/server/handlers/test_webhooks.py
+++ b/tests/server/handlers/test_webhooks.py
@@ -29,7 +29,7 @@ from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
 
-from aragora.server.handlers.webhooks import (
+from aragora.server.handlers.webhook_management import (
     WebhookHandler,
     generate_signature,
     verify_signature,

--- a/tests/server/handlers/test_webhooks_handler.py
+++ b/tests/server/handlers/test_webhooks_handler.py
@@ -1,5 +1,5 @@
 """
-Tests for aragora.server.handlers.webhooks - Webhook management API.
+Tests for aragora.server.handlers.webhook_management - Webhook management API.
 
 Tests cover:
 - WebhookConfig dataclass
@@ -72,7 +72,7 @@ def server_context():
 @pytest.fixture
 def webhook_handler(server_context):
     """Create webhook handler instance."""
-    from aragora.server.handlers.webhooks import WebhookHandler
+    from aragora.server.handlers.webhook_management import WebhookHandler
 
     handler = WebhookHandler(server_context)
     handler.get_current_user = MagicMock(
@@ -95,7 +95,7 @@ class TestWebhookConfig:
 
     def test_default_values(self):
         """WebhookConfig should have sensible defaults."""
-        from aragora.server.handlers.webhooks import WebhookConfig
+        from aragora.server.handlers.webhook_management import WebhookConfig
 
         config = WebhookConfig(
             id="test-id",
@@ -111,7 +111,7 @@ class TestWebhookConfig:
 
     def test_to_dict_excludes_secret(self):
         """to_dict should exclude secret by default."""
-        from aragora.server.handlers.webhooks import WebhookConfig
+        from aragora.server.handlers.webhook_management import WebhookConfig
 
         config = WebhookConfig(
             id="test-id",
@@ -125,7 +125,7 @@ class TestWebhookConfig:
 
     def test_to_dict_includes_secret_when_requested(self):
         """to_dict should include secret when explicitly requested."""
-        from aragora.server.handlers.webhooks import WebhookConfig
+        from aragora.server.handlers.webhook_management import WebhookConfig
 
         config = WebhookConfig(
             id="test-id",
@@ -139,7 +139,7 @@ class TestWebhookConfig:
 
     def test_matches_event_when_active(self):
         """matches_event should return True for subscribed events."""
-        from aragora.server.handlers.webhooks import WebhookConfig
+        from aragora.server.handlers.webhook_management import WebhookConfig
 
         config = WebhookConfig(
             id="test-id",
@@ -155,7 +155,7 @@ class TestWebhookConfig:
 
     def test_matches_event_when_inactive(self):
         """matches_event should return False when webhook is inactive."""
-        from aragora.server.handlers.webhooks import WebhookConfig
+        from aragora.server.handlers.webhook_management import WebhookConfig
 
         config = WebhookConfig(
             id="test-id",
@@ -169,7 +169,7 @@ class TestWebhookConfig:
 
     def test_matches_event_wildcard(self):
         """matches_event should accept any valid event with '*' subscription."""
-        from aragora.server.handlers.webhooks import WebhookConfig, WEBHOOK_EVENTS
+        from aragora.server.handlers.webhook_management import WebhookConfig, WEBHOOK_EVENTS
 
         config = WebhookConfig(
             id="test-id",
@@ -332,7 +332,7 @@ class TestSignatureUtilities:
 
     def test_generate_signature_format(self):
         """generate_signature should return sha256= prefixed hex string."""
-        from aragora.server.handlers.webhooks import generate_signature
+        from aragora.server.handlers.webhook_management import generate_signature
 
         signature = generate_signature('{"test": "data"}', "secret-key")
 
@@ -341,7 +341,7 @@ class TestSignatureUtilities:
 
     def test_generate_signature_deterministic(self):
         """generate_signature should be deterministic."""
-        from aragora.server.handlers.webhooks import generate_signature
+        from aragora.server.handlers.webhook_management import generate_signature
 
         sig1 = generate_signature("test payload", "secret")
         sig2 = generate_signature("test payload", "secret")
@@ -350,7 +350,7 @@ class TestSignatureUtilities:
 
     def test_generate_signature_different_for_different_secrets(self):
         """generate_signature should differ for different secrets."""
-        from aragora.server.handlers.webhooks import generate_signature
+        from aragora.server.handlers.webhook_management import generate_signature
 
         sig1 = generate_signature("test payload", "secret1")
         sig2 = generate_signature("test payload", "secret2")
@@ -359,7 +359,7 @@ class TestSignatureUtilities:
 
     def test_verify_signature_valid(self):
         """verify_signature should return True for valid signature."""
-        from aragora.server.handlers.webhooks import generate_signature, verify_signature
+        from aragora.server.handlers.webhook_management import generate_signature, verify_signature
 
         payload = '{"event": "test"}'
         secret = "webhook-secret"
@@ -369,7 +369,7 @@ class TestSignatureUtilities:
 
     def test_verify_signature_invalid(self):
         """verify_signature should return False for invalid signature."""
-        from aragora.server.handlers.webhooks import verify_signature
+        from aragora.server.handlers.webhook_management import verify_signature
 
         payload = '{"event": "test"}'
         secret = "webhook-secret"
@@ -379,7 +379,7 @@ class TestSignatureUtilities:
 
     def test_verify_signature_tampered_payload(self):
         """verify_signature should return False for tampered payload."""
-        from aragora.server.handlers.webhooks import generate_signature, verify_signature
+        from aragora.server.handlers.webhook_management import generate_signature, verify_signature
 
         original_payload = '{"event": "test"}'
         tampered_payload = '{"event": "tampered"}'
@@ -400,7 +400,7 @@ class TestWebhookHandlerListEvents:
     @pytest.mark.asyncio
     async def test_list_events_returns_all_event_types(self, webhook_handler):
         """Should return all available webhook event types."""
-        from aragora.server.handlers.webhooks import WEBHOOK_EVENTS
+        from aragora.server.handlers.webhook_management import WEBHOOK_EVENTS
 
         handler = MockHandler(headers={})
         result = await webhook_handler.handle("/api/v1/webhooks/events", {}, handler)
@@ -573,7 +573,7 @@ class TestWebhookHandlerList:
     @pytest.mark.no_auto_auth
     async def test_list_webhooks_requires_authentication(self, server_context):
         """Unauthenticated callers should not be able to enumerate webhooks."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         handler_obj = WebhookHandler(server_context)
         handler = MockHandler(headers={})
@@ -709,7 +709,7 @@ class TestWebhookHandlerGet:
     @pytest.mark.asyncio
     async def test_get_webhook_denies_workspace_mismatch(self, server_context):
         """Workspace-scoped records should not leak across orgs."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         store = server_context["webhook_store"]
         webhook = store.register(
@@ -734,7 +734,7 @@ class TestWebhookHandlerGet:
     @pytest.mark.asyncio
     async def test_get_webhook_denies_missing_workspace_context(self, server_context):
         """Workspace-scoped records should fail closed when requester has no org scope."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         store = server_context["webhook_store"]
         webhook = store.register(
@@ -806,7 +806,7 @@ class TestWebhookHandlerDelete:
 
     @pytest.mark.asyncio
     async def test_delete_webhook_hides_workspace_mismatch(self, server_context):
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         store = server_context["webhook_store"]
         webhook = store.register(
@@ -988,7 +988,7 @@ class TestWebhookHandlerUpdate:
         assert b"description must be a string" in result.body.lower()
 
     def test_update_webhook_hides_workspace_mismatch(self, server_context):
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         store = server_context["webhook_store"]
         webhook = store.register(
@@ -1073,7 +1073,7 @@ class TestWebhookHandlerTest:
 
     @pytest.mark.asyncio
     async def test_test_webhook_hides_workspace_mismatch(self, server_context):
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         store = server_context["webhook_store"]
         webhook = store.register(
@@ -1106,7 +1106,7 @@ class TestGetWebhookStore:
 
     def test_returns_singleton(self):
         """get_webhook_store should return the same instance."""
-        import aragora.server.handlers.webhooks as webhooks_module
+        import aragora.server.handlers.webhook_management as webhooks_module
 
         # Reset the global store
         webhooks_module._webhook_store = None
@@ -1166,7 +1166,7 @@ class TestWebhookRBAC:
 
     @pytest.fixture
     def handler(self, server_context):
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         handler = WebhookHandler(server_context)
         handler.get_current_user = MagicMock(
@@ -1195,7 +1195,7 @@ class TestWebhookRBAC:
     @pytest.mark.no_auto_auth
     def test_permission_check_requires_authentication(self, server_context):
         """Permission helper should fail closed when no user is attached."""
-        from aragora.server.handlers.webhooks import WebhookHandler
+        from aragora.server.handlers.webhook_management import WebhookHandler
 
         handler = WebhookHandler(server_context)
         mock_http = MockHandler(headers={})


### PR DESCRIPTION
## Summary

Follow-up to #9830: consolidates the remaining deliberate shim-surface consumption in webhook tests. All test imports of the deprecated `aragora.server.handlers.webhooks` shim now target the canonical `aragora.server.handlers.webhook_management` (assertions and semantics unchanged), and a new tests-tree AST census pins zero stray shim-path consumption going forward. The shim and the deprecated `generate_signature` wrapper are NOT removed (retained by design as public deprecation surface, per the 2026-08-27 deferred-policy item).

## Changes (9 files, +106/−51, tests-only)

- **Repoint (8 files, 51 sites):** 48 `from aragora.server.handlers.webhooks import ...` sites, 1 `import ... as webhooks_module` site, and 2 decoy `@patch("...webhooks.validate_webhook_url")` targets now name `webhook_management`:
  - `tests/handlers/test_webhooks.py` (17 from-imports + 2 patch targets)
  - `tests/server/handlers/test_webhooks_handler.py` (22 from-imports + module import + docstring)
  - `tests/server/handlers/test_webhooks.py`, `tests/handlers/test_handlers_webhooks.py` (1 each)
  - `tests/observability/metrics/test_webhook_metrics.py` (2), `tests/integration/test_slo_webhook_flow.py` (2), `tests/security/test_security_regressions.py` (1), `tests/security/test_webhook_signing.py` (1, see disclosure)
- **New census test** in `tests/handlers/test_webhooks_module_structure.py`: `test_shim_path_consumption_is_confined_to_the_designated_shim_test` walks `tests/**/*.py` via AST and flags shim-path from-imports, module imports, and patch targets outside the designated file. The native `webhooks.github_app` submodule is exempt (canonical package resident, not shim surface).
- **Exactly one explicit shim-consumption test remains:** the existing `test_canonical_module_is_silent_and_package_shim_warns` (asserts the DeprecationWarning message and byte-equivalent delegation). No second shim probe was added.

## Disclosures

- **Run-time census delta:** the authoring-time estimate in the work order (~8 sites in one file + a few siblings) was stale; the run-time census found **51 sites across 8 files**. All repointed.
- **Guard-test evolution (`tests/security/test_webhook_signing.py`):** the #9822 probe `test_legacy_handler_signature_warns_and_delegates` imported `generate_signature as legacy` via the shim path. It now imports via `webhook_management`. The assertion still holds because the warning it checks is the **call-time** wrapper warning, whose message names the legacy path (`aragora.server.handlers.webhooks.generate_signature is deprecated; ...`). The string-literal source assertions (lines 52/77/89) are intentionally unchanged.
- **`webhooks_module._webhook_store = None` reset** (singleton test): `webhook_management` has no module-level `_webhook_store` global (the singleton lives in `aragora.storage.webhook_config_store`), so this reset was inert before and stays inert; behavior is identical.
- **Battery counts:** the four-file battery measures **224 passed** on current main (the "122" figure in the work order was not reproducible from #9830's commit; actual counts reported below).
- No `shims.md` entry needed: no module moved; only test imports repointed.

## Red-first evidence

The new census test was written and run **before** the repoint: FAILED with **51 offenders** (48 from-imports + 1 module import + 2 patch targets), exactly matching the manual `rg` census. After the repoint it passes and the only remaining shim-path strings in the 8 files are the intentional string-literal guard assertions.

## Validation

- `pytest tests/handlers/test_webhooks_module_structure.py` — **10 passed** (incl. new census)
- Four-file battery (`tests/handlers/test_webhooks.py`, `test_handlers_webhooks.py`, `tests/server/handlers/test_webhooks.py`, `test_webhooks_handler.py`) — **224 passed**
- Wider consumer battery (signing, security_regressions, webhook_metrics, slo_webhook_flow, dispatcher_server_boundary, both github_app dirs, event_subscribers) — **218 passed**
- Multi-seed sweep over all 9 touched files, seeds {1, 42, 100, 2024, 12345} — **301 passed** each
- `python3 scripts/report_code_quality.py --check` — Ratchet PASS (noqa 2693/2800, type_ignore 700/700; no new suppressions)
- `make lint` PASS, `ruff format --check` PASS, `make test-smoke` PASS, `bash scripts/test_tiers.sh smoke` — **138 passed**
- `bash scripts/preflight_mypy.sh --diff-base origin/main` — no issues in 9 files
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — ok
