### PR TITLE
fix(server): close C1 control-char and huge-int OverflowError input gaps

### DIFF
--- a/aragora/server/handlers/budgets.py
+++ b/aragora/server/handlers/budgets.py
@@ -65,7 +65,12 @@ _circuit_breaker_lock = threading.Lock()
 
 def _coerce_finite_float(value: Any) -> float:
     """Coerce numeric input to a finite float."""
-    parsed = float(value)
+    try:
+        parsed = float(value)
+    except OverflowError as exc:
+        # float() of an arbitrary-precision JSON int raises OverflowError,
+        # which the ValueError-based call sites would let escape as a 500.
+        raise ValueError("Value must be finite") from exc
     if not math.isfinite(parsed):
         raise ValueError("Value must be finite")
     return parsed
@@ -189,7 +194,7 @@ class BudgetHandler(BaseHandler):
             from aragora.rbac.models import AuthorizationContext
 
             auth_ctx = AuthorizationContext(
-                user_id=user_ctx.user_id,
+                user_id=user_ctx.user_id or "unknown",
                 user_email=user_ctx.email,
                 org_id=user_ctx.org_id,
                 workspace_id=None,

--- a/aragora/server/handlers/usage_metering.py
+++ b/aragora/server/handlers/usage_metering.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import math
+import unicodedata
 import uuid
 from datetime import datetime, timezone
 
@@ -740,8 +741,11 @@ class UsageMeteringHandler(SecureHandler):
             return error_response("Field 'resource' is required", 400)
         resource = resource.strip()
         # The value feeds the audit log line below; control characters and
-        # unicode line separators would allow forged log entries.
-        if any(ord(ch) < 0x20 or ord(ch) == 0x7F or ch in "\u0085\u2028\u2029" for ch in resource):
+        # unicode line separators would allow forged log entries. Category Cc
+        # covers C0, DEL, and C1 (e.g. U+009B bare CSI, a terminal-escape
+        # vector when logs are viewed in terminals); LS/PS are separators
+        # outside Cc.
+        if any(unicodedata.category(ch) == "Cc" or ch in "\u2028\u2029" for ch in resource):
             return error_response("Field 'resource' contains invalid characters", 400)
         if len(resource) > 256:
             return error_response("Field 'resource' exceeds maximum length of 256", 400)

--- a/tests/server/handlers/test_budgets.py
+++ b/tests/server/handlers/test_budgets.py
@@ -631,6 +631,30 @@ class TestCreateBudget:
             assert status == 400
             assert "amount_usd" in body.get("error", "").lower()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("huge_amount", [10**400, -(10**400)])
+    async def test_create_budget_huge_integer_amount_returns_400(
+        self, budget_handler, mock_budget_manager, mock_user_context, huge_amount
+    ):
+        """Arbitrary-precision JSON ints must yield 400, not an OverflowError 500."""
+        handler = create_json_handler({"name": "Test", "amount_usd": huge_amount})
+
+        with (
+            patch("aragora.billing.jwt_auth.extract_user_from_request") as mock_extract,
+            patch.object(budget_handler, "_get_budget_manager", return_value=mock_budget_manager),
+            patch.object(budget_handler, "read_json_body") as mock_read_body,
+            patch("aragora.rbac.checker.get_permission_checker") as mock_checker,
+        ):
+            mock_extract.return_value = mock_user_context
+            mock_checker.return_value.check_permission.return_value = MagicMock(allowed=True)
+            mock_read_body.return_value = {"name": "Test", "amount_usd": huge_amount}
+
+            result = await budget_handler.handle("/api/v1/budgets", "POST", handler)
+            body, status = parse_response(result)
+
+            assert status == 400
+            assert "amount_usd" in body.get("error", "").lower()
+
 
 # ===========================================================================
 # Test: Get Budget
@@ -733,6 +757,33 @@ class TestUpdateBudget:
             assert status == 200
             assert body["name"] == "Updated Budget"
             assert body["amount_usd"] == 2000.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("huge_amount", [10**400, -(10**400)])
+    async def test_update_budget_huge_integer_amount_returns_400(
+        self, budget_handler, mock_budget_manager, mock_user_context, huge_amount
+    ):
+        """Arbitrary-precision JSON ints must yield 400, not an OverflowError 500."""
+        handler = create_json_handler(
+            {"amount_usd": huge_amount},
+            path="/api/v1/budgets/budget-123",
+        )
+
+        with (
+            patch("aragora.billing.jwt_auth.extract_user_from_request") as mock_extract,
+            patch.object(budget_handler, "_get_budget_manager", return_value=mock_budget_manager),
+            patch.object(budget_handler, "read_json_body") as mock_read_body,
+            patch("aragora.rbac.checker.get_permission_checker") as mock_checker,
+        ):
+            mock_extract.return_value = mock_user_context
+            mock_checker.return_value.check_permission.return_value = MagicMock(allowed=True)
+            mock_read_body.return_value = {"amount_usd": huge_amount}
+
+            result = await budget_handler.handle("/api/v1/budgets/budget-123", "PATCH", handler)
+            body, status = parse_response(result)
+
+            assert status == 400
+            assert "amount_usd" in body.get("error", "").lower()
 
 
 # ===========================================================================

--- a/tests/server/handlers/test_usage_metering.py
+++ b/tests/server/handlers/test_usage_metering.py
@@ -399,7 +399,20 @@ class TestQuotaIncreaseRequest:
 
     @pytest.mark.parametrize(
         "bad_resource",
-        ["debates\nfake-entry", "tok\rens", "a\x00b", "a\u0085b", "a\u2028b", "a\u2029b"],
+        [
+            "debates\nfake-entry",
+            "tok\rens",
+            "a\x00b",
+            "a\u0085b",
+            "a\u2028b",
+            "a\u2029b",
+            # C1 controls: not caught by an ord()<0x20/DEL check. U+009B is a
+            # bare CSI, a terminal-escape vector when logs are viewed in
+            # terminals.
+            "a\x80b",
+            "a\x9bb",
+            "a\x9fb",
+        ],
     )
     @pytest.mark.asyncio
     async def test_post_request_increase_rejects_control_chars_in_resource(


### PR DESCRIPTION
## Summary

Two bounded server-input hardening follow-ups from PR #9839's review rounds (merged as `98455f23`).

### 1. Quotas request-increase resource field: close the C1 gap

`POST /api/v1/quotas/request-increase` rejected C0/DEL/NEL/LS/PS in `resource`, but C1 controls (U+0080-U+009F) passed through, including U+009B bare CSI, a terminal-escape vector when audit logs are viewed in terminals. The check now rejects every Unicode `Cc` char (C0 + DEL + C1, incl. NEL) plus the LS/PS separators via `unicodedata.category`.

### 2. isfinite/OverflowError census + budgets fix

Measure-first census of every `math.isfinite` site applied to request/JSON-derived numbers (JSON parses arbitrary-precision ints natively; `float()` raises OverflowError on them, and OverflowError is not in `_EXCEPTION_STATUS_MAP`, so it surfaces as a 500 traceback — the class that bit #9839 round 2).

- 19 sites across 14 files in `aragora/` enumerated (plus scripts/, out of serving scope).
- Exactly ONE affected request-derived site: `aragora/server/handlers/budgets.py::_coerce_finite_float`. `float(10**400)` raises OverflowError, escaping both the call sites' `except (ValueError, TypeError)` and the methods' broad except tuples, so POST `/api/v1/budgets` and PATCH `/api/v1/budgets/:id` 500 on a huge `amount_usd` int. Fixed inside the helper by converting OverflowError to the ValueError contract the callers already handle; both paths now return 400.
- All other sites proven safe by provenance: `usage_metering` already fixed in #9839; `swarm/settle_plan` + `swarm/wip_budget` already scoped; `burnin` (typed dataclass), `evaluation/viah` (argparse-coerced), `vibeproxy`/`claude_vibeproxy`/`quorum_evidence`/`review_adjudicator`/`loop_budget` (env/config strings through `float()`, no huge-int path), `gti/receipt` (no external callers), `gti/scenarios` (CLI-loaded, isinstance-guarded), `essay/rubric` (model output, not request JSON; noted as latent, not fixed here).
- `_EXCEPTION_STATUS_MAP` untouched: with a single affected site the scoped fix is the sane fix, no server-wide semantics decision needed.

Also includes a 1-line pre-existing mypy repair in `budgets.py` (`user_id or "unknown"`, the sibling pattern from `canvas_pipeline.py:690`), required because the changed-file `typecheck` CI gate has no baseline and would go red on the touched file.

## Red-first proof

On unmodified production code: the 3 new C1 param cases returned 200 (`assert 200 == 400`) and all 4 huge-int cases died with raw `OverflowError: int too large to convert to float`. After the fix: 73 passed across both test files.

## Validation

- `make lint` + `ruff format --check` clean
- `scripts/preflight_mypy.sh --diff-base origin/main`: no issues in 4 source files
- Hook-variant mypy (`--ignore-missing-imports --follow-imports=skip`) on both touched `aragora/` files: clean
- Targeted: 73 passed; 5-seed randomized sweep all green
- AWS-neutralized `make test-smoke` pass; smoke tier 138 passed (matches baseline)
- +77/-4 across 4 files; path-freeze census over all 82 open PRs: every touched path CLEAN
