### PR TITLE
refactor(redis): repoint tier-1/2 consumers to canonical aragora.utils.redis_config

### DIFF
--- a/aragora/server/middleware/rate_limit/redis_limiter.py
+++ b/aragora/server/middleware/rate_limit/redis_limiter.py
@@ -92,7 +92,7 @@ def get_redis_client() -> redis.Redis | None:
 
     # Try centralized redis_config first (preferred)
     try:
-        from aragora.server.redis_config import get_redis_client as get_shared_client
+        from aragora.utils.redis_config import get_redis_client as get_shared_client
 
         shared_client = get_shared_client()
         if shared_client is not None:

--- a/aragora/server/middleware/rate_limit/redis_limiter.py
+++ b/aragora/server/middleware/rate_limit/redis_limiter.py
@@ -478,7 +478,8 @@ class RedisRateLimiter:
             # Use Redis hash to store per-instance metrics
             instance_key = f"{self._metrics_key}{self.instance_id}"
             with self._lock:
-                metrics_data = {
+                # Keyed wider than str to satisfy redis-py's invariant Mapping type.
+                metrics_data: dict[str | bytes, bytes | float | int | str] = {
                     "requests_allowed": str(self._requests_allowed),
                     "requests_rejected": str(self._requests_rejected),
                     "redis_failures": str(self._redis_failures),

--- a/aragora/server/pubsub.py
+++ b/aragora/server/pubsub.py
@@ -37,7 +37,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from collections.abc import Callable, Coroutine
 
-from aragora.server.redis_config import get_redis_client, is_redis_available
+from aragora.utils.redis_config import get_redis_client, is_redis_available
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/server/session_store.py
+++ b/aragora/server/session_store.py
@@ -862,7 +862,7 @@ class RedisSessionStore(SessionStore):
         self._prefix = self._config.key_prefix
 
         # Get Redis client
-        from aragora.server.redis_config import get_redis_client
+        from aragora.utils.redis_config import get_redis_client
 
         redis_client = get_redis_client()
         if redis_client is None:
@@ -1471,7 +1471,7 @@ def get_session_store(force_memory: bool = False) -> SessionStore:
 
         # Try Redis first
         try:
-            from aragora.server.redis_config import is_redis_available
+            from aragora.utils.redis_config import is_redis_available
 
             if is_redis_available():
                 _session_store = RedisSessionStore()

--- a/aragora/server/shutdown_sequence.py
+++ b/aragora/server/shutdown_sequence.py
@@ -640,7 +640,7 @@ class ShutdownPhaseBuilder:
 
         # Redis connection pool
         async def close_redis():
-            from aragora.server.redis_config import close_redis_pool
+            from aragora.utils.redis_config import close_redis_pool
 
             close_redis_pool()
             logger.debug("Redis connection pool closed")

--- a/aragora/tenancy/quota_persistence.py
+++ b/aragora/tenancy/quota_persistence.py
@@ -183,7 +183,7 @@ class QuotaPersistence:
 
         try:
             # Try to get async redis client
-            from aragora.server.redis_config import get_async_redis_client
+            from aragora.utils.redis_config import get_async_redis_client
 
             self._redis = await get_async_redis_client()
             if self._redis:

--- a/aragora/workflow/checkpoints/_compat.py
+++ b/aragora/workflow/checkpoints/_compat.py
@@ -53,7 +53,7 @@ _get_redis_client: _RedisClientGetter | None = None
 REDIS_AVAILABLE = False
 
 try:
-    from aragora.server.redis_config import get_redis_client as _redis_getter
+    from aragora.utils.redis_config import get_redis_client as _redis_getter
 
     _get_redis_client = _redis_getter
     REDIS_AVAILABLE = True

--- a/aragora/workflow/checkpoints/redis.py
+++ b/aragora/workflow/checkpoints/redis.py
@@ -38,7 +38,7 @@ class RedisCheckpointStore:
 
     Environment:
         Requires REDIS_URL environment variable or Redis configuration
-        in aragora.server.redis_config.
+        in aragora.utils.redis_config.
     """
 
     # Key prefixes for Redis
@@ -67,7 +67,7 @@ class RedisCheckpointStore:
         if not _compat_stub.REDIS_AVAILABLE:
             raise RuntimeError(
                 "Redis checkpoint store requires Redis configuration. "
-                "Ensure aragora.server.redis_config is available and REDIS_URL is set."
+                "Ensure aragora.utils.redis_config is available and REDIS_URL is set."
             )
 
         self._ttl_seconds = int(ttl_hours * 3600)

--- a/tests/server/test_redis_config_deprecation.py
+++ b/tests/server/test_redis_config_deprecation.py
@@ -14,8 +14,13 @@ importable as a shim that:
 from __future__ import annotations
 
 import importlib
+import os
+import re
+import subprocess
 import sys
+import textwrap
 import warnings
+from pathlib import Path
 
 import pytest
 
@@ -89,3 +94,126 @@ class TestReExportIdentity:
         shim.reset_redis_state()
         assert canonical._redis_available is None
         assert canonical._redis_pool is None
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The shim warns once per interpreter at its own import time, so an in-process
+# probe would be masked by module caching from earlier tests; each probe runs
+# the consumer in a fresh interpreter and counts shim warnings there.
+_PROBE_TEMPLATE = """\
+import warnings
+
+with warnings.catch_warnings(record=True) as _caught:
+    warnings.simplefilter("always")
+__BODY__
+
+_shim_warnings = [
+    w
+    for w in _caught
+    if issubclass(w.category, DeprecationWarning)
+    and "aragora.server.redis_config" in str(w.message)
+]
+print("SHIM_WARNINGS=%d" % len(_shim_warnings))
+"""
+
+
+def _run_shim_warning_probe(body: str) -> int:
+    """Run *body* in a fresh interpreter and count shim DeprecationWarnings."""
+    env = os.environ.copy()
+    # aragora.server imports probe AWS secrets at import time; neutralize so
+    # the probe is hermetic on machines with real AWS configuration.
+    env["AWS_CONFIG_FILE"] = "/dev/null"
+    env["AWS_SHARED_CREDENTIALS_FILE"] = "/dev/null"
+    env["AWS_EC2_METADATA_DISABLED"] = "true"
+    env["ARAGORA_QUOTA_REDIS_ENABLED"] = "true"
+    for var in (
+        "ARAGORA_REQUIRE_DISTRIBUTED",
+        "ARAGORA_REQUIRE_DISTRIBUTED_STATE",
+        "ARAGORA_MULTI_INSTANCE",
+        "ARAGORA_ENV",
+    ):
+        env.pop(var, None)
+    code = _PROBE_TEMPLATE.replace(
+        "__BODY__", textwrap.indent(textwrap.dedent(body).strip(), "    ")
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"probe failed rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    match = re.search(r"SHIM_WARNINGS=(\d+)", result.stdout)
+    assert match, f"probe emitted no marker\nstdout={result.stdout}\nstderr={result.stderr}"
+    return int(match.group(1))
+
+
+class TestConsumersUseCanonicalPath:
+    """Repointed tier-1/2 consumers must not touch the deprecated shim.
+
+    Covers import time (module-level importers) and call time (function-level
+    importers) for every consumer repointed to aragora.utils.redis_config.
+    """
+
+    def test_pubsub_import_chain_emits_no_shim_warning(self):
+        assert _run_shim_warning_probe("import aragora.server.pubsub") == 0
+
+    def test_checkpoint_compat_import_emits_no_shim_warning(self):
+        assert _run_shim_warning_probe("import aragora.workflow.checkpoints._compat") == 0
+
+    def test_redis_limiter_get_redis_client_emits_no_shim_warning(self):
+        body = """
+        from aragora.server.middleware.rate_limit import redis_limiter
+
+        redis_limiter.get_redis_client()
+        """
+        assert _run_shim_warning_probe(body) == 0
+
+    def test_get_session_store_emits_no_shim_warning(self):
+        body = """
+        from aragora.server import session_store
+
+        session_store.reset_session_store()
+        session_store.get_session_store()
+        session_store.reset_session_store()
+        """
+        assert _run_shim_warning_probe(body) == 0
+
+    def test_shutdown_close_redis_phase_emits_no_shim_warning(self):
+        body = """
+        import asyncio
+
+        from aragora.server.shutdown_sequence import ShutdownPhaseBuilder, ShutdownSequence
+
+        sequence = ShutdownSequence()
+        ShutdownPhaseBuilder(server=None)._phase_close_connection_pools(sequence)
+        phase = next(p for p in sequence._phases if p.name == "Close Redis pool")
+        asyncio.run(phase.execute())
+        """
+        assert _run_shim_warning_probe(body) == 0
+
+    def test_quota_persistence_get_redis_emits_no_shim_warning(self):
+        body = """
+        import asyncio
+        import inspect
+
+        from aragora.tenancy.quota_persistence import QuotaPersistence
+
+        async def _probe():
+            client = await QuotaPersistence()._get_redis()
+            if client is not None:
+                closer = getattr(client, "aclose", None) or getattr(client, "close", None)
+                if closer is not None:
+                    result = closer()
+                    if inspect.isawaitable(result):
+                        await result
+
+        asyncio.run(_probe())
+        """
+        assert _run_shim_warning_probe(body) == 0

--- a/tests/server/test_session_store.py
+++ b/tests/server/test_session_store.py
@@ -328,7 +328,7 @@ class TestGetSessionStore:
         reset_session_store()
         # The import of is_redis_available happens inside get_session_store
         # Patch at the source module
-        with patch("aragora.server.redis_config.is_redis_available") as mock_check:
+        with patch("aragora.utils.redis_config.is_redis_available") as mock_check:
             mock_check.side_effect = RuntimeError("Redis connection failed")
 
             store = get_session_store()


### PR DESCRIPTION
## Summary

Repoints six tier-1/2 consumers of the deprecated `aragora.server.redis_config` shim to the canonical `aragora.utils.redis_config` module (mission feature `misc-redis-config-import-repoint`, follow-up from #9833; epic #8257):

- `aragora/server/pubsub.py:40` (the only module-level import-time warner)
- `aragora/server/middleware/rate_limit/redis_limiter.py:95` (call-time, under the recorded overlap lift, see below)
- `aragora/server/session_store.py:865` + `:1474`
- `aragora/server/shutdown_sequence.py:643`
- `aragora/workflow/checkpoints/_compat.py:56` (+ docstring/error-message prose in `workflow/checkpoints/redis.py:41,70`)
- `aragora/tenancy/quota_persistence.py:186`

Semantics identical: the shim itself delegates to the canonical module (all 7 exports identity-equal), so this only removes the deprecation-warning hops. The shim module and its deprecation-pin tests in `tests/server/test_redis_config_deprecation.py` are untouched (public deprecation surface). The one in-subset test seam (`tests/server/test_session_store.py:331`) is retargeted patch-string-only with identical assertions.

**Red-first tests:** `tests/server/test_redis_config_deprecation.py` gains `TestConsumersUseCanonicalPath` — six hermetic subprocess probes asserting zero shim `DeprecationWarning`s at import time (pubsub, checkpoint `_compat` chain) and call time (`redis_limiter.get_redis_client()`, `get_session_store()`, shutdown close-redis phase, quota persistence `_get_redis()`). All six failed at base with exactly one shim warning each (matching the measured red repro); all pass after the repoint.

**Out of scope:** tier-3 consumers (`rbac/quotas.py`, `rbac/emergency.py`, `handlers/explainability_store.py`, `handlers/public/status_page.py`) and their test seams are owned by follow-up feature `misc-redis-config-repoint-tier3-remainder`.

## Overlap-lift disclosure (required)

`aragora/server/middleware/rate_limit/redis_limiter.py` is also touched by open PR **#8939** (head `4028b9e3f7ab13dbdb02a75d4a8b1dd32e220a91`, branch `codex/fix-ci-required-typecheck-8933`). This PR proceeds under the operator Decision "per-feature exact-head overlap lift — redis_limiter.py vs PR #8939 (2026-08-28)" recorded in both `AGENTS.md` and the mission `library/operator-approvals.md`. The lift covers ONLY this file's shim-import repoint at `:95` and is VOID if #8939's head moves; the head was re-verified unchanged at path-freeze, pre-commit, and pre-push. No other open-PR overlap exists (82 open PRs censused, none with >=100 files).

## Additional bounded change

One-line local type annotation in `redis_limiter.py` (`metrics_data` mapping): pre-existing main-side typing debt surfaced by the changed-file mypy gate (`preflight_mypy.sh` checks every touched file; the identical error reproduces on the base version of the file). Identical runtime semantics.

## Validation

- Red: `python3 -m pytest tests/server/test_redis_config_deprecation.py::TestConsumersUseCanonicalPath -q` at base -> 6 failed (`assert 1 == 0` each)
- Green: same command post-change -> 17 passed (full file, shim pins intact)
- `python3 -m pytest tests/server/test_session_store.py tests/server/test_shutdown_sequence_pool.py tests/server/test_shutdown_drain.py tests/workflow/test_checkpoint_store*.py tests/tenancy/test_quota_persistence.py tests/server/middleware/test_redis_limiter.py tests/server/middleware/rate_limit/test_redis_limiter.py tests/server/middleware/test_redis_rate_limiter_distributed.py -q` -> 630 passed
- `make lint` + `ruff format --check aragora/ tests/ scripts/` -> clean
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (committed state) -> no issues in 9 source files
- AWS-neutralized `make test-smoke` -> pass; `scripts/test_tiers.sh smoke` -> 138 passed
- 5-seed randomized sweep of the two touched test files -> 121 passed on every seed

## Risks

Low. Import-path change to an identity-equal canonical module; no behavior change. Rollback = revert.

Measured diff: +140/-11 = 151 changed lines across 9 files.
