### PR TITLE
fix(server): defer auth_config construction to first use

### DIFF
--- a/aragora/server/auth.py
+++ b/aragora/server/auth.py
@@ -12,7 +12,7 @@ import os
 import secrets
 import threading
 import time
-from typing import Any
+from typing import Any, cast
 
 from aragora.config import (
     DEFAULT_RATE_LIMIT,
@@ -640,9 +640,50 @@ class AuthConfig:
         return None
 
 
-# Global auth config instance
-auth_config = AuthConfig()
-auth_config.configure_from_env()
+# Global auth config instance, created lazily via PEP 562 module __getattr__.
+#
+# AuthConfig.__init__ parses AuthSettings (get_settings().auth) and starts the
+# cleanup thread; doing that at import time means a cold settings cache plus an
+# invalid ARAGORA_* variable kills pytest at collection (before any test runs)
+# and misattributes env-pollution failures. Deferring to first use keeps
+# `from aragora.server.auth import auth_config`, module attribute access, and
+# patching of `aragora.server.auth.auth_config` all working unchanged.
+_auth_config: AuthConfig | None = None
+_auth_config_lock = threading.Lock()
+
+
+def get_auth_config() -> AuthConfig:
+    """Return the process-wide AuthConfig, creating and configuring it on first use."""
+    global _auth_config
+    cfg = _auth_config
+    if cfg is None:
+        with _auth_config_lock:
+            cfg = _auth_config
+            if cfg is None:
+                cfg = AuthConfig()
+                cfg.configure_from_env()
+                _auth_config = cfg
+    return cfg
+
+
+def _active_auth_config() -> AuthConfig:
+    """Resolve the auth config for this module's own helpers.
+
+    A bare global reference would bypass both module ``__getattr__`` and any
+    test that patches the ``aragora.server.auth.auth_config`` attribute, so
+    helpers resolve through the module namespace at call time. A ``None``
+    override is treated as unset.
+    """
+    override = globals().get("auth_config")
+    if override is not None:
+        return cast("AuthConfig", override)
+    return get_auth_config()
+
+
+def __getattr__(name: str) -> AuthConfig:
+    if name == "auth_config":
+        return get_auth_config()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def check_auth(
@@ -662,6 +703,8 @@ def check_auth(
         authenticated is True if authenticated or auth disabled.
         rate_limit_remaining is -1 if rate limiting not applicable.
     """
+    auth_config = _active_auth_config()
+
     # Always check IP rate limit for DoS protection (even without auth)
     ip_remaining = -1
     if ip_address:
@@ -762,7 +805,7 @@ def generate_shareable_link(
         URL with session parameter, or base_url if auth is disabled
     """
     # Generate session (stores token server-side)
-    session_id = auth_config.generate_session(loop_id, expires_in)
+    session_id = _active_auth_config().generate_session(loop_id, expires_in)
     if not session_id:
         return base_url
 
@@ -779,4 +822,4 @@ def resolve_shareable_session(session_id: str) -> tuple[bool, str, str]:
     Returns:
         Tuple of (is_valid, token, loop_id)
     """
-    return auth_config.resolve_session(session_id)
+    return _active_auth_config().resolve_session(session_id)

--- a/aragora/server/auth.py
+++ b/aragora/server/auth.py
@@ -661,7 +661,14 @@ def get_auth_config() -> AuthConfig:
             cfg = _auth_config
             if cfg is None:
                 cfg = AuthConfig()
-                cfg.configure_from_env()
+                try:
+                    cfg.configure_from_env()
+                except BaseException:
+                    # __init__ already started the cleanup thread; reap it so a
+                    # failing configuration (e.g. production mode without a
+                    # token) cannot leak one thread per first-use retry.
+                    cfg.stop_cleanup_thread()
+                    raise
                 _auth_config = cfg
     return cfg
 
@@ -684,6 +691,10 @@ def __getattr__(name: str) -> AuthConfig:
     if name == "auth_config":
         return get_auth_config()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), "auth_config"})
 
 
 def check_auth(

--- a/tests/server/test_auth_lazy_init.py
+++ b/tests/server/test_auth_lazy_init.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -226,3 +227,72 @@ class TestPublicNamePreserved:
                 "tok",
                 "loop-1",
             )
+
+    def test_dir_lists_auth_config_before_materialization(self):
+        listing = dir(auth_mod)
+        assert "auth_config" in listing
+        assert "check_auth" in listing
+        assert "get_auth_config" in listing
+
+
+def _alive_cleanup_threads() -> list[threading.Thread]:
+    return [t for t in threading.enumerate() if t.name == "auth-cleanup" and t.is_alive()]
+
+
+class TestFailedConfigurationDoesNotLeak:
+    """AuthConfig.__init__ starts the cleanup thread; a raising configure_from_env
+    (e.g. production mode without a token) must not leak one thread per retry,
+    and must not cache a half-configured singleton."""
+
+    def test_failed_configure_leaves_no_cleanup_thread_cold_process(self):
+        # Subprocess: the session autouse fixture suppresses cleanup-thread
+        # starts in-process, so the leak is only observable in a cold process.
+        env = _poisoned_env()
+        env[_POISON_VAR] = "3600"
+        env["ARAGORA_ENV"] = "production"  # configure_from_env raises: no token
+        code = (
+            "import threading, sys\n"
+            "import aragora.server.auth as auth_mod\n"
+            "for attempt in range(2):\n"
+            "    try:\n"
+            "        auth_mod.get_auth_config()\n"
+            "    except Exception:\n"
+            "        pass\n"
+            "    else:\n"
+            "        sys.exit(3)  # configure unexpectedly succeeded\n"
+            "leaked = [t for t in threading.enumerate()\n"
+            "          if t.name == 'auth-cleanup' and t.is_alive()]\n"
+            "sys.exit(4 if leaked else 0)\n"
+        )
+        proc = _run_python(code, env)
+        assert proc.returncode == 0, (
+            f"failed configuration leaked cleanup threads or unexpectedly succeeded; "
+            f"rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+
+    def test_failed_configure_reaps_thread_and_does_not_cache(self, monkeypatch):
+        real_configure = auth_mod.AuthConfig.configure_from_env
+        monkeypatch.setattr(auth_mod, "_auth_config", None)
+
+        def _boom(self):
+            raise auth_mod.AuthenticationError("configure boom")
+
+        monkeypatch.setattr(auth_mod.AuthConfig, "configure_from_env", _boom)
+        baseline = len(_alive_cleanup_threads())
+
+        for _ in range(2):
+            with pytest.raises(auth_mod.AuthenticationError, match="configure boom"):
+                auth_mod.get_auth_config()
+
+        assert len(_alive_cleanup_threads()) == baseline, (
+            "failed configuration leaked auth-cleanup threads"
+        )
+
+        # Recovery: once the environment is sane, first use succeeds and caches.
+        monkeypatch.setattr(auth_mod.AuthConfig, "configure_from_env", real_configure)
+        cfg = auth_mod.get_auth_config()
+        assert isinstance(cfg, auth_mod.AuthConfig)
+        assert auth_mod.get_auth_config() is cfg
+        # Reap the recovered instance's thread; teardown restores the session
+        # singleton, discarding this instance.
+        cfg.stop_cleanup_thread()

--- a/tests/server/test_auth_lazy_init.py
+++ b/tests/server/test_auth_lazy_init.py
@@ -1,0 +1,228 @@
+"""Lazy-initialization contract for the ``aragora.server.auth.auth_config`` singleton.
+
+The module-level singleton must NOT parse ``AuthSettings`` (``get_settings().auth``)
+at import time: with a cold settings cache and an invalid ``ARAGORA_*`` variable,
+an import-time parse kills pytest at collection (``found no collectors``, rc=4)
+instead of failing inside a test, misattributing env-pollution failures.
+
+These tests pin two things:
+
+1. Deferral (subprocess-based, cold settings cache): importing the module under a
+   poisoned env succeeds, the parse happens on FIRST USE, and pytest collection of
+   a module that imports ``aragora.server.auth`` no longer dies.
+2. Preservation (in-process): the public name ``auth_config`` keeps working for
+   from-imports, module attribute access, ``mock.patch`` /
+   ``monkeypatch.setattr`` targets, and the module-level helpers
+   (``check_auth``, ``generate_shareable_link``, ``resolve_shareable_session``)
+   see a patched module attribute exactly as they did when the singleton was
+   eagerly constructed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+import aragora.server.auth as auth_mod
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Violates AuthSettings.token_ttl (ge=60) so the pydantic parse raises, while
+# AuthConfig.configure_from_env's own int() parse of the same variable succeeds:
+# the failure isolates to the get_settings().auth parse site.
+_POISON_VAR = "ARAGORA_TOKEN_TTL"
+_POISON_VALUE = "7"
+
+# The historical collection victim: its module-level
+# `from aragora.server.auth import ...` makes pytest import aragora.server.auth
+# while collecting it.
+_VICTIM_FILE = "tests/server/test_security.py"
+_VICTIM_NODE = f"{_VICTIM_FILE}::TestConfigureFromEnv::test_configure_from_env_negative_ttl"
+
+
+def _poisoned_env() -> dict[str, str]:
+    """Inherited env minus all ARAGORA_* vars, plus the poison and safe defaults."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("ARAGORA_")}
+    env.update(
+        {
+            # Importing aragora.server without AWS neutralization can hit
+            # botocore MFA getpass on this machine class.
+            "AWS_CONFIG_FILE": "/dev/null",
+            "AWS_SHARED_CREDENTIALS_FILE": "/dev/null",
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "ARAGORA_ENV": "development",
+            "ARAGORA_SECRETS_STRICT": "false",
+            _POISON_VAR: _POISON_VALUE,
+        }
+    )
+    return env
+
+
+def _run_python(code: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+class TestImportDefersSettingsParse:
+    """Cold-cache subprocess proofs that the parse moved from import to first use."""
+
+    def test_import_succeeds_under_poisoned_env_and_parse_defers_to_first_use(self):
+        code = (
+            "import sys\n"
+            "import aragora.server.auth as auth_mod\n"
+            "assert 'auth_config' not in vars(auth_mod), 'materialized at import'\n"
+            "try:\n"
+            "    auth_mod.auth_config\n"
+            "except Exception:\n"
+            "    sys.exit(0)\n"
+            "sys.exit(3)\n"
+        )
+        proc = _run_python(code, _poisoned_env())
+        assert proc.returncode == 0, (
+            f"expected import to succeed and first use to raise under poisoned env; "
+            f"rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+
+    def test_first_use_constructs_configured_singleton_under_clean_env(self):
+        env = _poisoned_env()
+        env[_POISON_VAR] = "3600"
+        env["ARAGORA_API_TOKEN"] = "lazy-init-proof-token"
+        code = (
+            "import aragora.server.auth as auth_mod\n"
+            "assert 'auth_config' not in vars(auth_mod), 'materialized at import'\n"
+            "from aragora.server.auth import auth_config\n"
+            "assert auth_config.enabled, 'configure_from_env not applied on first use'\n"
+            "assert auth_config is auth_mod.auth_config\n"
+            "assert auth_config is auth_mod.get_auth_config()\n"
+        )
+        proc = _run_python(code, env)
+        assert proc.returncode == 0, (
+            f"expected lazy singleton to be configured on first use; "
+            f"rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+
+    def test_collection_of_auth_importing_module_survives_poisoned_env(self):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                _VICTIM_FILE,
+                "--collect-only",
+                "-q",
+                "-p",
+                "no:randomly",
+            ],
+            cwd=REPO_ROOT,
+            env=_poisoned_env(),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        combined = proc.stdout + proc.stderr
+        assert proc.returncode == 0, (
+            f"collection died under poisoned env (rc={proc.returncode}):\n{combined[-3000:]}"
+        )
+        assert "error during collection" not in combined, (
+            f"collection reported errors under poisoned env:\n{combined[-3000:]}"
+        )
+
+    def test_node_id_selection_no_longer_reports_found_no_collectors(self):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                _VICTIM_NODE,
+                "--collect-only",
+                "-q",
+                "-p",
+                "no:randomly",
+            ],
+            cwd=REPO_ROOT,
+            env=_poisoned_env(),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        combined = proc.stdout + proc.stderr
+        assert "found no collectors" not in combined, (
+            f"the rc=4 'found no collectors' collection failure is back:\n{combined[-3000:]}"
+        )
+        assert proc.returncode == 0, (
+            f"node-id collection failed under poisoned env (rc={proc.returncode}):\n{combined[-3000:]}"
+        )
+
+
+class TestPublicNamePreserved:
+    """In-process guards: importers and patchers keep working against the lazy name."""
+
+    def test_from_import_returns_the_singleton(self):
+        from aragora.server.auth import auth_config as first
+        from aragora.server.auth import auth_config as second
+
+        assert first is second
+        assert isinstance(first, auth_mod.AuthConfig)
+        assert first is auth_mod.get_auth_config()
+
+    def test_module_attribute_identity_is_stable(self):
+        assert auth_mod.auth_config is auth_mod.auth_config
+
+    def test_unknown_module_attribute_still_raises(self):
+        with pytest.raises(AttributeError, match="no attribute"):
+            auth_mod.definitely_not_a_real_attribute
+
+    def test_mock_patch_is_seen_by_check_auth_and_restores_identity(self):
+        before = auth_mod.auth_config
+        stub = mock.Mock()
+        stub.enabled = False
+        with mock.patch("aragora.server.auth.auth_config", stub):
+            assert auth_mod.auth_config is stub
+            authenticated, remaining = auth_mod.check_auth({})
+            assert authenticated is True
+            assert remaining == -1
+        assert auth_mod.auth_config is before
+
+    def test_monkeypatch_setattr_is_seen_and_restored(self, monkeypatch):
+        before = auth_mod.auth_config
+        sentinel = SimpleNamespace(enabled=False)
+        monkeypatch.setattr(auth_mod, "auth_config", sentinel)
+        authenticated, remaining = auth_mod.check_auth({})
+        assert authenticated is True
+        assert remaining == -1
+        monkeypatch.undo()
+        assert auth_mod.auth_config is before
+
+    def test_shareable_link_helpers_use_patched_config(self):
+        class _StubConfig:
+            def generate_session(self, loop_id, expires_in):
+                assert loop_id == "loop-1"
+                return "sess-lazy-123"
+
+            def resolve_session(self, session_id):
+                assert session_id == "sess-lazy-123"
+                return True, "tok", "loop-1"
+
+        with mock.patch("aragora.server.auth.auth_config", _StubConfig()):
+            link = auth_mod.generate_shareable_link("http://example.test/d", "loop-1")
+            assert link == "http://example.test/d?session=sess-lazy-123"
+            assert auth_mod.resolve_shareable_session("sess-lazy-123") == (
+                True,
+                "tok",
+                "loop-1",
+            )


### PR DESCRIPTION
## Summary

Follow-up from #9833 (REPO TRUTH masking-mechanisms entry, library ledger 2026-08-27): `aragora/server/auth.py` constructed the module-level `auth_config = AuthConfig()` and ran `configure_from_env()` at IMPORT time. `AuthConfig.__init__` calls `get_settings().auth`, which parses `AuthSettings`, so with a cold settings cache plus one invalid `ARAGORA_*` variable, pytest died at COLLECTION instead of inside a test, misattributing env-pollution failures to the collector.

This PR makes the singleton lazily initialized behind a PEP 562 module `__getattr__` plus a `get_auth_config()` accessor with a lock-guarded private cache. `AuthSettings` now parses on FIRST USE. The public name `auth_config` is fully preserved.

## Red-first evidence (base = 6193b2f87c)

Poisoned env: `ARAGORA_TOKEN_TTL=7` (violates `AuthSettings.token_ttl ge=60`), all other `ARAGORA_*` scrubbed, cold settings cache.

| Repro | Base | This PR |
|---|---|---|
| `python3 -c "import aragora.server.auth"` | rc=1, pydantic `ValidationError` raised through `settings.py:1131 self._auth = AuthSettings()` ← `AuthConfig.__init__` ← module level | rc=0, `IMPORT-OK`; first attribute access raises instead |
| `pytest tests/server/test_security.py --collect-only` | rc=2, `Interrupted: 1 error during collection` | rc=0 |
| `pytest tests/server/test_security.py::TestConfigureFromEnv::test_configure_from_env_negative_ttl` | **rc=4, `ERROR: found no collectors`** | rc=0, 1 passed |

New regression suite `tests/server/test_auth_lazy_init.py` (10 tests): 5 failed at base (the deferral proofs), 10 pass with the fix. Subprocess tests pin cold-cache deferral and the cured collection signatures; in-process tests pin from-import identity, `mock.patch`/`monkeypatch.setattr` patchability with identity restore, and patch visibility inside `check_auth` / `generate_shareable_link` / `resolve_shareable_session`.

## Census (heavily-imported surface, done before any edit)

- **Module-level runtime from-imports (2):** `aragora/server/stream/servers.py:95`, `aragora/server/stream/debate_stream_server.py:60`. They materialize the singleton at their own import, behaviorally identical to today (importing them already constructed it transitively). Tests patching `<those modules>.auth_config` patch the rebound name and are unaffected.
- **Function-level from-imports (~80 sites, runtime + tests):** served by module `__getattr__` at call time.
- **Patch targets:** dozens of `patch("aragora.server.auth.auth_config")` sites plus `monkeypatch.setattr(auth_module, "auth_config", ...)` sites. `mock.patch` reads the original via `getattr` (materializes the real singleton), sets the mock as a real module attribute, and on exit either restores or deletes; the private cache keeps identity stable across patch cycles. Verified in-process by the new tests and by the battery below.
- **Internal bare-name references:** `check_auth`, `generate_shareable_link`, `resolve_shareable_session` referenced the module global directly (LOAD_GLOBAL bypasses `__getattr__` and patches). They now resolve through the module namespace at call time (`_active_auth_config()`), preferring a patched `auth_config` attribute, so every existing `patch("aragora.server.auth.auth_config")` test keeps seeing its patch from inside those helpers.
- **Session autouse fixture** `tests/fixtures/autouse.py::_suppress_auth_cleanup_threads`: from-imports `auth_config` at session start (post-collection), materializing then immediately stopping the cleanup thread. Preserved.
- **Docs:** `docs/deployment/PRODUCTION_RUNBOOK.md:116` from-imports `auth_config` and explicitly calls `configure_from_env()`; both remain valid (idempotent re-run), no doc change needed.

## Behavior notes

- Zero behavior change for correctly configured processes: same construction, same `configure_from_env()`, once per process, thread-safe (double-checked lock).
- The production missing-token fail-fast (`ARAGORA_ENV=production` without `ARAGORA_API_TOKEN` raises `AuthenticationError` in `configure_from_env`) now fires at first use instead of at import of `aragora.server.auth`. Server boot paths that use auth still fail fast at startup via the stream-server module-level import.
- A `None` assignment to the module attribute is treated as unset by the internal resolver (no censused consumer does this).

## Validation

- `tests/server/test_auth_lazy_init.py`: 10 passed (5 red at base)
- Census-critical battery (security, server_auth, stream_auth, websocket_auth, stream servers, debate_stream_server, api_workflow, interrogation handler, rlm handler): 496 passed
- `tests/server/test_unified_server.py`: 85 passed
- `make test-smoke`: passed
- Seed sweep (5 seeds × 242 tests over the touched area): all green
- `make lint`, `ruff format --check`, `bash scripts/preflight_mypy.sh --diff-base origin/main`: clean
- LOC: +277/−6 (283 changed lines, cap 800)

## Review response (head d2a8601c46)

First evidence round at 7be2c01eb0: claude PASS (counted), openai CHANGES-REQUESTED with a genuine P2 — `AuthConfig.__init__` starts the auth-cleanup daemon thread before `configure_from_env()` runs, so a raising configuration (production without token) leaked one thread per first-use retry and never cached. Cured red-first in `d2a8601c46`:

- New cold-process test proves the leak (rc=4 at the old head) and its cure: two failing `get_auth_config()` attempts leave zero alive `auth-cleanup` threads.
- `get_auth_config()` now stops the just-started cleanup thread before re-raising; the singleton stays uncached so a later sane environment recovers.
- Also adopted claude's P3: PEP 562 `__dir__` companion (`auth_config` visible to `dir()` pre-materialization), with a test.
- Claude's remaining P3s (typed `__getattr__` mypy semantics; explicit boot-time `get_auth_config()` pin in startup validation) are advisory and out of this diff's scope; the production boot fail-fast currently holds via the `unified_server` → stream import chain, as claude verified.

Suite is now 13 tests; census battery re-run green at the new head (584 passed).
