### PR TITLE
fix(deploy): invoke the actual migrations CLI from Docker entrypoint

### DIFF
--- a/deploy/scripts/docker-entrypoint.sh
+++ b/deploy/scripts/docker-entrypoint.sh
@@ -46,7 +46,7 @@ fi
 if [ "${SKIP_MIGRATIONS}" != "1" ]; then
     if [ -n "${DATABASE_URL}" ] || [ -n "${ARAGORA_POSTGRES_DSN}" ]; then
         echo "[entrypoint] Running database migrations..."
-        python -m aragora.migrations upgrade 2>&1 || {
+        python -m aragora.migrations upgrade --database-url "${DATABASE_URL:-${ARAGORA_POSTGRES_DSN}}" 2>&1 || {
             echo "[entrypoint] WARNING: Migration failed. Server will start but may use degraded mode."
             echo "[entrypoint] Check DATABASE_URL and database connectivity."
         }

--- a/deploy/scripts/docker-entrypoint.sh
+++ b/deploy/scripts/docker-entrypoint.sh
@@ -46,7 +46,7 @@ fi
 if [ "${SKIP_MIGRATIONS}" != "1" ]; then
     if [ -n "${DATABASE_URL}" ] || [ -n "${ARAGORA_POSTGRES_DSN}" ]; then
         echo "[entrypoint] Running database migrations..."
-        python -m aragora.migrations.runner upgrade 2>&1 || {
+        python -m aragora.migrations upgrade 2>&1 || {
             echo "[entrypoint] WARNING: Migration failed. Server will start but may use degraded mode."
             echo "[entrypoint] Check DATABASE_URL and database connectivity."
         }

--- a/deploy/scripts/docker-entrypoint.sh
+++ b/deploy/scripts/docker-entrypoint.sh
@@ -5,9 +5,15 @@
 # Usage: Set as ENTRYPOINT in Dockerfile, or call directly.
 # Environment:
 #   SKIP_MIGRATIONS=1  - Skip migration step (e.g., for worker containers)
-#   DATABASE_URL       - PostgreSQL connection string (required for migrations)
+#   DATABASE_URL / ARAGORA_POSTGRES_DSN - PostgreSQL connection string
 
 set -e
+
+if [ -n "${DATABASE_URL}" ] || [ -n "${ARAGORA_POSTGRES_DSN}" ]; then
+    DATABASE_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}"
+    ARAGORA_POSTGRES_DSN="$DATABASE_URL"
+    export DATABASE_URL ARAGORA_POSTGRES_DSN
+fi
 
 echo "[entrypoint] Aragora server starting..."
 echo "[entrypoint] ARAGORA_ENV=${ARAGORA_ENV:-not set}"
@@ -16,9 +22,9 @@ echo "[entrypoint] ARAGORA_ENV=${ARAGORA_ENV:-not set}"
 # Wait for PostgreSQL (if configured)
 # --------------------------------------------------------------------------
 if [ -n "${DATABASE_URL}" ] || [ -n "${ARAGORA_POSTGRES_DSN}" ]; then
-    # Extract host and port from DATABASE_URL for a simple TCP check.
+    # Extract host and port from the resolved PostgreSQL URL for a simple TCP check.
     # Format: postgresql://user:pass@host:port/dbname
-    DB_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}"
+    DB_URL="$DATABASE_URL"
     DB_HOST=$(echo "$DB_URL" | sed -n 's|.*@\([^:/]*\).*|\1|p')
     DB_PORT=$(echo "$DB_URL" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
     DB_PORT=${DB_PORT:-5432}
@@ -46,7 +52,7 @@ fi
 if [ "${SKIP_MIGRATIONS}" != "1" ]; then
     if [ -n "${DATABASE_URL}" ] || [ -n "${ARAGORA_POSTGRES_DSN}" ]; then
         echo "[entrypoint] Running database migrations..."
-        DATABASE_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}" python -m aragora.migrations upgrade 2>&1 || {
+        python -m aragora.migrations upgrade 2>&1 || {
             echo "[entrypoint] WARNING: Migration failed. Server will start but may use degraded mode."
             echo "[entrypoint] Check DATABASE_URL and database connectivity."
         }

--- a/deploy/scripts/docker-entrypoint.sh
+++ b/deploy/scripts/docker-entrypoint.sh
@@ -18,7 +18,7 @@ echo "[entrypoint] ARAGORA_ENV=${ARAGORA_ENV:-not set}"
 if [ -n "${DATABASE_URL}" ] || [ -n "${ARAGORA_POSTGRES_DSN}" ]; then
     # Extract host and port from DATABASE_URL for a simple TCP check.
     # Format: postgresql://user:pass@host:port/dbname
-    DB_URL="${DATABASE_URL:-${ARAGORA_POSTGRES_DSN}}"
+    DB_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}"
     DB_HOST=$(echo "$DB_URL" | sed -n 's|.*@\([^:/]*\).*|\1|p')
     DB_PORT=$(echo "$DB_URL" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
     DB_PORT=${DB_PORT:-5432}
@@ -46,7 +46,7 @@ fi
 if [ "${SKIP_MIGRATIONS}" != "1" ]; then
     if [ -n "${DATABASE_URL}" ] || [ -n "${ARAGORA_POSTGRES_DSN}" ]; then
         echo "[entrypoint] Running database migrations..."
-        python -m aragora.migrations upgrade --database-url "${DATABASE_URL:-${ARAGORA_POSTGRES_DSN}}" 2>&1 || {
+        DATABASE_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}" python -m aragora.migrations upgrade 2>&1 || {
             echo "[entrypoint] WARNING: Migration failed. Server will start but may use degraded mode."
             echo "[entrypoint] Check DATABASE_URL and database connectivity."
         }

--- a/tests/scripts/test_docker_entrypoint_migrations.py
+++ b/tests/scripts/test_docker_entrypoint_migrations.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_docker_entrypoint_invokes_the_migration_cli() -> None:
+    entrypoint = (
+        Path(__file__).resolve().parents[2] / "deploy/scripts/docker-entrypoint.sh"
+    ).read_text(encoding="utf-8")
+    assert "python -m aragora.migrations upgrade" in entrypoint
+    assert "python -m aragora.migrations.runner upgrade" not in entrypoint

--- a/tests/scripts/test_docker_entrypoint_migrations.py
+++ b/tests/scripts/test_docker_entrypoint_migrations.py
@@ -7,10 +7,10 @@ def test_docker_entrypoint_invokes_the_migration_cli() -> None:
     entrypoint = (
         Path(__file__).resolve().parents[2] / "deploy/scripts/docker-entrypoint.sh"
     ).read_text(encoding="utf-8")
-    assert (
-        'DATABASE_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}" '
-        "python -m aragora.migrations upgrade" in entrypoint
-    )
+    assert 'DATABASE_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}"' in entrypoint
+    assert 'ARAGORA_POSTGRES_DSN="$DATABASE_URL"' in entrypoint
+    assert "export DATABASE_URL ARAGORA_POSTGRES_DSN" in entrypoint
+    assert "python -m aragora.migrations upgrade" in entrypoint
     assert 'upgrade --database-url "${' not in entrypoint
     assert "python -m aragora.migrations.runner upgrade" not in entrypoint
 

--- a/tests/scripts/test_docker_entrypoint_migrations.py
+++ b/tests/scripts/test_docker_entrypoint_migrations.py
@@ -1,9 +1,25 @@
 from pathlib import Path
+import subprocess
+import sys
 
 
 def test_docker_entrypoint_invokes_the_migration_cli() -> None:
     entrypoint = (
         Path(__file__).resolve().parents[2] / "deploy/scripts/docker-entrypoint.sh"
     ).read_text(encoding="utf-8")
-    assert "python -m aragora.migrations upgrade" in entrypoint
+    assert (
+        'python -m aragora.migrations upgrade --database-url "${DATABASE_URL:-${ARAGORA_POSTGRES_DSN}}"'
+        in entrypoint
+    )
     assert "python -m aragora.migrations.runner upgrade" not in entrypoint
+
+
+def test_migration_module_exposes_upgrade_cli() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "aragora.migrations", "upgrade", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--database-url" in result.stdout

--- a/tests/scripts/test_docker_entrypoint_migrations.py
+++ b/tests/scripts/test_docker_entrypoint_migrations.py
@@ -8,9 +8,10 @@ def test_docker_entrypoint_invokes_the_migration_cli() -> None:
         Path(__file__).resolve().parents[2] / "deploy/scripts/docker-entrypoint.sh"
     ).read_text(encoding="utf-8")
     assert (
-        'python -m aragora.migrations upgrade --database-url "${DATABASE_URL:-${ARAGORA_POSTGRES_DSN}}"'
-        in entrypoint
+        'DATABASE_URL="${ARAGORA_POSTGRES_DSN:-${DATABASE_URL}}" '
+        "python -m aragora.migrations upgrade" in entrypoint
     )
+    assert 'upgrade --database-url "${' not in entrypoint
     assert "python -m aragora.migrations.runner upgrade" not in entrypoint
 
 


### PR DESCRIPTION
## Summary
- Fix a pre-existing silent no-op: `python -m aragora.migrations.runner upgrade` only imports a module with no CLI.
- Invoke `python -m aragora.migrations upgrade`, whose `__main__` dispatches the real upgrade command.
- Add a regression pinning the entrypoint command.

Discovered during provider-neutral canary review; independent of #9391 stack.

## Test plan
- [x] focused pytest
- [x] `bash -n deploy/scripts/docker-entrypoint.sh`
- [x] pre-commit/pre-push hooks

Generated with [Devin](https://devin.ai)

Folded into and superseded by #9882 through merge of commit c814bcdba5ecb5be9006fc2486a49b3e14f57cc0. The combined deploy pack carries the entrypoint fix and runtime verification; settlement remains operator-owned.
