### PR TITLE
docs(openapi): backfill runtime-true contracts for served sdk_missing entries

### DIFF
--- a/aragora/server/openapi/endpoints/sdk_missing.py
+++ b/aragora/server/openapi/endpoints/sdk_missing.py
@@ -238,13 +238,31 @@ SDK_MISSING_ENDPOINTS: dict = {
         },
     },
     # --- matches ---
+    # Served: MatchesStatsHandler.handle exact-matches the version-stripped
+    # path and returns EloSystem.get_stats() verbatim. Public read (no auth
+    # check), like the other ranking reads; every key is always present
+    # because missing aggregates fall back to defaults.
     "/api/matches/stats": {
         "get": {
             "tags": ["Matches"],
             "summary": "Get match statistics",
             "description": "Return aggregate statistics for the match system.",
             "operationId": "getMatchStats",
-            "responses": {"200": _ok_response("Match statistics", _obj)},
+            "responses": {
+                "200": _ok_response(
+                    "Match statistics",
+                    {
+                        "type": "object",
+                        "properties": {
+                            "total_agents": {"type": "integer"},
+                            "avg_elo": {"type": "number"},
+                            "max_elo": {"type": "number"},
+                            "min_elo": {"type": "number"},
+                            "total_matches": {"type": "integer"},
+                        },
+                    },
+                )
+            },
         },
     },
     "/api/matches/{match_id}": {
@@ -340,22 +358,141 @@ SDK_MISSING_ENDPOINTS: dict = {
         },
     },
     # --- reputation ---
+    # Served: CritiqueHandler.handle lists the raw path in ROUTES and sits
+    # behind require_permission("critiques:read"). Missing ?domain= is a 400;
+    # limit is clamped to 1..1000 (default 100). The reputation rows mirror
+    # _get_reputation_by_domain's projection of AgentReputation.
     "/api/reputation/domain": {
         "get": {
             "tags": ["Reputation"],
             "summary": "Get domain reputation scores",
-            "description": "Return domain-level reputation scores or reputation summaries.",
+            "description": (
+                "Return domain-level reputation scores or reputation summaries. "
+                "Requires the critiques:read permission."
+            ),
             "operationId": "getReputationDomain",
-            "responses": {"200": _ok_response("Domain reputation", _obj)},
+            "parameters": [
+                {
+                    "name": "domain",
+                    "in": "query",
+                    "required": True,
+                    "description": "Domain token matched against agent names.",
+                    "schema": _str,
+                },
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "required": False,
+                    "description": "Maximum reputations to return.",
+                    "schema": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 1000,
+                        "default": 100,
+                    },
+                },
+            ],
+            "responses": {
+                "200": _ok_response(
+                    "Domain reputation",
+                    {
+                        "type": "object",
+                        "properties": {
+                            "domain": _str,
+                            "reputations": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "agent": _str,
+                                        "score": {"type": "number"},
+                                        "vote_weight": {"type": "number"},
+                                        "proposal_acceptance_rate": {"type": "number"},
+                                        "critique_value": {"type": "number"},
+                                        "debates_participated": {"type": "integer"},
+                                    },
+                                },
+                            },
+                            "count": {"type": "integer"},
+                        },
+                    },
+                )
+            },
+            "security": [{"bearerAuth": []}],
         },
     },
+    # Served: same CritiqueHandler ROUTES dispatch and critiques:read
+    # permission as /api/reputation/domain. Snapshots derive from stored
+    # reputation rows; timestamp is AgentReputation.updated_at (a string
+    # defaulting to "", never null) and event is always "snapshot".
     "/api/reputation/history": {
         "get": {
             "tags": ["Reputation"],
             "summary": "Get reputation history",
-            "description": "List historical reputation events or score snapshots.",
+            "description": (
+                "List historical reputation events or score snapshots. "
+                "Requires the critiques:read permission."
+            ),
             "operationId": "getReputationHistory",
-            "responses": {"200": _ok_response("Reputation history", _arr_obj)},
+            "parameters": [
+                {
+                    "name": "agent",
+                    "in": "query",
+                    "required": False,
+                    "description": "Restrict snapshots to a single agent.",
+                    "schema": _str,
+                },
+                {
+                    "name": "start_date",
+                    "in": "query",
+                    "required": False,
+                    "description": "ISO-8601 lower bound; invalid values are a 400.",
+                    "schema": _str,
+                },
+                {
+                    "name": "end_date",
+                    "in": "query",
+                    "required": False,
+                    "description": "ISO-8601 upper bound; invalid values are a 400.",
+                    "schema": _str,
+                },
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "required": False,
+                    "description": "Maximum snapshots to return.",
+                    "schema": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 1000,
+                        "default": 100,
+                    },
+                },
+            ],
+            "responses": {
+                "200": _ok_response(
+                    "Reputation history",
+                    {
+                        "type": "object",
+                        "properties": {
+                            "history": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "timestamp": _str,
+                                        "agent": _str,
+                                        "reputation": {"type": "number"},
+                                        "event": _str,
+                                    },
+                                },
+                            },
+                            "count": {"type": "integer"},
+                        },
+                    },
+                )
+            },
+            "security": [{"bearerAuth": []}],
         },
     },
     "/api/reputation/{agent_id}": {

--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -39279,7 +39279,24 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "total_agents": {
+                      "type": "integer"
+                    },
+                    "avg_elo": {
+                      "type": "number"
+                    },
+                    "max_elo": {
+                      "type": "number"
+                    },
+                    "min_elo": {
+                      "type": "number"
+                    },
+                    "total_matches": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -50502,7 +50519,30 @@
           "Reputation"
         ],
         "summary": "Get domain reputation scores",
-        "description": "Return domain-level reputation scores or reputation summaries.",
+        "description": "Return domain-level reputation scores or reputation summaries. Requires the critiques:read permission.",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "required": true,
+            "description": "Domain token matched against agent names.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum reputations to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Domain reputation",
@@ -50524,12 +50564,51 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "domain": {
+                      "type": "string"
+                    },
+                    "reputations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "agent": {
+                            "type": "string"
+                          },
+                          "score": {
+                            "type": "number"
+                          },
+                          "vote_weight": {
+                            "type": "number"
+                          },
+                          "proposal_acceptance_rate": {
+                            "type": "number"
+                          },
+                          "critique_value": {
+                            "type": "number"
+                          },
+                          "debates_participated": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "deprecated": true,
         "x-aragora-stability": "deprecated",
         "operationId": "listReputationDomain"
@@ -50541,7 +50620,48 @@
           "Reputation"
         ],
         "summary": "Get reputation history",
-        "description": "List historical reputation events or score snapshots.",
+        "description": "List historical reputation events or score snapshots. Requires the critiques:read permission.",
+        "parameters": [
+          {
+            "name": "agent",
+            "in": "query",
+            "required": false,
+            "description": "Restrict snapshots to a single agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "description": "ISO-8601 lower bound; invalid values are a 400.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "description": "ISO-8601 upper bound; invalid values are a 400.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum snapshots to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Reputation history",
@@ -50563,15 +50683,42 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "history": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "timestamp": {
+                            "type": "string"
+                          },
+                          "agent": {
+                            "type": "string"
+                          },
+                          "reputation": {
+                            "type": "number"
+                          },
+                          "event": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "deprecated": true,
         "x-aragora-stability": "deprecated",
         "operationId": "listReputationHistory"
@@ -182676,7 +182823,24 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "total_agents": {
+                      "type": "integer"
+                    },
+                    "avg_elo": {
+                      "type": "number"
+                    },
+                    "max_elo": {
+                      "type": "number"
+                    },
+                    "min_elo": {
+                      "type": "number"
+                    },
+                    "total_matches": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -215735,8 +215899,31 @@
           "Reputation"
         ],
         "summary": "Get domain reputation scores",
-        "description": "Return domain-level reputation scores or reputation summaries.",
+        "description": "Return domain-level reputation scores or reputation summaries. Requires the critiques:read permission.",
         "operationId": "getReputationDomain",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "required": true,
+            "description": "Domain token matched against agent names.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum reputations to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Domain reputation",
@@ -215758,12 +215945,51 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "domain": {
+                      "type": "string"
+                    },
+                    "reputations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "agent": {
+                            "type": "string"
+                          },
+                          "score": {
+                            "type": "number"
+                          },
+                          "vote_weight": {
+                            "type": "number"
+                          },
+                          "proposal_acceptance_rate": {
+                            "type": "number"
+                          },
+                          "critique_value": {
+                            "type": "number"
+                          },
+                          "debates_participated": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-aragora-stability": "stable"
       }
     },
@@ -215773,8 +215999,49 @@
           "Reputation"
         ],
         "summary": "Get reputation history",
-        "description": "List historical reputation events or score snapshots.",
+        "description": "List historical reputation events or score snapshots. Requires the critiques:read permission.",
         "operationId": "getReputationHistory",
+        "parameters": [
+          {
+            "name": "agent",
+            "in": "query",
+            "required": false,
+            "description": "Restrict snapshots to a single agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "description": "ISO-8601 lower bound; invalid values are a 400.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "description": "ISO-8601 upper bound; invalid values are a 400.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum snapshots to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Reputation history",
@@ -215796,15 +216063,42 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "history": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "timestamp": {
+                            "type": "string"
+                          },
+                          "agent": {
+                            "type": "string"
+                          },
+                          "reputation": {
+                            "type": "number"
+                          },
+                          "event": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-aragora-stability": "stable"
       }
     },

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -22907,6 +22907,17 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  total_agents:
+                    type: integer
+                  avg_elo:
+                    type: number
+                  max_elo:
+                    type: number
+                  min_elo:
+                    type: number
+                  total_matches:
+                    type: integer
       deprecated: true
       x-aragora-stability: deprecated
   /api/matches/{match_id}:
@@ -29577,7 +29588,23 @@ paths:
       tags:
       - Reputation
       summary: Get domain reputation scores
-      description: Return domain-level reputation scores or reputation summaries.
+      description: Return domain-level reputation scores or reputation summaries. Requires the critiques:read permission.
+      parameters:
+      - name: domain
+        in: query
+        required: true
+        description: Domain token matched against agent names.
+        schema: &id189
+          type: string
+      - name: limit
+        in: query
+        required: false
+        description: Maximum reputations to return.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 100
       responses:
         '200':
           description: Domain reputation
@@ -29595,6 +29622,28 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  domain: *id189
+                  reputations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        agent: *id189
+                        score:
+                          type: number
+                        vote_weight:
+                          type: number
+                        proposal_acceptance_rate:
+                          type: number
+                        critique_value:
+                          type: number
+                        debates_participated:
+                          type: integer
+                  count:
+                    type: integer
+      security:
+      - bearerAuth: []
       deprecated: true
       x-aragora-stability: deprecated
   /api/reputation/history:
@@ -29602,7 +29651,33 @@ paths:
       tags:
       - Reputation
       summary: Get reputation history
-      description: List historical reputation events or score snapshots.
+      description: List historical reputation events or score snapshots. Requires the critiques:read permission.
+      parameters:
+      - name: agent
+        in: query
+        required: false
+        description: Restrict snapshots to a single agent.
+        schema: &id190
+          type: string
+      - name: start_date
+        in: query
+        required: false
+        description: ISO-8601 lower bound; invalid values are a 400.
+        schema: *id190
+      - name: end_date
+        in: query
+        required: false
+        description: ISO-8601 upper bound; invalid values are a 400.
+        schema: *id190
+      - name: limit
+        in: query
+        required: false
+        description: Maximum snapshots to return.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 100
       responses:
         '200':
           description: Reputation history
@@ -29619,9 +29694,22 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
+                type: object
+                properties:
+                  history:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        timestamp: *id190
+                        agent: *id190
+                        reputation:
+                          type: number
+                        event: *id190
+                  count:
+                    type: integer
+      security:
+      - bearerAuth: []
       deprecated: true
       x-aragora-stability: deprecated
   /api/reputation/{agent_id}:
@@ -29674,7 +29762,7 @@ paths:
       responses:
         '200':
           description: List of expiring items
-          headers: &id189
+          headers: &id191
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -29697,7 +29785,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id189
+          headers: *id191
           content:
             application/json:
               schema:
@@ -29728,7 +29816,7 @@ paths:
       responses:
         '200':
           description: List of retention policies
-          headers: &id190
+          headers: &id192
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -29742,9 +29830,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicyList'
-        '401': &id191
+        '401': &id193
           description: Unauthorized - Authentication required or token invalid
-          headers: *id190
+          headers: *id192
           content:
             application/json:
               schema:
@@ -29802,14 +29890,14 @@ paths:
       responses:
         '201':
           description: Policy created
-          headers: *id190
+          headers: *id192
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id190
+          headers: *id192
           content:
             application/json:
               schema:
@@ -29835,10 +29923,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id191
+        '401': *id193
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id190
+          headers: *id192
           content:
             application/json:
               schema:
@@ -29877,7 +29965,7 @@ paths:
       responses:
         '200':
           description: Execution result with affected items count
-          headers: &id192
+          headers: &id194
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -29900,7 +29988,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id192
+          headers: *id194
           content:
             application/json:
               schema:
@@ -29920,7 +30008,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id192
+          headers: *id194
           content:
             application/json:
               schema:
@@ -29942,7 +30030,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id192
+          headers: *id194
           content:
             application/json:
               schema:
@@ -29973,7 +30061,7 @@ paths:
       responses:
         '200':
           description: Rolling-window triage metrics
-          headers: &id194
+          headers: &id196
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -29995,7 +30083,7 @@ paths:
                     - 7d
                     - 30d
                     properties:
-                      7d: &id193
+                      7d: &id195
                         type: object
                         additionalProperties: false
                         required:
@@ -30092,7 +30180,7 @@ paths:
                               type: string
                             description: Explanations keyed by metric name for any null-valued metric above. Empty when no
                               metrics were suppressed.
-                      30d: *id193
+                      30d: *id195
                   drift:
                     type: object
                     additionalProperties:
@@ -30129,7 +30217,7 @@ paths:
           description: "Not Modified \u2014 ETag matched If-None-Match."
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id194
+          headers: *id196
           content:
             application/json:
               schema:
@@ -30149,7 +30237,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id194
+          headers: *id196
           content:
             application/json:
               schema:
@@ -30171,7 +30259,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id194
+          headers: *id196
           content:
             application/json:
               schema:
@@ -30188,7 +30276,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id194
+          headers: *id196
           content:
             application/json:
               schema:
@@ -30501,7 +30589,7 @@ paths:
       responses:
         '200':
           description: Execution timeline
-          headers: &id195
+          headers: &id197
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -30522,7 +30610,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id195
+          headers: *id197
           content:
             application/json:
               schema:
@@ -30542,7 +30630,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id195
+          headers: *id197
           content:
             application/json:
               schema:
@@ -30684,272 +30772,6 @@ paths:
       responses:
         '201':
           description: Queued improvement goal
-          headers: &id196
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                    properties:
-                      id:
-                        type: string
-                      goal:
-                        type: string
-                      priority:
-                        type: integer
-                      source:
-                        type: string
-                      status:
-                        type: string
-                      createdAt:
-                        type: string
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id196
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id196
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id196
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '503':
-          description: Improvement queue unavailable
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                properties:
-                  error:
-                    type: string
-      security:
-      - bearerAuth: []
-      deprecated: true
-      x-aragora-stability: deprecated
-  /api/self-improve/improvement-queue/{id}:
-    delete:
-      tags:
-      - Nomic
-      summary: Delete self-improvement queue item
-      description: Remove an item from the self-improvement queue.
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Self-improvement queue item id.
-      responses:
-        '200':
-          description: Deleted queue item
-          headers: &id197
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                    properties:
-                      id:
-                        type: string
-                      goal:
-                        type: string
-                      priority:
-                        type: integer
-                      source:
-                        type: string
-                      status:
-                        type: string
-                      createdAt:
-                        type: string
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id197
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id197
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id197
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '503':
-          description: Improvement queue unavailable
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                properties:
-                  error:
-                    type: string
-      security:
-      - bearerAuth: []
-      deprecated: true
-      x-aragora-stability: deprecated
-  /api/self-improve/improvement-queue/{id}/priority:
-    put:
-      tags:
-      - Nomic
-      summary: Update self-improvement queue priority
-      description: Update the priority for a self-improvement queue item.
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Self-improvement queue item id.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-              properties:
-                priority:
-                  type: integer
-                  minimum: 0
-                  maximum: 100
-              required:
-              - priority
-      responses:
-        '200':
-          description: Updated queue item priority
           headers: &id198
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -31052,9 +30874,275 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
+        '503':
+          description: Improvement queue unavailable
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  error:
+                    type: string
+      security:
+      - bearerAuth: []
+      deprecated: true
+      x-aragora-stability: deprecated
+  /api/self-improve/improvement-queue/{id}:
+    delete:
+      tags:
+      - Nomic
+      summary: Delete self-improvement queue item
+      description: Remove an item from the self-improvement queue.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Self-improvement queue item id.
+      responses:
+        '200':
+          description: Deleted queue item
+          headers: &id199
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                    properties:
+                      id:
+                        type: string
+                      goal:
+                        type: string
+                      priority:
+                        type: integer
+                      source:
+                        type: string
+                      status:
+                        type: string
+                      createdAt:
+                        type: string
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id199
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id199
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id198
+          headers: *id199
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '503':
+          description: Improvement queue unavailable
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  error:
+                    type: string
+      security:
+      - bearerAuth: []
+      deprecated: true
+      x-aragora-stability: deprecated
+  /api/self-improve/improvement-queue/{id}/priority:
+    put:
+      tags:
+      - Nomic
+      summary: Update self-improvement queue priority
+      description: Update the priority for a self-improvement queue item.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Self-improvement queue item id.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              properties:
+                priority:
+                  type: integer
+                  minimum: 0
+                  maximum: 100
+              required:
+              - priority
+      responses:
+        '200':
+          description: Updated queue item priority
+          headers: &id200
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                    properties:
+                      id:
+                        type: string
+                      goal:
+                        type: string
+                      priority:
+                        type: integer
+                      source:
+                        type: string
+                      status:
+                        type: string
+                      createdAt:
+                        type: string
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id200
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id200
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id200
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id200
           content:
             application/json:
               schema:
@@ -31091,155 +31179,6 @@ paths:
       responses:
         '200':
           description: Learning insights
-          headers: &id199
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id199
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id199
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      deprecated: true
-      x-aragora-stability: deprecated
-  /api/self-improve/meta-planner/goals:
-    get:
-      tags:
-      - Nomic
-      summary: List self-improvement meta-planner goals
-      description: Return prioritized MetaPlanner goals, codebase signals, and queue summary data for the self-improvement
-        dashboard.
-      responses:
-        '200':
-          description: Meta-planner goals
-          headers: &id200
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id200
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id200
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      deprecated: true
-      x-aragora-stability: deprecated
-  /api/self-improve/metrics/comparison:
-    get:
-      tags:
-      - Nomic
-      summary: Get self-improvement metrics comparison
-      description: Return before/after codebase metrics and regression comparisons across self-improvement cycles.
-      responses:
-        '200':
-          description: Metrics comparison
           headers: &id201
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -31282,6 +31221,155 @@ paths:
         '403':
           description: Forbidden - Insufficient permissions for this operation
           headers: *id201
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      deprecated: true
+      x-aragora-stability: deprecated
+  /api/self-improve/meta-planner/goals:
+    get:
+      tags:
+      - Nomic
+      summary: List self-improvement meta-planner goals
+      description: Return prioritized MetaPlanner goals, codebase signals, and queue summary data for the self-improvement
+        dashboard.
+      responses:
+        '200':
+          description: Meta-planner goals
+          headers: &id202
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id202
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id202
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      deprecated: true
+      x-aragora-stability: deprecated
+  /api/self-improve/metrics/comparison:
+    get:
+      tags:
+      - Nomic
+      summary: Get self-improvement metrics comparison
+      description: Return before/after codebase metrics and regression comparisons across self-improvement cycles.
+      responses:
+        '200':
+          description: Metrics comparison
+          headers: &id203
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id203
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id203
           content:
             application/json:
               schema:
@@ -31475,7 +31563,7 @@ paths:
       responses:
         '200':
           description: Cycle trends
-          headers: &id204
+          headers: &id206
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -31495,16 +31583,16 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      cycles: &id203
+                      cycles: &id205
                         type: array
-                        items: &id202
+                        items: &id204
                           type: object
                           additionalProperties: true
-                      summary: *id202
-                      run_costs: *id203
+                      summary: *id204
+                      run_costs: *id205
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id204
+          headers: *id206
           content:
             application/json:
               schema:
@@ -31524,7 +31612,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id204
+          headers: *id206
           content:
             application/json:
               schema:
@@ -32535,13 +32623,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id205
+        schema: &id207
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id205
+        schema: *id207
       responses:
         '200':
           description: Ticket updated
@@ -32572,13 +32660,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id206
+        schema: &id208
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id206
+        schema: *id208
       responses:
         '200':
           description: Reply sent
@@ -33217,7 +33305,7 @@ paths:
       responses:
         '200':
           description: List of linked providers
-          headers: &id207
+          headers: &id209
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -33244,7 +33332,7 @@ paths:
                           format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id207
+          headers: *id209
           content:
             application/json:
               schema:
@@ -33415,7 +33503,7 @@ paths:
       responses:
         '200':
           description: Agent details
-          headers: &id208
+          headers: &id210
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -33454,7 +33542,7 @@ paths:
                     - offline
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id208
+          headers: *id210
           content:
             application/json:
               schema:
@@ -33474,7 +33562,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id208
+          headers: *id210
           content:
             application/json:
               schema:
@@ -33664,7 +33752,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id209
+          headers: &id211
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -33701,7 +33789,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id209
+          headers: *id211
           content:
             application/json:
               schema:
@@ -33721,7 +33809,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id209
+          headers: *id211
           content:
             application/json:
               schema:
@@ -33804,9 +33892,9 @@ paths:
                   completed_at:
                     type: string
                     format: date-time
-        '401': &id211
+        '401': &id213
           description: Unauthorized - Authentication required or token invalid
-          headers: &id210
+          headers: &id212
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -33833,9 +33921,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id212
+        '404': &id214
           description: Not found - The requested resource does not exist
-          headers: *id210
+          headers: *id212
           content:
             application/json:
               schema:
@@ -33878,11 +33966,11 @@ paths:
       responses:
         '204':
           description: Task cancelled successfully
-        '401': *id211
-        '404': *id212
+        '401': *id213
+        '404': *id214
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id210
+          headers: *id212
           content:
             application/json:
               schema:
@@ -34415,7 +34503,7 @@ paths:
       responses:
         '200':
           description: Callback
-          headers: &id213
+          headers: &id215
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -34431,7 +34519,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id213
+          headers: *id215
           content:
             application/json:
               schema:
@@ -34459,7 +34547,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id213
+          headers: *id215
           content:
             application/json:
               schema:
@@ -34485,7 +34573,7 @@ paths:
       responses:
         '200':
           description: Connect
-          headers: &id214
+          headers: &id216
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -34501,7 +34589,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id214
+          headers: *id216
           content:
             application/json:
               schema:
@@ -34527,7 +34615,7 @@ paths:
       responses:
         '200':
           description: Customers
-          headers: &id215
+          headers: &id217
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -34543,7 +34631,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id215
+          headers: *id217
           content:
             application/json:
               schema:
@@ -34569,7 +34657,7 @@ paths:
       responses:
         '200':
           description: Disconnected
-          headers: &id216
+          headers: &id218
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -34585,7 +34673,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id216
+          headers: *id218
           content:
             application/json:
               schema:
@@ -34910,7 +34998,7 @@ paths:
       responses:
         '200':
           description: Callback
-          headers: &id217
+          headers: &id219
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -34926,7 +35014,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id217
+          headers: *id219
           content:
             application/json:
               schema:
@@ -34954,7 +35042,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id217
+          headers: *id219
           content:
             application/json:
               schema:
@@ -34980,7 +35068,7 @@ paths:
       responses:
         '200':
           description: Connect
-          headers: &id218
+          headers: &id220
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -34996,7 +35084,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id218
+          headers: *id220
           content:
             application/json:
               schema:
@@ -35022,7 +35110,7 @@ paths:
       responses:
         '200':
           description: Disconnected
-          headers: &id219
+          headers: &id221
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35038,7 +35126,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id219
+          headers: *id221
           content:
             application/json:
               schema:
@@ -35069,7 +35157,7 @@ paths:
       responses:
         '200':
           description: Employees
-          headers: &id220
+          headers: &id222
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35085,7 +35173,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id220
+          headers: *id222
           content:
             application/json:
               schema:
@@ -35124,7 +35212,7 @@ paths:
       responses:
         '200':
           description: Payrolls
-          headers: &id221
+          headers: &id223
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35140,7 +35228,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id221
+          headers: *id223
           content:
             application/json:
               schema:
@@ -35168,7 +35256,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id221
+          headers: *id223
           content:
             application/json:
               schema:
@@ -35200,7 +35288,7 @@ paths:
       responses:
         '200':
           description: Payroll
-          headers: &id222
+          headers: &id224
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35216,7 +35304,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id222
+          headers: *id224
           content:
             application/json:
               schema:
@@ -35232,7 +35320,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id222
+          headers: *id224
           content:
             application/json:
               schema:
@@ -35286,7 +35374,7 @@ paths:
       responses:
         '200':
           description: Journal entry
-          headers: &id223
+          headers: &id225
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35302,7 +35390,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id223
+          headers: *id225
           content:
             application/json:
               schema:
@@ -35318,7 +35406,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id223
+          headers: *id225
           content:
             application/json:
               schema:
@@ -35344,7 +35432,7 @@ paths:
       responses:
         '200':
           description: Status
-          headers: &id224
+          headers: &id226
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35360,7 +35448,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id224
+          headers: *id226
           content:
             application/json:
               schema:
@@ -35765,7 +35853,7 @@ paths:
       responses:
         '200':
           description: Report
-          headers: &id225
+          headers: &id227
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35781,7 +35869,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id225
+          headers: *id227
           content:
             application/json:
               schema:
@@ -35809,7 +35897,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id225
+          headers: *id227
           content:
             application/json:
               schema:
@@ -35856,7 +35944,7 @@ paths:
       responses:
         '200':
           description: Status
-          headers: &id226
+          headers: &id228
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35872,7 +35960,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id226
+          headers: *id228
           content:
             application/json:
               schema:
@@ -35898,7 +35986,7 @@ paths:
       responses:
         '200':
           description: Transactions
-          headers: &id227
+          headers: &id229
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -35914,7 +36002,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id227
+          headers: *id229
           content:
             application/json:
               schema:
@@ -36199,9 +36287,9 @@ paths:
                   stats:
                     type: object
                     additionalProperties: true
-        '401': &id229
+        '401': &id231
           description: Unauthorized - Authentication required or token invalid
-          headers: &id228
+          headers: &id230
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -36228,9 +36316,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id230
+        '403': &id232
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id228
+          headers: *id230
           content:
             application/json:
               schema:
@@ -36314,7 +36402,7 @@ paths:
                       type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id228
+          headers: *id230
           content:
             application/json:
               schema:
@@ -36340,11 +36428,11 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id229
-        '403': *id230
+        '401': *id231
+        '403': *id232
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id228
+          headers: *id230
           content:
             application/json:
               schema:
@@ -36444,9 +36532,9 @@ paths:
                         type: object
                         additionalProperties:
                           type: integer
-        '401': &id232
+        '401': &id234
           description: Unauthorized - Authentication required or token invalid
-          headers: &id231
+          headers: &id233
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -36473,9 +36561,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id233
+        '403': &id235
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id231
+          headers: *id233
           content:
             application/json:
               schema:
@@ -36495,9 +36583,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id234
+        '404': &id236
           description: Not found - The requested resource does not exist
-          headers: *id231
+          headers: *id233
           content:
             application/json:
               schema:
@@ -36582,7 +36670,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id231
+          headers: *id233
           content:
             application/json:
               schema:
@@ -36608,9 +36696,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id232
-        '403': *id233
-        '404': *id234
+        '401': *id234
+        '403': *id235
+        '404': *id236
         '503':
           description: Feature flag system not available
       security:
@@ -36699,7 +36787,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id235
+          headers: &id237
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -36728,7 +36816,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id235
+          headers: *id237
           content:
             application/json:
               schema:
@@ -36750,7 +36838,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id235
+          headers: *id237
           content:
             application/json:
               schema:
@@ -37227,7 +37315,7 @@ paths:
                     description: Non-critical warnings
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id236
+          headers: &id238
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -37256,7 +37344,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id236
+          headers: *id238
           content:
             application/json:
               schema:
@@ -37278,7 +37366,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id236
+          headers: *id238
           content:
             application/json:
               schema:
@@ -37347,9 +37435,9 @@ paths:
                     type: string
                   total_keys:
                     type: integer
-        '400': &id238
+        '400': &id240
           description: Bad request - Invalid input or malformed JSON
-          headers: &id237
+          headers: &id239
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -37384,9 +37472,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id239
+        '401': &id241
           description: Unauthorized - Authentication required or token invalid
-          headers: *id237
+          headers: *id239
           content:
             application/json:
               schema:
@@ -37404,9 +37492,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id240
+        '403': &id242
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id237
+          headers: *id239
           content:
             application/json:
               schema:
@@ -37426,9 +37514,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id241
+        '500': &id243
           description: Internal server error - Unexpected error occurred
-          headers: *id237
+          headers: *id239
           content:
             application/json:
               schema:
@@ -37524,10 +37612,10 @@ paths:
                   metadata:
                     type: object
                     additionalProperties: true
-        '400': *id238
-        '401': *id239
-        '403': *id240
-        '500': *id241
+        '400': *id240
+        '401': *id241
+        '403': *id242
+        '500': *id243
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -37620,7 +37708,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id242
+          headers: &id244
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -37657,7 +37745,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id242
+          headers: *id244
           content:
             application/json:
               schema:
@@ -37677,7 +37765,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id242
+          headers: *id244
           content:
             application/json:
               schema:
@@ -37699,7 +37787,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id242
+          headers: *id244
           content:
             application/json:
               schema:
@@ -37767,7 +37855,7 @@ paths:
                             type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id243
+          headers: &id245
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -37796,7 +37884,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id243
+          headers: *id245
           content:
             application/json:
               schema:
@@ -37818,7 +37906,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id243
+          headers: *id245
           content:
             application/json:
               schema:
@@ -37835,7 +37923,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id243
+          headers: *id245
           content:
             application/json:
               schema:
@@ -37923,7 +38011,7 @@ paths:
                     description: Total number of encryption keys
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id244
+          headers: &id246
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -37952,7 +38040,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id244
+          headers: *id246
           content:
             application/json:
               schema:
@@ -37974,7 +38062,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id244
+          headers: *id246
           content:
             application/json:
               schema:
@@ -38474,7 +38562,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id245
+          headers: &id247
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -38511,7 +38599,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id245
+          headers: *id247
           content:
             application/json:
               schema:
@@ -38531,7 +38619,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id245
+          headers: *id247
           content:
             application/json:
               schema:
@@ -38622,7 +38710,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id246
+          headers: &id248
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -38651,7 +38739,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id246
+          headers: *id248
           content:
             application/json:
               schema:
@@ -38726,7 +38814,7 @@ paths:
                       type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id247
+          headers: &id249
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -38755,7 +38843,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id247
+          headers: *id249
           content:
             application/json:
               schema:
@@ -38853,7 +38941,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id248
+          headers: &id250
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -38890,7 +38978,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id248
+          headers: *id250
           content:
             application/json:
               schema:
@@ -38910,7 +38998,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id248
+          headers: *id250
           content:
             application/json:
               schema:
@@ -39007,7 +39095,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id249
+          headers: &id251
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -39036,7 +39124,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id249
+          headers: *id251
           content:
             application/json:
               schema:
@@ -39160,7 +39248,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id250
+          headers: &id252
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -39189,7 +39277,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id250
+          headers: *id252
           content:
             application/json:
               schema:
@@ -39211,7 +39299,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id250
+          headers: *id252
           content:
             application/json:
               schema:
@@ -39271,9 +39359,9 @@ paths:
                     type: integer
                   platform:
                     type: string
-        '401': &id252
+        '401': &id254
           description: Unauthorized - Authentication required or token invalid
-          headers: &id251
+          headers: &id253
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -39300,9 +39388,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id253
+        '403': &id255
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id251
+          headers: *id253
           content:
             application/json:
               schema:
@@ -39322,9 +39410,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id254
+        '404': &id256
           description: Not found - The requested resource does not exist
-          headers: *id251
+          headers: *id253
           content:
             application/json:
               schema:
@@ -39407,7 +39495,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id251
+          headers: *id253
           content:
             application/json:
               schema:
@@ -39433,9 +39521,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id252
-        '403': *id253
-        '404': *id254
+        '401': *id254
+        '403': *id255
+        '404': *id256
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -39486,9 +39574,9 @@ paths:
                   end_date:
                     type: string
                     format: date-time
-        '401': &id256
+        '401': &id258
           description: Unauthorized - Authentication required or token invalid
-          headers: &id255
+          headers: &id257
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -39515,9 +39603,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id257
+        '403': &id259
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id255
+          headers: *id257
           content:
             application/json:
               schema:
@@ -39537,9 +39625,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id258
+        '404': &id260
           description: Not found - The requested resource does not exist
-          headers: *id255
+          headers: *id257
           content:
             application/json:
               schema:
@@ -39613,7 +39701,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id255
+          headers: *id257
           content:
             application/json:
               schema:
@@ -39639,9 +39727,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id256
-        '403': *id257
-        '404': *id258
+        '401': *id258
+        '403': *id259
+        '404': *id260
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -39691,7 +39779,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id259
+          headers: &id261
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -39720,7 +39808,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id259
+          headers: *id261
           content:
             application/json:
               schema:
@@ -39742,7 +39830,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id259
+          headers: *id261
           content:
             application/json:
               schema:
@@ -39766,7 +39854,7 @@ paths:
       summary: List agent bridge runs
       description: List persisted agent bridge runs in newest-first order.
       operationId: listAgentBridgeRuns
-      security: &id263
+      security: &id265
       - bearerAuth: []
       parameters:
       - name: limit
@@ -39787,7 +39875,7 @@ paths:
       responses:
         '200':
           description: Paginated list of agent bridge runs
-          headers: &id262
+          headers: &id264
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -39806,7 +39894,7 @@ paths:
                 - schema_version
                 - runs
                 properties:
-                  schema_version: &id260
+                  schema_version: &id262
                     type: integer
                     enum:
                     - 1
@@ -39831,37 +39919,37 @@ paths:
                       - participants
                       - last_event_id
                       properties:
-                        schema_version: *id260
-                        run_id: &id264
+                        schema_version: *id262
+                        run_id: &id266
                           type: string
-                        task: &id265
+                        task: &id267
                           type: string
-                        status: &id266
+                        status: &id268
                           type: string
-                        created_at: &id267
-                          type: string
-                          format: date-time
-                        updated_at: &id268
+                        created_at: &id269
                           type: string
                           format: date-time
-                        completed_at: &id269
+                        updated_at: &id270
+                          type: string
+                          format: date-time
+                        completed_at: &id271
                           type:
                           - string
                           - 'null'
                           format: date-time
-                        last_turn_index: &id270
+                        last_turn_index: &id272
                           type: integer
-                        next_actor: &id261
+                        next_actor: &id263
                           type:
                           - string
                           - 'null'
-                        repair_budget_per_turn: &id271
+                        repair_budget_per_turn: &id273
                           type: integer
-                        footer_mode: &id272
+                        footer_mode: &id274
                           type: string
-                        worktree_cleanup_mode: &id273
+                        worktree_cleanup_mode: &id275
                           type: string
-                        participants: &id274
+                        participants: &id276
                           type: array
                           items:
                             type: object
@@ -39877,11 +39965,11 @@ paths:
                                 type: string
                               model:
                                 type: string
-                        last_event_id: *id261
-                  next_cursor: *id261
-        '400': &id275
+                        last_event_id: *id263
+                  next_cursor: *id263
+        '400': &id277
           description: Bad request - Invalid input or malformed JSON
-          headers: *id262
+          headers: *id264
           content:
             application/json:
               schema:
@@ -39907,9 +39995,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id276
+        '401': &id278
           description: Unauthorized - Authentication required or token invalid
-          headers: *id262
+          headers: *id264
           content:
             application/json:
               schema:
@@ -39927,9 +40015,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id277
+        '403': &id279
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id262
+          headers: *id264
           content:
             application/json:
               schema:
@@ -39949,9 +40037,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id278
+        '500': &id280
           description: Internal server error - Unexpected error occurred
-          headers: *id262
+          headers: *id264
           content:
             application/json:
               schema:
@@ -39972,7 +40060,7 @@ paths:
       description: Start a persisted bridge run without dispatching a turn. This operator-local write endpoint is separately
         feature-gated because subsequent dispatch can spawn local model harness processes.
       operationId: startAgentBridgeRun
-      security: *id263
+      security: *id265
       parameters: []
       requestBody:
         required: true
@@ -40029,7 +40117,7 @@ paths:
       responses:
         '201':
           description: Started agent bridge run
-          headers: *id262
+          headers: *id264
           content:
             application/json:
               schema:
@@ -40054,20 +40142,20 @@ paths:
                 - worktree_path
                 - worktree_agent_slug
                 properties:
-                  schema_version: *id260
-                  run_id: *id264
-                  task: *id265
-                  status: *id266
-                  created_at: *id267
-                  updated_at: *id268
-                  completed_at: *id269
-                  last_turn_index: *id270
-                  next_actor: *id261
-                  repair_budget_per_turn: *id271
-                  footer_mode: *id272
-                  worktree_cleanup_mode: *id273
-                  participants: *id274
-                  last_event_id: *id261
+                  schema_version: *id262
+                  run_id: *id266
+                  task: *id267
+                  status: *id268
+                  created_at: *id269
+                  updated_at: *id270
+                  completed_at: *id271
+                  last_turn_index: *id272
+                  next_actor: *id263
+                  repair_budget_per_turn: *id273
+                  footer_mode: *id274
+                  worktree_cleanup_mode: *id275
+                  participants: *id276
+                  last_event_id: *id263
                   roles:
                     type: object
                     additionalProperties:
@@ -40092,10 +40180,10 @@ paths:
                           type: string
                         model:
                           type: string
-                        session_id: *id261
-                        worktree_agent_slug: *id261
-                        worktree_path: *id261
-                        branch: *id261
+                        session_id: *id263
+                        worktree_agent_slug: *id263
+                        worktree_path: *id263
+                        branch: *id263
                         session_status:
                           type: string
                           enum:
@@ -40103,26 +40191,26 @@ paths:
                           - active
                           - completed
                           - failed
-                        started_at: *id269
+                        started_at: *id271
                         last_turn_index:
                           type: integer
-                        last_completed_at: *id269
+                        last_completed_at: *id271
                         harness_options:
                           type: object
                           additionalProperties: true
-                  worktree_path: *id261
-                  worktree_agent_slug: *id261
-        '400': *id275
-        '401': *id276
-        '403': *id277
+                  worktree_path: *id263
+                  worktree_agent_slug: *id263
+        '400': *id277
+        '401': *id278
+        '403': *id279
         '409':
           description: Conflict - The request could not be completed
-          headers: *id262
+          headers: *id264
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id278
+        '500': *id280
       x-aragora-stability: stable
   /api/v1/agent-bridge/runs/{run_id}:
     get:
@@ -40144,16 +40232,16 @@ paths:
         '200':
           description: Agent bridge run detail
           headers:
-            X-Request-ID: &id281
+            X-Request-ID: &id283
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id282
+            X-Response-Time: &id284
               description: Server processing time in milliseconds
               schema:
                 type: integer
-            ETag: &id283
+            ETag: &id285
               description: Weak entity tag for polling and conditional requests.
               schema:
                 type: string
@@ -40197,14 +40285,14 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-                  completed_at: &id280
+                  completed_at: &id282
                     type:
                     - string
                     - 'null'
                     format: date-time
                   last_turn_index:
                     type: integer
-                  next_actor: &id279
+                  next_actor: &id281
                     type:
                     - string
                     - 'null'
@@ -40230,7 +40318,7 @@ paths:
                           type: string
                         model:
                           type: string
-                  last_event_id: *id279
+                  last_event_id: *id281
                   roles:
                     type: object
                     additionalProperties:
@@ -40255,10 +40343,10 @@ paths:
                           type: string
                         model:
                           type: string
-                        session_id: *id279
-                        worktree_agent_slug: *id279
-                        worktree_path: *id279
-                        branch: *id279
+                        session_id: *id281
+                        worktree_agent_slug: *id281
+                        worktree_path: *id281
+                        branch: *id281
                         session_status:
                           type: string
                           enum:
@@ -40266,26 +40354,26 @@ paths:
                           - active
                           - completed
                           - failed
-                        started_at: *id280
+                        started_at: *id282
                         last_turn_index:
                           type: integer
-                        last_completed_at: *id280
+                        last_completed_at: *id282
                         harness_options:
                           type: object
                           additionalProperties: true
-                  worktree_path: *id279
-                  worktree_agent_slug: *id279
+                  worktree_path: *id281
+                  worktree_agent_slug: *id281
         '304':
           description: Not modified
           headers:
-            X-Request-ID: *id281
-            X-Response-Time: *id282
-            ETag: *id283
+            X-Request-ID: *id283
+            X-Response-Time: *id284
+            ETag: *id285
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id284
-            X-Request-ID: *id281
-            X-Response-Time: *id282
+          headers: &id286
+            X-Request-ID: *id283
+            X-Response-Time: *id284
           content:
             application/json:
               schema:
@@ -40305,7 +40393,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id284
+          headers: *id286
           content:
             application/json:
               schema:
@@ -40327,7 +40415,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id284
+          headers: *id286
           content:
             application/json:
               schema:
@@ -40343,7 +40431,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id284
+          headers: *id286
           content:
             application/json:
               schema:
@@ -40392,7 +40480,7 @@ paths:
       responses:
         '200':
           description: Auto-step dispatch result
-          headers: &id285
+          headers: &id287
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -40468,7 +40556,7 @@ paths:
                         type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id285
+          headers: *id287
           content:
             application/json:
               schema:
@@ -40496,7 +40584,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id285
+          headers: *id287
           content:
             application/json:
               schema:
@@ -40516,7 +40604,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id285
+          headers: *id287
           content:
             application/json:
               schema:
@@ -40538,7 +40626,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id285
+          headers: *id287
           content:
             application/json:
               schema:
@@ -40554,14 +40642,14 @@ paths:
                     trace_id: req_abc123xyz
         '409':
           description: Conflict - The request could not be completed
-          headers: *id285
+          headers: *id287
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id285
+          headers: *id287
           content:
             application/json:
               schema:
@@ -40609,7 +40697,7 @@ paths:
       responses:
         '200':
           description: Agent bridge turn event
-          headers: &id286
+          headers: &id288
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -40685,7 +40773,7 @@ paths:
                     additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id286
+          headers: *id288
           content:
             application/json:
               schema:
@@ -40713,7 +40801,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id286
+          headers: *id288
           content:
             application/json:
               schema:
@@ -40733,7 +40821,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id286
+          headers: *id288
           content:
             application/json:
               schema:
@@ -40755,7 +40843,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id286
+          headers: *id288
           content:
             application/json:
               schema:
@@ -40771,14 +40859,14 @@ paths:
                     trace_id: req_abc123xyz
         '409':
           description: Conflict - The request could not be completed
-          headers: *id286
+          headers: *id288
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id286
+          headers: *id288
           content:
             application/json:
               schema:
@@ -40827,16 +40915,16 @@ paths:
         '200':
           description: Paginated list of agent bridge events
           headers:
-            X-Request-ID: &id289
+            X-Request-ID: &id291
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id290
+            X-Response-Time: &id292
               description: Server processing time in milliseconds
               schema:
                 type: integer
-            ETag: &id291
+            ETag: &id293
               description: Weak entity tag for polling and conditional requests.
               schema:
                 type: string
@@ -40849,7 +40937,7 @@ paths:
                 - schema_version
                 - events
                 properties:
-                  schema_version: &id287
+                  schema_version: &id289
                     type: integer
                     enum:
                     - 1
@@ -40871,7 +40959,7 @@ paths:
                       - parse_status
                       - payload
                       properties:
-                        schema_version: *id287
+                        schema_version: *id289
                         event_id:
                           type: string
                         run_id:
@@ -40898,7 +40986,7 @@ paths:
                           type: string
                         harness:
                           type: string
-                        session_id: &id288
+                        session_id: &id290
                           type:
                           - string
                           - 'null'
@@ -40914,18 +41002,18 @@ paths:
                         payload:
                           type: object
                           additionalProperties: true
-                  next_cursor: *id288
+                  next_cursor: *id290
         '304':
           description: Not modified
           headers:
-            X-Request-ID: *id289
-            X-Response-Time: *id290
-            ETag: *id291
+            X-Request-ID: *id291
+            X-Response-Time: *id292
+            ETag: *id293
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id292
-            X-Request-ID: *id289
-            X-Response-Time: *id290
+          headers: &id294
+            X-Request-ID: *id291
+            X-Response-Time: *id292
           content:
             application/json:
               schema:
@@ -40953,7 +41041,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id292
+          headers: *id294
           content:
             application/json:
               schema:
@@ -40973,7 +41061,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id292
+          headers: *id294
           content:
             application/json:
               schema:
@@ -40995,7 +41083,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id292
+          headers: *id294
           content:
             application/json:
               schema:
@@ -41011,7 +41099,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id292
+          headers: *id294
           content:
             application/json:
               schema:
@@ -41044,7 +41132,7 @@ paths:
       responses:
         '200':
           description: Reconstructed agent bridge transcript
-          headers: &id294
+          headers: &id296
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -41088,7 +41176,7 @@ paths:
                         started_at:
                           type: string
                           format: date-time
-                        completed_at: &id293
+                        completed_at: &id295
                           type:
                           - string
                           - 'null'
@@ -41112,7 +41200,7 @@ paths:
                             properties:
                               summary:
                                 type: string
-                              next_actor: *id293
+                              next_actor: *id295
                               needs_human:
                                 type: boolean
                               done:
@@ -41130,7 +41218,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id294
+          headers: *id296
           content:
             application/json:
               schema:
@@ -41150,7 +41238,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id294
+          headers: *id296
           content:
             application/json:
               schema:
@@ -41172,7 +41260,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id294
+          headers: *id296
           content:
             application/json:
               schema:
@@ -41188,7 +41276,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id294
+          headers: *id296
           content:
             application/json:
               schema:
@@ -41550,7 +41638,7 @@ paths:
       responses:
         '200':
           description: Head-to-head comparison data
-          headers: &id295
+          headers: &id297
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -41575,7 +41663,7 @@ paths:
                     type: number
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id295
+          headers: *id297
           content:
             application/json:
               schema:
@@ -41591,7 +41679,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id295
+          headers: *id297
           content:
             application/json:
               schema:
@@ -41639,7 +41727,7 @@ paths:
       responses:
         '200':
           description: Opponent briefing data
-          headers: &id296
+          headers: &id298
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -41668,7 +41756,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id296
+          headers: *id298
           content:
             application/json:
               schema:
@@ -41684,7 +41772,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id296
+          headers: *id298
           content:
             application/json:
               schema:
@@ -42375,7 +42463,7 @@ paths:
       responses:
         '200':
           description: Persona data
-          headers: &id297
+          headers: &id299
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -42415,7 +42503,7 @@ paths:
       responses:
         '200':
           description: Success
-          headers: *id297
+          headers: *id299
           content:
             application/json:
               schema:
@@ -42447,7 +42535,7 @@ paths:
       responses:
         '200':
           description: Success
-          headers: *id297
+          headers: *id299
           content:
             application/json:
               schema:
@@ -42509,7 +42597,7 @@ paths:
       responses:
         '200':
           description: Agent profile
-          headers: &id298
+          headers: &id300
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -42525,7 +42613,7 @@ paths:
                 $ref: '#/components/schemas/Agent'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id298
+          headers: *id300
           content:
             application/json:
               schema:
@@ -42541,7 +42629,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id298
+          headers: *id300
           content:
             application/json:
               schema:
@@ -44656,12 +44744,12 @@ paths:
         '200':
           description: Spend budget status
           headers:
-            X-Request-ID: &id299
+            X-Request-ID: &id301
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id300
+            X-Response-Time: &id302
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -44733,9 +44821,9 @@ paths:
                     - 'null'
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id301
-            X-Request-ID: *id299
-            X-Response-Time: *id300
+          headers: &id303
+            X-Request-ID: *id301
+            X-Response-Time: *id302
           content:
             application/json:
               schema:
@@ -44752,7 +44840,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id301
+          headers: *id303
           content:
             application/json:
               schema:
@@ -44782,12 +44870,12 @@ paths:
         '200':
           description: Spend by agent
           headers:
-            X-Request-ID: &id302
+            X-Request-ID: &id304
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id303
+            X-Response-Time: &id305
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -44829,9 +44917,9 @@ paths:
                           description: Percentage of the workspace spend attributed to the agent
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id304
-            X-Request-ID: *id302
-            X-Response-Time: *id303
+          headers: &id306
+            X-Request-ID: *id304
+            X-Response-Time: *id305
           content:
             application/json:
               schema:
@@ -44848,7 +44936,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id304
+          headers: *id306
           content:
             application/json:
               schema:
@@ -44884,12 +44972,12 @@ paths:
         '200':
           description: Spend by decision
           headers:
-            X-Request-ID: &id305
+            X-Request-ID: &id307
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id306
+            X-Response-Time: &id308
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -44927,9 +45015,9 @@ paths:
                     type: integer
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id307
-            X-Request-ID: *id305
-            X-Response-Time: *id306
+          headers: &id309
+            X-Request-ID: *id307
+            X-Response-Time: *id308
           content:
             application/json:
               schema:
@@ -44946,7 +45034,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id307
+          headers: *id309
           content:
             application/json:
               schema:
@@ -44981,12 +45069,12 @@ paths:
         '200':
           description: Spend summary
           headers:
-            X-Request-ID: &id308
+            X-Request-ID: &id310
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id309
+            X-Response-Time: &id311
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -45037,9 +45125,9 @@ paths:
                     description: Average spend per recorded API call
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id310
-            X-Request-ID: *id308
-            X-Response-Time: *id309
+          headers: &id312
+            X-Request-ID: *id310
+            X-Response-Time: *id311
           content:
             application/json:
               schema:
@@ -45056,7 +45144,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id310
+          headers: *id312
           content:
             application/json:
               schema:
@@ -45100,12 +45188,12 @@ paths:
         '200':
           description: Spend trends
           headers:
-            X-Request-ID: &id311
+            X-Request-ID: &id313
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id312
+            X-Response-Time: &id314
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -45144,9 +45232,9 @@ paths:
                     description: Budget-manager trend rows for the selected period
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id313
-            X-Request-ID: *id311
-            X-Response-Time: *id312
+          headers: &id315
+            X-Request-ID: *id313
+            X-Response-Time: *id314
           content:
             application/json:
               schema:
@@ -45163,7 +45251,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id313
+          headers: *id315
           content:
             application/json:
               schema:
@@ -45752,9 +45840,9 @@ paths:
                           format: date-time
                   count:
                     type: integer
-        '401': &id315
+        '401': &id317
           description: Unauthorized - Authentication required or token invalid
-          headers: &id314
+          headers: &id316
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -45781,9 +45869,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id316
+        '404': &id318
           description: Not found - The requested resource does not exist
-          headers: *id314
+          headers: *id316
           content:
             application/json:
               schema:
@@ -45845,10 +45933,10 @@ paths:
                     format: date-time
                   message:
                     type: string
-        '401': *id315
+        '401': *id317
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id314
+          headers: *id316
           content:
             application/json:
               schema:
@@ -45868,7 +45956,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id316
+        '404': *id318
         '503':
           description: Service unavailable
       security:
@@ -45891,8 +45979,8 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id315
-        '404': *id316
+        '401': *id317
+        '404': *id318
         '503':
           description: Service unavailable
       security:
@@ -46156,7 +46244,7 @@ paths:
       responses:
         '200':
           description: Filtered audit entries
-          headers: &id317
+          headers: &id319
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46179,7 +46267,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id317
+          headers: *id319
           content:
             application/json:
               schema:
@@ -46199,7 +46287,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id317
+          headers: *id319
           content:
             application/json:
               schema:
@@ -46590,7 +46678,7 @@ paths:
       responses:
         '200':
           description: Compliance report
-          headers: &id318
+          headers: &id320
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46618,7 +46706,7 @@ paths:
                     format: date
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id318
+          headers: *id320
           content:
             application/json:
               schema:
@@ -46646,7 +46734,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id318
+          headers: *id320
           content:
             application/json:
               schema:
@@ -46666,7 +46754,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id318
+          headers: *id320
           content:
             application/json:
               schema:
@@ -46780,7 +46868,7 @@ paths:
       summary: List audit sessions
       operationId: listAuditSessions
       description: List audit sessions with optional filters.
-      security: &id320
+      security: &id322
       - {}
       parameters:
       - name: status
@@ -46798,7 +46886,7 @@ paths:
       responses:
         '200':
           description: Sessions
-          headers: &id319
+          headers: &id321
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46812,9 +46900,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '500': &id321
+        '500': &id323
           description: Internal server error - Unexpected error occurred
-          headers: *id319
+          headers: *id321
           content:
             application/json:
               schema:
@@ -46834,7 +46922,7 @@ paths:
       summary: Create audit session
       operationId: createAuditSessions
       description: Create a new audit session.
-      security: *id320
+      security: *id322
       requestBody:
         required: true
         content:
@@ -46858,14 +46946,14 @@ paths:
       responses:
         '200':
           description: Session created
-          headers: *id319
+          headers: *id321
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id319
+          headers: *id321
           content:
             application/json:
               schema:
@@ -46891,7 +46979,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id321
+        '500': *id323
       x-aragora-stability: stable
   /api/v1/audit/sessions/{session_id}:
     get:
@@ -46900,7 +46988,7 @@ paths:
       summary: Get audit session
       operationId: getAuditSession
       description: Get audit session details.
-      security: &id323
+      security: &id325
       - {}
       parameters:
       - name: session_id
@@ -46911,7 +46999,7 @@ paths:
       responses:
         '200':
           description: Session
-          headers: &id322
+          headers: &id324
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46925,9 +47013,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '404': &id324
+        '404': &id326
           description: Not found - The requested resource does not exist
-          headers: *id322
+          headers: *id324
           content:
             application/json:
               schema:
@@ -46941,9 +47029,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id325
+        '500': &id327
           description: Internal server error - Unexpected error occurred
-          headers: *id322
+          headers: *id324
           content:
             application/json:
               schema:
@@ -46963,7 +47051,7 @@ paths:
       summary: Delete audit session
       operationId: deleteAuditSession
       description: Delete an audit session.
-      security: *id323
+      security: *id325
       parameters:
       - name: session_id
         in: path
@@ -46973,13 +47061,13 @@ paths:
       responses:
         '200':
           description: Session deleted
-          headers: *id322
+          headers: *id324
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '404': *id324
-        '500': *id325
+        '404': *id326
+        '500': *id327
       x-aragora-stability: stable
   /api/v1/audit/sessions/{session_id}/cancel:
     post:
@@ -46999,7 +47087,7 @@ paths:
       responses:
         '200':
           description: Audit cancelled
-          headers: &id326
+          headers: &id328
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47015,7 +47103,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id326
+          headers: *id328
           content:
             application/json:
               schema:
@@ -47031,7 +47119,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id326
+          headers: *id328
           content:
             application/json:
               schema:
@@ -47063,7 +47151,7 @@ paths:
       responses:
         '200':
           description: Event stream
-          headers: &id327
+          headers: &id329
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47079,7 +47167,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id327
+          headers: *id329
           content:
             application/json:
               schema:
@@ -47095,7 +47183,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id327
+          headers: *id329
           content:
             application/json:
               schema:
@@ -47131,7 +47219,7 @@ paths:
       responses:
         '200':
           description: Findings
-          headers: &id328
+          headers: &id330
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47147,7 +47235,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id328
+          headers: *id330
           content:
             application/json:
               schema:
@@ -47163,7 +47251,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id328
+          headers: *id330
           content:
             application/json:
               schema:
@@ -47218,7 +47306,7 @@ paths:
       responses:
         '200':
           description: Intervention recorded
-          headers: &id329
+          headers: &id331
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47234,7 +47322,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id329
+          headers: *id331
           content:
             application/json:
               schema:
@@ -47262,7 +47350,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id329
+          headers: *id331
           content:
             application/json:
               schema:
@@ -47278,7 +47366,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id329
+          headers: *id331
           content:
             application/json:
               schema:
@@ -47310,138 +47398,6 @@ paths:
       responses:
         '200':
           description: Audit paused
-          headers: &id330
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id330
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id330
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/audit/sessions/{session_id}/report:
-    get:
-      tags:
-      - Audit
-      summary: Export audit report
-      operationId: getAuditSessionsReport
-      description: Export audit report for a session.
-      security:
-      - {}
-      parameters:
-      - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: format
-        in: query
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Report
-          headers: &id331
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id331
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id331
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/audit/sessions/{session_id}/resume:
-    post:
-      tags:
-      - Audit
-      summary: Resume audit
-      operationId: createAuditSessionsResume
-      description: Resume an audit session.
-      security:
-      - {}
-      parameters:
-      - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Audit resumed
           headers: &id332
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -47488,13 +47444,13 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/audit/sessions/{session_id}/start:
-    post:
+  /api/v1/audit/sessions/{session_id}/report:
+    get:
       tags:
       - Audit
-      summary: Start audit
-      operationId: createAuditSessionsStart
-      description: Start an audit session.
+      summary: Export audit report
+      operationId: getAuditSessionsReport
+      description: Export audit report for a session.
       security:
       - {}
       parameters:
@@ -47503,9 +47459,13 @@ paths:
         required: true
         schema:
           type: string
+      - name: format
+        in: query
+        schema:
+          type: string
       responses:
         '200':
-          description: Audit started
+          description: Report
           headers: &id333
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -47539,6 +47499,134 @@ paths:
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id333
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/audit/sessions/{session_id}/resume:
+    post:
+      tags:
+      - Audit
+      summary: Resume audit
+      operationId: createAuditSessionsResume
+      description: Resume an audit session.
+      security:
+      - {}
+      parameters:
+      - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Audit resumed
+          headers: &id334
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id334
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id334
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/audit/sessions/{session_id}/start:
+    post:
+      tags:
+      - Audit
+      summary: Start audit
+      operationId: createAuditSessionsStart
+      description: Start an audit session.
+      security:
+      - {}
+      parameters:
+      - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Audit started
+          headers: &id335
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id335
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id335
           content:
             application/json:
               schema:
@@ -47594,7 +47682,7 @@ paths:
       responses:
         '200':
           description: Verification result with integrity status
-          headers: &id334
+          headers: &id336
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47617,7 +47705,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id334
+          headers: *id336
           content:
             application/json:
               schema:
@@ -47637,7 +47725,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id334
+          headers: *id336
           content:
             application/json:
               schema:
@@ -47793,9 +47881,9 @@ paths:
                     format: date-time
                   message:
                     type: string
-        '401': &id336
+        '401': &id338
           description: Unauthorized - Authentication required or token invalid
-          headers: &id335
+          headers: &id337
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47824,7 +47912,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id335
+          headers: *id337
           content:
             application/json:
               schema:
@@ -47844,9 +47932,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id337
+        '404': &id339
           description: Not found - The requested resource does not exist
-          headers: *id335
+          headers: *id337
           content:
             application/json:
               schema:
@@ -47882,8 +47970,8 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id336
-        '404': *id337
+        '401': *id338
+        '404': *id339
         '503':
           description: Service unavailable
       security:
@@ -47932,9 +48020,9 @@ paths:
                           format: date-time
                   count:
                     type: integer
-        '401': &id339
+        '401': &id341
           description: Unauthorized - Authentication required or token invalid
-          headers: &id338
+          headers: &id340
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47961,9 +48049,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id340
+        '404': &id342
           description: Not found - The requested resource does not exist
-          headers: *id338
+          headers: *id340
           content:
             application/json:
               schema:
@@ -48025,10 +48113,10 @@ paths:
                     format: date-time
                   message:
                     type: string
-        '401': *id339
+        '401': *id341
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id338
+          headers: *id340
           content:
             application/json:
               schema:
@@ -48048,7 +48136,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id340
+        '404': *id342
         '503':
           description: Service unavailable
       security:
@@ -48071,8 +48159,8 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id339
-        '404': *id340
+        '401': *id341
+        '404': *id342
         '503':
           description: Service unavailable
       security:
@@ -48290,7 +48378,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id341
+          headers: &id343
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48327,7 +48415,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id341
+          headers: *id343
           content:
             application/json:
               schema:
@@ -48347,7 +48435,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id341
+          headers: *id343
           content:
             application/json:
               schema:
@@ -48703,7 +48791,7 @@ paths:
                 additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id342
+          headers: &id344
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48740,7 +48828,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id342
+          headers: *id344
           content:
             application/json:
               schema:
@@ -48760,7 +48848,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id342
+          headers: *id344
           content:
             application/json:
               schema:
@@ -48782,7 +48870,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id342
+          headers: *id344
           content:
             application/json:
               schema:
@@ -48798,14 +48886,14 @@ paths:
                     trace_id: req_abc123xyz
         '409':
           description: Conflict - The request could not be completed
-          headers: *id342
+          headers: *id344
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         '402':
           description: Payment required - Quota exceeded, upgrade required
-          headers: *id342
+          headers: *id344
           content:
             application/json:
               schema:
@@ -48823,7 +48911,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id342
+          headers: *id344
           content:
             application/json:
               schema:
@@ -48840,7 +48928,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id342
+          headers: *id344
           content:
             application/json:
               schema:
@@ -49167,170 +49255,6 @@ paths:
           description: Redirect to GitHub OAuth consent screen
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id343
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '429':
-          description: Too many requests - Rate limit exceeded
-          headers: *id343
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                rate_limited:
-                  summary: Rate limit exceeded
-                  value:
-                    error: Rate limit exceeded
-                    code: RATE_LIMITED
-                    limit: 60
-                    window: 1 minute
-                    retry_after: 45
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id343
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/auth/oauth/github/callback:
-    get:
-      tags:
-      - OAuth
-      summary: GitHub OAuth callback
-      operationId: listAuthOauthGithubCallback
-      description: Handle the OAuth callback from GitHub after user consent.
-      parameters:
-      - name: code
-        in: query
-        required: true
-        description: Authorization code from GitHub
-        schema:
-          type: string
-      - name: state
-        in: query
-        required: true
-        description: State parameter for CSRF protection
-        schema:
-          type: string
-      responses:
-        '302':
-          description: Redirect to success URL with auth token
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: &id344
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id344
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/auth/oauth/google:
-    get:
-      tags:
-      - OAuth
-      summary: Start Google OAuth flow
-      operationId: listAuthOauthGoogle
-      description: Redirect user to Google OAuth consent screen for authentication. Supports optional account linking for
-        already-authenticated users.
-      parameters:
-      - name: redirect_url
-        in: query
-        description: URL to redirect after successful authentication (must be in allowlist)
-        schema:
-          type: string
-          format: uri
-      responses:
-        '302':
-          description: Redirect to Google OAuth consent screen
-        '400':
-          description: Bad request - Invalid input or malformed JSON
           headers: &id345
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -49399,30 +49323,24 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: experimental
-  /api/v1/auth/oauth/google/callback:
+  /api/v1/auth/oauth/github/callback:
     get:
       tags:
       - OAuth
-      summary: Google OAuth callback
-      operationId: listAuthOauthGoogleCallback
-      description: Handle the OAuth callback from Google after user consent. Exchanges authorization code for tokens and creates/links
-        user account.
+      summary: GitHub OAuth callback
+      operationId: listAuthOauthGithubCallback
+      description: Handle the OAuth callback from GitHub after user consent.
       parameters:
       - name: code
         in: query
         required: true
-        description: Authorization code from Google
+        description: Authorization code from GitHub
         schema:
           type: string
       - name: state
         in: query
         required: true
         description: State parameter for CSRF protection
-        schema:
-          type: string
-      - name: error
-        in: query
-        description: Error code if user denied consent
         schema:
           type: string
       responses:
@@ -49481,6 +49399,176 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: experimental
+  /api/v1/auth/oauth/google:
+    get:
+      tags:
+      - OAuth
+      summary: Start Google OAuth flow
+      operationId: listAuthOauthGoogle
+      description: Redirect user to Google OAuth consent screen for authentication. Supports optional account linking for
+        already-authenticated users.
+      parameters:
+      - name: redirect_url
+        in: query
+        description: URL to redirect after successful authentication (must be in allowlist)
+        schema:
+          type: string
+          format: uri
+      responses:
+        '302':
+          description: Redirect to Google OAuth consent screen
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id347
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '429':
+          description: Too many requests - Rate limit exceeded
+          headers: *id347
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                rate_limited:
+                  summary: Rate limit exceeded
+                  value:
+                    error: Rate limit exceeded
+                    code: RATE_LIMITED
+                    limit: 60
+                    window: 1 minute
+                    retry_after: 45
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id347
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/auth/oauth/google/callback:
+    get:
+      tags:
+      - OAuth
+      summary: Google OAuth callback
+      operationId: listAuthOauthGoogleCallback
+      description: Handle the OAuth callback from Google after user consent. Exchanges authorization code for tokens and creates/links
+        user account.
+      parameters:
+      - name: code
+        in: query
+        required: true
+        description: Authorization code from Google
+        schema:
+          type: string
+      - name: state
+        in: query
+        required: true
+        description: State parameter for CSRF protection
+        schema:
+          type: string
+      - name: error
+        in: query
+        description: Error code if user denied consent
+        schema:
+          type: string
+      responses:
+        '302':
+          description: Redirect to success URL with auth token
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id348
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id348
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
   /api/v1/auth/oauth/link:
     post:
       tags:
@@ -49512,7 +49600,7 @@ paths:
       responses:
         '200':
           description: Account linked successfully
-          headers: &id347
+          headers: &id349
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49533,7 +49621,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id347
+          headers: *id349
           content:
             application/json:
               schema:
@@ -49561,7 +49649,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id347
+          headers: *id349
           content:
             application/json:
               schema:
@@ -49711,7 +49799,7 @@ paths:
       responses:
         '200':
           description: Account unlinked successfully
-          headers: &id348
+          headers: &id350
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49732,7 +49820,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id348
+          headers: *id350
           content:
             application/json:
               schema:
@@ -49760,7 +49848,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id348
+          headers: *id350
           content:
             application/json:
               schema:
@@ -49780,7 +49868,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id348
+          headers: *id350
           content:
             application/json:
               schema:
@@ -50395,7 +50483,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id349
+          headers: &id351
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50432,7 +50520,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id349
+          headers: *id351
           content:
             application/json:
               schema:
@@ -51871,7 +51959,7 @@ paths:
       responses:
         '200':
           description: Interaction response
-          headers: &id350
+          headers: &id352
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -51892,7 +51980,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id350
+          headers: *id352
           content:
             application/json:
               schema:
@@ -51921,7 +52009,7 @@ paths:
       responses:
         '200':
           description: Discord integration status
-          headers: &id351
+          headers: &id353
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -51944,7 +52032,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id351
+          headers: *id353
           content:
             application/json:
               schema:
@@ -51993,7 +52081,7 @@ paths:
       responses:
         '200':
           description: Email integration status
-          headers: &id352
+          headers: &id354
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52016,7 +52104,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id352
+          headers: *id354
           content:
             application/json:
               schema:
@@ -52176,7 +52264,7 @@ paths:
       responses:
         '200':
           description: Google Chat integration status
-          headers: &id353
+          headers: &id355
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52197,7 +52285,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id353
+          headers: *id355
           content:
             application/json:
               schema:
@@ -52325,7 +52413,7 @@ paths:
       responses:
         '200':
           description: Command acknowledged
-          headers: &id354
+          headers: &id356
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52349,7 +52437,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id354
+          headers: *id356
           content:
             application/json:
               schema:
@@ -52420,7 +52508,7 @@ paths:
       responses:
         '200':
           description: Event processed
-          headers: &id355
+          headers: &id357
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52441,7 +52529,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id355
+          headers: *id357
           content:
             application/json:
               schema:
@@ -52496,7 +52584,7 @@ paths:
       responses:
         '200':
           description: Interaction handled
-          headers: &id356
+          headers: &id358
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52508,7 +52596,7 @@ paths:
                 type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id356
+          headers: *id358
           content:
             application/json:
               schema:
@@ -52548,7 +52636,7 @@ paths:
       responses:
         '200':
           description: Slack integration status
-          headers: &id357
+          headers: &id359
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52574,7 +52662,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id357
+          headers: *id359
           content:
             application/json:
               schema:
@@ -52707,7 +52795,7 @@ paths:
       responses:
         '200':
           description: Telegram integration status
-          headers: &id358
+          headers: &id360
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52730,7 +52818,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id358
+          headers: *id360
           content:
             application/json:
               schema:
@@ -52834,7 +52922,7 @@ paths:
       responses:
         '200':
           description: Update processed
-          headers: &id359
+          headers: &id361
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52846,7 +52934,7 @@ paths:
                 type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id359
+          headers: *id361
           content:
             application/json:
               schema:
@@ -52893,7 +52981,7 @@ paths:
       responses:
         '200':
           description: WhatsApp integration status
-          headers: &id360
+          headers: &id362
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52916,7 +53004,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id360
+          headers: *id362
           content:
             application/json:
               schema:
@@ -53082,7 +53170,7 @@ paths:
       responses:
         '200':
           description: Zoom integration status
-          headers: &id361
+          headers: &id363
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53103,7 +53191,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id361
+          headers: *id363
           content:
             application/json:
               schema:
@@ -53243,37 +53331,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BudgetListResponse'
-        '400': &id362
+        '400': &id364
           description: Bad request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '401': &id363
+        '401': &id365
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '404': &id364
+        '404': &id366
           description: Not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '402': &id365
+        '402': &id367
           description: Quota exceeded
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '429': &id366
+        '429': &id368
           description: Rate limited
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': &id367
+        '500': &id369
           description: Server error
           content:
             application/json:
@@ -53307,12 +53395,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
-        '400': *id362
-        '401': *id363
-        '404': *id364
-        '402': *id365
-        '429': *id366
-        '500': *id367
+        '400': *id364
+        '401': *id365
+        '404': *id366
+        '402': *id367
+        '429': *id368
+        '500': *id369
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -53478,37 +53566,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
-        '400': &id368
+        '400': &id370
           description: Bad request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '401': &id369
+        '401': &id371
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '404': &id370
+        '404': &id372
           description: Not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '402': &id371
+        '402': &id373
           description: Quota exceeded
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '429': &id372
+        '429': &id374
           description: Rate limited
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': &id373
+        '500': &id375
           description: Server error
           content:
             application/json:
@@ -53543,12 +53631,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
-        '400': *id368
-        '401': *id369
-        '404': *id370
-        '402': *id371
-        '429': *id372
-        '500': *id373
+        '400': *id370
+        '401': *id371
+        '404': *id372
+        '402': *id373
+        '429': *id374
+        '500': *id375
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -53577,12 +53665,12 @@ paths:
                     type: boolean
                   budget_id:
                     type: string
-        '400': *id368
-        '401': *id369
-        '404': *id370
-        '402': *id371
-        '429': *id372
-        '500': *id373
+        '400': *id370
+        '401': *id371
+        '404': *id372
+        '402': *id373
+        '429': *id374
+        '500': *id375
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -54036,7 +54124,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id374
+          headers: &id376
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54073,7 +54161,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id374
+          headers: *id376
           content:
             application/json:
               schema:
@@ -54111,7 +54199,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id375
+          headers: &id377
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54148,7 +54236,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id375
+          headers: *id377
           content:
             application/json:
               schema:
@@ -54234,7 +54322,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id376
+          headers: &id378
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54271,7 +54359,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id376
+          headers: *id378
           content:
             application/json:
               schema:
@@ -54325,7 +54413,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id377
+          headers: &id379
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54362,7 +54450,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id377
+          headers: *id379
           content:
             application/json:
               schema:
@@ -54412,7 +54500,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id378
+          headers: &id380
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54449,7 +54537,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id378
+          headers: *id380
           content:
             application/json:
               schema:
@@ -54564,7 +54652,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id379
+          headers: &id381
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54601,7 +54689,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id379
+          headers: *id381
           content:
             application/json:
               schema:
@@ -54648,7 +54736,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id380
+          headers: &id382
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54685,7 +54773,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id380
+          headers: *id382
           content:
             application/json:
               schema:
@@ -54734,7 +54822,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id381
+          headers: &id383
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54771,7 +54859,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id381
+          headers: *id383
           content:
             application/json:
               schema:
@@ -54834,7 +54922,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id382
+          headers: &id384
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54871,7 +54959,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id382
+          headers: *id384
           content:
             application/json:
               schema:
@@ -54917,7 +55005,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id383
+          headers: &id385
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54954,7 +55042,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id383
+          headers: *id385
           content:
             application/json:
               schema:
@@ -55046,7 +55134,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id384
+          headers: &id386
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55083,7 +55171,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id384
+          headers: *id386
           content:
             application/json:
               schema:
@@ -55180,13 +55268,13 @@ paths:
       summary: Get pipeline
       operationId: getPipeline
       description: Get a pipeline result by ID.
-      security: &id385
+      security: &id387
       - {}
       parameters:
       - name: id
         in: path
         required: true
-        schema: &id386
+        schema: &id388
           type: string
         description: Pipeline ID
       responses:
@@ -55196,9 +55284,9 @@ paths:
             application/json:
               schema:
                 type: object
-        '404': &id387
+        '404': &id389
           description: Not found - The requested resource does not exist
-          headers: &id388
+          headers: &id390
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55228,12 +55316,12 @@ paths:
       summary: Save pipeline canvas state
       operationId: savePipeline
       description: Save the current canvas state for a pipeline.
-      security: *id385
+      security: *id387
       parameters:
       - name: id
         in: path
         required: true
-        schema: *id386
+        schema: *id388
         description: Pipeline ID
       requestBody:
         required: true
@@ -55248,10 +55336,10 @@ paths:
             application/json:
               schema:
                 type: object
-        '404': *id387
+        '404': *id389
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id388
+          headers: *id390
           content:
             application/json:
               schema:
@@ -55309,7 +55397,7 @@ paths:
                 type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: &id389
+          headers: &id391
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55334,7 +55422,7 @@ paths:
                     trace_id: req_abc123xyz
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id389
+          headers: *id391
           content:
             application/json:
               schema:
@@ -55450,7 +55538,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id390
+          headers: &id392
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55487,7 +55575,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id390
+          headers: *id392
           content:
             application/json:
               schema:
@@ -56043,7 +56131,7 @@ paths:
       responses:
         '200':
           description: Channel summary
-          headers: &id391
+          headers: &id393
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56059,7 +56147,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id391
+          headers: *id393
           content:
             application/json:
               schema:
@@ -56137,7 +56225,7 @@ paths:
       responses:
         '200':
           description: Injected context
-          headers: &id392
+          headers: &id394
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56153,7 +56241,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id392
+          headers: *id394
           content:
             application/json:
               schema:
@@ -56181,7 +56269,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id392
+          headers: *id394
           content:
             application/json:
               schema:
@@ -56232,7 +56320,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id393
+          headers: &id395
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56248,7 +56336,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id393
+          headers: *id395
           content:
             application/json:
               schema:
@@ -56276,7 +56364,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id393
+          headers: *id395
           content:
             application/json:
               schema:
@@ -56332,7 +56420,7 @@ paths:
       responses:
         '200':
           description: Knowledge stored
-          headers: &id394
+          headers: &id396
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56348,7 +56436,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id394
+          headers: *id396
           content:
             application/json:
               schema:
@@ -56376,7 +56464,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id394
+          headers: *id396
           content:
             application/json:
               schema:
@@ -56687,7 +56775,7 @@ paths:
       responses:
         '200':
           description: Classification result with level and confidence
-          headers: &id395
+          headers: &id397
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56710,7 +56798,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id395
+          headers: *id397
           content:
             application/json:
               schema:
@@ -56738,7 +56826,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id395
+          headers: *id397
           content:
             application/json:
               schema:
@@ -56780,7 +56868,7 @@ paths:
       responses:
         '200':
           description: Policy details for the sensitivity level
-          headers: &id396
+          headers: &id398
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56807,7 +56895,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id396
+          headers: *id398
           content:
             application/json:
               schema:
@@ -56835,7 +56923,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id396
+          headers: *id398
           content:
             application/json:
               schema:
@@ -57236,7 +57324,7 @@ paths:
       responses:
         '200':
           description: Dependency analysis
-          headers: &id397
+          headers: &id399
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57252,7 +57340,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDependencyAnalysisResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id397
+          headers: *id399
           content:
             application/json:
               schema:
@@ -57280,7 +57368,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id397
+          headers: *id399
           content:
             application/json:
               schema:
@@ -57300,7 +57388,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id397
+          headers: *id399
           content:
             application/json:
               schema:
@@ -57322,7 +57410,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id397
+          headers: *id399
           content:
             application/json:
               schema:
@@ -57417,7 +57505,7 @@ paths:
       responses:
         '200':
           description: License check
-          headers: &id398
+          headers: &id400
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57433,7 +57521,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseLicenseCheckResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id398
+          headers: *id400
           content:
             application/json:
               schema:
@@ -57461,7 +57549,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id398
+          headers: *id400
           content:
             application/json:
               schema:
@@ -57481,7 +57569,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id398
+          headers: *id400
           content:
             application/json:
               schema:
@@ -57503,7 +57591,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id398
+          headers: *id400
           content:
             application/json:
               schema:
@@ -57529,7 +57617,7 @@ paths:
       responses:
         '200':
           description: Cache cleared
-          headers: &id399
+          headers: &id401
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57545,7 +57633,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id399
+          headers: *id401
           content:
             application/json:
               schema:
@@ -57565,7 +57653,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id399
+          headers: *id401
           content:
             application/json:
               schema:
@@ -57587,7 +57675,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id399
+          headers: *id401
           content:
             application/json:
               schema:
@@ -57831,7 +57919,7 @@ paths:
       responses:
         '200':
           description: Package vulnerabilities
-          headers: &id400
+          headers: &id402
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57847,7 +57935,7 @@ paths:
                 $ref: '#/components/schemas/CodebasePackageVulnerabilityResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id400
+          headers: *id402
           content:
             application/json:
               schema:
@@ -57867,7 +57955,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id400
+          headers: *id402
           content:
             application/json:
               schema:
@@ -57889,7 +57977,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id400
+          headers: *id402
           content:
             application/json:
               schema:
@@ -57946,7 +58034,7 @@ paths:
       responses:
         '200':
           description: Scan started
-          headers: &id401
+          headers: &id403
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57962,7 +58050,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id401
+          headers: *id403
           content:
             application/json:
               schema:
@@ -57990,7 +58078,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id401
+          headers: *id403
           content:
             application/json:
               schema:
@@ -58022,7 +58110,7 @@ paths:
       responses:
         '200':
           description: Scan result
-          headers: &id402
+          headers: &id404
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58038,7 +58126,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id402
+          headers: *id404
           content:
             application/json:
               schema:
@@ -58054,7 +58142,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id402
+          headers: *id404
           content:
             application/json:
               schema:
@@ -58080,7 +58168,7 @@ paths:
       responses:
         '200':
           description: Scan list
-          headers: &id403
+          headers: &id405
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58096,7 +58184,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id403
+          headers: *id405
           content:
             application/json:
               schema:
@@ -58149,7 +58237,7 @@ paths:
       responses:
         '200':
           description: SBOM generated
-          headers: &id404
+          headers: &id406
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58165,7 +58253,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSBOMResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id404
+          headers: *id406
           content:
             application/json:
               schema:
@@ -58193,7 +58281,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id404
+          headers: *id406
           content:
             application/json:
               schema:
@@ -58213,7 +58301,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id404
+          headers: *id406
           content:
             application/json:
               schema:
@@ -58235,7 +58323,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id404
+          headers: *id406
           content:
             application/json:
               schema:
@@ -58288,7 +58376,7 @@ paths:
       responses:
         '200':
           description: Vulnerability scan
-          headers: &id405
+          headers: &id407
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58304,7 +58392,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDependencyScanResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id405
+          headers: *id407
           content:
             application/json:
               schema:
@@ -58332,7 +58420,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id405
+          headers: *id407
           content:
             application/json:
               schema:
@@ -58352,7 +58440,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id405
+          headers: *id407
           content:
             application/json:
               schema:
@@ -58374,7 +58462,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id405
+          headers: *id407
           content:
             application/json:
               schema:
@@ -58536,7 +58624,7 @@ paths:
       responses:
         '200':
           description: Analysis
-          headers: &id406
+          headers: &id408
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58552,7 +58640,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id406
+          headers: *id408
           content:
             application/json:
               schema:
@@ -58580,7 +58668,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id406
+          headers: *id408
           content:
             application/json:
               schema:
@@ -58640,7 +58728,7 @@ paths:
       responses:
         '200':
           description: Audit started
-          headers: &id407
+          headers: &id409
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58656,7 +58744,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id407
+          headers: *id409
           content:
             application/json:
               schema:
@@ -58684,7 +58772,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id407
+          headers: *id409
           content:
             application/json:
               schema:
@@ -58721,7 +58809,7 @@ paths:
       responses:
         '200':
           description: Audit status
-          headers: &id408
+          headers: &id410
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58737,7 +58825,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id408
+          headers: *id410
           content:
             application/json:
               schema:
@@ -58753,7 +58841,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id408
+          headers: *id410
           content:
             application/json:
               schema:
@@ -58785,7 +58873,7 @@ paths:
       responses:
         '200':
           description: Call graph
-          headers: &id409
+          headers: &id411
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58801,7 +58889,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id409
+          headers: *id411
           content:
             application/json:
               schema:
@@ -58833,7 +58921,7 @@ paths:
       responses:
         '200':
           description: Dead code
-          headers: &id410
+          headers: &id412
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58849,7 +58937,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id410
+          headers: *id412
           content:
             application/json:
               schema:
@@ -58891,7 +58979,7 @@ paths:
       responses:
         '200':
           description: Duplicates
-          headers: &id411
+          headers: &id413
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58907,7 +58995,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDuplicateListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id411
+          headers: *id413
           content:
             application/json:
               schema:
@@ -58927,7 +59015,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id411
+          headers: *id413
           content:
             application/json:
               schema:
@@ -58949,7 +59037,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id411
+          headers: *id413
           content:
             application/json:
               schema:
@@ -58991,7 +59079,7 @@ paths:
       responses:
         '200':
           description: Hotspots
-          headers: &id412
+          headers: &id414
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59007,7 +59095,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseHotspotListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id412
+          headers: *id414
           content:
             application/json:
               schema:
@@ -59027,7 +59115,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id412
+          headers: *id414
           content:
             application/json:
               schema:
@@ -59049,7 +59137,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id412
+          headers: *id414
           content:
             application/json:
               schema:
@@ -59101,7 +59189,7 @@ paths:
       responses:
         '200':
           description: Impact
-          headers: &id413
+          headers: &id415
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59117,7 +59205,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id413
+          headers: *id415
           content:
             application/json:
               schema:
@@ -59145,7 +59233,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id413
+          headers: *id415
           content:
             application/json:
               schema:
@@ -59177,7 +59265,7 @@ paths:
       responses:
         '200':
           description: Metrics report
-          headers: &id414
+          headers: &id416
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59193,7 +59281,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsReportResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id414
+          headers: *id416
           content:
             application/json:
               schema:
@@ -59213,7 +59301,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id414
+          headers: *id416
           content:
             application/json:
               schema:
@@ -59235,7 +59323,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id414
+          headers: *id416
           content:
             application/json:
               schema:
@@ -59251,7 +59339,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id414
+          headers: *id416
           content:
             application/json:
               schema:
@@ -59308,7 +59396,7 @@ paths:
       responses:
         '200':
           description: Metrics analysis started
-          headers: &id415
+          headers: &id417
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59324,7 +59412,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id415
+          headers: *id417
           content:
             application/json:
               schema:
@@ -59352,7 +59440,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id415
+          headers: *id417
           content:
             application/json:
               schema:
@@ -59372,7 +59460,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id415
+          headers: *id417
           content:
             application/json:
               schema:
@@ -59394,7 +59482,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id415
+          headers: *id417
           content:
             application/json:
               schema:
@@ -59431,7 +59519,7 @@ paths:
       responses:
         '200':
           description: File metrics
-          headers: &id416
+          headers: &id418
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59447,7 +59535,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseFileMetricsResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id416
+          headers: *id418
           content:
             application/json:
               schema:
@@ -59467,7 +59555,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id416
+          headers: *id418
           content:
             application/json:
               schema:
@@ -59489,7 +59577,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id416
+          headers: *id418
           content:
             application/json:
               schema:
@@ -59505,7 +59593,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id416
+          headers: *id418
           content:
             application/json:
               schema:
@@ -59547,7 +59635,7 @@ paths:
       responses:
         '200':
           description: Metrics history
-          headers: &id417
+          headers: &id419
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59563,7 +59651,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsHistoryResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id417
+          headers: *id419
           content:
             application/json:
               schema:
@@ -59583,7 +59671,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id417
+          headers: *id419
           content:
             application/json:
               schema:
@@ -59605,7 +59693,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id417
+          headers: *id419
           content:
             application/json:
               schema:
@@ -59642,7 +59730,7 @@ paths:
       responses:
         '200':
           description: Metrics report
-          headers: &id418
+          headers: &id420
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59658,7 +59746,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsReportResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id418
+          headers: *id420
           content:
             application/json:
               schema:
@@ -59678,7 +59766,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id418
+          headers: *id420
           content:
             application/json:
               schema:
@@ -59700,7 +59788,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id418
+          headers: *id420
           content:
             application/json:
               schema:
@@ -59716,7 +59804,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id418
+          headers: *id420
           content:
             application/json:
               schema:
@@ -59766,7 +59854,7 @@ paths:
       responses:
         '200':
           description: SAST findings
-          headers: &id419
+          headers: &id421
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59782,7 +59870,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id419
+          headers: *id421
           content:
             application/json:
               schema:
@@ -59802,7 +59890,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id419
+          headers: *id421
           content:
             application/json:
               schema:
@@ -59824,7 +59912,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id419
+          headers: *id421
           content:
             application/json:
               schema:
@@ -59856,7 +59944,7 @@ paths:
       responses:
         '200':
           description: OWASP summary
-          headers: &id420
+          headers: &id422
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59872,7 +59960,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id420
+          headers: *id422
           content:
             application/json:
               schema:
@@ -59892,7 +59980,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id420
+          headers: *id422
           content:
             application/json:
               schema:
@@ -59914,7 +60002,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id420
+          headers: *id422
           content:
             application/json:
               schema:
@@ -59963,7 +60051,7 @@ paths:
       responses:
         '200':
           description: Scan started
-          headers: &id421
+          headers: &id423
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59979,7 +60067,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id421
+          headers: *id423
           content:
             application/json:
               schema:
@@ -60007,7 +60095,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id421
+          headers: *id423
           content:
             application/json:
               schema:
@@ -60027,7 +60115,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id421
+          headers: *id423
           content:
             application/json:
               schema:
@@ -60049,7 +60137,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id421
+          headers: *id423
           content:
             application/json:
               schema:
@@ -60081,7 +60169,7 @@ paths:
       responses:
         '200':
           description: Latest scan
-          headers: &id422
+          headers: &id424
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60097,7 +60185,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id422
+          headers: *id424
           content:
             application/json:
               schema:
@@ -60117,7 +60205,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id422
+          headers: *id424
           content:
             application/json:
               schema:
@@ -60139,7 +60227,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id422
+          headers: *id424
           content:
             application/json:
               schema:
@@ -60155,7 +60243,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id422
+          headers: *id424
           content:
             application/json:
               schema:
@@ -60204,7 +60292,7 @@ paths:
       responses:
         '200':
           description: SAST scan started
-          headers: &id423
+          headers: &id425
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60220,7 +60308,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id423
+          headers: *id425
           content:
             application/json:
               schema:
@@ -60248,7 +60336,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id423
+          headers: *id425
           content:
             application/json:
               schema:
@@ -60268,7 +60356,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id423
+          headers: *id425
           content:
             application/json:
               schema:
@@ -60290,7 +60378,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id423
+          headers: *id425
           content:
             application/json:
               schema:
@@ -60327,7 +60415,7 @@ paths:
       responses:
         '200':
           description: SAST scan status
-          headers: &id424
+          headers: &id426
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60343,7 +60431,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id424
+          headers: *id426
           content:
             application/json:
               schema:
@@ -60363,7 +60451,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id424
+          headers: *id426
           content:
             application/json:
               schema:
@@ -60385,7 +60473,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id424
+          headers: *id426
           content:
             application/json:
               schema:
@@ -60401,7 +60489,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id424
+          headers: *id426
           content:
             application/json:
               schema:
@@ -60439,7 +60527,7 @@ paths:
       responses:
         '200':
           description: Secrets scan started
-          headers: &id425
+          headers: &id427
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60455,7 +60543,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id425
+          headers: *id427
           content:
             application/json:
               schema:
@@ -60483,7 +60571,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id425
+          headers: *id427
           content:
             application/json:
               schema:
@@ -60503,7 +60591,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id425
+          headers: *id427
           content:
             application/json:
               schema:
@@ -60525,7 +60613,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id425
+          headers: *id427
           content:
             application/json:
               schema:
@@ -60557,7 +60645,7 @@ paths:
       responses:
         '200':
           description: Secrets scan
-          headers: &id426
+          headers: &id428
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60573,7 +60661,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id426
+          headers: *id428
           content:
             application/json:
               schema:
@@ -60593,7 +60681,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id426
+          headers: *id428
           content:
             application/json:
               schema:
@@ -60615,7 +60703,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id426
+          headers: *id428
           content:
             application/json:
               schema:
@@ -60631,7 +60719,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id426
+          headers: *id428
           content:
             application/json:
               schema:
@@ -60668,7 +60756,7 @@ paths:
       responses:
         '200':
           description: Secrets scan
-          headers: &id427
+          headers: &id429
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60684,7 +60772,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id427
+          headers: *id429
           content:
             application/json:
               schema:
@@ -60704,7 +60792,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id427
+          headers: *id429
           content:
             application/json:
               schema:
@@ -60726,7 +60814,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id427
+          headers: *id429
           content:
             application/json:
               schema:
@@ -60742,7 +60830,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id427
+          headers: *id429
           content:
             application/json:
               schema:
@@ -60779,7 +60867,7 @@ paths:
       responses:
         '200':
           description: Scan result
-          headers: &id428
+          headers: &id430
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60795,7 +60883,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id428
+          headers: *id430
           content:
             application/json:
               schema:
@@ -60815,7 +60903,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id428
+          headers: *id430
           content:
             application/json:
               schema:
@@ -60837,7 +60925,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id428
+          headers: *id430
           content:
             application/json:
               schema:
@@ -60853,7 +60941,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id428
+          headers: *id430
           content:
             application/json:
               schema:
@@ -60899,7 +60987,7 @@ paths:
       responses:
         '200':
           description: Scan list
-          headers: &id429
+          headers: &id431
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60915,7 +61003,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id429
+          headers: *id431
           content:
             application/json:
               schema:
@@ -60935,7 +61023,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id429
+          headers: *id431
           content:
             application/json:
               schema:
@@ -60957,7 +61045,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id429
+          headers: *id431
           content:
             application/json:
               schema:
@@ -60989,7 +61077,7 @@ paths:
       responses:
         '200':
           description: Secrets scan list
-          headers: &id430
+          headers: &id432
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61005,7 +61093,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id430
+          headers: *id432
           content:
             application/json:
               schema:
@@ -61025,7 +61113,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id430
+          headers: *id432
           content:
             application/json:
               schema:
@@ -61047,7 +61135,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id430
+          headers: *id432
           content:
             application/json:
               schema:
@@ -61079,7 +61167,7 @@ paths:
       responses:
         '200':
           description: Secrets list
-          headers: &id431
+          headers: &id433
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61095,7 +61183,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id431
+          headers: *id433
           content:
             application/json:
               schema:
@@ -61115,7 +61203,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id431
+          headers: *id433
           content:
             application/json:
               schema:
@@ -61137,7 +61225,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id431
+          headers: *id433
           content:
             application/json:
               schema:
@@ -61169,7 +61257,7 @@ paths:
       responses:
         '200':
           description: Symbols
-          headers: &id432
+          headers: &id434
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61185,7 +61273,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id432
+          headers: *id434
           content:
             application/json:
               schema:
@@ -61237,7 +61325,7 @@ paths:
       responses:
         '200':
           description: Answer
-          headers: &id433
+          headers: &id435
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61253,7 +61341,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id433
+          headers: *id435
           content:
             application/json:
               schema:
@@ -61281,7 +61369,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id433
+          headers: *id435
           content:
             application/json:
               schema:
@@ -61335,7 +61423,7 @@ paths:
       responses:
         '200':
           description: Vulnerability list
-          headers: &id434
+          headers: &id436
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61351,7 +61439,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseVulnerabilityListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id434
+          headers: *id436
           content:
             application/json:
               schema:
@@ -61371,7 +61459,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id434
+          headers: *id436
           content:
             application/json:
               schema:
@@ -61393,7 +61481,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id434
+          headers: *id436
           content:
             application/json:
               schema:
@@ -61966,9 +62054,9 @@ paths:
                     - string
                     - 'null'
                     format: date-time
-        '401': &id436
+        '401': &id438
           description: Unauthorized - Authentication required or token invalid
-          headers: &id435
+          headers: &id437
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61995,9 +62083,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id437
+        '403': &id439
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id435
+          headers: *id437
           content:
             application/json:
               schema:
@@ -62017,9 +62105,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id438
+        '404': &id440
           description: Not found - The requested resource does not exist
-          headers: *id435
+          headers: *id437
           content:
             application/json:
               schema:
@@ -62033,9 +62121,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id439
+        '500': &id441
           description: Internal server error - Unexpected error occurred
-          headers: *id435
+          headers: *id437
           content:
             application/json:
               schema:
@@ -62110,7 +62198,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id435
+          headers: *id437
           content:
             application/json:
               schema:
@@ -62136,10 +62224,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id436
-        '403': *id437
-        '404': *id438
-        '500': *id439
+        '401': *id438
+        '403': *id439
+        '404': *id440
+        '500': *id441
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -62213,9 +62301,9 @@ paths:
                           format: date-time
                   total:
                     type: integer
-        '401': &id441
+        '401': &id443
           description: Unauthorized - Authentication required or token invalid
-          headers: &id440
+          headers: &id442
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62242,9 +62330,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id442
+        '500': &id444
           description: Internal server error - Unexpected error occurred
-          headers: *id440
+          headers: *id442
           content:
             application/json:
               schema:
@@ -62331,7 +62419,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id440
+          headers: *id442
           content:
             application/json:
               schema:
@@ -62357,10 +62445,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id441
+        '401': *id443
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id440
+          headers: *id442
           content:
             application/json:
               schema:
@@ -62380,7 +62468,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id442
+        '500': *id444
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -62417,7 +62505,7 @@ paths:
                         type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id443
+          headers: &id445
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62446,7 +62534,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id443
+          headers: *id445
           content:
             application/json:
               schema:
@@ -62508,9 +62596,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '401': &id445
+        '401': &id447
           description: Unauthorized - Authentication required or token invalid
-          headers: &id444
+          headers: &id446
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62537,9 +62625,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id446
+        '404': &id448
           description: Not found - The requested resource does not exist
-          headers: *id444
+          headers: *id446
           content:
             application/json:
               schema:
@@ -62553,9 +62641,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id447
+        '500': &id449
           description: Internal server error - Unexpected error occurred
-          headers: *id444
+          headers: *id446
           content:
             application/json:
               schema:
@@ -62596,9 +62684,9 @@ paths:
                     type: boolean
                   action_id:
                     type: string
-        '401': *id445
-        '404': *id446
-        '500': *id447
+        '401': *id447
+        '404': *id448
+        '500': *id449
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -62643,7 +62731,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id448
+          headers: &id450
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62680,7 +62768,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id448
+          headers: *id450
           content:
             application/json:
               schema:
@@ -62700,7 +62788,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id448
+          headers: *id450
           content:
             application/json:
               schema:
@@ -62722,7 +62810,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id448
+          headers: *id450
           content:
             application/json:
               schema:
@@ -62762,246 +62850,6 @@ paths:
                 properties:
                   approval:
                     type: object
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: &id449
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id449
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id449
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id449
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/computer-use/approvals/{request_id}/approve:
-    post:
-      tags:
-      - Computer Use
-      summary: Approve a computer-use request
-      description: Approve a pending computer-use approval request.
-      operationId: approveComputerUseRequest
-      parameters:
-      - name: request_id
-        in: path
-        required: true
-        description: Approval request ID
-        schema:
-          type: string
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                reason:
-                  type: string
-      responses:
-        '200':
-          description: Approval granted
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  approved:
-                    type: boolean
-                  request_id:
-                    type: string
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: &id450
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id450
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id450
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id450
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/computer-use/approvals/{request_id}/deny:
-    post:
-      tags:
-      - Computer Use
-      summary: Deny a computer-use request
-      description: Deny a pending computer-use approval request.
-      operationId: denyComputerUseRequest
-      parameters:
-      - name: request_id
-        in: path
-        required: true
-        description: Approval request ID
-        schema:
-          type: string
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                reason:
-                  type: string
-      responses:
-        '200':
-          description: Approval denied
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  denied:
-                    type: boolean
-                  request_id:
-                    type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
           headers: &id451
@@ -63087,6 +62935,246 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
+  /api/v1/computer-use/approvals/{request_id}/approve:
+    post:
+      tags:
+      - Computer Use
+      summary: Approve a computer-use request
+      description: Approve a pending computer-use approval request.
+      operationId: approveComputerUseRequest
+      parameters:
+      - name: request_id
+        in: path
+        required: true
+        description: Approval request ID
+        schema:
+          type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+      responses:
+        '200':
+          description: Approval granted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  approved:
+                    type: boolean
+                  request_id:
+                    type: string
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: &id452
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id452
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id452
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id452
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/computer-use/approvals/{request_id}/deny:
+    post:
+      tags:
+      - Computer Use
+      summary: Deny a computer-use request
+      description: Deny a pending computer-use approval request.
+      operationId: denyComputerUseRequest
+      parameters:
+      - name: request_id
+        in: path
+        required: true
+        description: Approval request ID
+        schema:
+          type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+      responses:
+        '200':
+          description: Approval denied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  denied:
+                    type: boolean
+                  request_id:
+                    type: string
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: &id453
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id453
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id453
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id453
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
   /api/v1/computer-use/policies:
     get:
       tags:
@@ -63124,9 +63212,9 @@ paths:
                             type: string
                   total:
                     type: integer
-        '401': &id453
+        '401': &id455
           description: Unauthorized - Authentication required or token invalid
-          headers: &id452
+          headers: &id454
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63153,9 +63241,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id454
+        '500': &id456
           description: Internal server error - Unexpected error occurred
-          headers: *id452
+          headers: *id454
           content:
             application/json:
               schema:
@@ -63231,7 +63319,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id452
+          headers: *id454
           content:
             application/json:
               schema:
@@ -63257,10 +63345,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id453
+        '401': *id455
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id452
+          headers: *id454
           content:
             application/json:
               schema:
@@ -63280,7 +63368,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id454
+        '500': *id456
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63331,9 +63419,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '401': &id456
+        '401': &id458
           description: Unauthorized - Authentication required or token invalid
-          headers: &id455
+          headers: &id457
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63360,9 +63448,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id457
+        '404': &id459
           description: Not found - The requested resource does not exist
-          headers: *id455
+          headers: *id457
           content:
             application/json:
               schema:
@@ -63376,9 +63464,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id458
+        '500': &id460
           description: Internal server error - Unexpected error occurred
-          headers: *id455
+          headers: *id457
           content:
             application/json:
               schema:
@@ -63456,7 +63544,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id455
+          headers: *id457
           content:
             application/json:
               schema:
@@ -63482,10 +63570,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id456
-        '403': &id459
+        '401': *id458
+        '403': &id461
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id455
+          headers: *id457
           content:
             application/json:
               schema:
@@ -63505,8 +63593,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id457
-        '500': *id458
+        '404': *id459
+        '500': *id460
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63535,10 +63623,10 @@ paths:
                     type: boolean
                   policy_id:
                     type: string
-        '401': *id456
-        '403': *id459
-        '404': *id457
-        '500': *id458
+        '401': *id458
+        '403': *id461
+        '404': *id459
+        '500': *id460
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63613,9 +63701,9 @@ paths:
                               type: integer
                   total:
                     type: integer
-        '401': &id461
+        '401': &id463
           description: Unauthorized - Authentication required or token invalid
-          headers: &id460
+          headers: &id462
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63642,9 +63730,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id462
+        '500': &id464
           description: Internal server error - Unexpected error occurred
-          headers: *id460
+          headers: *id462
           content:
             application/json:
               schema:
@@ -63708,7 +63796,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id460
+          headers: *id462
           content:
             application/json:
               schema:
@@ -63734,10 +63822,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id461
+        '401': *id463
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id460
+          headers: *id462
           content:
             application/json:
               schema:
@@ -63759,7 +63847,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id460
+          headers: *id462
           content:
             application/json:
               schema:
@@ -63774,7 +63862,7 @@ paths:
                     window: 1 minute
                     retry_after: 45
                     trace_id: req_abc123xyz
-        '500': *id462
+        '500': *id464
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63848,9 +63936,9 @@ paths:
                             type: string
                           steps_taken:
                             type: integer
-        '401': &id464
+        '401': &id466
           description: Unauthorized - Authentication required or token invalid
-          headers: &id463
+          headers: &id465
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63877,9 +63965,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id465
+        '404': &id467
           description: Not found - The requested resource does not exist
-          headers: *id463
+          headers: *id465
           content:
             application/json:
               schema:
@@ -63893,9 +63981,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id466
+        '500': &id468
           description: Internal server error - Unexpected error occurred
-          headers: *id463
+          headers: *id465
           content:
             application/json:
               schema:
@@ -63939,7 +64027,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id463
+          headers: *id465
           content:
             application/json:
               schema:
@@ -63965,9 +64053,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id464
-        '404': *id465
-        '500': *id466
+        '401': *id466
+        '404': *id467
+        '500': *id468
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63998,7 +64086,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id467
+          headers: &id469
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64035,7 +64123,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id467
+          headers: *id469
           content:
             application/json:
               schema:
@@ -64055,7 +64143,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id467
+          headers: *id469
           content:
             application/json:
               schema:
@@ -64077,7 +64165,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id467
+          headers: *id469
           content:
             application/json:
               schema:
@@ -64093,7 +64181,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id467
+          headers: *id469
           content:
             application/json:
               schema:
@@ -64903,7 +64991,7 @@ paths:
       responses:
         '200':
           description: Active work snapshot
-          headers: &id468
+          headers: &id470
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64989,7 +65077,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id468
+          headers: *id470
           content:
             application/json:
               schema:
@@ -65009,7 +65097,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id468
+          headers: *id470
           content:
             application/json:
               schema:
@@ -65031,7 +65119,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id468
+          headers: *id470
           content:
             application/json:
               schema:
@@ -65785,7 +65873,7 @@ paths:
       responses:
         '200':
           description: Cost summary
-          headers: &id469
+          headers: &id471
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65801,7 +65889,7 @@ paths:
                 $ref: '#/components/schemas/CostSummaryResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id469
+          headers: *id471
           content:
             application/json:
               schema:
@@ -65821,7 +65909,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id469
+          headers: *id471
           content:
             application/json:
               schema:
@@ -65843,7 +65931,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id469
+          headers: *id471
           content:
             application/json:
               schema:
@@ -65894,7 +65982,7 @@ paths:
       responses:
         '200':
           description: Alerts
-          headers: &id470
+          headers: &id472
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65910,7 +65998,7 @@ paths:
                 $ref: '#/components/schemas/CostAlertsResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id470
+          headers: *id472
           content:
             application/json:
               schema:
@@ -65930,7 +66018,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id470
+          headers: *id472
           content:
             application/json:
               schema:
@@ -65952,7 +66040,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id470
+          headers: *id472
           content:
             application/json:
               schema:
@@ -66002,7 +66090,7 @@ paths:
       responses:
         '201':
           description: Alert created
-          headers: &id471
+          headers: &id473
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66018,7 +66106,7 @@ paths:
                 $ref: '#/components/schemas/CostAlertCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id471
+          headers: *id473
           content:
             application/json:
               schema:
@@ -66046,7 +66134,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id471
+          headers: *id473
           content:
             application/json:
               schema:
@@ -66066,7 +66154,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id471
+          headers: *id473
           content:
             application/json:
               schema:
@@ -66088,7 +66176,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id471
+          headers: *id473
           content:
             application/json:
               schema:
@@ -66120,7 +66208,7 @@ paths:
       responses:
         '200':
           description: Alert dismissed
-          headers: &id472
+          headers: &id474
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66136,7 +66224,7 @@ paths:
                 $ref: '#/components/schemas/CostDismissAlertResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id472
+          headers: *id474
           content:
             application/json:
               schema:
@@ -66156,7 +66244,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id472
+          headers: *id474
           content:
             application/json:
               schema:
@@ -66178,7 +66266,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id472
+          headers: *id474
           content:
             application/json:
               schema:
@@ -66194,7 +66282,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id472
+          headers: *id474
           content:
             application/json:
               schema:
@@ -66433,7 +66521,7 @@ paths:
       responses:
         '200':
           description: Cost breakdown
-          headers: &id473
+          headers: &id475
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66449,7 +66537,7 @@ paths:
                 $ref: '#/components/schemas/CostBreakdownResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id473
+          headers: *id475
           content:
             application/json:
               schema:
@@ -66469,7 +66557,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id473
+          headers: *id475
           content:
             application/json:
               schema:
@@ -66491,7 +66579,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id473
+          headers: *id475
           content:
             application/json:
               schema:
@@ -66523,7 +66611,7 @@ paths:
       responses:
         '200':
           description: Budget updated
-          headers: &id474
+          headers: &id476
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66539,7 +66627,7 @@ paths:
                 $ref: '#/components/schemas/CostBudgetResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id474
+          headers: *id476
           content:
             application/json:
               schema:
@@ -66567,7 +66655,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id474
+          headers: *id476
           content:
             application/json:
               schema:
@@ -66587,7 +66675,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id474
+          headers: *id476
           content:
             application/json:
               schema:
@@ -66609,7 +66697,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id474
+          headers: *id476
           content:
             application/json:
               schema:
@@ -66630,7 +66718,7 @@ paths:
       summary: List budgets
       operationId: listCostsBudgets
       description: List all budgets for the workspace.
-      security: &id476
+      security: &id478
       - {}
       parameters:
       - name: workspace_id
@@ -66645,7 +66733,7 @@ paths:
       responses:
         '200':
           description: Budgets list
-          headers: &id475
+          headers: &id477
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66659,9 +66747,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostBudgetsListResponse'
-        '401': &id477
+        '401': &id479
           description: Unauthorized - Authentication required or token invalid
-          headers: *id475
+          headers: *id477
           content:
             application/json:
               schema:
@@ -66679,9 +66767,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id478
+        '403': &id480
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id475
+          headers: *id477
           content:
             application/json:
               schema:
@@ -66701,9 +66789,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id479
+        '500': &id481
           description: Internal server error - Unexpected error occurred
-          headers: *id475
+          headers: *id477
           content:
             application/json:
               schema:
@@ -66723,7 +66811,7 @@ paths:
       summary: Create budget
       operationId: createCostsBudgets
       description: Create a new budget for the workspace.
-      security: *id476
+      security: *id478
       requestBody:
         required: true
         content:
@@ -66733,14 +66821,14 @@ paths:
       responses:
         '201':
           description: Budget created
-          headers: *id475
+          headers: *id477
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostBudgetResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id475
+          headers: *id477
           content:
             application/json:
               schema:
@@ -66766,9 +66854,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id477
-        '403': *id478
-        '500': *id479
+        '401': *id479
+        '403': *id480
+        '500': *id481
       x-aragora-stability: stable
   /api/v1/costs/constraints/check:
     post:
@@ -66797,7 +66885,7 @@ paths:
       responses:
         '200':
           description: Constraint check result
-          headers: &id480
+          headers: &id482
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66813,7 +66901,7 @@ paths:
                 $ref: '#/components/schemas/CostConstraintCheckResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id480
+          headers: *id482
           content:
             application/json:
               schema:
@@ -66841,7 +66929,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id480
+          headers: *id482
           content:
             application/json:
               schema:
@@ -66861,7 +66949,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id480
+          headers: *id482
           content:
             application/json:
               schema:
@@ -66883,7 +66971,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id480
+          headers: *id482
           content:
             application/json:
               schema:
@@ -66916,7 +67004,7 @@ paths:
       responses:
         '200':
           description: Debate session costs
-          headers: &id481
+          headers: &id483
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66959,7 +67047,7 @@ paths:
                         additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id481
+          headers: *id483
           content:
             application/json:
               schema:
@@ -66987,7 +67075,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id481
+          headers: *id483
           content:
             application/json:
               schema:
@@ -67007,7 +67095,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id481
+          headers: *id483
           content:
             application/json:
               schema:
@@ -67031,7 +67119,7 @@ paths:
           description: Cost tracker unavailable
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id481
+          headers: *id483
           content:
             application/json:
               schema:
@@ -67094,7 +67182,7 @@ paths:
       responses:
         '200':
           description: Debate cost line items
-          headers: &id482
+          headers: &id484
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67132,7 +67220,7 @@ paths:
                         type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id482
+          headers: *id484
           content:
             application/json:
               schema:
@@ -67160,7 +67248,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id482
+          headers: *id484
           content:
             application/json:
               schema:
@@ -67180,7 +67268,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id482
+          headers: *id484
           content:
             application/json:
               schema:
@@ -67204,7 +67292,7 @@ paths:
           description: Cost tracker unavailable
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id482
+          headers: *id484
           content:
             application/json:
               schema:
@@ -67237,7 +67325,7 @@ paths:
       responses:
         '200':
           description: Debate cost performance
-          headers: &id483
+          headers: &id485
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67285,7 +67373,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id483
+          headers: *id485
           content:
             application/json:
               schema:
@@ -67313,7 +67401,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id483
+          headers: *id485
           content:
             application/json:
               schema:
@@ -67333,7 +67421,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id483
+          headers: *id485
           content:
             application/json:
               schema:
@@ -67357,7 +67445,7 @@ paths:
           description: Cost tracker unavailable
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id483
+          headers: *id485
           content:
             application/json:
               schema:
@@ -67392,7 +67480,7 @@ paths:
       responses:
         '200':
           description: Efficiency metrics
-          headers: &id484
+          headers: &id486
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67416,7 +67504,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id484
+          headers: *id486
           content:
             application/json:
               schema:
@@ -67436,7 +67524,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id484
+          headers: *id486
           content:
             application/json:
               schema:
@@ -67458,7 +67546,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id484
+          headers: *id486
           content:
             application/json:
               schema:
@@ -67501,7 +67589,7 @@ paths:
       responses:
         '200':
           description: Cost estimate
-          headers: &id485
+          headers: &id487
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67517,7 +67605,7 @@ paths:
                 $ref: '#/components/schemas/CostEstimateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id485
+          headers: *id487
           content:
             application/json:
               schema:
@@ -67545,7 +67633,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id485
+          headers: *id487
           content:
             application/json:
               schema:
@@ -67565,7 +67653,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id485
+          headers: *id487
           content:
             application/json:
               schema:
@@ -67587,7 +67675,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id485
+          headers: *id487
           content:
             application/json:
               schema:
@@ -67630,7 +67718,7 @@ paths:
       responses:
         '200':
           description: Export generated
-          headers: &id486
+          headers: &id488
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67653,7 +67741,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id486
+          headers: *id488
           content:
             application/json:
               schema:
@@ -67673,7 +67761,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id486
+          headers: *id488
           content:
             application/json:
               schema:
@@ -67695,7 +67783,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id486
+          headers: *id488
           content:
             application/json:
               schema:
@@ -67733,7 +67821,7 @@ paths:
       responses:
         '200':
           description: Forecast
-          headers: &id487
+          headers: &id489
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67758,7 +67846,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id487
+          headers: *id489
           content:
             application/json:
               schema:
@@ -67778,7 +67866,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id487
+          headers: *id489
           content:
             application/json:
               schema:
@@ -67800,7 +67888,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id487
+          headers: *id489
           content:
             application/json:
               schema:
@@ -67843,7 +67931,7 @@ paths:
       responses:
         '200':
           description: Detailed forecast
-          headers: &id488
+          headers: &id490
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67859,7 +67947,7 @@ paths:
                 $ref: '#/components/schemas/CostForecastDetailedResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id488
+          headers: *id490
           content:
             application/json:
               schema:
@@ -67879,7 +67967,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id488
+          headers: *id490
           content:
             application/json:
               schema:
@@ -67901,7 +67989,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id488
+          headers: *id490
           content:
             application/json:
               schema:
@@ -67965,7 +68053,7 @@ paths:
       responses:
         '200':
           description: Recommendations
-          headers: &id489
+          headers: &id491
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67988,7 +68076,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id489
+          headers: *id491
           content:
             application/json:
               schema:
@@ -68008,7 +68096,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id489
+          headers: *id491
           content:
             application/json:
               schema:
@@ -68030,7 +68118,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id489
+          headers: *id491
           content:
             application/json:
               schema:
@@ -68071,7 +68159,7 @@ paths:
       responses:
         '200':
           description: Detailed recommendations
-          headers: &id490
+          headers: &id492
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68087,7 +68175,7 @@ paths:
                 $ref: '#/components/schemas/CostRecommendationsDetailedResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id490
+          headers: *id492
           content:
             application/json:
               schema:
@@ -68107,7 +68195,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id490
+          headers: *id492
           content:
             application/json:
               schema:
@@ -68129,7 +68217,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id490
+          headers: *id492
           content:
             application/json:
               schema:
@@ -68252,7 +68340,7 @@ paths:
       responses:
         '200':
           description: Cost timeline
-          headers: &id491
+          headers: &id493
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68268,7 +68356,7 @@ paths:
                 $ref: '#/components/schemas/CostTimelineResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id491
+          headers: *id493
           content:
             application/json:
               schema:
@@ -68288,7 +68376,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id491
+          headers: *id493
           content:
             application/json:
               schema:
@@ -68310,7 +68398,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id491
+          headers: *id493
           content:
             application/json:
               schema:
@@ -68358,7 +68446,7 @@ paths:
       responses:
         '200':
           description: Usage data
-          headers: &id492
+          headers: &id494
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68374,7 +68462,7 @@ paths:
                 $ref: '#/components/schemas/CostUsageResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id492
+          headers: *id494
           content:
             application/json:
               schema:
@@ -68394,7 +68482,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id492
+          headers: *id494
           content:
             application/json:
               schema:
@@ -68416,7 +68504,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id492
+          headers: *id494
           content:
             application/json:
               schema:
@@ -69062,7 +69150,7 @@ paths:
       responses:
         '200':
           description: Circuit breaker status with state and failure count
-          headers: &id493
+          headers: &id495
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69102,7 +69190,7 @@ paths:
       responses:
         '200':
           description: Circuit breaker reset confirmation
-          headers: *id493
+          headers: *id495
           content:
             application/json:
               schema:
@@ -69444,7 +69532,7 @@ paths:
       responses:
         '200':
           description: CVE details
-          headers: &id494
+          headers: &id496
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69460,7 +69548,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseCVEResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id494
+          headers: *id496
           content:
             application/json:
               schema:
@@ -69480,7 +69568,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id494
+          headers: *id496
           content:
             application/json:
               schema:
@@ -69502,7 +69590,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id494
+          headers: *id496
           content:
             application/json:
               schema:
@@ -69518,7 +69606,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id494
+          headers: *id496
           content:
             application/json:
               schema:
@@ -69565,7 +69653,7 @@ paths:
       responses:
         '200':
           description: Activity feed
-          headers: &id495
+          headers: &id497
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69600,7 +69688,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id495
+          headers: *id497
           content:
             application/json:
               schema:
@@ -69620,7 +69708,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id495
+          headers: *id497
           content:
             application/json:
               schema:
@@ -69701,7 +69789,7 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: &id496
+          headers: &id498
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69737,7 +69825,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id496
+          headers: *id498
           content:
             application/json:
               schema:
@@ -69757,7 +69845,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id496
+          headers: *id498
           content:
             application/json:
               schema:
@@ -69773,7 +69861,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id496
+          headers: *id498
           content:
             application/json:
               schema:
@@ -69925,7 +70013,7 @@ paths:
       responses:
         '200':
           description: Inbox summary
-          headers: &id497
+          headers: &id499
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69950,7 +70038,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id497
+          headers: *id499
           content:
             application/json:
               schema:
@@ -69970,7 +70058,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id497
+          headers: *id499
           content:
             application/json:
               schema:
@@ -69996,7 +70084,7 @@ paths:
       responses:
         '200':
           description: Labels list
-          headers: &id498
+          headers: &id500
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70026,7 +70114,7 @@ paths:
                           type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id498
+          headers: *id500
           content:
             application/json:
               schema:
@@ -70046,7 +70134,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id498
+          headers: *id500
           content:
             application/json:
               schema:
@@ -70072,7 +70160,7 @@ paths:
       responses:
         '200':
           description: Dashboard overview data
-          headers: &id499
+          headers: &id501
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70111,7 +70199,7 @@ paths:
                     - unhealthy
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id499
+          headers: *id501
           content:
             application/json:
               schema:
@@ -70131,7 +70219,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id499
+          headers: *id501
           content:
             application/json:
               schema:
@@ -70157,7 +70245,7 @@ paths:
       responses:
         '200':
           description: Pending actions
-          headers: &id500
+          headers: &id502
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70192,7 +70280,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id500
+          headers: *id502
           content:
             application/json:
               schema:
@@ -70212,7 +70300,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id500
+          headers: *id502
           content:
             application/json:
               schema:
@@ -70244,7 +70332,7 @@ paths:
       responses:
         '200':
           description: Action completed
-          headers: &id501
+          headers: &id503
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70268,7 +70356,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id501
+          headers: *id503
           content:
             application/json:
               schema:
@@ -70288,7 +70376,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id501
+          headers: *id503
           content:
             application/json:
               schema:
@@ -70304,7 +70392,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id501
+          headers: *id503
           content:
             application/json:
               schema:
@@ -70330,7 +70418,7 @@ paths:
       responses:
         '200':
           description: Quality metrics
-          headers: &id502
+          headers: &id504
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70355,7 +70443,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id502
+          headers: *id504
           content:
             application/json:
               schema:
@@ -70375,7 +70463,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id502
+          headers: *id504
           content:
             application/json:
               schema:
@@ -70401,7 +70489,7 @@ paths:
       responses:
         '200':
           description: Quick actions
-          headers: &id503
+          headers: &id505
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70431,7 +70519,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id503
+          headers: *id505
           content:
             application/json:
               schema:
@@ -70451,7 +70539,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id503
+          headers: *id505
           content:
             application/json:
               schema:
@@ -70483,7 +70571,7 @@ paths:
       responses:
         '200':
           description: Action executed
-          headers: &id504
+          headers: &id506
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70506,7 +70594,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id504
+          headers: *id506
           content:
             application/json:
               schema:
@@ -70526,7 +70614,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id504
+          headers: *id506
           content:
             application/json:
               schema:
@@ -70542,7 +70630,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id504
+          headers: *id506
           content:
             application/json:
               schema:
@@ -70574,7 +70662,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id505
+          headers: &id507
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70610,7 +70698,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id505
+          headers: *id507
           content:
             application/json:
               schema:
@@ -70630,7 +70718,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id505
+          headers: *id507
           content:
             application/json:
               schema:
@@ -70656,7 +70744,7 @@ paths:
       responses:
         '200':
           description: Stat cards
-          headers: &id506
+          headers: &id508
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70690,7 +70778,7 @@ paths:
                           - stable
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id506
+          headers: *id508
           content:
             application/json:
               schema:
@@ -70710,7 +70798,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id506
+          headers: *id508
           content:
             application/json:
               schema:
@@ -70736,7 +70824,7 @@ paths:
       responses:
         '200':
           description: Dashboard statistics
-          headers: &id507
+          headers: &id509
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70763,7 +70851,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id507
+          headers: *id509
           content:
             application/json:
               schema:
@@ -70783,7 +70871,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id507
+          headers: *id509
           content:
             application/json:
               schema:
@@ -70809,7 +70897,7 @@ paths:
       responses:
         '200':
           description: Team performance
-          headers: &id508
+          headers: &id510
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70839,7 +70927,7 @@ paths:
                           type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id508
+          headers: *id510
           content:
             application/json:
               schema:
@@ -70859,7 +70947,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id508
+          headers: *id510
           content:
             application/json:
               schema:
@@ -70891,7 +70979,7 @@ paths:
       responses:
         '200':
           description: Team performance detail
-          headers: &id509
+          headers: &id511
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70922,7 +71010,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id509
+          headers: *id511
           content:
             application/json:
               schema:
@@ -70942,7 +71030,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id509
+          headers: *id511
           content:
             application/json:
               schema:
@@ -70958,7 +71046,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id509
+          headers: *id511
           content:
             application/json:
               schema:
@@ -70984,7 +71072,7 @@ paths:
       responses:
         '200':
           description: Top senders
-          headers: &id510
+          headers: &id512
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71014,7 +71102,7 @@ paths:
                           type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id510
+          headers: *id512
           content:
             application/json:
               schema:
@@ -71034,7 +71122,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id510
+          headers: *id512
           content:
             application/json:
               schema:
@@ -71060,7 +71148,7 @@ paths:
       responses:
         '200':
           description: Urgent items
-          headers: &id511
+          headers: &id513
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71095,7 +71183,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id511
+          headers: *id513
           content:
             application/json:
               schema:
@@ -71115,7 +71203,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id511
+          headers: *id513
           content:
             application/json:
               schema:
@@ -71147,7 +71235,7 @@ paths:
       responses:
         '200':
           description: Item dismissed
-          headers: &id512
+          headers: &id514
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71168,7 +71256,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id512
+          headers: *id514
           content:
             application/json:
               schema:
@@ -71188,7 +71276,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id512
+          headers: *id514
           content:
             application/json:
               schema:
@@ -71204,7 +71292,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id512
+          headers: *id514
           content:
             application/json:
               schema:
@@ -71356,7 +71444,7 @@ paths:
       responses:
         '200':
           description: Debate created successfully
-          headers: &id513
+          headers: &id515
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71372,7 +71460,7 @@ paths:
                 $ref: '#/components/schemas/DebateCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id513
+          headers: *id515
           content:
             application/json:
               schema:
@@ -71400,7 +71488,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id513
+          headers: *id515
           content:
             application/json:
               schema:
@@ -71495,7 +71583,7 @@ paths:
       responses:
         '200':
           description: Meta-critique
-          headers: &id514
+          headers: &id516
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71534,7 +71622,7 @@ paths:
                       type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id514
+          headers: *id516
           content:
             application/json:
               schema:
@@ -71604,7 +71692,7 @@ paths:
       responses:
         '200':
           description: Paginated list of debates
-          headers: &id515
+          headers: &id517
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71626,9 +71714,9 @@ paths:
                   count:
                     type: integer
                     description: Total number of debates matching filters
-        '401': &id516
+        '401': &id518
           description: Unauthorized - Authentication required or token invalid
-          headers: *id515
+          headers: *id517
           content:
             application/json:
               schema:
@@ -71646,9 +71734,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '429': &id517
+        '429': &id519
           description: Too many requests - Rate limit exceeded
-          headers: *id515
+          headers: *id517
           content:
             application/json:
               schema:
@@ -71724,14 +71812,14 @@ paths:
       responses:
         '200':
           description: Debate created successfully
-          headers: *id515
+          headers: *id517
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DebateCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id515
+          headers: *id517
           content:
             application/json:
               schema:
@@ -71757,10 +71845,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id516
+        '401': *id518
         '402':
           description: Payment required - Quota exceeded, upgrade required
-          headers: *id515
+          headers: *id517
           content:
             application/json:
               schema:
@@ -71776,10 +71864,10 @@ paths:
                     resets_at: '2024-01-16T00:00:00Z'
                     upgrade_url: https://aragora.ai/pricing
                     trace_id: req_abc123xyz
-        '429': *id517
+        '429': *id519
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id515
+          headers: *id517
           content:
             application/json:
               schema:
@@ -71804,7 +71892,7 @@ paths:
       responses:
         '200':
           description: Active debates returned
-          headers: &id518
+          headers: &id520
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71851,7 +71939,7 @@ paths:
                 - debates
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id518
+          headers: *id520
           content:
             application/json:
               schema:
@@ -71974,7 +72062,7 @@ paths:
       responses:
         '200':
           description: Batch list
-          headers: &id519
+          headers: &id521
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71995,9 +72083,9 @@ paths:
                       type: object
                   count:
                     type: integer
-        '400': &id520
+        '400': &id522
           description: Bad request - Invalid input or malformed JSON
-          headers: *id519
+          headers: *id521
           content:
             application/json:
               schema:
@@ -72045,7 +72133,7 @@ paths:
       responses:
         '200':
           description: Batch submitted
-          headers: *id519
+          headers: *id521
           content:
             application/json:
               schema:
@@ -72061,7 +72149,7 @@ paths:
                     type: integer
                   submitted_at:
                     type: string
-        '400': *id520
+        '400': *id522
       x-aragora-stability: stable
   /api/v1/debates/batch/{id}/status:
     get:
@@ -72079,7 +72167,7 @@ paths:
       responses:
         '200':
           description: Batch status
-          headers: &id521
+          headers: &id523
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72110,7 +72198,7 @@ paths:
                       type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id521
+          headers: *id523
           content:
             application/json:
               schema:
@@ -72296,7 +72384,7 @@ paths:
       responses:
         '200':
           description: Cost estimate
-          headers: &id522
+          headers: &id524
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72312,7 +72400,7 @@ paths:
                 $ref: '#/components/schemas/DebateCostEstimateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id522
+          headers: *id524
           content:
             application/json:
               schema:
@@ -72555,7 +72643,7 @@ paths:
       responses:
         '200':
           description: Debate graph
-          headers: &id523
+          headers: &id525
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72582,7 +72670,7 @@ paths:
                     type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id523
+          headers: *id525
           content:
             application/json:
               schema:
@@ -72647,7 +72735,7 @@ paths:
       responses:
         '200':
           description: Hybrid debates
-          headers: &id524
+          headers: &id526
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72690,9 +72778,9 @@ paths:
                 required:
                 - debates
                 - total
-        '401': &id525
+        '401': &id527
           description: Unauthorized - Authentication required or token invalid
-          headers: *id524
+          headers: *id526
           content:
             application/json:
               schema:
@@ -72710,9 +72798,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id526
+        '403': &id528
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id524
+          headers: *id526
           content:
             application/json:
               schema:
@@ -72732,9 +72820,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '429': &id527
+        '429': &id529
           description: Too many requests - Rate limit exceeded
-          headers: *id524
+          headers: *id526
           content:
             application/json:
               schema:
@@ -72749,9 +72837,9 @@ paths:
                     window: 1 minute
                     retry_after: 45
                     trace_id: req_abc123xyz
-        '500': &id528
+        '500': &id530
           description: Internal server error - Unexpected error occurred
-          headers: *id524
+          headers: *id526
           content:
             application/json:
               schema:
@@ -72814,7 +72902,7 @@ paths:
       responses:
         '201':
           description: Hybrid debate created
-          headers: *id524
+          headers: *id526
           content:
             application/json:
               schema:
@@ -72872,7 +72960,7 @@ paths:
                 additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id524
+          headers: *id526
           content:
             application/json:
               schema:
@@ -72898,10 +72986,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id525
-        '403': *id526
-        '429': *id527
-        '500': *id528
+        '401': *id527
+        '403': *id528
+        '429': *id529
+        '500': *id530
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -72923,7 +73011,7 @@ paths:
       responses:
         '200':
           description: Hybrid debate details
-          headers: &id529
+          headers: &id531
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72990,7 +73078,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id529
+          headers: *id531
           content:
             application/json:
               schema:
@@ -73010,7 +73098,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id529
+          headers: *id531
           content:
             application/json:
               schema:
@@ -73032,7 +73120,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id529
+          headers: *id531
           content:
             application/json:
               schema:
@@ -73048,7 +73136,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id529
+          headers: *id531
           content:
             application/json:
               schema:
@@ -73142,7 +73230,7 @@ paths:
       responses:
         '200':
           description: Matrix comparison
-          headers: &id530
+          headers: &id532
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73177,7 +73265,7 @@ paths:
                     - 'null'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id530
+          headers: *id532
           content:
             application/json:
               schema:
@@ -73367,7 +73455,7 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: &id531
+          headers: &id533
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73383,7 +73471,7 @@ paths:
                 $ref: '#/components/schemas/Debate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id531
+          headers: *id533
           content:
             application/json:
               schema:
@@ -73598,7 +73686,7 @@ paths:
       responses:
         '200':
           description: Counterfactuals
-          headers: &id532
+          headers: &id534
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73614,7 +73702,7 @@ paths:
                 $ref: '#/components/schemas/Counterfactuals'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id532
+          headers: *id534
           content:
             application/json:
               schema:
@@ -73652,7 +73740,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id533
+          headers: &id535
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73668,7 +73756,7 @@ paths:
                 $ref: '#/components/schemas/DecisionExplanation'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id533
+          headers: *id535
           content:
             application/json:
               schema:
@@ -73810,7 +73898,7 @@ paths:
       responses:
         '200':
           description: Argument injected
-          headers: &id534
+          headers: &id536
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73837,7 +73925,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id534
+          headers: *id536
           content:
             application/json:
               schema:
@@ -73865,7 +73953,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id534
+          headers: *id536
           content:
             application/json:
               schema:
@@ -73909,7 +73997,7 @@ paths:
       responses:
         '200':
           description: Intervention log
-          headers: &id535
+          headers: &id537
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73934,7 +74022,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id535
+          headers: *id537
           content:
             application/json:
               schema:
@@ -73972,7 +74060,7 @@ paths:
       responses:
         '200':
           description: Debate paused
-          headers: &id536
+          headers: &id538
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73998,7 +74086,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id536
+          headers: *id538
           content:
             application/json:
               schema:
@@ -74026,7 +74114,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id536
+          headers: *id538
           content:
             application/json:
               schema:
@@ -74064,7 +74152,7 @@ paths:
       responses:
         '200':
           description: Debate resumed
-          headers: &id537
+          headers: &id539
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74094,7 +74182,7 @@ paths:
                     - 'null'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id537
+          headers: *id539
           content:
             application/json:
               schema:
@@ -74122,7 +74210,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id537
+          headers: *id539
           content:
             application/json:
               schema:
@@ -74160,7 +74248,7 @@ paths:
       responses:
         '200':
           description: Intervention state
-          headers: &id538
+          headers: &id540
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74192,7 +74280,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id538
+          headers: *id540
           content:
             application/json:
               schema:
@@ -74236,7 +74324,7 @@ paths:
       responses:
         '200':
           description: Threshold updated
-          headers: &id539
+          headers: &id541
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74261,7 +74349,7 @@ paths:
                     type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id539
+          headers: *id541
           content:
             application/json:
               schema:
@@ -74289,7 +74377,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id539
+          headers: *id541
           content:
             application/json:
               schema:
@@ -74333,7 +74421,7 @@ paths:
       responses:
         '200':
           description: Weight updated
-          headers: &id540
+          headers: &id542
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74360,7 +74448,7 @@ paths:
                     type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id540
+          headers: *id542
           content:
             application/json:
               schema:
@@ -74388,7 +74476,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id540
+          headers: *id542
           content:
             application/json:
               schema:
@@ -74539,7 +74627,7 @@ paths:
       responses:
         '200':
           description: Summary
-          headers: &id541
+          headers: &id543
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74555,7 +74643,7 @@ paths:
                 $ref: '#/components/schemas/DebateSummary'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id541
+          headers: *id543
           content:
             application/json:
               schema:
@@ -74591,7 +74679,7 @@ paths:
       responses:
         '200':
           description: Vote pivots
-          headers: &id542
+          headers: &id544
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74607,7 +74695,7 @@ paths:
                 $ref: '#/components/schemas/VotePivots'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id542
+          headers: *id544
           content:
             application/json:
               schema:
@@ -74638,7 +74726,7 @@ paths:
       responses:
         '200':
           description: Delete result
-          headers: &id543
+          headers: &id545
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74655,9 +74743,9 @@ paths:
                 properties:
                   success:
                     type: boolean
-        '404': &id544
+        '404': &id546
           description: Not found - The requested resource does not exist
-          headers: *id543
+          headers: *id545
           content:
             application/json:
               schema:
@@ -74706,15 +74794,15 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: *id543
+          headers: *id545
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Debate'
-        '404': *id544
-        '500': &id545
+        '404': *id546
+        '500': &id547
           description: Internal server error - Unexpected error occurred
-          headers: *id543
+          headers: *id545
           content:
             application/json:
               schema:
@@ -74767,7 +74855,7 @@ paths:
       responses:
         '200':
           description: Update result with the updated debate summary
-          headers: *id543
+          headers: *id545
           content:
             application/json:
               schema:
@@ -74796,7 +74884,7 @@ paths:
                           type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id543
+          headers: *id545
           content:
             application/json:
               schema:
@@ -74824,7 +74912,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id543
+          headers: *id545
           content:
             application/json:
               schema:
@@ -74844,8 +74932,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id544
-        '500': *id545
+        '404': *id546
+        '500': *id547
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -74865,7 +74953,7 @@ paths:
       responses:
         '200':
           description: Archive result
-          headers: &id546
+          headers: &id548
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74884,7 +74972,7 @@ paths:
                     type: boolean
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id546
+          headers: *id548
           content:
             application/json:
               schema:
@@ -75000,7 +75088,7 @@ paths:
       responses:
         '200':
           description: Cancel result
-          headers: &id547
+          headers: &id549
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75021,7 +75109,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id547
+          headers: *id549
           content:
             application/json:
               schema:
@@ -75129,7 +75217,7 @@ paths:
       responses:
         '200':
           description: Clone result
-          headers: &id548
+          headers: &id550
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75148,7 +75236,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id548
+          headers: *id550
           content:
             application/json:
               schema:
@@ -75179,7 +75267,7 @@ paths:
       responses:
         '200':
           description: Consensus data
-          headers: &id549
+          headers: &id551
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75208,7 +75296,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id549
+          headers: *id551
           content:
             application/json:
               schema:
@@ -75374,7 +75462,7 @@ paths:
       responses:
         '200':
           description: Diagnostic report
-          headers: &id550
+          headers: &id552
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75490,7 +75578,7 @@ paths:
                   - Consider adding OPENROUTER_API_KEY as fallback for failed providers
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id550
+          headers: *id552
           content:
             application/json:
               schema:
@@ -75506,7 +75594,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id550
+          headers: *id552
           content:
             application/json:
               schema:
@@ -75587,7 +75675,7 @@ paths:
       responses:
         '200':
           description: Evidence chain
-          headers: &id551
+          headers: &id553
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75603,7 +75691,7 @@ paths:
                 $ref: '#/components/schemas/EvidenceChain'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id551
+          headers: *id553
           content:
             application/json:
               schema:
@@ -75634,7 +75722,7 @@ paths:
       responses:
         '200':
           description: Explainability data
-          headers: &id552
+          headers: &id554
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75661,7 +75749,7 @@ paths:
                     type: number
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id552
+          headers: *id554
           content:
             application/json:
               schema:
@@ -75692,7 +75780,7 @@ paths:
       responses:
         '200':
           description: Counterfactual scenarios
-          headers: &id553
+          headers: &id555
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75718,9 +75806,9 @@ paths:
                           type: string
                         probability:
                           type: number
-        '404': &id554
+        '404': &id556
           description: Not found - The requested resource does not exist
-          headers: *id553
+          headers: *id555
           content:
             application/json:
               schema:
@@ -75756,7 +75844,7 @@ paths:
       responses:
         '200':
           description: Counterfactual result
-          headers: *id553
+          headers: *id555
           content:
             application/json:
               schema:
@@ -75772,7 +75860,7 @@ paths:
                       type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id553
+          headers: *id555
           content:
             application/json:
               schema:
@@ -75798,7 +75886,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id554
+        '404': *id556
       x-aragora-stability: stable
   /api/v1/debates/{id}/explainability/factors:
     get:
@@ -75816,7 +75904,7 @@ paths:
       responses:
         '200':
           description: Factors
-          headers: &id555
+          headers: &id557
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75848,7 +75936,7 @@ paths:
                             type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id555
+          headers: *id557
           content:
             application/json:
               schema:
@@ -75879,7 +75967,7 @@ paths:
       responses:
         '200':
           description: Narrative
-          headers: &id556
+          headers: &id558
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75904,7 +75992,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id556
+          headers: *id558
           content:
             application/json:
               schema:
@@ -75935,7 +76023,7 @@ paths:
       responses:
         '200':
           description: Provenance
-          headers: &id557
+          headers: &id559
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75967,7 +76055,7 @@ paths:
                           type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id557
+          headers: *id559
           content:
             application/json:
               schema:
@@ -76056,7 +76144,7 @@ paths:
       responses:
         '200':
           description: Follow-up created
-          headers: &id558
+          headers: &id560
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76075,7 +76163,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id558
+          headers: *id560
           content:
             application/json:
               schema:
@@ -76118,7 +76206,7 @@ paths:
       responses:
         '201':
           description: Forked debate created
-          headers: &id559
+          headers: &id561
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76141,7 +76229,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id559
+          headers: *id561
           content:
             application/json:
               schema:
@@ -76314,7 +76402,7 @@ paths:
       responses:
         '200':
           description: Joined debate
-          headers: &id560
+          headers: &id562
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76339,7 +76427,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id560
+          headers: *id562
           content:
             application/json:
               schema:
@@ -76435,7 +76523,7 @@ paths:
       responses:
         '200':
           description: Message
-          headers: &id561
+          headers: &id563
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76451,7 +76539,7 @@ paths:
                 $ref: '#/components/schemas/Message'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id561
+          headers: *id563
           content:
             application/json:
               schema:
@@ -76479,7 +76567,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id561
+          headers: *id563
           content:
             application/json:
               schema:
@@ -76583,7 +76671,7 @@ paths:
       responses:
         '200':
           description: Pause result
-          headers: &id562
+          headers: &id564
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76604,7 +76692,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id562
+          headers: *id564
           content:
             application/json:
               schema:
@@ -76757,114 +76845,6 @@ paths:
       responses:
         '200':
           description: Resume result
-          headers: &id563
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                  status:
-                    type: string
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id563
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-      x-aragora-stability: stable
-  /api/v1/debates/{id}/rhetorical:
-    get:
-      tags:
-      - Auditing
-      summary: Get rhetorical analysis
-      operationId: getDebateRhetoricalV1
-      description: Get rhetorical pattern observations for a debate.
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Rhetorical analysis
-          headers: &id564
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  debate_id:
-                    type: string
-                  observations:
-                    type: array
-                    items:
-                      type: object
-                  summary:
-                    type: object
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id564
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-      x-aragora-stability: stable
-  /api/v1/debates/{id}/start:
-    post:
-      tags:
-      - Debates
-      summary: Start debate
-      operationId: startDebateV1
-      description: Start a debate.
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Start result
           headers: &id565
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -76901,13 +76881,13 @@ paths:
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
       x-aragora-stability: stable
-  /api/v1/debates/{id}/stop:
-    post:
+  /api/v1/debates/{id}/rhetorical:
+    get:
       tags:
-      - Debates
-      summary: Stop debate
-      operationId: stopDebateV1
-      description: Stop a running debate.
+      - Auditing
+      summary: Get rhetorical analysis
+      operationId: getDebateRhetoricalV1
+      description: Get rhetorical pattern observations for a debate.
       parameters:
       - name: id
         in: path
@@ -76916,8 +76896,64 @@ paths:
           type: string
       responses:
         '200':
-          description: Stop result
+          description: Rhetorical analysis
           headers: &id566
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  debate_id:
+                    type: string
+                  observations:
+                    type: array
+                    items:
+                      type: object
+                  summary:
+                    type: object
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id566
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: stable
+  /api/v1/debates/{id}/start:
+    post:
+      tags:
+      - Debates
+      summary: Start debate
+      operationId: startDebateV1
+      description: Start a debate.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Start result
+          headers: &id567
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76938,7 +76974,59 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id566
+          headers: *id567
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: stable
+  /api/v1/debates/{id}/stop:
+    post:
+      tags:
+      - Debates
+      summary: Stop debate
+      operationId: stopDebateV1
+      description: Stop a running debate.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Stop result
+          headers: &id568
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  status:
+                    type: string
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id568
           content:
             application/json:
               schema:
@@ -76975,7 +77063,7 @@ paths:
       responses:
         '200':
           description: Suggestion recorded
-          headers: &id567
+          headers: &id569
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76998,7 +77086,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id567
+          headers: *id569
           content:
             application/json:
               schema:
@@ -77026,7 +77114,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id567
+          headers: *id569
           content:
             application/json:
               schema:
@@ -77079,7 +77167,7 @@ paths:
                 type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: &id568
+          headers: &id570
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77104,7 +77192,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id568
+          headers: *id570
           content:
             application/json:
               schema:
@@ -77134,7 +77222,7 @@ paths:
       responses:
         '200':
           description: Trickster status
-          headers: &id569
+          headers: &id571
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77165,7 +77253,7 @@ paths:
                     - 'null'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id569
+          headers: *id571
           content:
             application/json:
               schema:
@@ -77202,7 +77290,7 @@ paths:
       responses:
         '200':
           description: Debate updated
-          headers: &id570
+          headers: &id572
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77227,7 +77315,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id570
+          headers: *id572
           content:
             application/json:
               schema:
@@ -77255,7 +77343,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id570
+          headers: *id572
           content:
             application/json:
               schema:
@@ -77305,7 +77393,7 @@ paths:
       responses:
         '200':
           description: User input added
-          headers: &id571
+          headers: &id573
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77326,7 +77414,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id571
+          headers: *id573
           content:
             application/json:
               schema:
@@ -77354,7 +77442,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id571
+          headers: *id573
           content:
             application/json:
               schema:
@@ -77385,7 +77473,7 @@ paths:
       responses:
         '200':
           description: Verification report
-          headers: &id572
+          headers: &id574
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77422,7 +77510,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id572
+          headers: *id574
           content:
             application/json:
               schema:
@@ -77465,7 +77553,7 @@ paths:
       responses:
         '200':
           description: Verification result
-          headers: &id573
+          headers: &id575
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77498,7 +77586,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id573
+          headers: *id575
           content:
             application/json:
               schema:
@@ -77526,7 +77614,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id573
+          headers: *id575
           content:
             application/json:
               schema:
@@ -77563,7 +77651,7 @@ paths:
       responses:
         '200':
           description: Vote recorded
-          headers: &id574
+          headers: &id576
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77588,7 +77676,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id574
+          headers: *id576
           content:
             application/json:
               schema:
@@ -77616,7 +77704,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id574
+          headers: *id576
           content:
             application/json:
               schema:
@@ -78016,7 +78104,7 @@ paths:
       summary: List decisions
       operationId: listDecisions
       description: List recent decision records (most recent first).
-      security: &id576
+      security: &id578
       - {}
       parameters:
       - name: limit
@@ -78028,7 +78116,7 @@ paths:
       responses:
         '200':
           description: Decision list
-          headers: &id575
+          headers: &id577
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78042,9 +78130,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DecisionList'
-        '500': &id577
+        '500': &id579
           description: Internal server error - Unexpected error occurred
-          headers: *id575
+          headers: *id577
           content:
             application/json:
               schema:
@@ -78064,7 +78152,7 @@ paths:
       summary: Create decision
       operationId: createDecisions
       description: Submit a decision request for debate, workflow, or gauntlet routing.
-      security: *id576
+      security: *id578
       requestBody:
         required: true
         content:
@@ -78074,14 +78162,14 @@ paths:
       responses:
         '200':
           description: Decision result
-          headers: *id575
+          headers: *id577
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DecisionResult'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id575
+          headers: *id577
           content:
             application/json:
               schema:
@@ -78107,7 +78195,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id577
+        '500': *id579
       x-aragora-stability: stable
   /api/v1/decisions/plans:
     post:
@@ -78286,7 +78374,7 @@ paths:
       responses:
         '200':
           description: Decision result
-          headers: &id578
+          headers: &id580
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78302,7 +78390,7 @@ paths:
                 $ref: '#/components/schemas/DecisionResult'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id578
+          headers: *id580
           content:
             application/json:
               schema:
@@ -78318,7 +78406,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id578
+          headers: *id580
           content:
             application/json:
               schema:
@@ -78350,7 +78438,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id579
+          headers: &id581
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78386,7 +78474,7 @@ paths:
                     description: Alternative outcomes under different conditions
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id579
+          headers: *id581
           content:
             application/json:
               schema:
@@ -78402,7 +78490,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id579
+          headers: *id581
           content:
             application/json:
               schema:
@@ -78434,7 +78522,7 @@ paths:
       responses:
         '200':
           description: Decision status
-          headers: &id580
+          headers: &id582
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78450,7 +78538,7 @@ paths:
                 $ref: '#/components/schemas/DecisionStatus'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id580
+          headers: *id582
           content:
             application/json:
               schema:
@@ -78733,7 +78821,7 @@ paths:
       responses:
         '200':
           description: Registered devices
-          headers: &id581
+          headers: &id583
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78768,7 +78856,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id581
+          headers: *id583
           content:
             application/json:
               schema:
@@ -78994,7 +79082,7 @@ paths:
       responses:
         '201':
           description: Device registered
-          headers: &id582
+          headers: &id584
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79018,7 +79106,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id582
+          headers: *id584
           content:
             application/json:
               schema:
@@ -79075,7 +79163,7 @@ paths:
       responses:
         '200':
           description: Device details
-          headers: &id583
+          headers: &id585
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79104,9 +79192,9 @@ paths:
                     type: string
                   metadata:
                     type: object
-        '404': &id584
+        '404': &id586
           description: Not found - The requested resource does not exist
-          headers: *id583
+          headers: *id585
           content:
             application/json:
               schema:
@@ -79150,7 +79238,7 @@ paths:
       responses:
         '200':
           description: Device unregistered
-          headers: *id583
+          headers: *id585
           content:
             application/json:
               schema:
@@ -79158,7 +79246,7 @@ paths:
                 properties:
                   success:
                     type: boolean
-        '404': *id584
+        '404': *id586
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -81499,7 +81587,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id585
+          headers: &id587
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81515,7 +81603,7 @@ paths:
                 $ref: '#/components/schemas/DecisionExplanation'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id585
+          headers: *id587
           content:
             application/json:
               schema:
@@ -81531,7 +81619,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id585
+          headers: *id587
           content:
             application/json:
               schema:
@@ -81574,7 +81662,7 @@ paths:
       responses:
         '200':
           description: Batch created
-          headers: &id586
+          headers: &id588
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81590,7 +81678,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatch'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id586
+          headers: *id588
           content:
             application/json:
               schema:
@@ -81633,7 +81721,7 @@ paths:
       responses:
         '200':
           description: Batch results
-          headers: &id587
+          headers: &id589
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81649,7 +81737,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatchResults'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id587
+          headers: *id589
           content:
             application/json:
               schema:
@@ -81700,7 +81788,7 @@ paths:
       responses:
         '200':
           description: Batch status
-          headers: &id588
+          headers: &id590
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81716,7 +81804,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatchStatus'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id588
+          headers: *id590
           content:
             application/json:
               schema:
@@ -82303,7 +82391,7 @@ paths:
       responses:
         '200':
           description: Feedback-hub routing history
-          headers: &id590
+          headers: &id592
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82327,24 +82415,24 @@ paths:
                       type: object
                       additionalProperties: true
                       properties:
-                        source: &id589
+                        source: &id591
                           type: string
                         targets_hit:
                           type: array
-                          items: *id589
+                          items: *id591
                         targets_failed:
                           type: array
-                          items: *id589
+                          items: *id591
                         errors:
                           type: array
-                          items: *id589
+                          items: *id591
                         routed_at:
                           type: number
                         success:
                           type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id590
+          headers: *id592
           content:
             application/json:
               schema:
@@ -82364,7 +82452,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id590
+          headers: *id592
           content:
             application/json:
               schema:
@@ -82386,7 +82474,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id590
+          headers: *id592
           content:
             application/json:
               schema:
@@ -82403,7 +82491,7 @@ paths:
                     trace_id: req_abc123xyz
         '503':
           description: Internal server error - Unexpected error occurred
-          headers: *id590
+          headers: *id592
           content:
             application/json:
               schema:
@@ -82430,7 +82518,7 @@ paths:
       responses:
         '200':
           description: Feedback-hub routing statistics
-          headers: &id593
+          headers: &id595
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82452,22 +82540,22 @@ paths:
                     type: object
                     additionalProperties: false
                     properties:
-                      total_routed: &id591
+                      total_routed: &id593
                         type: integer
-                      total_failures: *id591
-                      by_source: &id592
+                      total_failures: *id593
+                      by_source: &id594
                         type: object
                         additionalProperties:
                           type: integer
-                      by_target: *id592
-                      history_size: *id591
+                      by_target: *id594
+                      history_size: *id593
                       known_sources:
                         type: array
                         items:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id593
+          headers: *id595
           content:
             application/json:
               schema:
@@ -82487,7 +82575,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id593
+          headers: *id595
           content:
             application/json:
               schema:
@@ -82509,7 +82597,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id593
+          headers: *id595
           content:
             application/json:
               schema:
@@ -82526,7 +82614,7 @@ paths:
                     trace_id: req_abc123xyz
         '503':
           description: Internal server error - Unexpected error occurred
-          headers: *id593
+          headers: *id595
           content:
             application/json:
               schema:
@@ -82866,7 +82954,7 @@ paths:
                 properties:
                   channels:
                     type: array
-                    items: &id595
+                    items: &id597
                       type: object
                       properties:
                         name:
@@ -82880,9 +82968,9 @@ paths:
                           description: Channel availability status
                   total:
                     type: integer
-        '401': &id596
+        '401': &id598
           description: Unauthorized - Authentication required or token invalid
-          headers: &id594
+          headers: &id596
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82909,9 +82997,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id597
+        '403': &id599
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id594
+          headers: *id596
           content:
             application/json:
               schema:
@@ -82931,9 +83019,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id598
+        '500': &id600
           description: Internal server error - Unexpected error occurred
-          headers: *id594
+          headers: *id596
           content:
             application/json:
               schema:
@@ -82979,12 +83067,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  channel: *id595
+                  channel: *id597
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id594
+          headers: *id596
           content:
             application/json:
               schema:
@@ -83010,9 +83098,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id596
-        '403': *id597
-        '500': *id598
+        '401': *id598
+        '403': *id599
+        '500': *id600
       x-aragora-stability: experimental
   /api/v1/gateway/config:
     post:
@@ -83196,9 +83284,9 @@ paths:
                           description: Arbitrary key-value metadata
                   total:
                     type: integer
-        '401': &id600
+        '401': &id602
           description: Unauthorized - Authentication required or token invalid
-          headers: &id599
+          headers: &id601
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83225,9 +83313,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id601
+        '403': &id603
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id599
+          headers: *id601
           content:
             application/json:
               schema:
@@ -83247,9 +83335,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id602
+        '500': &id604
           description: Internal server error - Unexpected error occurred
-          headers: *id599
+          headers: *id601
           content:
             application/json:
               schema:
@@ -83316,7 +83404,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id599
+          headers: *id601
           content:
             application/json:
               schema:
@@ -83342,9 +83430,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id600
-        '403': *id601
-        '500': *id602
+        '401': *id602
+        '403': *id603
+        '500': *id604
       x-aragora-stability: stable
   /api/v1/gateway/devices/{device_id}:
     get:
@@ -83358,7 +83446,7 @@ paths:
         in: path
         required: true
         description: Unique device identifier
-        schema: &id604
+        schema: &id606
           type: string
       responses:
         '200':
@@ -83368,7 +83456,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  device: &id605
+                  device: &id607
                     type: object
                     properties:
                       device_id:
@@ -83409,9 +83497,9 @@ paths:
                       metadata:
                         type: object
                         description: Arbitrary key-value metadata
-        '401': &id606
+        '401': &id608
           description: Unauthorized - Authentication required or token invalid
-          headers: &id603
+          headers: &id605
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83438,9 +83526,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id607
+        '403': &id609
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id603
+          headers: *id605
           content:
             application/json:
               schema:
@@ -83460,9 +83548,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id608
+        '404': &id610
           description: Not found - The requested resource does not exist
-          headers: *id603
+          headers: *id605
           content:
             application/json:
               schema:
@@ -83476,9 +83564,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id609
+        '500': &id611
           description: Internal server error - Unexpected error occurred
-          headers: *id603
+          headers: *id605
           content:
             application/json:
               schema:
@@ -83503,7 +83591,7 @@ paths:
         in: path
         required: true
         description: Unique device identifier
-        schema: *id604
+        schema: *id606
       requestBody:
         required: true
         content:
@@ -83538,12 +83626,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  device: *id605
+                  device: *id607
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id603
+          headers: *id605
           content:
             application/json:
               schema:
@@ -83569,10 +83657,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id606
-        '403': *id607
-        '404': *id608
-        '500': *id609
+        '401': *id608
+        '403': *id609
+        '404': *id610
+        '500': *id611
       x-aragora-stability: experimental
     delete:
       tags:
@@ -83585,7 +83673,7 @@ paths:
         in: path
         required: true
         description: Unique device identifier
-        schema: *id604
+        schema: *id606
       responses:
         '200':
           description: Device unregistered
@@ -83596,10 +83684,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id606
-        '403': *id607
-        '404': *id608
-        '500': *id609
+        '401': *id608
+        '403': *id609
+        '404': *id610
+        '500': *id611
       x-aragora-stability: stable
   /api/v1/gateway/health:
     get:
@@ -83700,9 +83788,9 @@ paths:
                           description: Message delivery status
                   total:
                     type: integer
-        '401': &id611
+        '401': &id613
           description: Unauthorized - Authentication required or token invalid
-          headers: &id610
+          headers: &id612
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83729,9 +83817,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id612
+        '403': &id614
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id610
+          headers: *id612
           content:
             application/json:
               schema:
@@ -83751,9 +83839,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id613
+        '500': &id615
           description: Internal server error - Unexpected error occurred
-          headers: *id610
+          headers: *id612
           content:
             application/json:
               schema:
@@ -83810,7 +83898,7 @@ paths:
                     description: Routing rule that matched
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id610
+          headers: *id612
           content:
             application/json:
               schema:
@@ -83836,9 +83924,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id611
-        '403': *id612
-        '500': *id613
+        '401': *id613
+        '403': *id614
+        '500': *id615
       x-aragora-stability: stable
   /api/v1/gateway/messages/route:
     post:
@@ -83873,7 +83961,7 @@ paths:
         in: path
         required: true
         description: Unique message identifier
-        schema: &id615
+        schema: &id617
           type: string
       responses:
         '200':
@@ -83913,9 +84001,9 @@ paths:
                         - delivered
                         - failed
                         description: Message delivery status
-        '401': &id616
+        '401': &id618
           description: Unauthorized - Authentication required or token invalid
-          headers: &id614
+          headers: &id616
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83942,9 +84030,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id617
+        '403': &id619
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id614
+          headers: *id616
           content:
             application/json:
               schema:
@@ -83964,9 +84052,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id618
+        '404': &id620
           description: Not found - The requested resource does not exist
-          headers: *id614
+          headers: *id616
           content:
             application/json:
               schema:
@@ -83980,9 +84068,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id619
+        '500': &id621
           description: Internal server error - Unexpected error occurred
-          headers: *id614
+          headers: *id616
           content:
             application/json:
               schema:
@@ -84007,7 +84095,7 @@ paths:
         in: path
         required: true
         description: Unique message identifier
-        schema: *id615
+        schema: *id617
       responses:
         '200':
           description: Message deleted
@@ -84018,10 +84106,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id616
-        '403': *id617
-        '404': *id618
-        '500': *id619
+        '401': *id618
+        '403': *id619
+        '404': *id620
+        '500': *id621
       x-aragora-stability: experimental
   /api/v1/gateway/openclaw/actions:
     post:
@@ -84206,7 +84294,7 @@ paths:
                 properties:
                   rules:
                     type: array
-                    items: &id621
+                    items: &id623
                       type: object
                       properties:
                         id:
@@ -84239,9 +84327,9 @@ paths:
                       routing_errors:
                         type: integer
                     description: Aggregate routing statistics
-        '401': &id622
+        '401': &id624
           description: Unauthorized - Authentication required or token invalid
-          headers: &id620
+          headers: &id622
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84268,9 +84356,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id623
+        '403': &id625
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id620
+          headers: *id622
           content:
             application/json:
               schema:
@@ -84290,9 +84378,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id624
+        '500': &id626
           description: Internal server error - Unexpected error occurred
-          headers: *id620
+          headers: *id622
           content:
             application/json:
               schema:
@@ -84348,12 +84436,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id621
+                  rule: *id623
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id620
+          headers: *id622
           content:
             application/json:
               schema:
@@ -84379,9 +84467,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id622
-        '403': *id623
-        '500': *id624
+        '401': *id624
+        '403': *id625
+        '500': *id626
       x-aragora-stability: stable
   /api/v1/gateway/routing/rules:
     get:
@@ -84437,7 +84525,7 @@ paths:
         in: path
         required: true
         description: Unique routing rule identifier
-        schema: &id626
+        schema: &id628
           type: string
       responses:
         '200':
@@ -84447,7 +84535,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: &id627
+                  rule: &id629
                     type: object
                     properties:
                       id:
@@ -84468,9 +84556,9 @@ paths:
                       enabled:
                         type: boolean
                         description: Whether the rule is active
-        '401': &id628
+        '401': &id630
           description: Unauthorized - Authentication required or token invalid
-          headers: &id625
+          headers: &id627
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84497,9 +84585,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id629
+        '403': &id631
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id625
+          headers: *id627
           content:
             application/json:
               schema:
@@ -84519,9 +84607,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id630
+        '404': &id632
           description: Not found - The requested resource does not exist
-          headers: *id625
+          headers: *id627
           content:
             application/json:
               schema:
@@ -84535,9 +84623,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id631
+        '500': &id633
           description: Internal server error - Unexpected error occurred
-          headers: *id625
+          headers: *id627
           content:
             application/json:
               schema:
@@ -84562,7 +84650,7 @@ paths:
         in: path
         required: true
         description: Unique routing rule identifier
-        schema: *id626
+        schema: *id628
       requestBody:
         required: true
         content:
@@ -84593,12 +84681,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id627
+                  rule: *id629
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id625
+          headers: *id627
           content:
             application/json:
               schema:
@@ -84624,10 +84712,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id628
-        '403': *id629
-        '404': *id630
-        '500': *id631
+        '401': *id630
+        '403': *id631
+        '404': *id632
+        '500': *id633
       x-aragora-stability: experimental
     delete:
       tags:
@@ -84640,7 +84728,7 @@ paths:
         in: path
         required: true
         description: Unique routing rule identifier
-        schema: *id626
+        schema: *id628
       responses:
         '200':
           description: Routing rule deleted
@@ -84651,10 +84739,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id628
-        '403': *id629
-        '404': *id630
-        '500': *id631
+        '401': *id630
+        '403': *id631
+        '404': *id632
+        '500': *id633
       x-aragora-stability: experimental
   /api/v1/gauntlet:
     get:
@@ -84729,7 +84817,7 @@ paths:
       responses:
         '200':
           description: Risk heatmap details
-          headers: &id632
+          headers: &id634
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84745,7 +84833,7 @@ paths:
                 $ref: '#/components/schemas/RiskHeatmap'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id632
+          headers: *id634
           content:
             application/json:
               schema:
@@ -84956,7 +85044,7 @@ paths:
       responses:
         '200':
           description: Bundle of exported receipts
-          headers: &id633
+          headers: &id635
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84981,7 +85069,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id633
+          headers: *id635
           content:
             application/json:
               schema:
@@ -85024,7 +85112,7 @@ paths:
       responses:
         '200':
           description: Decision receipt details
-          headers: &id634
+          headers: &id636
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85040,7 +85128,7 @@ paths:
                 $ref: '#/components/schemas/DecisionReceipt'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id634
+          headers: *id636
           content:
             application/json:
               schema:
@@ -85278,7 +85366,7 @@ paths:
       responses:
         '200':
           description: Gauntlet run details
-          headers: &id635
+          headers: &id637
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85292,9 +85380,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GauntletRun'
-        '404': &id636
+        '404': &id638
           description: Not found - The requested resource does not exist
-          headers: *id635
+          headers: *id637
           content:
             application/json:
               schema:
@@ -85308,9 +85396,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id637
+        '500': &id639
           description: Internal server error - Unexpected error occurred
-          headers: *id635
+          headers: *id637
           content:
             application/json:
               schema:
@@ -85340,7 +85428,7 @@ paths:
       responses:
         '200':
           description: Gauntlet run deleted
-          headers: *id635
+          headers: *id637
           content:
             application/json:
               schema:
@@ -85350,8 +85438,8 @@ paths:
                     type: boolean
                   gauntlet_id:
                     type: string
-        '404': *id636
-        '500': *id637
+        '404': *id638
+        '500': *id639
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -85389,7 +85477,7 @@ paths:
       responses:
         '200':
           description: Gauntlet comparison results
-          headers: &id638
+          headers: &id640
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85405,7 +85493,7 @@ paths:
                 $ref: '#/components/schemas/GauntletComparison'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id638
+          headers: *id640
           content:
             application/json:
               schema:
@@ -85421,7 +85509,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id638
+          headers: *id640
           content:
             application/json:
               schema:
@@ -85655,7 +85743,7 @@ paths:
       responses:
         '200':
           description: Descendant genomes
-          headers: &id639
+          headers: &id641
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85687,7 +85775,7 @@ paths:
                             type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id639
+          headers: *id641
           content:
             application/json:
               schema:
@@ -85703,7 +85791,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id639
+          headers: *id641
           content:
             application/json:
               schema:
@@ -85829,7 +85917,7 @@ paths:
       responses:
         '200':
           description: Genome details
-          headers: &id640
+          headers: &id642
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85857,7 +85945,7 @@ paths:
                     format: date-time
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id640
+          headers: *id642
           content:
             application/json:
               schema:
@@ -85873,7 +85961,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id640
+          headers: *id642
           content:
             application/json:
               schema:
@@ -86105,235 +86193,6 @@ paths:
       responses:
         '200':
           description: Issues created
-          headers: &id641
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id641
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id641
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id641
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/github/audit/issues/bulk:
-    post:
-      tags:
-      - GitHub
-      summary: Bulk create issues
-      operationId: createGithubAuditIssuesBulk
-      description: Bulk create GitHub issues from findings.
-      security:
-      - {}
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                findings:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      finding_id:
-                        type: string
-                      title:
-                        type: string
-                      description:
-                        type: string
-                  description: Bulk audit findings to create issues for
-                repo:
-                  type: string
-                  description: Target repository
-              required:
-              - findings
-              - repo
-      responses:
-        '200':
-          description: Issues created
-          headers: &id642
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id642
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id642
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id642
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/github/audit/pr:
-    post:
-      tags:
-      - GitHub
-      summary: Create PR with fixes
-      operationId: createGithubAuditPr
-      description: Create a remediation PR from audit findings.
-      security:
-      - {}
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                finding_ids:
-                  type: array
-                  items:
-                    type: string
-                  description: Findings to address in PR
-                repo:
-                  type: string
-                  description: Target repository
-                branch:
-                  type: string
-                  description: Branch name for PR
-                title:
-                  type: string
-                  description: PR title
-              required:
-              - finding_ids
-              - repo
-      responses:
-        '200':
-          description: PR created
           headers: &id643
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -86411,25 +86270,44 @@ paths:
                     code: INTERNAL_ERROR
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/github/audit/sync/{session_id}:
-    get:
+      x-aragora-stability: experimental
+  /api/v1/github/audit/issues/bulk:
+    post:
       tags:
       - GitHub
-      summary: Get sync status
-      operationId: getGithubAuditSync
-      description: Get status of a GitHub audit sync.
-      security: &id645
+      summary: Bulk create issues
+      operationId: createGithubAuditIssuesBulk
+      description: Bulk create GitHub issues from findings.
+      security:
       - {}
-      parameters:
-      - name: session_id
-        in: path
+      requestBody:
         required: true
-        schema:
-          type: string
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                findings:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      finding_id:
+                        type: string
+                      title:
+                        type: string
+                      description:
+                        type: string
+                  description: Bulk audit findings to create issues for
+                repo:
+                  type: string
+                  description: Target repository
+              required:
+              - findings
+              - repo
       responses:
         '200':
-          description: Sync status
+          description: Issues created
           headers: &id644
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -86444,118 +86322,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id646
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id644
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '404': &id647
-          description: Not found - The requested resource does not exist
-          headers: *id644
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500': &id648
-          description: Internal server error - Unexpected error occurred
-          headers: *id644
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-    post:
-      tags:
-      - GitHub
-      summary: Sync findings
-      operationId: createGithubAuditSync
-      description: Sync an audit session to GitHub.
-      security: *id645
-      parameters:
-      - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Sync started
-          headers: *id644
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id646
-        '404': *id647
-        '500': *id648
-      x-aragora-stability: experimental
-  /api/v1/github/pr/review:
-    post:
-      tags:
-      - GitHub
-      summary: Trigger PR review
-      operationId: createGithubPrReview
-      description: Trigger an automated PR review run.
-      security:
-      - {}
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GitHubPRReviewTriggerRequest'
-      responses:
-        '200':
-          description: Review started
-          headers: &id649
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GitHubPRReviewTriggerResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id649
+          headers: *id644
           content:
             application/json:
               schema:
@@ -86583,7 +86352,326 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id649
+          headers: *id644
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id644
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/github/audit/pr:
+    post:
+      tags:
+      - GitHub
+      summary: Create PR with fixes
+      operationId: createGithubAuditPr
+      description: Create a remediation PR from audit findings.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                finding_ids:
+                  type: array
+                  items:
+                    type: string
+                  description: Findings to address in PR
+                repo:
+                  type: string
+                  description: Target repository
+                branch:
+                  type: string
+                  description: Branch name for PR
+                title:
+                  type: string
+                  description: PR title
+              required:
+              - finding_ids
+              - repo
+      responses:
+        '200':
+          description: PR created
+          headers: &id645
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id645
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id645
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id645
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/github/audit/sync/{session_id}:
+    get:
+      tags:
+      - GitHub
+      summary: Get sync status
+      operationId: getGithubAuditSync
+      description: Get status of a GitHub audit sync.
+      security: &id647
+      - {}
+      parameters:
+      - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Sync status
+          headers: &id646
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401': &id648
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id646
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '404': &id649
+          description: Not found - The requested resource does not exist
+          headers: *id646
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500': &id650
+          description: Internal server error - Unexpected error occurred
+          headers: *id646
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+    post:
+      tags:
+      - GitHub
+      summary: Sync findings
+      operationId: createGithubAuditSync
+      description: Sync an audit session to GitHub.
+      security: *id647
+      parameters:
+      - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Sync started
+          headers: *id646
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401': *id648
+        '404': *id649
+        '500': *id650
+      x-aragora-stability: experimental
+  /api/v1/github/pr/review:
+    post:
+      tags:
+      - GitHub
+      summary: Trigger PR review
+      operationId: createGithubPrReview
+      description: Trigger an automated PR review run.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GitHubPRReviewTriggerRequest'
+      responses:
+        '200':
+          description: Review started
+          headers: &id651
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitHubPRReviewTriggerResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id651
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id651
           content:
             application/json:
               schema:
@@ -86603,7 +86691,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id649
+          headers: *id651
           content:
             application/json:
               schema:
@@ -86625,7 +86713,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id649
+          headers: *id651
           content:
             application/json:
               schema:
@@ -86657,7 +86745,7 @@ paths:
       responses:
         '200':
           description: Review status
-          headers: &id650
+          headers: &id652
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86673,7 +86761,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewStatusResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id650
+          headers: *id652
           content:
             application/json:
               schema:
@@ -86693,7 +86781,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id650
+          headers: *id652
           content:
             application/json:
               schema:
@@ -86715,7 +86803,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id650
+          headers: *id652
           content:
             application/json:
               schema:
@@ -86731,7 +86819,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id650
+          headers: *id652
           content:
             application/json:
               schema:
@@ -86768,7 +86856,7 @@ paths:
       responses:
         '200':
           description: PR details
-          headers: &id651
+          headers: &id653
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86784,7 +86872,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRDetailsResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id651
+          headers: *id653
           content:
             application/json:
               schema:
@@ -86812,7 +86900,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id651
+          headers: *id653
           content:
             application/json:
               schema:
@@ -86832,7 +86920,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id651
+          headers: *id653
           content:
             application/json:
               schema:
@@ -86854,7 +86942,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id651
+          headers: *id653
           content:
             application/json:
               schema:
@@ -86870,7 +86958,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id651
+          headers: *id653
           content:
             application/json:
               schema:
@@ -86908,7 +86996,7 @@ paths:
       responses:
         '200':
           description: Review submitted
-          headers: &id652
+          headers: &id654
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86924,7 +87012,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRSubmitReviewResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id652
+          headers: *id654
           content:
             application/json:
               schema:
@@ -86952,7 +87040,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id652
+          headers: *id654
           content:
             application/json:
               schema:
@@ -86972,7 +87060,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id652
+          headers: *id654
           content:
             application/json:
               schema:
@@ -86994,7 +87082,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id652
+          headers: *id654
           content:
             application/json:
               schema:
@@ -87031,7 +87119,7 @@ paths:
       responses:
         '200':
           description: Review list
-          headers: &id653
+          headers: &id655
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87047,7 +87135,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewListResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id653
+          headers: *id655
           content:
             application/json:
               schema:
@@ -87075,7 +87163,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id653
+          headers: *id655
           content:
             application/json:
               schema:
@@ -87095,7 +87183,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id653
+          headers: *id655
           content:
             application/json:
               schema:
@@ -87117,7 +87205,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id653
+          headers: *id655
           content:
             application/json:
               schema:
@@ -87285,7 +87373,7 @@ paths:
       summary: List drafts
       operationId: listGmailDrafts
       description: List Gmail drafts.
-      security: &id655
+      security: &id657
       - {}
       parameters:
       - name: user_id
@@ -87303,7 +87391,7 @@ paths:
       responses:
         '200':
           description: Drafts
-          headers: &id654
+          headers: &id656
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87317,9 +87405,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id656
+        '401': &id658
           description: Unauthorized - Authentication required or token invalid
-          headers: *id654
+          headers: *id656
           content:
             application/json:
               schema:
@@ -87337,9 +87425,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id657
+        '500': &id659
           description: Internal server error - Unexpected error occurred
-          headers: *id654
+          headers: *id656
           content:
             application/json:
               schema:
@@ -87359,7 +87447,7 @@ paths:
       summary: Create draft
       operationId: createGmailDrafts
       description: Create a Gmail draft.
-      security: *id655
+      security: *id657
       requestBody:
         required: true
         content:
@@ -87401,14 +87489,14 @@ paths:
       responses:
         '200':
           description: Draft created
-          headers: *id654
+          headers: *id656
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id654
+          headers: *id656
           content:
             application/json:
               schema:
@@ -87434,8 +87522,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id656
-        '500': *id657
+        '401': *id658
+        '500': *id659
       x-aragora-stability: experimental
   /api/v1/gmail/drafts/{draft_id}:
     get:
@@ -87444,7 +87532,7 @@ paths:
       summary: Get draft
       operationId: getGmailDraft
       description: Get a Gmail draft by ID.
-      security: &id659
+      security: &id661
       - {}
       parameters:
       - name: draft_id
@@ -87459,7 +87547,7 @@ paths:
       responses:
         '200':
           description: Draft
-          headers: &id658
+          headers: &id660
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87473,9 +87561,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id660
+        '401': &id662
           description: Unauthorized - Authentication required or token invalid
-          headers: *id658
+          headers: *id660
           content:
             application/json:
               schema:
@@ -87493,9 +87581,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id661
+        '404': &id663
           description: Not found - The requested resource does not exist
-          headers: *id658
+          headers: *id660
           content:
             application/json:
               schema:
@@ -87509,9 +87597,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id662
+        '500': &id664
           description: Internal server error - Unexpected error occurred
-          headers: *id658
+          headers: *id660
           content:
             application/json:
               schema:
@@ -87531,7 +87619,7 @@ paths:
       summary: Update draft
       operationId: updateGmailDraft
       description: Update a Gmail draft.
-      security: *id659
+      security: *id661
       parameters:
       - name: draft_id
         in: path
@@ -87575,14 +87663,14 @@ paths:
       responses:
         '200':
           description: Draft updated
-          headers: *id658
+          headers: *id660
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id658
+          headers: *id660
           content:
             application/json:
               schema:
@@ -87608,9 +87696,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id660
-        '404': *id661
-        '500': *id662
+        '401': *id662
+        '404': *id663
+        '500': *id664
       x-aragora-stability: experimental
     delete:
       tags:
@@ -87618,7 +87706,7 @@ paths:
       summary: Delete draft
       operationId: deleteGmailDraft
       description: Delete a Gmail draft.
-      security: *id659
+      security: *id661
       parameters:
       - name: draft_id
         in: path
@@ -87632,14 +87720,14 @@ paths:
       responses:
         '200':
           description: Draft deleted
-          headers: *id658
+          headers: *id660
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id660
-        '404': *id661
-        '500': *id662
+        '401': *id662
+        '404': *id663
+        '500': *id664
       x-aragora-stability: experimental
   /api/v1/gmail/drafts/{draft_id}/send:
     post:
@@ -87659,7 +87747,7 @@ paths:
       responses:
         '200':
           description: Draft sent
-          headers: &id663
+          headers: &id665
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87675,7 +87763,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id663
+          headers: *id665
           content:
             application/json:
               schema:
@@ -87695,7 +87783,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id663
+          headers: *id665
           content:
             application/json:
               schema:
@@ -87716,7 +87804,7 @@ paths:
       summary: List Gmail filters
       operationId: listGmailFilters
       description: List Gmail filters.
-      security: &id665
+      security: &id667
       - {}
       parameters:
       - name: user_id
@@ -87726,7 +87814,7 @@ paths:
       responses:
         '200':
           description: Filters
-          headers: &id664
+          headers: &id666
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87740,9 +87828,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id666
+        '401': &id668
           description: Unauthorized - Authentication required or token invalid
-          headers: *id664
+          headers: *id666
           content:
             application/json:
               schema:
@@ -87760,9 +87848,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id667
+        '500': &id669
           description: Internal server error - Unexpected error occurred
-          headers: *id664
+          headers: *id666
           content:
             application/json:
               schema:
@@ -87782,7 +87870,7 @@ paths:
       summary: Create Gmail filter
       operationId: createGmailFilters
       description: Create a Gmail filter.
-      security: *id665
+      security: *id667
       requestBody:
         required: true
         content:
@@ -87824,14 +87912,14 @@ paths:
       responses:
         '200':
           description: Filter created
-          headers: *id664
+          headers: *id666
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id664
+          headers: *id666
           content:
             application/json:
               schema:
@@ -87857,8 +87945,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id666
-        '500': *id667
+        '401': *id668
+        '500': *id669
       x-aragora-stability: experimental
   /api/v1/gmail/filters/{filter_id}:
     delete:
@@ -87882,7 +87970,7 @@ paths:
       responses:
         '200':
           description: Filter deleted
-          headers: &id668
+          headers: &id670
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87898,7 +87986,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id668
+          headers: *id670
           content:
             application/json:
               schema:
@@ -87918,7 +88006,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id668
+          headers: *id670
           content:
             application/json:
               schema:
@@ -87934,7 +88022,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id668
+          headers: *id670
           content:
             application/json:
               schema:
@@ -87997,7 +88085,7 @@ paths:
       summary: List Gmail labels
       operationId: listGmailLabels
       description: List Gmail labels for a connected account.
-      security: &id670
+      security: &id672
       - {}
       parameters:
       - name: user_id
@@ -88007,7 +88095,7 @@ paths:
       responses:
         '200':
           description: Labels
-          headers: &id669
+          headers: &id671
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88021,9 +88109,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id671
+        '401': &id673
           description: Unauthorized - Authentication required or token invalid
-          headers: *id669
+          headers: *id671
           content:
             application/json:
               schema:
@@ -88041,9 +88129,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id672
+        '500': &id674
           description: Internal server error - Unexpected error occurred
-          headers: *id669
+          headers: *id671
           content:
             application/json:
               schema:
@@ -88063,7 +88151,7 @@ paths:
       summary: Create Gmail label
       operationId: createGmailLabels
       description: Create a Gmail label.
-      security: *id670
+      security: *id672
       requestBody:
         required: true
         content:
@@ -88084,14 +88172,14 @@ paths:
       responses:
         '200':
           description: Label created
-          headers: *id669
+          headers: *id671
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id669
+          headers: *id671
           content:
             application/json:
               schema:
@@ -88117,8 +88205,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id671
-        '500': *id672
+        '401': *id673
+        '500': *id674
       x-aragora-stability: experimental
   /api/v1/gmail/labels/{label_id}:
     patch:
@@ -88127,7 +88215,7 @@ paths:
       summary: Update Gmail label
       operationId: patchGmailLabel
       description: Update a Gmail label.
-      security: &id674
+      security: &id676
       - {}
       parameters:
       - name: label_id
@@ -88153,7 +88241,7 @@ paths:
       responses:
         '200':
           description: Label updated
-          headers: &id673
+          headers: &id675
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88169,7 +88257,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id673
+          headers: *id675
           content:
             application/json:
               schema:
@@ -88195,9 +88283,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id675
+        '401': &id677
           description: Unauthorized - Authentication required or token invalid
-          headers: *id673
+          headers: *id675
           content:
             application/json:
               schema:
@@ -88215,9 +88303,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id676
+        '404': &id678
           description: Not found - The requested resource does not exist
-          headers: *id673
+          headers: *id675
           content:
             application/json:
               schema:
@@ -88231,9 +88319,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id677
+        '500': &id679
           description: Internal server error - Unexpected error occurred
-          headers: *id673
+          headers: *id675
           content:
             application/json:
               schema:
@@ -88253,7 +88341,7 @@ paths:
       summary: Delete Gmail label
       operationId: deleteGmailLabel
       description: Delete a Gmail label.
-      security: *id674
+      security: *id676
       parameters:
       - name: label_id
         in: path
@@ -88267,14 +88355,14 @@ paths:
       responses:
         '200':
           description: Label deleted
-          headers: *id673
+          headers: *id675
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id675
-        '404': *id676
-        '500': *id677
+        '401': *id677
+        '404': *id678
+        '500': *id679
       x-aragora-stability: experimental
   /api/v1/gmail/messages:
     post:
@@ -88315,7 +88403,7 @@ paths:
       responses:
         '200':
           description: Message archived
-          headers: &id678
+          headers: &id680
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88331,7 +88419,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id678
+          headers: *id680
           content:
             application/json:
               schema:
@@ -88351,7 +88439,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id678
+          headers: *id680
           content:
             application/json:
               schema:
@@ -88392,7 +88480,7 @@ paths:
       responses:
         '200':
           description: Attachment
-          headers: &id679
+          headers: &id681
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88408,7 +88496,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id679
+          headers: *id681
           content:
             application/json:
               schema:
@@ -88428,7 +88516,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id679
+          headers: *id681
           content:
             application/json:
               schema:
@@ -88444,7 +88532,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id679
+          headers: *id681
           content:
             application/json:
               schema:
@@ -88493,7 +88581,7 @@ paths:
       responses:
         '200':
           description: Labels updated
-          headers: &id680
+          headers: &id682
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88509,7 +88597,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id680
+          headers: *id682
           content:
             application/json:
               schema:
@@ -88537,7 +88625,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id680
+          headers: *id682
           content:
             application/json:
               schema:
@@ -88557,7 +88645,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id680
+          headers: *id682
           content:
             application/json:
               schema:
@@ -88600,7 +88688,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id681
+          headers: &id683
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88616,7 +88704,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id681
+          headers: *id683
           content:
             application/json:
               schema:
@@ -88636,7 +88724,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id681
+          headers: *id683
           content:
             application/json:
               schema:
@@ -88679,7 +88767,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id682
+          headers: &id684
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88695,7 +88783,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id682
+          headers: *id684
           content:
             application/json:
               schema:
@@ -88715,7 +88803,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id682
+          headers: *id684
           content:
             application/json:
               schema:
@@ -88758,7 +88846,7 @@ paths:
       responses:
         '200':
           description: Message trashed
-          headers: &id683
+          headers: &id685
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88774,7 +88862,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id683
+          headers: *id685
           content:
             application/json:
               schema:
@@ -88794,7 +88882,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id683
+          headers: *id685
           content:
             application/json:
               schema:
@@ -89058,162 +89146,6 @@ paths:
       responses:
         '200':
           description: Threads
-          headers: &id684
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id684
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id684
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/gmail/threads/{thread_id}:
-    get:
-      tags:
-      - Email
-      summary: Get Gmail thread
-      operationId: getGmailThread
-      description: Fetch a thread with messages.
-      security:
-      - {}
-      parameters:
-      - name: thread_id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: user_id
-        in: query
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Thread
-          headers: &id685
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id685
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id685
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id685
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/gmail/threads/{thread_id}/archive:
-    post:
-      tags:
-      - Email
-      summary: Archive thread
-      operationId: createGmailThreadsArchive
-      description: Archive a Gmail thread.
-      security:
-      - {}
-      parameters:
-      - name: thread_id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Thread archived
           headers: &id686
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -89251,6 +89183,162 @@ paths:
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id686
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/gmail/threads/{thread_id}:
+    get:
+      tags:
+      - Email
+      summary: Get Gmail thread
+      operationId: getGmailThread
+      description: Fetch a thread with messages.
+      security:
+      - {}
+      parameters:
+      - name: thread_id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: user_id
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Thread
+          headers: &id687
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id687
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id687
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id687
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/gmail/threads/{thread_id}/archive:
+    post:
+      tags:
+      - Email
+      summary: Archive thread
+      operationId: createGmailThreadsArchive
+      description: Archive a Gmail thread.
+      security:
+      - {}
+      parameters:
+      - name: thread_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Thread archived
+          headers: &id688
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id688
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id688
           content:
             application/json:
               schema:
@@ -89302,7 +89390,7 @@ paths:
       responses:
         '200':
           description: Thread updated
-          headers: &id687
+          headers: &id689
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89318,7 +89406,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id687
+          headers: *id689
           content:
             application/json:
               schema:
@@ -89338,7 +89426,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id687
+          headers: *id689
           content:
             application/json:
               schema:
@@ -89383,7 +89471,7 @@ paths:
       responses:
         '200':
           description: Thread trashed
-          headers: &id688
+          headers: &id690
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89399,7 +89487,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id688
+          headers: *id690
           content:
             application/json:
               schema:
@@ -89419,7 +89507,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id688
+          headers: *id690
           content:
             application/json:
               schema:
@@ -89511,7 +89599,7 @@ paths:
       responses:
         '200':
           description: Graph debate details
-          headers: &id689
+          headers: &id691
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89540,7 +89628,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id689
+          headers: *id691
           content:
             application/json:
               schema:
@@ -90917,7 +91005,7 @@ paths:
       responses:
         '200':
           description: List of mentions
-          headers: &id690
+          headers: &id692
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90940,7 +91028,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id690
+          headers: *id692
           content:
             application/json:
               schema:
@@ -90960,7 +91048,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id690
+          headers: *id692
           content:
             application/json:
               schema:
@@ -90982,7 +91070,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id690
+          headers: *id692
           content:
             application/json:
               schema:
@@ -91219,7 +91307,7 @@ paths:
       summary: Create routing rule
       operationId: createInboxRoutingRules
       description: Create a routing rule for inbox automation.
-      security: &id692
+      security: &id694
       - {}
       requestBody:
         required: true
@@ -91230,7 +91318,7 @@ paths:
       responses:
         '200':
           description: Rule created
-          headers: &id691
+          headers: &id693
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91246,7 +91334,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id691
+          headers: *id693
           content:
             application/json:
               schema:
@@ -91272,9 +91360,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id693
+        '401': &id695
           description: Unauthorized - Authentication required or token invalid
-          headers: *id691
+          headers: *id693
           content:
             application/json:
               schema:
@@ -91292,9 +91380,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id694
+        '403': &id696
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id691
+          headers: *id693
           content:
             application/json:
               schema:
@@ -91314,9 +91402,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id695
+        '500': &id697
           description: Internal server error - Unexpected error occurred
-          headers: *id691
+          headers: *id693
           content:
             application/json:
               schema:
@@ -91336,7 +91424,7 @@ paths:
       summary: List routing rules
       operationId: listInboxRoutingRules
       description: List routing rules for a workspace.
-      security: *id692
+      security: *id694
       parameters:
       - name: workspace_id
         in: query
@@ -91357,14 +91445,14 @@ paths:
       responses:
         '200':
           description: Rule list
-          headers: *id691
+          headers: *id693
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RoutingRuleListResponse'
-        '401': *id693
-        '403': *id694
-        '500': *id695
+        '401': *id695
+        '403': *id696
+        '500': *id697
       x-aragora-stability: stable
   /api/v1/inbox/routing/rules/{id}:
     patch:
@@ -91373,7 +91461,7 @@ paths:
       summary: Update routing rule
       operationId: patchInboxRoutingRule
       description: Update an inbox routing rule.
-      security: &id697
+      security: &id699
       - {}
       parameters:
       - name: id
@@ -91390,7 +91478,7 @@ paths:
       responses:
         '200':
           description: Rule updated
-          headers: &id696
+          headers: &id698
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91406,7 +91494,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id696
+          headers: *id698
           content:
             application/json:
               schema:
@@ -91432,9 +91520,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id698
+        '401': &id700
           description: Unauthorized - Authentication required or token invalid
-          headers: *id696
+          headers: *id698
           content:
             application/json:
               schema:
@@ -91452,9 +91540,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id699
+        '403': &id701
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id696
+          headers: *id698
           content:
             application/json:
               schema:
@@ -91474,9 +91562,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id700
+        '404': &id702
           description: Not found - The requested resource does not exist
-          headers: *id696
+          headers: *id698
           content:
             application/json:
               schema:
@@ -91490,9 +91578,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id701
+        '500': &id703
           description: Internal server error - Unexpected error occurred
-          headers: *id696
+          headers: *id698
           content:
             application/json:
               schema:
@@ -91512,7 +91600,7 @@ paths:
       summary: Delete routing rule
       operationId: deleteInboxRoutingRule
       description: Delete an inbox routing rule.
-      security: *id697
+      security: *id699
       parameters:
       - name: id
         in: path
@@ -91522,15 +91610,15 @@ paths:
       responses:
         '200':
           description: Rule deleted
-          headers: *id696
+          headers: *id698
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RoutingRuleDeleteResponse'
-        '401': *id698
-        '403': *id699
-        '404': *id700
-        '500': *id701
+        '401': *id700
+        '403': *id701
+        '404': *id702
+        '500': *id703
       x-aragora-stability: experimental
   /api/v1/inbox/routing/rules/{id}/test:
     post:
@@ -91556,7 +91644,7 @@ paths:
       responses:
         '200':
           description: Rule test
-          headers: &id702
+          headers: &id704
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91572,7 +91660,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleTestResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id702
+          headers: *id704
           content:
             application/json:
               schema:
@@ -91600,7 +91688,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id702
+          headers: *id704
           content:
             application/json:
               schema:
@@ -91620,7 +91708,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id702
+          headers: *id704
           content:
             application/json:
               schema:
@@ -91642,7 +91730,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id702
+          headers: *id704
           content:
             application/json:
               schema:
@@ -91658,7 +91746,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id702
+          headers: *id704
           content:
             application/json:
               schema:
@@ -91698,7 +91786,7 @@ paths:
       summary: Create shared inbox
       operationId: createInboxShared
       description: Create a shared inbox for collaborative triage.
-      security: &id704
+      security: &id706
       - {}
       requestBody:
         required: true
@@ -91709,7 +91797,7 @@ paths:
       responses:
         '200':
           description: Inbox created
-          headers: &id703
+          headers: &id705
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91725,7 +91813,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id703
+          headers: *id705
           content:
             application/json:
               schema:
@@ -91751,9 +91839,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id705
+        '401': &id707
           description: Unauthorized - Authentication required or token invalid
-          headers: *id703
+          headers: *id705
           content:
             application/json:
               schema:
@@ -91771,9 +91859,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id706
+        '403': &id708
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id703
+          headers: *id705
           content:
             application/json:
               schema:
@@ -91793,9 +91881,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id707
+        '500': &id709
           description: Internal server error - Unexpected error occurred
-          headers: *id703
+          headers: *id705
           content:
             application/json:
               schema:
@@ -91815,7 +91903,7 @@ paths:
       summary: List shared inboxes
       operationId: listInboxShared
       description: List shared inboxes for a workspace.
-      security: *id704
+      security: *id706
       parameters:
       - name: workspace_id
         in: query
@@ -91828,14 +91916,14 @@ paths:
       responses:
         '200':
           description: Inbox list
-          headers: *id703
+          headers: *id705
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SharedInboxListResponse'
-        '401': *id705
-        '403': *id706
-        '500': *id707
+        '401': *id707
+        '403': *id708
+        '500': *id709
       x-aragora-stability: stable
   /api/v1/inbox/shared/{id}:
     get:
@@ -91855,7 +91943,7 @@ paths:
       responses:
         '200':
           description: Inbox detail
-          headers: &id708
+          headers: &id710
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91871,7 +91959,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id708
+          headers: *id710
           content:
             application/json:
               schema:
@@ -91891,7 +91979,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id708
+          headers: *id710
           content:
             application/json:
               schema:
@@ -91913,7 +92001,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id708
+          headers: *id710
           content:
             application/json:
               schema:
@@ -91929,7 +92017,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id708
+          headers: *id710
           content:
             application/json:
               schema:
@@ -91981,7 +92069,7 @@ paths:
       responses:
         '200':
           description: Inbox messages
-          headers: &id709
+          headers: &id711
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91997,7 +92085,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id709
+          headers: *id711
           content:
             application/json:
               schema:
@@ -92017,7 +92105,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id709
+          headers: *id711
           content:
             application/json:
               schema:
@@ -92039,7 +92127,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id709
+          headers: *id711
           content:
             application/json:
               schema:
@@ -92055,7 +92143,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id709
+          headers: *id711
           content:
             application/json:
               schema:
@@ -92098,296 +92186,6 @@ paths:
       responses:
         '200':
           description: Message assigned
-          headers: &id710
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SharedInboxMessageResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id710
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id710
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id710
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id710
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id710
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/inbox/shared/{id}/messages/{msg_id}/status:
-    post:
-      tags:
-      - Inbox
-      summary: Update message status
-      operationId: createInboxSharedMessagesStatu
-      description: Update shared inbox message status.
-      security:
-      - {}
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: msg_id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SharedInboxStatusRequest'
-      responses:
-        '200':
-          description: Message updated
-          headers: &id711
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SharedInboxMessageResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id711
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id711
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id711
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id711
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id711
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/inbox/shared/{id}/messages/{msg_id}/tag:
-    post:
-      tags:
-      - Inbox
-      summary: Add message tag
-      operationId: createInboxSharedMessagesTag
-      description: Add a tag to a shared inbox message.
-      security:
-      - {}
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: msg_id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SharedInboxTagRequest'
-      responses:
-        '200':
-          description: Tag added
           headers: &id712
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -92491,6 +92289,296 @@ paths:
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id712
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/inbox/shared/{id}/messages/{msg_id}/status:
+    post:
+      tags:
+      - Inbox
+      summary: Update message status
+      operationId: createInboxSharedMessagesStatu
+      description: Update shared inbox message status.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: msg_id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SharedInboxStatusRequest'
+      responses:
+        '200':
+          description: Message updated
+          headers: &id713
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SharedInboxMessageResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id713
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id713
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id713
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id713
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id713
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/inbox/shared/{id}/messages/{msg_id}/tag:
+    post:
+      tags:
+      - Inbox
+      summary: Add message tag
+      operationId: createInboxSharedMessagesTag
+      description: Add a tag to a shared inbox message.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: msg_id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SharedInboxTagRequest'
+      responses:
+        '200':
+          description: Tag added
+          headers: &id714
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SharedInboxMessageResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id714
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id714
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id714
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id714
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id714
           content:
             application/json:
               schema:
@@ -92680,7 +92768,7 @@ paths:
       summary: List inbox trust wedge receipts
       operationId: listInboxTrustWedgeReceipts
       description: List receipt-backed inbox review decisions staged by the trust wedge.
-      security: &id714
+      security: &id716
       - {}
       parameters:
       - name: state
@@ -92704,7 +92792,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt list
-          headers: &id713
+          headers: &id715
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92718,9 +92806,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InboxTrustWedgeReceiptListResponse'
-        '400': &id715
+        '400': &id717
           description: Bad request - Invalid input or malformed JSON
-          headers: *id713
+          headers: *id715
           content:
             application/json:
               schema:
@@ -92746,9 +92834,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id716
+        '401': &id718
           description: Unauthorized - Authentication required or token invalid
-          headers: *id713
+          headers: *id715
           content:
             application/json:
               schema:
@@ -92766,9 +92854,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id717
+        '403': &id719
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id713
+          headers: *id715
           content:
             application/json:
               schema:
@@ -92788,9 +92876,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id718
+        '500': &id720
           description: Internal server error - Unexpected error occurred
-          headers: *id713
+          headers: *id715
           content:
             application/json:
               schema:
@@ -92810,7 +92898,7 @@ paths:
       summary: Create inbox trust wedge receipt
       operationId: createInboxTrustWedgeReceipt
       description: Stage a receipt-gated inbox action for later review or execution.
-      security: *id714
+      security: *id716
       requestBody:
         required: true
         content:
@@ -92820,15 +92908,15 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt staged
-          headers: *id713
+          headers: *id715
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/InboxTrustWedgeActionResponse'
-        '400': *id715
-        '401': *id716
-        '403': *id717
-        '500': *id718
+        '400': *id717
+        '401': *id718
+        '403': *id719
+        '500': *id720
       x-aragora-stability: experimental
   /api/v1/inbox/wedge/receipts/{receipt_id}:
     get:
@@ -92848,7 +92936,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt
-          headers: &id719
+          headers: &id721
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92864,7 +92952,7 @@ paths:
                 $ref: '#/components/schemas/InboxTrustWedgeEnvelope'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id719
+          headers: *id721
           content:
             application/json:
               schema:
@@ -92884,7 +92972,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id719
+          headers: *id721
           content:
             application/json:
               schema:
@@ -92906,7 +92994,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id719
+          headers: *id721
           content:
             application/json:
               schema:
@@ -92922,7 +93010,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id719
+          headers: *id721
           content:
             application/json:
               schema:
@@ -92954,7 +93042,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt executed
-          headers: &id720
+          headers: &id722
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92970,7 +93058,7 @@ paths:
                 $ref: '#/components/schemas/InboxTrustWedgeActionResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id720
+          headers: *id722
           content:
             application/json:
               schema:
@@ -92998,7 +93086,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id720
+          headers: *id722
           content:
             application/json:
               schema:
@@ -93018,7 +93106,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id720
+          headers: *id722
           content:
             application/json:
               schema:
@@ -93040,7 +93128,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id720
+          headers: *id722
           content:
             application/json:
               schema:
@@ -93056,7 +93144,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id720
+          headers: *id722
           content:
             application/json:
               schema:
@@ -93094,7 +93182,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt reviewed
-          headers: &id721
+          headers: &id723
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -93110,7 +93198,7 @@ paths:
                 $ref: '#/components/schemas/InboxTrustWedgeActionResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id721
+          headers: *id723
           content:
             application/json:
               schema:
@@ -93138,7 +93226,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id721
+          headers: *id723
           content:
             application/json:
               schema:
@@ -93158,7 +93246,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id721
+          headers: *id723
           content:
             application/json:
               schema:
@@ -93180,7 +93268,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id721
+          headers: *id723
           content:
             application/json:
               schema:
@@ -93196,7 +93284,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id721
+          headers: *id723
           content:
             application/json:
               schema:
@@ -93509,9 +93597,9 @@ paths:
                     type: object
                   enabled:
                     type: boolean
-        '401': &id723
+        '401': &id725
           description: Unauthorized - Authentication required or token invalid
-          headers: &id722
+          headers: &id724
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -93538,9 +93626,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id724
+        '404': &id726
           description: Not found - The requested resource does not exist
-          headers: *id722
+          headers: *id724
           content:
             application/json:
               schema:
@@ -93554,9 +93642,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id725
+        '500': &id727
           description: Internal server error - Unexpected error occurred
-          headers: *id722
+          headers: *id724
           content:
             application/json:
               schema:
@@ -93612,7 +93700,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id722
+          headers: *id724
           content:
             application/json:
               schema:
@@ -93638,9 +93726,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id723
-        '404': *id724
-        '500': *id725
+        '401': *id725
+        '404': *id726
+        '500': *id727
       x-aragora-stability: experimental
     delete:
       tags:
@@ -93669,9 +93757,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '401': *id723
-        '404': *id724
-        '500': *id725
+        '401': *id725
+        '404': *id726
+        '500': *id727
       x-aragora-stability: experimental
   /api/v1/integrations/discord/callback:
     get:
@@ -93699,7 +93787,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id726
+          headers: &id728
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -93736,7 +93824,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id726
+          headers: *id728
           content:
             application/json:
               schema:
@@ -93763,7 +93851,7 @@ paths:
           description: Redirect to Discord OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id727
+          headers: &id729
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -93800,7 +93888,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id727
+          headers: *id729
           content:
             application/json:
               schema:
@@ -93820,7 +93908,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id727
+          headers: *id729
           content:
             application/json:
               schema:
@@ -94185,7 +94273,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id728
+          headers: &id730
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94222,7 +94310,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id728
+          headers: *id730
           content:
             application/json:
               schema:
@@ -94299,7 +94387,7 @@ paths:
           description: Redirect to Slack OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id729
+          headers: &id731
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94336,7 +94424,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id729
+          headers: *id731
           content:
             application/json:
               schema:
@@ -94356,7 +94444,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id729
+          headers: *id731
           content:
             application/json:
               schema:
@@ -94416,7 +94504,7 @@ paths:
                     format: uri
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id730
+          headers: &id732
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94445,7 +94533,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id730
+          headers: *id732
           content:
             application/json:
               schema:
@@ -94502,7 +94590,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id731
+          headers: &id733
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94531,7 +94619,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id731
+          headers: *id733
           content:
             application/json:
               schema:
@@ -94575,7 +94663,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id732
+          headers: &id734
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94604,7 +94692,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id732
+          headers: *id734
           content:
             application/json:
               schema:
@@ -94670,7 +94758,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id733
+          headers: &id735
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94699,7 +94787,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id733
+          headers: *id735
           content:
             application/json:
               schema:
@@ -94739,7 +94827,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id734
+          headers: &id736
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94776,7 +94864,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id734
+          headers: *id736
           content:
             application/json:
               schema:
@@ -94925,7 +95013,7 @@ paths:
           description: Redirect to Microsoft OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id735
+          headers: &id737
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94962,7 +95050,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id735
+          headers: *id737
           content:
             application/json:
               schema:
@@ -94982,7 +95070,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id735
+          headers: *id737
           content:
             application/json:
               schema:
@@ -95197,7 +95285,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id736
+          headers: &id738
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95226,7 +95314,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id736
+          headers: *id738
           content:
             application/json:
               schema:
@@ -95556,9 +95644,9 @@ paths:
                   connected_at:
                     type: string
                     format: date-time
-        '401': &id739
+        '401': &id741
           description: Unauthorized - Authentication required or token invalid
-          headers: &id737
+          headers: &id739
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95587,7 +95675,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id737
+          headers: *id739
           content:
             application/json:
               schema:
@@ -95601,9 +95689,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id740
+        '500': &id742
           description: Internal server error - Unexpected error occurred
-          headers: *id737
+          headers: *id739
           content:
             application/json:
               schema:
@@ -95651,7 +95739,7 @@ paths:
           description: Integration configuration updated
           content:
             application/json:
-              schema: &id738
+              schema: &id740
                 type: object
                 properties:
                   integration:
@@ -95706,10 +95794,10 @@ paths:
           description: Integration configuration created
           content:
             application/json:
-              schema: *id738
-        '400': &id741
+              schema: *id740
+        '400': &id743
           description: Bad request - Invalid input or malformed JSON
-          headers: *id737
+          headers: *id739
           content:
             application/json:
               schema:
@@ -95735,8 +95823,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id739
-        '500': *id740
+        '401': *id741
+        '500': *id742
       x-aragora-stability: stable
     patch:
       tags:
@@ -95778,9 +95866,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '400': *id741
-        '401': *id739
-        '500': *id740
+        '400': *id743
+        '401': *id741
+        '500': *id742
       x-aragora-stability: stable
     delete:
       tags:
@@ -95809,8 +95897,8 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '401': *id739
-        '500': *id740
+        '401': *id741
+        '500': *id742
       x-aragora-stability: stable
   /api/v1/integrations/{type}/test:
     post:
@@ -95844,7 +95932,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id742
+          headers: &id744
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95873,7 +95961,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id742
+          headers: *id744
           content:
             application/json:
               schema:
@@ -96230,7 +96318,7 @@ paths:
       responses:
         '200':
           description: List of checkpoints
-          headers: &id743
+          headers: &id745
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96244,9 +96332,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointList'
-        '401': &id744
+        '401': &id746
           description: Unauthorized - Authentication required or token invalid
-          headers: *id743
+          headers: *id745
           content:
             application/json:
               schema:
@@ -96298,14 +96386,14 @@ paths:
       responses:
         '201':
           description: Checkpoint created
-          headers: *id743
+          headers: *id745
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id743
+          headers: *id745
           content:
             application/json:
               schema:
@@ -96331,7 +96419,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id744
+        '401': *id746
         '409':
           description: Checkpoint with this name already exists
           content:
@@ -96393,7 +96481,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id745
+          headers: &id747
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96430,7 +96518,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id745
+          headers: *id747
           content:
             application/json:
               schema:
@@ -96450,7 +96538,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id745
+          headers: *id747
           content:
             application/json:
               schema:
@@ -96483,7 +96571,7 @@ paths:
       responses:
         '200':
           description: Checkpoint metadata
-          headers: &id746
+          headers: &id748
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96497,9 +96585,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
-        '401': &id747
+        '401': &id749
           description: Unauthorized - Authentication required or token invalid
-          headers: *id746
+          headers: *id748
           content:
             application/json:
               schema:
@@ -96517,9 +96605,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id748
+        '404': &id750
           description: Not found - The requested resource does not exist
-          headers: *id746
+          headers: *id748
           content:
             application/json:
               schema:
@@ -96551,7 +96639,7 @@ paths:
       responses:
         '200':
           description: Checkpoint deleted
-          headers: *id746
+          headers: *id748
           content:
             application/json:
               schema:
@@ -96563,8 +96651,8 @@ paths:
                   name:
                     type: string
                     description: Name of deleted checkpoint
-        '401': *id747
-        '404': *id748
+        '401': *id749
+        '404': *id750
       x-aragora-stability: stable
   /api/v1/km/checkpoints/{checkpoint_name}/compare:
     get:
@@ -96605,7 +96693,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id749
+          headers: &id751
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96634,7 +96722,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id749
+          headers: *id751
           content:
             application/json:
               schema:
@@ -96674,7 +96762,7 @@ paths:
                 format: binary
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id750
+          headers: &id752
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96703,7 +96791,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id750
+          headers: *id752
           content:
             application/json:
               schema:
@@ -96754,7 +96842,7 @@ paths:
       responses:
         '200':
           description: Restore result
-          headers: &id751
+          headers: &id753
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96770,7 +96858,7 @@ paths:
                 $ref: '#/components/schemas/RestoreResult'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id751
+          headers: *id753
           content:
             application/json:
               schema:
@@ -96798,7 +96886,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id751
+          headers: *id753
           content:
             application/json:
               schema:
@@ -96818,7 +96906,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id751
+          headers: *id753
           content:
             application/json:
               schema:
@@ -96978,7 +97066,7 @@ paths:
       summary: List facts
       operationId: listKnowledgeFacts
       description: List knowledge facts with optional filtering.
-      security: &id753
+      security: &id755
       - bearerAuth: []
       parameters:
       - name: workspace_id
@@ -97014,7 +97102,7 @@ paths:
       responses:
         '200':
           description: Knowledge facts
-          headers: &id752
+          headers: &id754
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97028,9 +97116,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFactList'
-        '500': &id754
+        '500': &id756
           description: Internal server error - Unexpected error occurred
-          headers: *id752
+          headers: *id754
           content:
             application/json:
               schema:
@@ -97050,7 +97138,7 @@ paths:
       summary: Create fact
       operationId: createKnowledgeFact
       description: Create a new knowledge fact.
-      security: *id753
+      security: *id755
       requestBody:
         required: true
         content:
@@ -97083,14 +97171,14 @@ paths:
       responses:
         '201':
           description: Created fact
-          headers: *id752
+          headers: *id754
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id752
+          headers: *id754
           content:
             application/json:
               schema:
@@ -97116,7 +97204,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id754
+        '500': *id756
       x-aragora-stability: stable
   /api/v1/knowledge/facts/relations:
     post:
@@ -97167,7 +97255,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: &id755
+          headers: &id757
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97196,7 +97284,7 @@ paths:
                     description: Type of relation
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id755
+          headers: *id757
           content:
             application/json:
               schema:
@@ -97228,7 +97316,7 @@ paths:
 
         - Supersession history (if applicable)'
       operationId: getKnowledgeFact
-      security: &id757
+      security: &id759
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -97239,7 +97327,7 @@ paths:
       responses:
         '200':
           description: Knowledge fact
-          headers: &id756
+          headers: &id758
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97253,9 +97341,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': &id758
+        '404': &id760
           description: Not found - The requested resource does not exist
-          headers: *id756
+          headers: *id758
           content:
             application/json:
               schema:
@@ -97269,9 +97357,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id759
+        '500': &id761
           description: Internal server error - Unexpected error occurred
-          headers: *id756
+          headers: *id758
           content:
             application/json:
               schema:
@@ -97305,7 +97393,7 @@ paths:
 
         **Note:** Updates create an audit trail. Consider superseding instead of updating for significant changes.'
       operationId: updateKnowledgeFact
-      security: *id757
+      security: *id759
       parameters:
       - name: fact_id
         in: path
@@ -97336,13 +97424,13 @@ paths:
       responses:
         '200':
           description: Updated fact
-          headers: *id756
+          headers: *id758
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': *id758
-        '500': *id759
+        '404': *id760
+        '500': *id761
       x-aragora-stability: experimental
     delete:
       tags:
@@ -97362,7 +97450,7 @@ paths:
 
         **Note:** Deleted facts can be restored by admin if needed.'
       operationId: deleteKnowledgeFact
-      security: *id757
+      security: *id759
       parameters:
       - name: fact_id
         in: path
@@ -97372,7 +97460,7 @@ paths:
       responses:
         '200':
           description: Deleted fact
-          headers: *id756
+          headers: *id758
           content:
             application/json:
               schema:
@@ -97384,8 +97472,8 @@ paths:
                   fact_id:
                     type: string
                     description: ID of deleted fact
-        '404': *id758
-        '500': *id759
+        '404': *id760
+        '500': *id761
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/contradictions:
     get:
@@ -97423,7 +97511,7 @@ paths:
       responses:
         '200':
           description: Contradicting facts
-          headers: &id760
+          headers: &id762
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97439,7 +97527,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeFactList'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id760
+          headers: *id762
           content:
             application/json:
               schema:
@@ -97471,7 +97559,7 @@ paths:
 
         - derived_from: Source facts used to derive this one'
       operationId: listKnowledgeRelations
-      security: &id762
+      security: &id764
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -97482,7 +97570,7 @@ paths:
       responses:
         '200':
           description: Fact relations
-          headers: &id761
+          headers: &id763
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97496,9 +97584,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
-        '500': &id763
+        '500': &id765
           description: Internal server error - Unexpected error occurred
-          headers: *id761
+          headers: *id763
           content:
             application/json:
               schema:
@@ -97532,7 +97620,7 @@ paths:
 
         - evidence: Supporting evidence for the relation'
       operationId: addKnowledgeRelation
-      security: *id762
+      security: *id764
       parameters:
       - name: fact_id
         in: path
@@ -97569,7 +97657,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: *id761
+          headers: *id763
           content:
             application/json:
               schema:
@@ -97587,7 +97675,7 @@ paths:
                   relation_type:
                     type: string
                     description: Type of relation
-        '500': *id763
+        '500': *id765
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/verify:
     post:
@@ -97619,7 +97707,7 @@ paths:
       responses:
         '200':
           description: Fact verification started
-          headers: &id764
+          headers: &id766
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97648,7 +97736,7 @@ paths:
                     description: Verification status
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id764
+          headers: *id766
           content:
             application/json:
               schema:
@@ -98301,7 +98389,7 @@ paths:
       responses:
         '200':
           description: Culture patterns
-          headers: &id765
+          headers: &id767
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98317,7 +98405,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id765
+          headers: *id767
           content:
             application/json:
               schema:
@@ -98333,7 +98421,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id765
+          headers: *id767
           content:
             application/json:
               schema:
@@ -99325,7 +99413,7 @@ paths:
       responses:
         '200':
           description: Audit trail
-          headers: &id766
+          headers: &id768
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99341,7 +99429,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id766
+          headers: *id768
           content:
             application/json:
               schema:
@@ -99394,7 +99482,7 @@ paths:
       responses:
         '200':
           description: User audit
-          headers: &id767
+          headers: &id769
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99410,7 +99498,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id767
+          headers: *id769
           content:
             application/json:
               schema:
@@ -99426,7 +99514,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id767
+          headers: *id769
           content:
             application/json:
               schema:
@@ -99492,7 +99580,7 @@ paths:
       responses:
         '200':
           description: Permission check
-          headers: &id768
+          headers: &id770
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99508,7 +99596,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id768
+          headers: *id770
           content:
             application/json:
               schema:
@@ -99536,7 +99624,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id768
+          headers: *id770
           content:
             application/json:
               schema:
@@ -99568,7 +99656,7 @@ paths:
       responses:
         '200':
           description: Permissions
-          headers: &id769
+          headers: &id771
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99584,7 +99672,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id769
+          headers: *id771
           content:
             application/json:
               schema:
@@ -99600,7 +99688,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id769
+          headers: *id771
           content:
             application/json:
               schema:
@@ -99647,7 +99735,7 @@ paths:
       responses:
         '200':
           description: Role created
-          headers: &id770
+          headers: &id772
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99663,7 +99751,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id770
+          headers: *id772
           content:
             application/json:
               schema:
@@ -99691,7 +99779,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id770
+          headers: *id772
           content:
             application/json:
               schema:
@@ -99761,7 +99849,7 @@ paths:
       responses:
         '200':
           description: Role assigned
-          headers: &id771
+          headers: &id773
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99777,7 +99865,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id771
+          headers: *id773
           content:
             application/json:
               schema:
@@ -99805,7 +99893,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id771
+          headers: *id773
           content:
             application/json:
               schema:
@@ -99850,7 +99938,7 @@ paths:
       responses:
         '200':
           description: Role revoked
-          headers: &id772
+          headers: &id774
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99866,7 +99954,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id772
+          headers: *id774
           content:
             application/json:
               schema:
@@ -99894,7 +99982,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id772
+          headers: *id774
           content:
             application/json:
               schema:
@@ -99920,7 +100008,7 @@ paths:
       responses:
         '200':
           description: Stats
-          headers: &id773
+          headers: &id775
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99936,7 +100024,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id773
+          headers: *id775
           content:
             application/json:
               schema:
@@ -100681,7 +100769,7 @@ paths:
       responses:
         '200':
           description: Node revalidated
-          headers: &id774
+          headers: &id776
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100697,7 +100785,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id774
+          headers: *id776
           content:
             application/json:
               schema:
@@ -100725,7 +100813,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id774
+          headers: *id776
           content:
             application/json:
               schema:
@@ -100741,7 +100829,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id774
+          headers: *id776
           content:
             application/json:
               schema:
@@ -100986,7 +101074,7 @@ paths:
       responses:
         '200':
           description: Sync triggered
-          headers: &id775
+          headers: &id777
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101002,7 +101090,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id775
+          headers: *id777
           content:
             application/json:
               schema:
@@ -101030,7 +101118,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id775
+          headers: *id777
           content:
             application/json:
               schema:
@@ -101046,7 +101134,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id775
+          headers: *id777
           content:
             application/json:
               schema:
@@ -101087,7 +101175,7 @@ paths:
       responses:
         '200':
           description: Knowledge query response
-          headers: &id776
+          headers: &id778
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101103,7 +101191,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id776
+          headers: *id778
           content:
             application/json:
               schema:
@@ -101131,7 +101219,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id776
+          headers: *id778
           content:
             application/json:
               schema:
@@ -101213,7 +101301,7 @@ paths:
       responses:
         '200':
           description: Knowledge search response
-          headers: &id777
+          headers: &id779
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101229,7 +101317,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeSearchResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id777
+          headers: *id779
           content:
             application/json:
               schema:
@@ -101257,7 +101345,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id777
+          headers: *id779
           content:
             application/json:
               schema:
@@ -101288,7 +101376,7 @@ paths:
       responses:
         '200':
           description: Knowledge stats
-          headers: &id778
+          headers: &id780
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101304,7 +101392,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeStats'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id778
+          headers: *id780
           content:
             application/json:
               schema:
@@ -102179,7 +102267,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id779
+          headers: &id781
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102228,7 +102316,7 @@ paths:
                         type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id779
+          headers: *id781
           content:
             application/json:
               schema:
@@ -102256,7 +102344,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id779
+          headers: *id781
           content:
             application/json:
               schema:
@@ -102271,7 +102359,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id779
+          headers: *id781
           content:
             application/json:
               schema:
@@ -102291,7 +102379,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id779
+          headers: *id781
           content:
             application/json:
               schema:
@@ -102368,7 +102456,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id780
+          headers: &id782
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102417,7 +102505,7 @@ paths:
                         type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id780
+          headers: *id782
           content:
             application/json:
               schema:
@@ -102445,7 +102533,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id780
+          headers: *id782
           content:
             application/json:
               schema:
@@ -102460,7 +102548,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id780
+          headers: *id782
           content:
             application/json:
               schema:
@@ -102480,7 +102568,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id780
+          headers: *id782
           content:
             application/json:
               schema:
@@ -102522,7 +102610,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id781
+          headers: &id783
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102549,7 +102637,7 @@ paths:
                           type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id781
+          headers: *id783
           content:
             application/json:
               schema:
@@ -102577,7 +102665,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id781
+          headers: *id783
           content:
             application/json:
               schema:
@@ -102592,7 +102680,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id781
+          headers: *id783
           content:
             application/json:
               schema:
@@ -102612,7 +102700,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id781
+          headers: *id783
           content:
             application/json:
               schema:
@@ -102645,7 +102733,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id782
+          headers: &id784
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102686,7 +102774,7 @@ paths:
                               type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id782
+          headers: *id784
           content:
             application/json:
               schema:
@@ -102714,7 +102802,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id782
+          headers: *id784
           content:
             application/json:
               schema:
@@ -102729,7 +102817,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id782
+          headers: *id784
           content:
             application/json:
               schema:
@@ -102745,7 +102833,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id782
+          headers: *id784
           content:
             application/json:
               schema:
@@ -102765,7 +102853,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id782
+          headers: *id784
           content:
             application/json:
               schema:
@@ -102803,302 +102891,6 @@ paths:
       summary: Install marketplace listing
       operationId: marketplaceInstallListing
       description: Install a marketplace listing for the authenticated user.
-      responses:
-        '200':
-          description: Marketplace listing response.
-          headers: &id783
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id783
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id783
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id783
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id783
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id783
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: listing_id
-        in: path
-        required: true
-        schema:
-          type: string
-          maxLength: 128
-        description: Marketplace listing ID.
-      x-aragora-stability: experimental
-  /api/v1/marketplace/listings/{listing_id}/launch-debate:
-    post:
-      tags:
-      - Marketplace
-      summary: Launch debate from marketplace listing
-      operationId: marketplaceLaunchDebateFromListing
-      description: Build a debate configuration from a marketplace listing for the authenticated user.
-      responses:
-        '200':
-          description: Marketplace listing response.
-          headers: &id784
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id784
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id784
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id784
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id784
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id784
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: listing_id
-        in: path
-        required: true
-        schema:
-          type: string
-          maxLength: 128
-        description: Marketplace listing ID.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - question
-              properties:
-                question:
-                  type: string
-                  maxLength: 5000
-                rounds:
-                  type: integer
-                  minimum: 1
-                  maximum: 20
-      x-aragora-stability: experimental
-  /api/v1/marketplace/listings/{listing_id}/rate:
-    post:
-      tags:
-      - Marketplace
-      summary: Rate marketplace listing
-      operationId: marketplaceRateListing
-      description: Submit a rating and optional review for a marketplace listing.
       responses:
         '200':
           description: Marketplace listing response.
@@ -103231,6 +103023,302 @@ paths:
           type: string
           maxLength: 128
         description: Marketplace listing ID.
+      x-aragora-stability: experimental
+  /api/v1/marketplace/listings/{listing_id}/launch-debate:
+    post:
+      tags:
+      - Marketplace
+      summary: Launch debate from marketplace listing
+      operationId: marketplaceLaunchDebateFromListing
+      description: Build a debate configuration from a marketplace listing for the authenticated user.
+      responses:
+        '200':
+          description: Marketplace listing response.
+          headers: &id786
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id786
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id786
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id786
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id786
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id786
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: listing_id
+        in: path
+        required: true
+        schema:
+          type: string
+          maxLength: 128
+        description: Marketplace listing ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - question
+              properties:
+                question:
+                  type: string
+                  maxLength: 5000
+                rounds:
+                  type: integer
+                  minimum: 1
+                  maximum: 20
+      x-aragora-stability: experimental
+  /api/v1/marketplace/listings/{listing_id}/rate:
+    post:
+      tags:
+      - Marketplace
+      summary: Rate marketplace listing
+      operationId: marketplaceRateListing
+      description: Submit a rating and optional review for a marketplace listing.
+      responses:
+        '200':
+          description: Marketplace listing response.
+          headers: &id787
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id787
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id787
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id787
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id787
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id787
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: listing_id
+        in: path
+        required: true
+        schema:
+          type: string
+          maxLength: 128
+        description: Marketplace listing ID.
       requestBody:
         required: true
         content:
@@ -103300,7 +103388,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id786
+          headers: &id788
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103355,7 +103443,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id786
+          headers: *id788
           content:
             application/json:
               schema:
@@ -103383,7 +103471,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id786
+          headers: *id788
           content:
             application/json:
               schema:
@@ -103398,7 +103486,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id786
+          headers: *id788
           content:
             application/json:
               schema:
@@ -103418,7 +103506,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id786
+          headers: *id788
           content:
             application/json:
               schema:
@@ -103707,6 +103795,17 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  total_agents:
+                    type: integer
+                  avg_elo:
+                    type: number
+                  max_elo:
+                    type: number
+                  min_elo:
+                    type: number
+                  total_matches:
+                    type: integer
       x-aragora-stability: stable
   /api/v1/matches/{match_id}:
     get:
@@ -103797,7 +103896,7 @@ paths:
       responses:
         '200':
           description: Matrix debate details
-          headers: &id787
+          headers: &id789
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103826,7 +103925,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id787
+          headers: *id789
           content:
             application/json:
               schema:
@@ -103859,7 +103958,7 @@ paths:
       responses:
         '200':
           description: MCP tool catalog
-          headers: &id788
+          headers: &id790
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103901,7 +104000,7 @@ paths:
                     type: integer
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id788
+          headers: *id790
           content:
             application/json:
               schema:
@@ -103934,7 +104033,7 @@ paths:
       responses:
         '200':
           description: MCP tool details
-          headers: &id789
+          headers: &id791
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103972,7 +104071,7 @@ paths:
                             default: {}
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id789
+          headers: *id791
           content:
             application/json:
               schema:
@@ -103988,7 +104087,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id789
+          headers: *id791
           content:
             application/json:
               schema:
@@ -107475,7 +107574,7 @@ paths:
       responses:
         '200':
           description: Crash telemetry page
-          headers: &id791
+          headers: &id793
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107496,13 +107595,13 @@ paths:
                     items:
                       type: object
                       additionalProperties: true
-                  total: &id790
+                  total: &id792
                     type: integer
-                  limit: *id790
-                  offset: *id790
+                  limit: *id792
+                  offset: *id792
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id791
+          headers: *id793
           content:
             application/json:
               schema:
@@ -107522,7 +107621,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id791
+          headers: *id793
           content:
             application/json:
               schema:
@@ -107542,9 +107641,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '429': &id793
+        '429': &id795
           description: Too many requests - Rate limit exceeded
-          headers: *id791
+          headers: *id793
           content:
             application/json:
               schema:
@@ -107583,35 +107682,35 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      message: &id792
+                      message: &id794
                         type: string
-                      stack: *id792
-                      componentStack: *id792
-                      url: *id792
-                      timestamp: *id792
-                      userAgent: *id792
-                      sessionId: *id792
-                      componentName: *id792
-                      fingerprint: *id792
+                      stack: *id794
+                      componentStack: *id794
+                      url: *id794
+                      timestamp: *id794
+                      userAgent: *id794
+                      sessionId: *id794
+                      componentName: *id794
+                      fingerprint: *id794
                   maxItems: 50
               required:
               - reports
       responses:
         '202':
           description: Crash telemetry accepted
-          headers: *id791
+          headers: *id793
           content:
             application/json:
               schema:
                 type: object
                 additionalProperties: false
                 properties:
-                  accepted: *id790
-                  duplicates: *id790
-                  total_stored: *id790
+                  accepted: *id792
+                  duplicates: *id792
+                  total_stored: *id792
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id791
+          headers: *id793
           content:
             application/json:
               schema:
@@ -107637,7 +107736,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '429': *id793
+        '429': *id795
       security: []
       x-aragora-stability: stable
   /api/v1/observability/crashes/stats:
@@ -107650,7 +107749,7 @@ paths:
       responses:
         '200':
           description: Crash telemetry stats
-          headers: &id796
+          headers: &id798
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107666,23 +107765,23 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  total_ingested: &id794
+                  total_ingested: &id796
                     type: integer
-                  total_stored: *id794
-                  total_duplicates: *id794
-                  total_rate_limited: *id794
-                  unique_fingerprints: *id794
-                  last_hour: *id794
-                  last_24h: *id794
-                  top_fingerprints: &id795
+                  total_stored: *id796
+                  total_duplicates: *id796
+                  total_rate_limited: *id796
+                  unique_fingerprints: *id796
+                  last_hour: *id796
+                  last_24h: *id796
+                  top_fingerprints: &id797
                     type: array
                     items:
                       type: object
                       additionalProperties: true
-                  top_components: *id795
+                  top_components: *id797
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id796
+          headers: *id798
           content:
             application/json:
               schema:
@@ -107702,7 +107801,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id796
+          headers: *id798
           content:
             application/json:
               schema:
@@ -107724,7 +107823,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id796
+          headers: *id798
           content:
             application/json:
               schema:
@@ -107754,7 +107853,7 @@ paths:
       responses:
         '200':
           description: Aggregated observability dashboard
-          headers: &id799
+          headers: &id801
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107770,23 +107869,23 @@ paths:
                 type: object
                 additionalProperties: true
                 properties:
-                  timestamp: &id798
+                  timestamp: &id800
                     type: number
-                  debate_metrics: &id797
+                  debate_metrics: &id799
                     type: object
                     additionalProperties: true
-                  agent_rankings: *id797
-                  circuit_breakers: *id797
-                  self_improve: *id797
+                  agent_rankings: *id799
+                  circuit_breakers: *id799
+                  self_improve: *id799
                   alerts:
                     type: array
-                    items: *id797
-                  system_health: *id797
-                  error_rates: *id797
-                  collection_time_ms: *id798
+                    items: *id799
+                  system_health: *id799
+                  error_rates: *id799
+                  collection_time_ms: *id800
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id799
+          headers: *id801
           content:
             application/json:
               schema:
@@ -107806,7 +107905,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id799
+          headers: *id801
           content:
             application/json:
               schema:
@@ -107828,7 +107927,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id799
+          headers: *id801
           content:
             application/json:
               schema:
@@ -107856,7 +107955,7 @@ paths:
       responses:
         '200':
           description: Aggregated observability metrics
-          headers: &id800
+          headers: &id802
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107873,7 +107972,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id800
+          headers: *id802
           content:
             application/json:
               schema:
@@ -107893,7 +107992,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id800
+          headers: *id802
           content:
             application/json:
               schema:
@@ -107915,7 +108014,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id800
+          headers: *id802
           content:
             application/json:
               schema:
@@ -107989,7 +108088,7 @@ paths:
                         format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id801
+          headers: &id803
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108018,7 +108117,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id801
+          headers: *id803
           content:
             application/json:
               schema:
@@ -108040,7 +108139,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id801
+          headers: *id803
           content:
             application/json:
               schema:
@@ -108139,7 +108238,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id802
+          headers: &id804
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108176,7 +108275,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id802
+          headers: *id804
           content:
             application/json:
               schema:
@@ -108196,7 +108295,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id802
+          headers: *id804
           content:
             application/json:
               schema:
@@ -108300,9 +108399,9 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/StarterTemplate'
-        '401': &id804
+        '401': &id806
           description: Unauthorized - Authentication required or token invalid
-          headers: &id803
+          headers: &id805
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108329,9 +108428,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id805
+        '500': &id807
           description: Internal server error - Unexpected error occurred
-          headers: *id803
+          headers: *id805
           content:
             application/json:
               schema:
@@ -108421,7 +108520,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id803
+          headers: *id805
           content:
             application/json:
               schema:
@@ -108447,8 +108546,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id804
-        '500': *id805
+        '401': *id806
+        '500': *id807
       x-aragora-stability: stable
   /api/v1/onboarding/flow/step:
     put:
@@ -108530,7 +108629,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id806
+          headers: &id808
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108567,7 +108666,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id806
+          headers: *id808
           content:
             application/json:
               schema:
@@ -108587,7 +108686,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id806
+          headers: *id808
           content:
             application/json:
               schema:
@@ -108676,7 +108775,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id807
+          headers: &id809
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108713,7 +108812,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id807
+          headers: *id809
           content:
             application/json:
               schema:
@@ -108733,7 +108832,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id807
+          headers: *id809
           content:
             application/json:
               schema:
@@ -108827,7 +108926,7 @@ paths:
                     - 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id808
+          headers: &id810
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108856,7 +108955,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id808
+          headers: *id810
           content:
             application/json:
               schema:
@@ -109082,354 +109181,6 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id809
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id809
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id809
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id809
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id809
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/openclaw/actions/{action_id}:
-    get:
-      tags:
-      - OpenClaw
-      summary: Get action status
-      description: Get the current status and details of an OpenClaw action.
-      operationId: getOpenclawAction
-      parameters:
-      - name: action_id
-        in: path
-        required: true
-        description: Unique action identifier
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Action details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  action:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: Unique action identifier
-                      session_id:
-                        type: string
-                        description: Associated session ID
-                      action_type:
-                        type: string
-                        description: Type of action to execute
-                      status:
-                        type: string
-                        enum:
-                        - pending
-                        - running
-                        - completed
-                        - failed
-                        - cancelled
-                        - timeout
-                        description: Current action status
-                      input_data:
-                        type: object
-                        description: Input parameters for the action
-                      output_data:
-                        type:
-                        - object
-                        - 'null'
-                        description: Action output (when completed)
-                      error:
-                        type:
-                        - string
-                        - 'null'
-                        description: Error message (if failed)
-                      created_at:
-                        type: string
-                        format: date-time
-                        description: Action creation timestamp
-                      started_at:
-                        type:
-                        - string
-                        - 'null'
-                        format: date-time
-                        description: Action start timestamp
-                      completed_at:
-                        type:
-                        - string
-                        - 'null'
-                        format: date-time
-                        description: Action completion timestamp
-                      metadata:
-                        type: object
-                        description: Action metadata
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: &id810
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id810
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id810
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id810
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/openclaw/actions/{action_id}/cancel:
-    post:
-      tags:
-      - OpenClaw
-      summary: Cancel OpenClaw action
-      description: Cancel a running or pending OpenClaw action.
-      operationId: cancelOpenclawAction
-      parameters:
-      - name: action_id
-        in: path
-        required: true
-        description: Unique action identifier
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Action cancelled
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  action:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: Unique action identifier
-                      session_id:
-                        type: string
-                        description: Associated session ID
-                      action_type:
-                        type: string
-                        description: Type of action to execute
-                      status:
-                        type: string
-                        enum:
-                        - pending
-                        - running
-                        - completed
-                        - failed
-                        - cancelled
-                        - timeout
-                        description: Current action status
-                      input_data:
-                        type: object
-                        description: Input parameters for the action
-                      output_data:
-                        type:
-                        - object
-                        - 'null'
-                        description: Action output (when completed)
-                      error:
-                        type:
-                        - string
-                        - 'null'
-                        description: Error message (if failed)
-                      created_at:
-                        type: string
-                        format: date-time
-                        description: Action creation timestamp
-                      started_at:
-                        type:
-                        - string
-                        - 'null'
-                        format: date-time
-                        description: Action start timestamp
-                      completed_at:
-                        type:
-                        - string
-                        - 'null'
-                        format: date-time
-                        description: Action completion timestamp
-                      metadata:
-                        type: object
-                        description: Action metadata
-                  message:
-                    type: string
-        '400':
-          description: Bad request - Invalid input or malformed JSON
           headers: &id811
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -109539,83 +109290,82 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/openclaw/approvals:
+  /api/v1/openclaw/actions/{action_id}:
     get:
       tags:
       - OpenClaw
-      summary: List pending approvals
-      description: List actions requiring approval.
-      operationId: listOpenclawApprovals
+      summary: Get action status
+      description: Get the current status and details of an OpenClaw action.
+      operationId: getOpenclawAction
       parameters:
-      - name: status
-        in: query
-        description: Filter by approval status
+      - name: action_id
+        in: path
+        required: true
+        description: Unique action identifier
         schema:
           type: string
-          enum:
-          - pending
-          - approved
-          - denied
       responses:
         '200':
-          description: List of approvals
+          description: Action details
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  approvals:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          description: Unique approval identifier
-                        action_id:
-                          type: string
-                          description: Associated action ID
-                        session_id:
-                          type: string
-                          description: Associated session ID
-                        user_id:
-                          type: string
-                          description: User who requested the action
-                        status:
-                          type: string
-                          enum:
-                          - pending
-                          - approved
-                          - denied
-                          description: Approval status
-                        action_type:
-                          type: string
-                          description: Type of action requiring approval
-                        action_data:
-                          type: object
-                          description: Action input data for review
-                        requested_at:
-                          type: string
-                          format: date-time
-                          description: Request timestamp
-                        decided_at:
-                          type:
-                          - string
-                          - 'null'
-                          format: date-time
-                          description: Decision timestamp
-                        decided_by:
-                          type:
-                          - string
-                          - 'null'
-                          description: User who made the decision
-                        reason:
-                          type:
-                          - string
-                          - 'null'
-                          description: Decision reason
-                  total:
-                    type: integer
+                  action:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        description: Unique action identifier
+                      session_id:
+                        type: string
+                        description: Associated session ID
+                      action_type:
+                        type: string
+                        description: Type of action to execute
+                      status:
+                        type: string
+                        enum:
+                        - pending
+                        - running
+                        - completed
+                        - failed
+                        - cancelled
+                        - timeout
+                        description: Current action status
+                      input_data:
+                        type: object
+                        description: Input parameters for the action
+                      output_data:
+                        type:
+                        - object
+                        - 'null'
+                        description: Action output (when completed)
+                      error:
+                        type:
+                        - string
+                        - 'null'
+                        description: Error message (if failed)
+                      created_at:
+                        type: string
+                        format: date-time
+                        description: Action creation timestamp
+                      started_at:
+                        type:
+                        - string
+                        - 'null'
+                        format: date-time
+                        description: Action start timestamp
+                      completed_at:
+                        type:
+                        - string
+                        - 'null'
+                        format: date-time
+                        description: Action completion timestamp
+                      metadata:
+                        type: object
+                        description: Action metadata
         '401':
           description: Unauthorized - Authentication required or token invalid
           headers: &id812
@@ -109667,6 +109417,22 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id812
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id812
@@ -109683,86 +109449,82 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/openclaw/approvals/{approval_id}/approve:
+  /api/v1/openclaw/actions/{action_id}/cancel:
     post:
       tags:
       - OpenClaw
-      summary: Approve action
-      description: Approve a pending action request.
-      operationId: approveOpenclawAction
+      summary: Cancel OpenClaw action
+      description: Cancel a running or pending OpenClaw action.
+      operationId: cancelOpenclawAction
       parameters:
-      - name: approval_id
+      - name: action_id
         in: path
         required: true
-        description: Unique approval identifier
+        description: Unique action identifier
         schema:
           type: string
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                reason:
-                  type: string
-                  description: Optional approval reason
       responses:
         '200':
-          description: Action approved
+          description: Action cancelled
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  approval:
+                  action:
                     type: object
                     properties:
                       id:
                         type: string
-                        description: Unique approval identifier
-                      action_id:
-                        type: string
-                        description: Associated action ID
+                        description: Unique action identifier
                       session_id:
                         type: string
                         description: Associated session ID
-                      user_id:
+                      action_type:
                         type: string
-                        description: User who requested the action
+                        description: Type of action to execute
                       status:
                         type: string
                         enum:
                         - pending
-                        - approved
-                        - denied
-                        description: Approval status
-                      action_type:
-                        type: string
-                        description: Type of action requiring approval
-                      action_data:
+                        - running
+                        - completed
+                        - failed
+                        - cancelled
+                        - timeout
+                        description: Current action status
+                      input_data:
                         type: object
-                        description: Action input data for review
-                      requested_at:
+                        description: Input parameters for the action
+                      output_data:
+                        type:
+                        - object
+                        - 'null'
+                        description: Action output (when completed)
+                      error:
+                        type:
+                        - string
+                        - 'null'
+                        description: Error message (if failed)
+                      created_at:
                         type: string
                         format: date-time
-                        description: Request timestamp
-                      decided_at:
+                        description: Action creation timestamp
+                      started_at:
                         type:
                         - string
                         - 'null'
                         format: date-time
-                        description: Decision timestamp
-                      decided_by:
+                        description: Action start timestamp
+                      completed_at:
                         type:
                         - string
                         - 'null'
-                        description: User who made the decision
-                      reason:
-                        type:
-                        - string
-                        - 'null'
-                        description: Decision reason
+                        format: date-time
+                        description: Action completion timestamp
+                      metadata:
+                        type: object
+                        description: Action metadata
                   message:
                     type: string
         '400':
@@ -109876,6 +109638,343 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
+  /api/v1/openclaw/approvals:
+    get:
+      tags:
+      - OpenClaw
+      summary: List pending approvals
+      description: List actions requiring approval.
+      operationId: listOpenclawApprovals
+      parameters:
+      - name: status
+        in: query
+        description: Filter by approval status
+        schema:
+          type: string
+          enum:
+          - pending
+          - approved
+          - denied
+      responses:
+        '200':
+          description: List of approvals
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  approvals:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: Unique approval identifier
+                        action_id:
+                          type: string
+                          description: Associated action ID
+                        session_id:
+                          type: string
+                          description: Associated session ID
+                        user_id:
+                          type: string
+                          description: User who requested the action
+                        status:
+                          type: string
+                          enum:
+                          - pending
+                          - approved
+                          - denied
+                          description: Approval status
+                        action_type:
+                          type: string
+                          description: Type of action requiring approval
+                        action_data:
+                          type: object
+                          description: Action input data for review
+                        requested_at:
+                          type: string
+                          format: date-time
+                          description: Request timestamp
+                        decided_at:
+                          type:
+                          - string
+                          - 'null'
+                          format: date-time
+                          description: Decision timestamp
+                        decided_by:
+                          type:
+                          - string
+                          - 'null'
+                          description: User who made the decision
+                        reason:
+                          type:
+                          - string
+                          - 'null'
+                          description: Decision reason
+                  total:
+                    type: integer
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: &id814
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id814
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id814
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/openclaw/approvals/{approval_id}/approve:
+    post:
+      tags:
+      - OpenClaw
+      summary: Approve action
+      description: Approve a pending action request.
+      operationId: approveOpenclawAction
+      parameters:
+      - name: approval_id
+        in: path
+        required: true
+        description: Unique approval identifier
+        schema:
+          type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  description: Optional approval reason
+      responses:
+        '200':
+          description: Action approved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  approval:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        description: Unique approval identifier
+                      action_id:
+                        type: string
+                        description: Associated action ID
+                      session_id:
+                        type: string
+                        description: Associated session ID
+                      user_id:
+                        type: string
+                        description: User who requested the action
+                      status:
+                        type: string
+                        enum:
+                        - pending
+                        - approved
+                        - denied
+                        description: Approval status
+                      action_type:
+                        type: string
+                        description: Type of action requiring approval
+                      action_data:
+                        type: object
+                        description: Action input data for review
+                      requested_at:
+                        type: string
+                        format: date-time
+                        description: Request timestamp
+                      decided_at:
+                        type:
+                        - string
+                        - 'null'
+                        format: date-time
+                        description: Decision timestamp
+                      decided_by:
+                        type:
+                        - string
+                        - 'null'
+                        description: User who made the decision
+                      reason:
+                        type:
+                        - string
+                        - 'null'
+                        description: Decision reason
+                  message:
+                    type: string
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id815
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id815
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id815
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id815
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id815
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
   /api/v1/openclaw/approvals/{approval_id}/deny:
     post:
       tags:
@@ -109962,7 +110061,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id814
+          headers: &id816
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -109999,7 +110098,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id814
+          headers: *id816
           content:
             application/json:
               schema:
@@ -110019,7 +110118,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id814
+          headers: *id816
           content:
             application/json:
               schema:
@@ -110041,7 +110140,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id814
+          headers: *id816
           content:
             application/json:
               schema:
@@ -110057,7 +110156,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id814
+          headers: *id816
           content:
             application/json:
               schema:
@@ -110156,7 +110255,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id815
+          headers: &id817
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110185,7 +110284,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id815
+          headers: *id817
           content:
             application/json:
               schema:
@@ -110207,7 +110306,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id815
+          headers: *id817
           content:
             application/json:
               schema:
@@ -110234,7 +110333,7 @@ paths:
         description: Filter by credential type
         schema:
           type: string
-          enum: &id816
+          enum: &id818
           - api_key
           - oauth_token
           - password
@@ -110251,7 +110350,7 @@ paths:
                 properties:
                   credentials:
                     type: array
-                    items: &id818
+                    items: &id820
                       type: object
                       description: Credential metadata (never includes actual secret values)
                       properties:
@@ -110263,7 +110362,7 @@ paths:
                           description: Human-readable credential name
                         credential_type:
                           type: string
-                          enum: *id816
+                          enum: *id818
                           description: Type of credential
                         user_id:
                           type: string
@@ -110298,9 +110397,9 @@ paths:
                           description: Credential metadata
                   total:
                     type: integer
-        '401': &id819
+        '401': &id821
           description: Unauthorized - Authentication required or token invalid
-          headers: &id817
+          headers: &id819
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110327,9 +110426,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id820
+        '403': &id822
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id817
+          headers: *id819
           content:
             application/json:
               schema:
@@ -110349,9 +110448,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id821
+        '500': &id823
           description: Internal server error - Unexpected error occurred
-          headers: *id817
+          headers: *id819
           content:
             application/json:
               schema:
@@ -110387,7 +110486,7 @@ paths:
                   description: Human-readable credential name
                 credential_type:
                   type: string
-                  enum: *id816
+                  enum: *id818
                   description: Type of credential
                 value:
                   type: string
@@ -110407,12 +110506,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  credential: *id818
+                  credential: *id820
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id817
+          headers: *id819
           content:
             application/json:
               schema:
@@ -110438,9 +110537,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id819
-        '403': *id820
-        '500': *id821
+        '401': *id821
+        '403': *id822
+        '500': *id823
       x-aragora-stability: stable
   /api/v1/openclaw/credentials/{credential_id}:
     delete:
@@ -110468,7 +110567,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id822
+          headers: &id824
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110497,7 +110596,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id822
+          headers: *id824
           content:
             application/json:
               schema:
@@ -110519,7 +110618,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id822
+          headers: *id824
           content:
             application/json:
               schema:
@@ -110535,7 +110634,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id822
+          headers: *id824
           content:
             application/json:
               schema:
@@ -110638,7 +110737,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id823
+          headers: &id825
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110675,7 +110774,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id823
+          headers: *id825
           content:
             application/json:
               schema:
@@ -110695,7 +110794,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id823
+          headers: *id825
           content:
             application/json:
               schema:
@@ -110717,7 +110816,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id823
+          headers: *id825
           content:
             application/json:
               schema:
@@ -110733,7 +110832,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id823
+          headers: *id825
           content:
             application/json:
               schema:
@@ -110844,7 +110943,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id824
+          headers: &id826
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110873,7 +110972,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id824
+          headers: *id826
           content:
             application/json:
               schema:
@@ -110895,7 +110994,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id824
+          headers: *id826
           content:
             application/json:
               schema:
@@ -110932,7 +111031,7 @@ paths:
                 properties:
                   rules:
                     type: array
-                    items: &id826
+                    items: &id828
                       type: object
                       properties:
                         name:
@@ -110964,9 +111063,9 @@ paths:
                           description: Whether the rule is active
                   total:
                     type: integer
-        '401': &id827
+        '401': &id829
           description: Unauthorized - Authentication required or token invalid
-          headers: &id825
+          headers: &id827
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110993,9 +111092,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id828
+        '403': &id830
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id825
+          headers: *id827
           content:
             application/json:
               schema:
@@ -111015,9 +111114,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id829
+        '500': &id831
           description: Internal server error - Unexpected error occurred
-          headers: *id825
+          headers: *id827
           content:
             application/json:
               schema:
@@ -111084,12 +111183,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id826
+                  rule: *id828
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id825
+          headers: *id827
           content:
             application/json:
               schema:
@@ -111115,9 +111214,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id827
-        '403': *id828
-        '500': *id829
+        '401': *id829
+        '403': *id830
+        '500': *id831
       x-aragora-stability: stable
   /api/v1/openclaw/policy/rules/{rule_name}:
     delete:
@@ -111144,183 +111243,6 @@ paths:
                   message:
                     type: string
         '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: &id830
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id830
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id830
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id830
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/openclaw/sessions:
-    get:
-      tags:
-      - OpenClaw
-      summary: List OpenClaw sessions
-      description: List all OpenClaw sessions for the current user/tenant.
-      operationId: listOpenclawSessions
-      parameters:
-      - name: status
-        in: query
-        description: Filter by session status
-        schema:
-          type: string
-          enum: &id831
-          - active
-          - idle
-          - closing
-          - closed
-          - error
-      - name: limit
-        in: query
-        description: Maximum number of sessions to return
-        schema:
-          type: integer
-          default: 50
-          maximum: 100
-      - name: offset
-        in: query
-        description: Number of sessions to skip
-        schema:
-          type: integer
-          default: 0
-      responses:
-        '200':
-          description: List of sessions
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  sessions:
-                    type: array
-                    items: &id833
-                      type:
-                      - object
-                      - 'null'
-                      properties:
-                        id:
-                          type:
-                          - string
-                          - 'null'
-                          description: Unique session identifier
-                        user_id:
-                          type:
-                          - string
-                          - 'null'
-                          description: User who owns the session
-                        tenant_id:
-                          type:
-                          - string
-                          - 'null'
-                          description: Tenant identifier
-                        status:
-                          type:
-                          - string
-                          - 'null'
-                          enum: *id831
-                          description: Current session status
-                        created_at:
-                          type:
-                          - string
-                          - 'null'
-                          format: date-time
-                          description: Session creation timestamp
-                        updated_at:
-                          type:
-                          - string
-                          - 'null'
-                          format: date-time
-                          description: Last update timestamp
-                        last_activity_at:
-                          type:
-                          - string
-                          - 'null'
-                          format: date-time
-                          description: Last activity timestamp
-                        config:
-                          type: object
-                          description: Session configuration
-                        metadata:
-                          type: object
-                          description: Session metadata
-                  total:
-                    type: integer
-        '401': &id834
           description: Unauthorized - Authentication required or token invalid
           headers: &id832
             X-Request-ID:
@@ -111349,7 +111271,7 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id835
+        '403':
           description: Forbidden - Insufficient permissions for this operation
           headers: *id832
           content:
@@ -111371,9 +111293,186 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id836
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id832
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
           description: Internal server error - Unexpected error occurred
           headers: *id832
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/openclaw/sessions:
+    get:
+      tags:
+      - OpenClaw
+      summary: List OpenClaw sessions
+      description: List all OpenClaw sessions for the current user/tenant.
+      operationId: listOpenclawSessions
+      parameters:
+      - name: status
+        in: query
+        description: Filter by session status
+        schema:
+          type: string
+          enum: &id833
+          - active
+          - idle
+          - closing
+          - closed
+          - error
+      - name: limit
+        in: query
+        description: Maximum number of sessions to return
+        schema:
+          type: integer
+          default: 50
+          maximum: 100
+      - name: offset
+        in: query
+        description: Number of sessions to skip
+        schema:
+          type: integer
+          default: 0
+      responses:
+        '200':
+          description: List of sessions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessions:
+                    type: array
+                    items: &id835
+                      type:
+                      - object
+                      - 'null'
+                      properties:
+                        id:
+                          type:
+                          - string
+                          - 'null'
+                          description: Unique session identifier
+                        user_id:
+                          type:
+                          - string
+                          - 'null'
+                          description: User who owns the session
+                        tenant_id:
+                          type:
+                          - string
+                          - 'null'
+                          description: Tenant identifier
+                        status:
+                          type:
+                          - string
+                          - 'null'
+                          enum: *id833
+                          description: Current session status
+                        created_at:
+                          type:
+                          - string
+                          - 'null'
+                          format: date-time
+                          description: Session creation timestamp
+                        updated_at:
+                          type:
+                          - string
+                          - 'null'
+                          format: date-time
+                          description: Last update timestamp
+                        last_activity_at:
+                          type:
+                          - string
+                          - 'null'
+                          format: date-time
+                          description: Last activity timestamp
+                        config:
+                          type: object
+                          description: Session configuration
+                        metadata:
+                          type: object
+                          description: Session metadata
+                  total:
+                    type: integer
+        '401': &id836
+          description: Unauthorized - Authentication required or token invalid
+          headers: &id834
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403': &id837
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id834
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500': &id838
+          description: Internal server error - Unexpected error occurred
+          headers: *id834
           content:
             application/json:
               schema:
@@ -111414,12 +111513,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id833
+                  session: *id835
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id832
+          headers: *id834
           content:
             application/json:
               schema:
@@ -111445,9 +111544,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id834
-        '403': *id835
-        '500': *id836
+        '401': *id836
+        '403': *id837
+        '500': *id838
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}:
     get:
@@ -111461,7 +111560,7 @@ paths:
         in: path
         required: true
         description: Unique session identifier
-        schema: &id838
+        schema: &id840
           type: string
       responses:
         '200':
@@ -111471,7 +111570,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: &id839
+                  session: &id841
                     type:
                     - object
                     - 'null'
@@ -111526,9 +111625,9 @@ paths:
                       metadata:
                         type: object
                         description: Session metadata
-        '401': &id840
+        '401': &id842
           description: Unauthorized - Authentication required or token invalid
-          headers: &id837
+          headers: &id839
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111555,9 +111654,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id841
+        '403': &id843
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id837
+          headers: *id839
           content:
             application/json:
               schema:
@@ -111577,9 +111676,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id842
+        '404': &id844
           description: Not found - The requested resource does not exist
-          headers: *id837
+          headers: *id839
           content:
             application/json:
               schema:
@@ -111593,9 +111692,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id843
+        '500': &id845
           description: Internal server error - Unexpected error occurred
-          headers: *id837
+          headers: *id839
           content:
             application/json:
               schema:
@@ -111620,7 +111719,7 @@ paths:
         in: path
         required: true
         description: Unique session identifier
-        schema: *id838
+        schema: *id840
       responses:
         '200':
           description: Session closed
@@ -111629,13 +111728,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id839
+                  session: *id841
                   message:
                     type: string
-        '401': *id840
-        '403': *id841
-        '404': *id842
-        '500': *id843
+        '401': *id842
+        '403': *id843
+        '404': *id844
+        '500': *id845
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}/end:
     post:
@@ -111718,7 +111817,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id844
+          headers: &id846
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111747,7 +111846,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id844
+          headers: *id846
           content:
             application/json:
               schema:
@@ -111769,7 +111868,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id844
+          headers: *id846
           content:
             application/json:
               schema:
@@ -111785,7 +111884,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id844
+          headers: *id846
           content:
             application/json:
               schema:
@@ -111835,7 +111934,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id845
+          headers: &id847
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111864,7 +111963,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id845
+          headers: *id847
           content:
             application/json:
               schema:
@@ -111886,7 +111985,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id845
+          headers: *id847
           content:
             application/json:
               schema:
@@ -111961,7 +112060,7 @@ paths:
       responses:
         '200':
           description: Deliberation status.
-          headers: &id846
+          headers: &id848
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112020,7 +112119,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id846
+          headers: *id848
           content:
             application/json:
               schema:
@@ -112040,7 +112139,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id846
+          headers: *id848
           content:
             application/json:
               schema:
@@ -112062,7 +112161,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id846
+          headers: *id848
           content:
             application/json:
               schema:
@@ -112078,7 +112177,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id846
+          headers: *id848
           content:
             application/json:
               schema:
@@ -112135,7 +112234,7 @@ paths:
       responses:
         '200':
           description: Orchestration template list.
-          headers: &id847
+          headers: &id849
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112181,7 +112280,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id847
+          headers: *id849
           content:
             application/json:
               schema:
@@ -112201,7 +112300,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id847
+          headers: *id849
           content:
             application/json:
               schema:
@@ -112223,7 +112322,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id847
+          headers: *id849
           content:
             application/json:
               schema:
@@ -112660,7 +112759,7 @@ paths:
       responses:
         '200':
           description: Conversation
-          headers: &id848
+          headers: &id850
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112676,7 +112775,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id848
+          headers: *id850
           content:
             application/json:
               schema:
@@ -112696,7 +112795,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id848
+          headers: *id850
           content:
             application/json:
               schema:
@@ -112712,7 +112811,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id848
+          headers: *id850
           content:
             application/json:
               schema:
@@ -112743,7 +112842,7 @@ paths:
       responses:
         '200':
           description: Folders
-          headers: &id849
+          headers: &id851
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112759,7 +112858,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id849
+          headers: *id851
           content:
             application/json:
               schema:
@@ -112779,7 +112878,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id849
+          headers: *id851
           content:
             application/json:
               schema:
@@ -112826,7 +112925,7 @@ paths:
       responses:
         '200':
           description: Messages
-          headers: &id850
+          headers: &id852
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112842,7 +112941,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id850
+          headers: *id852
           content:
             application/json:
               schema:
@@ -112862,7 +112961,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id850
+          headers: *id852
           content:
             application/json:
               schema:
@@ -112946,7 +113045,7 @@ paths:
       summary: Get message
       operationId: getOutlookMessage
       description: Fetch Outlook message details.
-      security: &id852
+      security: &id854
       - {}
       parameters:
       - name: message_id
@@ -112961,7 +113060,7 @@ paths:
       responses:
         '200':
           description: Message
-          headers: &id851
+          headers: &id853
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112975,9 +113074,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id853
+        '401': &id855
           description: Unauthorized - Authentication required or token invalid
-          headers: *id851
+          headers: *id853
           content:
             application/json:
               schema:
@@ -112995,9 +113094,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id854
+        '404': &id856
           description: Not found - The requested resource does not exist
-          headers: *id851
+          headers: *id853
           content:
             application/json:
               schema:
@@ -113011,9 +113110,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id855
+        '500': &id857
           description: Internal server error - Unexpected error occurred
-          headers: *id851
+          headers: *id853
           content:
             application/json:
               schema:
@@ -113033,7 +113132,7 @@ paths:
       summary: Delete message
       operationId: deleteOutlookMessage
       description: Delete an Outlook message.
-      security: *id852
+      security: *id854
       parameters:
       - name: message_id
         in: path
@@ -113043,14 +113142,14 @@ paths:
       responses:
         '200':
           description: Message deleted
-          headers: *id851
+          headers: *id853
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id853
-        '404': *id854
-        '500': *id855
+        '401': *id855
+        '404': *id856
+        '500': *id857
       x-aragora-stability: stable
   /api/v1/outlook/messages/{message_id}/move:
     post:
@@ -113085,7 +113184,7 @@ paths:
       responses:
         '200':
           description: Message moved
-          headers: &id856
+          headers: &id858
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113101,7 +113200,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id856
+          headers: *id858
           content:
             application/json:
               schema:
@@ -113121,7 +113220,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id856
+          headers: *id858
           content:
             application/json:
               schema:
@@ -113166,7 +113265,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id857
+          headers: &id859
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113182,7 +113281,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id857
+          headers: *id859
           content:
             application/json:
               schema:
@@ -113202,7 +113301,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id857
+          headers: *id859
           content:
             application/json:
               schema:
@@ -113244,7 +113343,7 @@ paths:
       responses:
         '200':
           description: OAuth complete
-          headers: &id858
+          headers: &id860
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113260,7 +113359,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id858
+          headers: *id860
           content:
             application/json:
               schema:
@@ -113288,7 +113387,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id858
+          headers: *id860
           content:
             application/json:
               schema:
@@ -113324,7 +113423,7 @@ paths:
       responses:
         '200':
           description: OAuth URL
-          headers: &id859
+          headers: &id861
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113340,7 +113439,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id859
+          headers: *id861
           content:
             application/json:
               schema:
@@ -113368,7 +113467,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id859
+          headers: *id861
           content:
             application/json:
               schema:
@@ -113416,205 +113515,6 @@ paths:
       responses:
         '200':
           description: Reply sent
-          headers: &id860
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id860
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id860
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id860
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/outlook/search:
-    get:
-      tags:
-      - Email
-      summary: Search messages
-      operationId: listOutlookSearch
-      description: Search Outlook messages with OData filters.
-      security:
-      - {}
-      parameters:
-      - name: query
-        in: query
-        schema:
-          type: string
-      - name: workspace_id
-        in: query
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Search results
-          headers: &id861
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id861
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id861
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/outlook/send:
-    post:
-      tags:
-      - Email
-      summary: Send message
-      operationId: createOutlookSend
-      description: Send a new Outlook message.
-      security:
-      - {}
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                to:
-                  type: array
-                  items:
-                    type: string
-                    format: email
-                  description: Recipient email addresses
-                cc:
-                  type: array
-                  items:
-                    type: string
-                    format: email
-                  description: CC email addresses
-                bcc:
-                  type: array
-                  items:
-                    type: string
-                    format: email
-                  description: BCC email addresses
-                subject:
-                  type: string
-                  description: Email subject
-                body:
-                  type: string
-                  description: Email body (HTML or plain text)
-                workspace_id:
-                  type: string
-                  description: Workspace ID
-              required:
-              - to
-              - subject
-              - body
-      responses:
-        '200':
-          description: Message sent
           headers: &id862
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -113693,23 +113593,27 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/outlook/status:
+  /api/v1/outlook/search:
     get:
       tags:
       - Email
-      summary: Connection status
-      operationId: listOutlookStatus
-      description: Get Outlook integration status.
+      summary: Search messages
+      operationId: listOutlookSearch
+      description: Search Outlook messages with OData filters.
       security:
       - {}
       parameters:
+      - name: query
+        in: query
+        schema:
+          type: string
       - name: workspace_id
         in: query
         schema:
           type: string
       responses:
         '200':
-          description: Status
+          description: Search results
           headers: &id863
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -113747,6 +113651,201 @@ paths:
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id863
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/outlook/send:
+    post:
+      tags:
+      - Email
+      summary: Send message
+      operationId: createOutlookSend
+      description: Send a new Outlook message.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                to:
+                  type: array
+                  items:
+                    type: string
+                    format: email
+                  description: Recipient email addresses
+                cc:
+                  type: array
+                  items:
+                    type: string
+                    format: email
+                  description: CC email addresses
+                bcc:
+                  type: array
+                  items:
+                    type: string
+                    format: email
+                  description: BCC email addresses
+                subject:
+                  type: string
+                  description: Email subject
+                body:
+                  type: string
+                  description: Email body (HTML or plain text)
+                workspace_id:
+                  type: string
+                  description: Workspace ID
+              required:
+              - to
+              - subject
+              - body
+      responses:
+        '200':
+          description: Message sent
+          headers: &id864
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id864
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id864
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id864
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/outlook/status:
+    get:
+      tags:
+      - Email
+      summary: Connection status
+      operationId: listOutlookStatus
+      description: Get Outlook integration status.
+      security:
+      - {}
+      parameters:
+      - name: workspace_id
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Status
+          headers: &id865
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id865
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id865
           content:
             application/json:
               schema:
@@ -113902,7 +114001,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id864
+          headers: &id866
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113918,7 +114017,7 @@ paths:
                 $ref: '#/components/schemas/PatternTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id864
+          headers: *id866
           content:
             application/json:
               schema:
@@ -115432,7 +115531,7 @@ paths:
       responses:
         '200':
           description: List of playbooks
-          headers: &id865
+          headers: &id867
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115606,7 +115705,7 @@ paths:
                   count: 1
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id865
+          headers: *id867
           content:
             application/json:
               schema:
@@ -115643,7 +115742,7 @@ paths:
       responses:
         '200':
           description: Playbook details
-          headers: &id866
+          headers: &id868
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115807,7 +115906,7 @@ paths:
                   metadata: {}
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id866
+          headers: *id868
           content:
             application/json:
               schema:
@@ -115887,7 +115986,7 @@ paths:
       responses:
         '202':
           description: Playbook run queued
-          headers: &id867
+          headers: &id869
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115988,7 +116087,7 @@ paths:
                     consensus_threshold: 0.75
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id867
+          headers: *id869
           content:
             application/json:
               schema:
@@ -116016,7 +116115,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id867
+          headers: *id869
           content:
             application/json:
               schema:
@@ -116032,7 +116131,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id867
+          headers: *id869
           content:
             application/json:
               schema:
@@ -116052,7 +116151,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id867
+          headers: *id869
           content:
             application/json:
               schema:
@@ -116105,13 +116204,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  type: &id869
+                  type: &id871
                     type: string
-                  option: &id868
+                  option: &id870
                     type: object
-                  preflight: *id868
-                  error: *id869
-                  code: *id869
+                  preflight: *id870
+                  error: *id871
+                  code: *id871
                   retry_after:
                     type: integer
       x-aragora-stability: stable
@@ -116275,7 +116374,7 @@ paths:
       responses:
         '200':
           description: Landing feedback summary
-          headers: &id870
+          headers: &id872
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116301,7 +116400,7 @@ paths:
       responses:
         '202':
           description: Feedback accepted
-          headers: *id870
+          headers: *id872
           content:
             application/json:
               schema:
@@ -116339,9 +116438,9 @@ paths:
                 properties:
                   ok:
                     type: boolean
-                  id: &id871
+                  id: &id873
                     type: string
-                  review_status: *id871
+                  review_status: *id873
                   reviewed_at:
                     type:
                     - string
@@ -116690,7 +116789,7 @@ paths:
       - name: name
         in: path
         required: true
-        schema: &id872
+        schema: &id874
           type: string
         description: Plugin name (lowercase alphanumeric with hyphens)
       requestBody:
@@ -116708,7 +116807,7 @@ paths:
       responses:
         '200':
           description: Installation result
-          headers: &id873
+          headers: &id875
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116740,12 +116839,12 @@ paths:
       - name: name
         in: path
         required: true
-        schema: *id872
+        schema: *id874
         description: Plugin name (lowercase alphanumeric with hyphens)
       responses:
         '200':
           description: Uninstallation result
-          headers: *id873
+          headers: *id875
           content:
             application/json:
               schema:
@@ -117019,7 +117118,7 @@ paths:
       summary: Get policy by ID
       operationId: getPolicy
       description: Retrieve a specific governance policy by its unique identifier.
-      security: &id875
+      security: &id877
       - bearerAuth: []
       parameters:
       - name: policy_id
@@ -117031,7 +117130,7 @@ paths:
       responses:
         '200':
           description: Policy details
-          headers: &id874
+          headers: &id876
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117045,9 +117144,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
-        '401': &id876
+        '401': &id878
           description: Unauthorized - Authentication required or token invalid
-          headers: *id874
+          headers: *id876
           content:
             application/json:
               schema:
@@ -117065,9 +117164,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id877
+        '403': &id879
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id874
+          headers: *id876
           content:
             application/json:
               schema:
@@ -117087,9 +117186,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id878
+        '404': &id880
           description: Not found - The requested resource does not exist
-          headers: *id874
+          headers: *id876
           content:
             application/json:
               schema:
@@ -117103,9 +117202,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id879
+        '500': &id881
           description: Internal server error - Unexpected error occurred
-          headers: *id874
+          headers: *id876
           content:
             application/json:
               schema:
@@ -117126,7 +117225,7 @@ paths:
       summary: Update policy
       operationId: updatePolicy
       description: Update an existing governance policy. Validates for conflicts with other active policies.
-      security: *id875
+      security: *id877
       parameters:
       - name: policy_id
         in: path
@@ -117161,14 +117260,14 @@ paths:
       responses:
         '200':
           description: Policy updated
-          headers: *id874
+          headers: *id876
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id874
+          headers: *id876
           content:
             application/json:
               schema:
@@ -117194,16 +117293,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id876
-        '403': *id877
-        '404': *id878
+        '401': *id878
+        '403': *id879
+        '404': *id880
         '409':
           description: Policy conflict detected with existing policies
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id879
+        '500': *id881
       x-aragora-stability: experimental
     delete:
       tags:
@@ -117212,7 +117311,7 @@ paths:
       summary: Delete policy
       operationId: deletePolicy
       description: Delete a governance policy by ID. Active policies must be disabled before deletion.
-      security: *id875
+      security: *id877
       parameters:
       - name: policy_id
         in: path
@@ -117223,7 +117322,7 @@ paths:
       responses:
         '200':
           description: Policy deleted
-          headers: *id874
+          headers: *id876
           content:
             application/json:
               schema:
@@ -117233,16 +117332,16 @@ paths:
                     type: string
                   deleted:
                     type: boolean
-        '401': *id876
-        '403': *id877
-        '404': *id878
+        '401': *id878
+        '403': *id879
+        '404': *id880
         '409':
           description: Cannot delete an active policy - disable it first
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id879
+        '500': *id881
       x-aragora-stability: stable
   /api/v1/postman.json:
     get:
@@ -117293,7 +117392,7 @@ paths:
       responses:
         '200':
           description: Account deletion scheduled
-          headers: &id880
+          headers: &id882
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117320,7 +117419,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id880
+          headers: *id882
           content:
             application/json:
               schema:
@@ -117348,7 +117447,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id880
+          headers: *id882
           content:
             application/json:
               schema:
@@ -117368,7 +117467,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id880
+          headers: *id882
           content:
             application/json:
               schema:
@@ -117401,7 +117500,7 @@ paths:
       responses:
         '200':
           description: Privacy data inventory
-          headers: &id881
+          headers: &id883
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117439,7 +117538,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id881
+          headers: *id883
           content:
             application/json:
               schema:
@@ -117481,7 +117580,7 @@ paths:
       responses:
         '200':
           description: User data export
-          headers: &id882
+          headers: &id884
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117533,7 +117632,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id882
+          headers: *id884
           content:
             application/json:
               schema:
@@ -117564,7 +117663,7 @@ paths:
       responses:
         '200':
           description: Privacy preferences
-          headers: &id883
+          headers: &id885
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117576,10 +117675,10 @@ paths:
                 type: integer
           content:
             application/json:
-              schema: &id885
+              schema: &id887
                 type: object
                 properties:
-                  preferences: &id884
+                  preferences: &id886
                     type: object
                     properties:
                       do_not_sell:
@@ -117590,9 +117689,9 @@ paths:
                         type: boolean
                       third_party_sharing:
                         type: boolean
-        '401': &id886
+        '401': &id888
           description: Unauthorized - Authentication required or token invalid
-          headers: *id883
+          headers: *id885
           content:
             application/json:
               schema:
@@ -117623,17 +117722,17 @@ paths:
         required: true
         content:
           application/json:
-            schema: *id884
+            schema: *id886
       responses:
         '200':
           description: Privacy preferences updated
-          headers: *id883
+          headers: *id885
           content:
             application/json:
-              schema: *id885
+              schema: *id887
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id883
+          headers: *id885
           content:
             application/json:
               schema:
@@ -117659,7 +117758,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id886
+        '401': *id888
       x-aragora-stability: stable
   /api/v1/probes/capability:
     post:
@@ -117784,7 +117883,7 @@ paths:
       responses:
         '200':
           description: Prompt intent
-          headers: &id888
+          headers: &id890
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117799,7 +117898,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  intent: &id887
+                  intent: &id889
                     type: object
                     additionalProperties: true
                   timing:
@@ -117808,13 +117907,13 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id887
+                      stage_durations_ms: *id889
                       operation_timings:
                         type: array
-                        items: *id887
+                        items: *id889
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id888
+          headers: *id890
           content:
             application/json:
               schema:
@@ -117869,7 +117968,7 @@ paths:
       responses:
         '200':
           description: Clarifying questions
-          headers: &id891
+          headers: &id893
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117884,9 +117983,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  questions: &id890
+                  questions: &id892
                     type: array
-                    items: &id889
+                    items: &id891
                       type: object
                       additionalProperties: true
                   timing:
@@ -117895,11 +117994,11 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id889
-                      operation_timings: *id890
+                      stage_durations_ms: *id891
+                      operation_timings: *id892
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id891
+          headers: *id893
           content:
             application/json:
               schema:
@@ -117953,7 +118052,7 @@ paths:
       responses:
         '200':
           description: Research report
-          headers: &id893
+          headers: &id895
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117968,7 +118067,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  research: &id892
+                  research: &id894
                     type: object
                     additionalProperties: true
                   timing:
@@ -117977,13 +118076,13 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id892
+                      stage_durations_ms: *id894
                       operation_timings:
                         type: array
-                        items: *id892
+                        items: *id894
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id893
+          headers: *id895
           content:
             application/json:
               schema:
@@ -118032,13 +118131,13 @@ paths:
                   description: Natural-language operator prompt to transform into a structured specification.
                 context:
                   description: Optional contextual data to pass into the prompt-engine stage.
-                profile: &id894
+                profile: &id896
                   type: string
-                autonomy: *id894
-                skip_research: &id895
+                autonomy: *id896
+                skip_research: &id897
                   type: boolean
-                skip_interrogation: *id895
-                decision_plan: &id896
+                skip_interrogation: *id897
+                decision_plan: &id898
                   type: object
                   additionalProperties: true
               required:
@@ -118046,7 +118145,7 @@ paths:
       responses:
         '200':
           description: Prompt-engine pipeline result
-          headers: &id898
+          headers: &id900
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118062,35 +118161,35 @@ paths:
                 type: object
                 additionalProperties: true
                 properties:
-                  specification: *id896
-                  spec_bundle: *id896
-                  intent: *id896
-                  questions: &id897
+                  specification: *id898
+                  spec_bundle: *id898
+                  intent: *id898
+                  questions: &id899
                     type: array
-                    items: *id896
+                    items: *id898
                   research:
                     anyOf:
-                    - *id896
+                    - *id898
                     - type: 'null'
-                  auto_approved: *id895
+                  auto_approved: *id897
                   stages_completed:
                     type: array
-                    items: *id894
-                  validation: *id896
+                    items: *id896
+                  validation: *id898
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id896
-                      operation_timings: *id897
-                  run: *id896
-                  decision_plan: *id896
-                  execution: *id896
+                      stage_durations_ms: *id898
+                      operation_timings: *id899
+                  run: *id898
+                  decision_plan: *id898
+                  execution: *id898
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id898
+          headers: *id900
           content:
             application/json:
               schema:
@@ -118118,13 +118217,13 @@ paths:
                     trace_id: req_abc123xyz
         '422':
           description: Specification is not execution-grade
-          headers: *id898
+          headers: *id900
           content:
             application/json:
-              schema: *id896
+              schema: *id898
         '503':
           description: Internal server error - Unexpected error occurred
-          headers: *id898
+          headers: *id900
           content:
             application/json:
               schema:
@@ -118150,17 +118249,17 @@ paths:
       parameters:
       - name: status
         in: query
-        schema: &id899
+        schema: &id901
           type: string
       - name: plan_id
         in: query
-        schema: *id899
+        schema: *id901
       - name: debate_id
         in: query
-        schema: *id899
+        schema: *id901
       - name: execution_id
         in: query
-        schema: *id899
+        schema: *id901
       - name: limit
         in: query
         schema:
@@ -118217,7 +118316,7 @@ paths:
       responses:
         '200':
           description: Prompt-engine run
-          headers: &id900
+          headers: &id902
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118237,7 +118336,7 @@ paths:
                     additionalProperties: true
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id900
+          headers: *id902
           content:
             application/json:
               schema:
@@ -118273,19 +118372,19 @@ paths:
                   type: object
                   description: PromptIntent payload returned by decompose or by the full pipeline.
                   additionalProperties: true
-                questions: &id902
+                questions: &id904
                   type: array
-                  items: &id901
+                  items: &id903
                     type: object
                     additionalProperties: true
-                research: *id901
+                research: *id903
                 context: {}
               required:
               - intent
       responses:
         '200':
           description: Prompt specification
-          headers: &id903
+          headers: &id905
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118300,19 +118399,19 @@ paths:
               schema:
                 type: object
                 properties:
-                  specification: *id901
-                  spec_bundle: *id901
+                  specification: *id903
+                  spec_bundle: *id903
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id901
-                      operation_timings: *id902
+                      stage_durations_ms: *id903
+                      operation_timings: *id904
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id903
+          headers: *id905
           content:
             application/json:
               schema:
@@ -118356,7 +118455,7 @@ paths:
               type: object
               additionalProperties: true
               properties:
-                specification: &id904
+                specification: &id906
                   type: object
                   additionalProperties: true
               required:
@@ -118364,7 +118463,7 @@ paths:
       responses:
         '200':
           description: Validation result
-          headers: &id905
+          headers: &id907
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118379,21 +118478,21 @@ paths:
               schema:
                 type: object
                 properties:
-                  validation: *id904
-                  spec_bundle: *id904
+                  validation: *id906
+                  spec_bundle: *id906
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id904
+                      stage_durations_ms: *id906
                       operation_timings:
                         type: array
-                        items: *id904
+                        items: *id906
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id905
+          headers: *id907
           content:
             application/json:
               schema:
@@ -118506,9 +118605,9 @@ paths:
                           - placeholder_backed
                           - details
                           properties:
-                            id: &id906
+                            id: &id908
                               type: string
-                            name: *id906
+                            name: *id908
                             readiness:
                               type: string
                               enum:
@@ -118517,12 +118616,12 @@ paths:
                               description: Readiness state for this exposed public surface.
                             paths:
                               type: array
-                              items: *id906
+                              items: *id908
                               description: Public paths that belong to this surface.
-                            message: *id906
-                            backend_conditional: &id907
+                            message: *id908
+                            backend_conditional: &id909
                               type: boolean
-                            placeholder_backed: *id907
+                            placeholder_backed: *id909
                             details:
                               type: object
                               additionalProperties: true
@@ -119040,7 +119139,7 @@ paths:
       responses:
         '200':
           description: List of jobs
-          headers: &id908
+          headers: &id910
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119077,9 +119176,9 @@ paths:
                           format: date-time
                   total:
                     type: integer
-        '401': &id909
+        '401': &id911
           description: Unauthorized - Authentication required or token invalid
-          headers: *id908
+          headers: *id910
           content:
             application/json:
               schema:
@@ -119142,7 +119241,7 @@ paths:
       responses:
         '201':
           description: Job created
-          headers: *id908
+          headers: *id910
           content:
             application/json:
               schema:
@@ -119154,7 +119253,7 @@ paths:
                     type: string
                   position:
                     type: integer
-        '401': *id909
+        '401': *id911
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -119174,7 +119273,7 @@ paths:
       responses:
         '200':
           description: Job details
-          headers: &id910
+          headers: &id912
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119206,9 +119305,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id911
+        '404': &id913
           description: Not found - The requested resource does not exist
-          headers: *id910
+          headers: *id912
           content:
             application/json:
               schema:
@@ -119240,7 +119339,7 @@ paths:
       responses:
         '200':
           description: Job cancelled
-          headers: *id910
+          headers: *id912
           content:
             application/json:
               schema:
@@ -119248,7 +119347,7 @@ paths:
                 properties:
                   cancelled:
                     type: boolean
-        '404': *id911
+        '404': *id913
         '409':
           description: Job cannot be cancelled (already running or completed)
           content:
@@ -119279,7 +119378,7 @@ paths:
       responses:
         '200':
           description: Job re-queued
-          headers: &id912
+          headers: &id914
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119300,7 +119399,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id912
+          headers: *id914
           content:
             application/json:
               schema:
@@ -119618,199 +119717,6 @@ paths:
       responses:
         '200':
           description: Ralph blocker breakdown
-          headers: &id913
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: false
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id913
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id913
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '429':
-          description: Too many requests - Rate limit exceeded
-          headers: *id913
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                rate_limited:
-                  summary: Rate limit exceeded
-                  value:
-                    error: Rate limit exceeded
-                    code: RATE_LIMITED
-                    limit: 60
-                    window: 1 minute
-                    retry_after: 45
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/ralph/campaigns:
-    get:
-      tags:
-      - Ralph
-      summary: List Ralph campaigns
-      description: List persisted Ralph campaign supervisor states with summary fields for the campaign dashboard.
-      operationId: listRalphCampaigns
-      responses:
-        '200':
-          description: Ralph campaigns
-          headers: &id914
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: false
-                properties:
-                  campaigns:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: true
-                  count:
-                    type: integer
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id914
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id914
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '429':
-          description: Too many requests - Rate limit exceeded
-          headers: *id914
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                rate_limited:
-                  summary: Rate limit exceeded
-                  value:
-                    error: Rate limit exceeded
-                    code: RATE_LIMITED
-                    limit: 60
-                    window: 1 minute
-                    retry_after: 45
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}:
-    get:
-      tags:
-      - Ralph
-      summary: Get Ralph campaign detail
-      description: Return detailed state, progress, and health data for a Ralph campaign.
-      operationId: getRalphCampaign
-      parameters:
-      - name: campaign_id
-        in: path
-        required: true
-        description: Ralph campaign identifier
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Get Ralph campaign detail
           headers: &id915
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -119872,22 +119778,6 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id915
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
           headers: *id915
@@ -119908,23 +119798,16 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/blockers:
+  /api/v1/ralph/campaigns:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign blockers
-      description: Return blocker breakdown data for a specific Ralph campaign.
-      operationId: getRalphCampaignBlockers
-      parameters:
-      - name: campaign_id
-        in: path
-        required: true
-        description: Ralph campaign identifier
-        schema:
-          type: string
+      summary: List Ralph campaigns
+      description: List persisted Ralph campaign supervisor states with summary fields for the campaign dashboard.
+      operationId: listRalphCampaigns
       responses:
         '200':
-          description: Get Ralph campaign blockers
+          description: Ralph campaigns
           headers: &id916
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -119941,9 +119824,13 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  data:
-                    type: object
-                    additionalProperties: true
+                  campaigns:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                  count:
+                    type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
           headers: *id916
@@ -119986,22 +119873,6 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id916
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
           headers: *id916
@@ -120022,13 +119893,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/budget:
+  /api/v1/ralph/campaigns/{campaign_id}:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign budget
-      description: Return budget burn and limit data for a specific Ralph campaign.
-      operationId: getRalphCampaignBudget
+      summary: Get Ralph campaign detail
+      description: Return detailed state, progress, and health data for a Ralph campaign.
+      operationId: getRalphCampaign
       parameters:
       - name: campaign_id
         in: path
@@ -120038,7 +119909,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign budget
+          description: Get Ralph campaign detail
           headers: &id917
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -120136,13 +120007,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/pr-gate:
+  /api/v1/ralph/campaigns/{campaign_id}/blockers:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign PR gate
-      description: Return PR merge gate readiness for a specific Ralph campaign.
-      operationId: getRalphCampaignPrGate
+      summary: Get Ralph campaign blockers
+      description: Return blocker breakdown data for a specific Ralph campaign.
+      operationId: getRalphCampaignBlockers
       parameters:
       - name: campaign_id
         in: path
@@ -120152,7 +120023,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign PR gate
+          description: Get Ralph campaign blockers
           headers: &id918
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -120250,13 +120121,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/repairs:
+  /api/v1/ralph/campaigns/{campaign_id}/budget:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign repairs
-      description: Return repair statistics for a specific Ralph campaign.
-      operationId: getRalphCampaignRepairs
+      summary: Get Ralph campaign budget
+      description: Return budget burn and limit data for a specific Ralph campaign.
+      operationId: getRalphCampaignBudget
       parameters:
       - name: campaign_id
         in: path
@@ -120266,7 +120137,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign repairs
+          description: Get Ralph campaign budget
           headers: &id919
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -120364,13 +120235,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/timeline:
+  /api/v1/ralph/campaigns/{campaign_id}/pr-gate:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign timeline
-      description: Return the step timeline for a Ralph campaign supervisor run.
-      operationId: getRalphCampaignTimeline
+      summary: Get Ralph campaign PR gate
+      description: Return PR merge gate readiness for a specific Ralph campaign.
+      operationId: getRalphCampaignPrGate
       parameters:
       - name: campaign_id
         in: path
@@ -120380,7 +120251,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign timeline
+          description: Get Ralph campaign PR gate
           headers: &id920
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -120397,11 +120268,9 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  timeline:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: true
+                  data:
+                    type: object
+                    additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
           headers: *id920
@@ -120480,16 +120349,23 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/overview:
+  /api/v1/ralph/campaigns/{campaign_id}/repairs:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign overview
-      description: Return aggregate status, progress, and throughput metrics for Ralph campaign supervisor runs.
-      operationId: getRalphOverview
+      summary: Get Ralph campaign repairs
+      description: Return repair statistics for a specific Ralph campaign.
+      operationId: getRalphCampaignRepairs
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        description: Ralph campaign identifier
+        schema:
+          type: string
       responses:
         '200':
-          description: Ralph campaign overview
+          description: Get Ralph campaign repairs
           headers: &id921
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -120551,9 +120427,232 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id921
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
           headers: *id921
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                rate_limited:
+                  summary: Rate limit exceeded
+                  value:
+                    error: Rate limit exceeded
+                    code: RATE_LIMITED
+                    limit: 60
+                    window: 1 minute
+                    retry_after: 45
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/ralph/campaigns/{campaign_id}/timeline:
+    get:
+      tags:
+      - Ralph
+      summary: Get Ralph campaign timeline
+      description: Return the step timeline for a Ralph campaign supervisor run.
+      operationId: getRalphCampaignTimeline
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        description: Ralph campaign identifier
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Get Ralph campaign timeline
+          headers: &id922
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  timeline:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id922
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id922
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id922
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '429':
+          description: Too many requests - Rate limit exceeded
+          headers: *id922
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                rate_limited:
+                  summary: Rate limit exceeded
+                  value:
+                    error: Rate limit exceeded
+                    code: RATE_LIMITED
+                    limit: 60
+                    window: 1 minute
+                    retry_after: 45
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/ralph/overview:
+    get:
+      tags:
+      - Ralph
+      summary: Get Ralph campaign overview
+      description: Return aggregate status, progress, and throughput metrics for Ralph campaign supervisor runs.
+      operationId: getRalphOverview
+      responses:
+        '200':
+          description: Ralph campaign overview
+          headers: &id923
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id923
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id923
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '429':
+          description: Too many requests - Rate limit exceeded
+          headers: *id923
           content:
             application/json:
               schema:
@@ -120865,7 +120964,7 @@ paths:
       responses:
         '200':
           description: Readiness report
-          headers: &id922
+          headers: &id924
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120986,7 +121085,7 @@ paths:
                   timestamp: '2026-02-21T12:00:00Z'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id922
+          headers: *id924
           content:
             application/json:
               schema:
@@ -121063,7 +121162,7 @@ paths:
       responses:
         '200':
           description: Receipt delivery history
-          headers: &id923
+          headers: &id925
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121090,7 +121189,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id923
+          headers: *id925
           content:
             application/json:
               schema:
@@ -121110,7 +121209,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id923
+          headers: *id925
           content:
             application/json:
               schema:
@@ -121145,7 +121244,7 @@ paths:
       responses:
         '200':
           description: Recently anchored receipts
-          headers: &id924
+          headers: &id926
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121170,7 +121269,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id924
+          headers: *id926
           content:
             application/json:
               schema:
@@ -121190,7 +121289,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id924
+          headers: *id926
           content:
             application/json:
               schema:
@@ -121224,7 +121323,7 @@ paths:
       responses:
         '200':
           description: Receipt anchor verification status
-          headers: &id925
+          headers: &id927
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121249,7 +121348,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id925
+          headers: *id927
           content:
             application/json:
               schema:
@@ -121269,7 +121368,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id925
+          headers: *id927
           content:
             application/json:
               schema:
@@ -121285,7 +121384,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id925
+          headers: *id927
           content:
             application/json:
               schema:
@@ -121362,7 +121461,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id926
+          headers: &id928
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121399,7 +121498,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id926
+          headers: *id928
           content:
             application/json:
               schema:
@@ -121419,7 +121518,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id926
+          headers: *id928
           content:
             application/json:
               schema:
@@ -121435,7 +121534,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id926
+          headers: *id928
           content:
             application/json:
               schema:
@@ -121528,7 +121627,7 @@ paths:
       responses:
         '200':
           description: Bulk resolution results
-          headers: &id927
+          headers: &id929
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121544,7 +121643,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id927
+          headers: *id929
           content:
             application/json:
               schema:
@@ -121572,7 +121671,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id927
+          headers: *id929
           content:
             application/json:
               schema:
@@ -121642,7 +121741,7 @@ paths:
       responses:
         '200':
           description: Reconciliation job started
-          headers: &id928
+          headers: &id930
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121658,7 +121757,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id928
+          headers: *id930
           content:
             application/json:
               schema:
@@ -121686,7 +121785,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id928
+          headers: *id930
           content:
             application/json:
               schema:
@@ -121778,7 +121877,7 @@ paths:
       responses:
         '200':
           description: Approval confirmation
-          headers: &id929
+          headers: &id931
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121794,7 +121893,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id929
+          headers: *id931
           content:
             application/json:
               schema:
@@ -121810,7 +121909,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id929
+          headers: *id931
           content:
             application/json:
               schema:
@@ -121891,7 +121990,7 @@ paths:
       responses:
         '200':
           description: Resolution confirmation
-          headers: &id930
+          headers: &id932
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121907,7 +122006,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id930
+          headers: *id932
           content:
             application/json:
               schema:
@@ -121935,7 +122034,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id930
+          headers: *id932
           content:
             application/json:
               schema:
@@ -121951,7 +122050,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id930
+          headers: *id932
           content:
             application/json:
               schema:
@@ -122527,8 +122626,24 @@ paths:
       tags:
       - Reputation
       summary: Get domain reputation scores
-      description: Return domain-level reputation scores or reputation summaries.
+      description: Return domain-level reputation scores or reputation summaries. Requires the critiques:read permission.
       operationId: getReputationDomain
+      parameters:
+      - name: domain
+        in: query
+        required: true
+        description: Domain token matched against agent names.
+        schema: &id933
+          type: string
+      - name: limit
+        in: query
+        required: false
+        description: Maximum reputations to return.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 100
       responses:
         '200':
           description: Domain reputation
@@ -122546,14 +122661,62 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  domain: *id933
+                  reputations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        agent: *id933
+                        score:
+                          type: number
+                        vote_weight:
+                          type: number
+                        proposal_acceptance_rate:
+                          type: number
+                        critique_value:
+                          type: number
+                        debates_participated:
+                          type: integer
+                  count:
+                    type: integer
+      security:
+      - bearerAuth: []
       x-aragora-stability: stable
   /api/v1/reputation/history:
     get:
       tags:
       - Reputation
       summary: Get reputation history
-      description: List historical reputation events or score snapshots.
+      description: List historical reputation events or score snapshots. Requires the critiques:read permission.
       operationId: getReputationHistory
+      parameters:
+      - name: agent
+        in: query
+        required: false
+        description: Restrict snapshots to a single agent.
+        schema: &id934
+          type: string
+      - name: start_date
+        in: query
+        required: false
+        description: ISO-8601 lower bound; invalid values are a 400.
+        schema: *id934
+      - name: end_date
+        in: query
+        required: false
+        description: ISO-8601 upper bound; invalid values are a 400.
+        schema: *id934
+      - name: limit
+        in: query
+        required: false
+        description: Maximum snapshots to return.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 100
       responses:
         '200':
           description: Reputation history
@@ -122570,9 +122733,22 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
+                type: object
+                properties:
+                  history:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        timestamp: *id934
+                        agent: *id934
+                        reputation:
+                          type: number
+                        event: *id934
+                  count:
+                    type: integer
+      security:
+      - bearerAuth: []
       x-aragora-stability: stable
   /api/v1/reputation/{agent_id}:
     get:
@@ -122625,7 +122801,7 @@ paths:
       responses:
         '200':
           description: List of expiring items
-          headers: &id931
+          headers: &id935
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122648,7 +122824,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id931
+          headers: *id935
           content:
             application/json:
               schema:
@@ -122679,7 +122855,7 @@ paths:
       responses:
         '200':
           description: List of retention policies
-          headers: &id932
+          headers: &id936
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122693,9 +122869,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicyList'
-        '401': &id933
+        '401': &id937
           description: Unauthorized - Authentication required or token invalid
-          headers: *id932
+          headers: *id936
           content:
             application/json:
               schema:
@@ -122753,14 +122929,14 @@ paths:
       responses:
         '201':
           description: Policy created
-          headers: *id932
+          headers: *id936
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id932
+          headers: *id936
           content:
             application/json:
               schema:
@@ -122786,10 +122962,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id933
+        '401': *id937
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id932
+          headers: *id936
           content:
             application/json:
               schema:
@@ -122900,7 +123076,7 @@ paths:
       responses:
         '200':
           description: Execution result with affected items count
-          headers: &id934
+          headers: &id938
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122923,7 +123099,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id934
+          headers: *id938
           content:
             application/json:
               schema:
@@ -122943,7 +123119,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id934
+          headers: *id938
           content:
             application/json:
               schema:
@@ -122965,7 +123141,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id934
+          headers: *id938
           content:
             application/json:
               schema:
@@ -122996,7 +123172,7 @@ paths:
       responses:
         '200':
           description: Rolling-window triage metrics
-          headers: &id936
+          headers: &id940
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123018,7 +123194,7 @@ paths:
                     - 7d
                     - 30d
                     properties:
-                      7d: &id935
+                      7d: &id939
                         type: object
                         additionalProperties: false
                         required:
@@ -123115,7 +123291,7 @@ paths:
                               type: string
                             description: Explanations keyed by metric name for any null-valued metric above. Empty when no
                               metrics were suppressed.
-                      30d: *id935
+                      30d: *id939
                   drift:
                     type: object
                     additionalProperties:
@@ -123152,7 +123328,7 @@ paths:
           description: "Not Modified \u2014 ETag matched If-None-Match."
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id936
+          headers: *id940
           content:
             application/json:
               schema:
@@ -123172,7 +123348,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id936
+          headers: *id940
           content:
             application/json:
               schema:
@@ -123194,7 +123370,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id936
+          headers: *id940
           content:
             application/json:
               schema:
@@ -123211,7 +123387,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id936
+          headers: *id940
           content:
             application/json:
               schema:
@@ -123291,7 +123467,7 @@ paths:
       responses:
         '200':
           description: Review details
-          headers: &id937
+          headers: &id941
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123319,9 +123495,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '400': &id938
+        '400': &id942
           description: Bad request - Invalid input or malformed JSON
-          headers: *id937
+          headers: *id941
           content:
             application/json:
               schema:
@@ -123347,9 +123523,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id939
+        '404': &id943
           description: Not found - The requested resource does not exist
-          headers: *id937
+          headers: *id941
           content:
             application/json:
               schema:
@@ -123363,9 +123539,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id940
+        '500': &id944
           description: Internal server error - Unexpected error occurred
-          headers: *id937
+          headers: *id941
           content:
             application/json:
               schema:
@@ -123414,7 +123590,7 @@ paths:
       responses:
         '200':
           description: Review updated
-          headers: *id937
+          headers: *id941
           content:
             application/json:
               schema:
@@ -123424,9 +123600,9 @@ paths:
                     type: boolean
                   review_id:
                     type: string
-        '400': *id938
-        '404': *id939
-        '500': *id940
+        '400': *id942
+        '404': *id943
+        '500': *id944
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -123446,7 +123622,7 @@ paths:
       responses:
         '200':
           description: Review deleted
-          headers: *id937
+          headers: *id941
           content:
             application/json:
               schema:
@@ -123456,8 +123632,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id939
-        '500': *id940
+        '404': *id943
+        '500': *id944
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -124290,7 +124466,7 @@ paths:
       responses:
         '200':
           description: Execution timeline
-          headers: &id941
+          headers: &id945
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124311,7 +124487,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id941
+          headers: *id945
           content:
             application/json:
               schema:
@@ -124331,7 +124507,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id941
+          headers: *id945
           content:
             application/json:
               schema:
@@ -124469,7 +124645,7 @@ paths:
       responses:
         '201':
           description: Queued improvement goal
-          headers: &id942
+          headers: &id946
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124503,7 +124679,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id942
+          headers: *id946
           content:
             application/json:
               schema:
@@ -124531,7 +124707,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id942
+          headers: *id946
           content:
             application/json:
               schema:
@@ -124551,7 +124727,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id942
+          headers: *id946
           content:
             application/json:
               schema:
@@ -124601,7 +124777,7 @@ paths:
       responses:
         '200':
           description: Deleted queue item
-          headers: &id943
+          headers: &id947
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124635,7 +124811,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id943
+          headers: *id947
           content:
             application/json:
               schema:
@@ -124655,7 +124831,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id943
+          headers: *id947
           content:
             application/json:
               schema:
@@ -124677,7 +124853,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id943
+          headers: *id947
           content:
             application/json:
               schema:
@@ -124735,7 +124911,7 @@ paths:
       responses:
         '200':
           description: Updated queue item priority
-          headers: &id944
+          headers: &id948
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124769,7 +124945,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id944
+          headers: *id948
           content:
             application/json:
               schema:
@@ -124797,7 +124973,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id944
+          headers: *id948
           content:
             application/json:
               schema:
@@ -124817,7 +124993,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id944
+          headers: *id948
           content:
             application/json:
               schema:
@@ -124839,7 +125015,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id944
+          headers: *id948
           content:
             application/json:
               schema:
@@ -124876,7 +125052,7 @@ paths:
       responses:
         '200':
           description: Learning insights
-          headers: &id945
+          headers: &id949
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124897,7 +125073,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id945
+          headers: *id949
           content:
             application/json:
               schema:
@@ -124917,7 +125093,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id945
+          headers: *id949
           content:
             application/json:
               schema:
@@ -124951,7 +125127,7 @@ paths:
       responses:
         '200':
           description: Meta-planner goals
-          headers: &id946
+          headers: &id950
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124972,7 +125148,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id946
+          headers: *id950
           content:
             application/json:
               schema:
@@ -124992,7 +125168,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id946
+          headers: *id950
           content:
             application/json:
               schema:
@@ -125025,7 +125201,7 @@ paths:
       responses:
         '200':
           description: Metrics comparison
-          headers: &id947
+          headers: &id951
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125046,7 +125222,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id947
+          headers: *id951
           content:
             application/json:
               schema:
@@ -125066,7 +125242,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id947
+          headers: *id951
           content:
             application/json:
               schema:
@@ -125278,7 +125454,7 @@ paths:
       responses:
         '200':
           description: Cycle trends
-          headers: &id950
+          headers: &id954
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125298,16 +125474,16 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      cycles: &id949
+                      cycles: &id953
                         type: array
-                        items: &id948
+                        items: &id952
                           type: object
                           additionalProperties: true
-                      summary: *id948
-                      run_costs: *id949
+                      summary: *id952
+                      run_costs: *id953
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id950
+          headers: *id954
           content:
             application/json:
               schema:
@@ -125327,7 +125503,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id950
+          headers: *id954
           content:
             application/json:
               schema:
@@ -126202,7 +126378,7 @@ paths:
       responses:
         '200':
           description: Spectate events emitted
-          headers: &id951
+          headers: &id955
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -126223,7 +126399,7 @@ paths:
                     type: string
         '503':
           description: Bridge unavailable
-          headers: *id951
+          headers: *id955
           content:
             application/json:
               schema:
@@ -126248,12 +126424,12 @@ paths:
       - name: debate_id
         in: query
         description: Limit results to one debate.
-        schema: &id952
+        schema: &id956
           type: string
       - name: pipeline_id
         in: query
         description: Limit results to one pipeline.
-        schema: *id952
+        schema: *id956
       responses:
         '200':
           description: Recent spectate events
@@ -126316,12 +126492,12 @@ paths:
       - name: debate_id
         in: query
         description: Limit results to one debate.
-        schema: &id953
+        schema: &id957
           type: string
       - name: pipeline_id
         in: query
         description: Limit results to one pipeline.
-        schema: *id953
+        schema: *id957
       - name: format
         in: query
         description: Use `sse` to request a finite SSE snapshot instead of JSON.
@@ -126831,13 +127007,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id954
+        schema: &id958
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id954
+        schema: *id958
       responses:
         '200':
           description: Ticket updated
@@ -126868,13 +127044,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id955
+        schema: &id959
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id955
+        schema: *id959
       responses:
         '200':
           description: Reply sent
@@ -127155,7 +127331,7 @@ paths:
       responses:
         '200':
           description: Active leases
-          headers: &id956
+          headers: &id960
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127180,7 +127356,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id956
+          headers: *id960
           content:
             application/json:
               schema:
@@ -127200,7 +127376,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id956
+          headers: *id960
           content:
             application/json:
               schema:
@@ -127300,7 +127476,7 @@ paths:
       responses:
         '200':
           description: Completion receipt
-          headers: &id957
+          headers: &id961
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127321,7 +127497,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id957
+          headers: *id961
           content:
             application/json:
               schema:
@@ -127341,7 +127517,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id957
+          headers: *id961
           content:
             application/json:
               schema:
@@ -127363,7 +127539,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id957
+          headers: *id961
           content:
             application/json:
               schema:
@@ -127426,408 +127602,6 @@ paths:
       responses:
         '200':
           description: Updated lease
-          headers: &id958
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id958
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id958
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id958
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/tasks/leases/{lease_id}/release:
-    post:
-      tags:
-      - Tasks
-      summary: Release task lease
-      description: Release a task lease without recording completion.
-      operationId: releaseTaskQueueLease
-      parameters:
-      - name: lease_id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Task lease id.
-      responses:
-        '200':
-          description: Released lease
-          headers: &id959
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id959
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id959
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id959
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/tasks/queue:
-    get:
-      tags:
-      - Tasks
-      summary: List task queue items
-      description: List pending work queue items with optional status, work type, and limit filters.
-      operationId: listTaskQueueItems
-      parameters:
-      - name: status
-        in: query
-        schema:
-          type: string
-        description: Optional work status filter.
-      - name: work_type
-        in: query
-        schema:
-          type: string
-        description: Optional work type filter.
-      - name: limit
-        in: query
-        schema:
-          type: integer
-          default: 20
-          minimum: 1
-          maximum: 100
-        description: Maximum queue items to return.
-      responses:
-        '200':
-          description: Queue items
-          headers: &id960
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: true
-                  count:
-                    type: integer
-                additionalProperties: true
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id960
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id960
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id960
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/tasks/queue/stats:
-    get:
-      tags:
-      - Tasks
-      summary: Get task queue statistics
-      description: Return aggregate statistics for the global developer work queue.
-      operationId: getTaskQueueStats
-      responses:
-        '200':
-          description: Queue statistics
-          headers: &id961
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id961
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id961
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/tasks/queue/sync:
-    post:
-      tags:
-      - Tasks
-      summary: Synchronize task queue
-      description: Project pending and developer coordination work into the global task queue.
-      operationId: syncTaskQueue
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                include_pending:
-                  type: boolean
-                  default: true
-                include_developer_tasks:
-                  type: boolean
-                  default: true
-                complete_missing:
-                  type: boolean
-                  default: true
-              additionalProperties: true
-      responses:
-        '200':
-          description: Queue synchronization result
           headers: &id962
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -127889,41 +127663,42 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
+        '404':
+          description: Not found - The requested resource does not exist
           headers: *id962
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
               examples:
-                internal_error:
-                  summary: Internal server error
+                not_found:
+                  summary: Resource not found
                   value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
                     trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/tasks/queue/{task_id}:
-    get:
+  /api/v1/tasks/leases/{lease_id}/release:
+    post:
       tags:
       - Tasks
-      summary: Get task queue item
-      description: Retrieve a single task queue item by id.
-      operationId: getTaskQueueItem
+      summary: Release task lease
+      description: Release a task lease without recording completion.
+      operationId: releaseTaskQueueLease
       parameters:
-      - name: task_id
+      - name: lease_id
         in: path
         required: true
         schema:
           type: string
-        description: Task queue item id.
+        description: Task lease id.
       responses:
         '200':
-          description: Queue item
+          description: Released lease
           headers: &id963
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -128004,6 +127779,407 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
+  /api/v1/tasks/queue:
+    get:
+      tags:
+      - Tasks
+      summary: List task queue items
+      description: List pending work queue items with optional status, work type, and limit filters.
+      operationId: listTaskQueueItems
+      parameters:
+      - name: status
+        in: query
+        schema:
+          type: string
+        description: Optional work status filter.
+      - name: work_type
+        in: query
+        schema:
+          type: string
+        description: Optional work type filter.
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+          maximum: 100
+        description: Maximum queue items to return.
+      responses:
+        '200':
+          description: Queue items
+          headers: &id964
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                  count:
+                    type: integer
+                additionalProperties: true
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id964
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id964
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id964
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/tasks/queue/stats:
+    get:
+      tags:
+      - Tasks
+      summary: Get task queue statistics
+      description: Return aggregate statistics for the global developer work queue.
+      operationId: getTaskQueueStats
+      responses:
+        '200':
+          description: Queue statistics
+          headers: &id965
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id965
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id965
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/tasks/queue/sync:
+    post:
+      tags:
+      - Tasks
+      summary: Synchronize task queue
+      description: Project pending and developer coordination work into the global task queue.
+      operationId: syncTaskQueue
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                include_pending:
+                  type: boolean
+                  default: true
+                include_developer_tasks:
+                  type: boolean
+                  default: true
+                complete_missing:
+                  type: boolean
+                  default: true
+              additionalProperties: true
+      responses:
+        '200':
+          description: Queue synchronization result
+          headers: &id966
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id966
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id966
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id966
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/tasks/queue/{task_id}:
+    get:
+      tags:
+      - Tasks
+      summary: Get task queue item
+      description: Retrieve a single task queue item by id.
+      operationId: getTaskQueueItem
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Task queue item id.
+      responses:
+        '200':
+          description: Queue item
+          headers: &id967
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id967
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id967
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id967
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
   /api/v1/tasks/queue/{task_id}/claim:
     post:
       tags:
@@ -128061,7 +128237,7 @@ paths:
       responses:
         '201':
           description: Created lease
-          headers: &id964
+          headers: &id968
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -128082,7 +128258,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id964
+          headers: *id968
           content:
             application/json:
               schema:
@@ -128102,7 +128278,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id964
+          headers: *id968
           content:
             application/json:
               schema:
@@ -128124,7 +128300,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id964
+          headers: *id968
           content:
             application/json:
               schema:
@@ -128171,7 +128347,7 @@ paths:
       responses:
         '200':
           description: Salvage candidates
-          headers: &id965
+          headers: &id969
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -128196,7 +128372,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id965
+          headers: *id969
           content:
             application/json:
               schema:
@@ -128216,7 +128392,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id965
+          headers: *id969
           content:
             application/json:
               schema:
@@ -128542,7 +128718,7 @@ paths:
       responses:
         '200':
           description: Template registry listing
-          headers: &id966
+          headers: &id970
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -128615,7 +128791,7 @@ paths:
                 - approved_by
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id966
+          headers: *id970
           content:
             application/json:
               schema:
@@ -128717,358 +128893,6 @@ paths:
       responses:
         '200':
           description: Email scan
-          headers: &id967
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id967
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id967
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id967
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/threat/hash/{hash_value}:
-    get:
-      tags:
-      - Threat Intel
-      summary: File hash lookup
-      operationId: getThreatHash
-      description: Check a file hash for malware.
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: hash_value
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Hash result
-          headers: &id968
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id968
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id968
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/threat/hashes:
-    post:
-      tags:
-      - Threat Intel
-      summary: Batch hash lookup
-      operationId: createThreatHashes
-      description: Check multiple hashes for malware.
-      security:
-      - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                hashes:
-                  type: array
-                  items:
-                    type: string
-                  description: File hashes to check (MD5, SHA1, or SHA256)
-                hash_type:
-                  type: string
-                  enum:
-                  - md5
-                  - sha1
-                  - sha256
-                  description: Type of hash provided
-              required:
-              - hashes
-      responses:
-        '200':
-          description: Hash results
-          headers: &id969
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id969
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id969
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id969
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/threat/ip/{ip_address}:
-    get:
-      tags:
-      - Threat Intel
-      summary: IP reputation
-      operationId: getThreatIp
-      description: Check IP reputation.
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: ip_address
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: IP result
-          headers: &id970
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id970
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id970
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/threat/ips:
-    post:
-      tags:
-      - Threat Intel
-      summary: Batch IP reputation
-      operationId: createThreatIps
-      description: Check multiple IPs for reputation.
-      security:
-      - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                ip_addresses:
-                  type: array
-                  items:
-                    type: string
-                    format: ipv4
-                  description: IP addresses to check reputation
-              required:
-              - ip_addresses
-      responses:
-        '200':
-          description: IP results
           headers: &id971
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -129147,18 +128971,24 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/threat/status:
+  /api/v1/threat/hash/{hash_value}:
     get:
       tags:
       - Threat Intel
-      summary: Service status
-      operationId: listThreatStatus
-      description: Get threat intel service status.
+      summary: File hash lookup
+      operationId: getThreatHash
+      description: Check a file hash for malware.
       security:
       - bearerAuth: []
+      parameters:
+      - name: hash_value
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         '200':
-          description: Status
+          description: Hash result
           headers: &id972
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -129209,13 +129039,13 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/threat/url:
+  /api/v1/threat/hashes:
     post:
       tags:
       - Threat Intel
-      summary: Scan URL
-      operationId: createThreatUrl
-      description: Check a URL against threat intel feeds.
+      summary: Batch hash lookup
+      operationId: createThreatHashes
+      description: Check multiple hashes for malware.
       security:
       - bearerAuth: []
       requestBody:
@@ -129225,15 +129055,23 @@ paths:
             schema:
               type: object
               properties:
-                url:
+                hashes:
+                  type: array
+                  items:
+                    type: string
+                  description: File hashes to check (MD5, SHA1, or SHA256)
+                hash_type:
                   type: string
-                  format: uri
-                  description: URL to scan for threats
+                  enum:
+                  - md5
+                  - sha1
+                  - sha256
+                  description: Type of hash provided
               required:
-              - url
+              - hashes
       responses:
         '200':
-          description: Threat result
+          description: Hash results
           headers: &id973
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -129312,13 +129150,81 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/threat/urls:
+  /api/v1/threat/ip/{ip_address}:
+    get:
+      tags:
+      - Threat Intel
+      summary: IP reputation
+      operationId: getThreatIp
+      description: Check IP reputation.
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: ip_address
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: IP result
+          headers: &id974
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id974
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id974
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/threat/ips:
     post:
       tags:
       - Threat Intel
-      summary: Batch scan URLs
-      operationId: createThreatUrls
-      description: Check multiple URLs for threats.
+      summary: Batch IP reputation
+      operationId: createThreatIps
+      description: Check multiple IPs for reputation.
       security:
       - bearerAuth: []
       requestBody:
@@ -129328,18 +129234,18 @@ paths:
             schema:
               type: object
               properties:
-                urls:
+                ip_addresses:
                   type: array
                   items:
                     type: string
-                    format: uri
-                  description: URLs to scan for threats
+                    format: ipv4
+                  description: IP addresses to check reputation
               required:
-              - urls
+              - ip_addresses
       responses:
         '200':
-          description: Threat results
-          headers: &id974
+          description: IP results
+          headers: &id975
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -129355,7 +129261,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id974
+          headers: *id975
           content:
             application/json:
               schema:
@@ -129383,7 +129289,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id974
+          headers: *id975
           content:
             application/json:
               schema:
@@ -129403,7 +129309,277 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id974
+          headers: *id975
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/threat/status:
+    get:
+      tags:
+      - Threat Intel
+      summary: Service status
+      operationId: listThreatStatus
+      description: Get threat intel service status.
+      security:
+      - bearerAuth: []
+      responses:
+        '200':
+          description: Status
+          headers: &id976
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id976
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id976
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/threat/url:
+    post:
+      tags:
+      - Threat Intel
+      summary: Scan URL
+      operationId: createThreatUrl
+      description: Check a URL against threat intel feeds.
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  format: uri
+                  description: URL to scan for threats
+              required:
+              - url
+      responses:
+        '200':
+          description: Threat result
+          headers: &id977
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id977
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id977
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id977
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/threat/urls:
+    post:
+      tags:
+      - Threat Intel
+      summary: Batch scan URLs
+      operationId: createThreatUrls
+      description: Check multiple URLs for threats.
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
+                  description: URLs to scan for threats
+              required:
+              - urls
+      responses:
+        '200':
+          description: Threat results
+          headers: &id978
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id978
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id978
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id978
           content:
             application/json:
               schema:
@@ -129645,7 +129821,7 @@ paths:
       responses:
         '200':
           description: Tournament details
-          headers: &id975
+          headers: &id979
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -129675,9 +129851,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id976
+        '404': &id980
           description: Not found - The requested resource does not exist
-          headers: *id975
+          headers: *id979
           content:
             application/json:
               schema:
@@ -129691,9 +129867,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id977
+        '500': &id981
           description: Internal server error - Unexpected error occurred
-          headers: *id975
+          headers: *id979
           content:
             application/json:
               schema:
@@ -129723,7 +129899,7 @@ paths:
       responses:
         '200':
           description: Tournament deleted
-          headers: *id975
+          headers: *id979
           content:
             application/json:
               schema:
@@ -129733,8 +129909,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id976
-        '500': *id977
+        '404': *id980
+        '500': *id981
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -130638,7 +130814,7 @@ paths:
       responses:
         '200':
           description: List of linked providers
-          headers: &id978
+          headers: &id982
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -130665,7 +130841,7 @@ paths:
                           format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id978
+          headers: *id982
           content:
             application/json:
               schema:
@@ -131316,9 +131492,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id980
+        '404': &id984
           description: Not found - The requested resource does not exist
-          headers: &id979
+          headers: &id983
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131379,7 +131555,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id979
+          headers: *id983
           content:
             application/json:
               schema:
@@ -131391,7 +131567,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id979
+          headers: *id983
           content:
             application/json:
               schema:
@@ -131417,7 +131593,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id980
+        '404': *id984
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -131940,7 +132116,7 @@ paths:
                     format: date-time
         '404':
           description: Delivery not found
-          headers: &id981
+          headers: &id985
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131970,7 +132146,7 @@ paths:
           description: Delivery deleted
         '404':
           description: Delivery not found
-          headers: *id981
+          headers: *id985
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -132421,7 +132597,7 @@ paths:
       - name: id
         in: path
         required: true
-        schema: &id982
+        schema: &id986
           type: string
           format: uuid
         description: Webhook ID
@@ -132469,7 +132645,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: &id983
+          headers: &id987
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132492,7 +132668,7 @@ paths:
       - name: id
         in: path
         required: true
-        schema: *id982
+        schema: *id986
         description: Webhook ID
       requestBody:
         required: true
@@ -132556,7 +132732,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: *id983
+          headers: *id987
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -132570,14 +132746,14 @@ paths:
       - name: id
         in: path
         required: true
-        schema: *id982
+        schema: *id986
         description: Webhook ID
       responses:
         '204':
           description: Webhook deleted
         '404':
           description: Webhook not found
-          headers: *id983
+          headers: *id987
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -132649,7 +132825,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id984
+          headers: &id988
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132672,7 +132848,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id984
+          headers: *id988
           content:
             application/json:
               schema:
@@ -132725,7 +132901,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id985
+          headers: &id989
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132748,7 +132924,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id985
+          headers: *id989
           content:
             application/json:
               schema:
@@ -132776,7 +132952,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id985
+          headers: *id989
           content:
             application/json:
               schema:
@@ -132796,7 +132972,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id985
+          headers: *id989
           content:
             application/json:
               schema:
@@ -132902,7 +133078,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id986
+          headers: &id990
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132929,9 +133105,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id987
+        '404': &id991
           description: Not found - The requested resource does not exist
-          headers: *id986
+          headers: *id990
           content:
             application/json:
               schema:
@@ -132961,7 +133137,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id986
+          headers: *id990
           content:
             application/json:
               schema:
@@ -132973,7 +133149,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id986
+          headers: *id990
           content:
             application/json:
               schema:
@@ -132999,7 +133175,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id987
+        '404': *id991
       x-aragora-stability: stable
   /api/v1/workflow-templates:
     get:
@@ -133048,7 +133224,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id988
+          headers: &id992
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133064,7 +133240,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id988
+          headers: *id992
           content:
             application/json:
               schema:
@@ -133148,7 +133324,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id989
+          headers: &id993
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133185,7 +133361,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id989
+          headers: *id993
           content:
             application/json:
               schema:
@@ -133231,7 +133407,7 @@ paths:
       responses:
         '201':
           description: Workflow instantiated
-          headers: &id990
+          headers: &id994
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133252,7 +133428,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id990
+          headers: *id994
           content:
             application/json:
               schema:
@@ -133280,7 +133456,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id990
+          headers: *id994
           content:
             application/json:
               schema:
@@ -133296,7 +133472,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id990
+          headers: *id994
           content:
             application/json:
               schema:
@@ -133383,7 +133559,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id991
+          headers: &id995
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133399,7 +133575,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id991
+          headers: *id995
           content:
             application/json:
               schema:
@@ -133427,7 +133603,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id991
+          headers: *id995
           content:
             application/json:
               schema:
@@ -133523,7 +133699,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id992
+          headers: &id996
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133539,7 +133715,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id992
+          headers: *id996
           content:
             application/json:
               schema:
@@ -133721,7 +133897,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id993
+          headers: &id997
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133758,7 +133934,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id993
+          headers: *id997
           content:
             application/json:
               schema:
@@ -133815,7 +133991,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id994
+          headers: &id998
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133876,14 +134052,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id994
+          headers: *id998
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id994
+          headers: *id998
           content:
             application/json:
               schema:
@@ -134006,7 +134182,7 @@ paths:
       responses:
         '200':
           description: Workflow execution details
-          headers: &id995
+          headers: &id999
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134029,9 +134205,9 @@ paths:
                     type: string
                   result:
                     type: object
-        '404': &id996
+        '404': &id1000
           description: Not found - The requested resource does not exist
-          headers: *id995
+          headers: *id999
           content:
             application/json:
               schema:
@@ -134064,7 +134240,7 @@ paths:
       responses:
         '200':
           description: Workflow execution deleted
-          headers: *id995
+          headers: *id999
           content:
             application/json:
               schema:
@@ -134076,7 +134252,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id995
+          headers: *id999
           content:
             application/json:
               schema:
@@ -134102,7 +134278,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id996
+        '404': *id1000
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -134244,7 +134420,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id997
+          headers: &id1001
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134258,9 +134434,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '404': &id998
+        '404': &id1002
           description: Not found - The requested resource does not exist
-          headers: *id997
+          headers: *id1001
           content:
             application/json:
               schema:
@@ -134322,14 +134498,14 @@ paths:
       responses:
         '200':
           description: Workflow template updated
-          headers: *id997
+          headers: *id1001
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '400': &id999
+        '400': &id1003
           description: Bad request - Invalid input or malformed JSON
-          headers: *id997
+          headers: *id1001
           content:
             application/json:
               schema:
@@ -134355,7 +134531,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id998
+        '404': *id1002
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -134375,7 +134551,7 @@ paths:
       responses:
         '200':
           description: Workflow template deleted
-          headers: *id997
+          headers: *id1001
           content:
             application/json:
               schema:
@@ -134385,8 +134561,8 @@ paths:
                     type: boolean
                   template_id:
                     type: string
-        '400': *id999
-        '404': *id998
+        '400': *id1003
+        '404': *id1002
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -134455,7 +134631,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id1000
+          headers: &id1004
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134469,9 +134645,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id1001
+        '404': &id1005
           description: Not found - The requested resource does not exist
-          headers: *id1000
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -134507,14 +134683,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id1000
+          headers: *id1004
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1000
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -134540,7 +134716,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1001
+        '404': *id1005
       x-aragora-stability: stable
     delete:
       tags:
@@ -134557,7 +134733,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id1000
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -134567,7 +134743,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id1001
+        '404': *id1005
       x-aragora-stability: stable
     patch:
       summary: Update a workflow
@@ -134626,7 +134802,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id1002
+          headers: &id1006
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134649,7 +134825,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1002
+          headers: *id1006
           content:
             application/json:
               schema:
@@ -134677,7 +134853,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1002
+          headers: *id1006
           content:
             application/json:
               schema:
@@ -134693,7 +134869,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1002
+          headers: *id1006
           content:
             application/json:
               schema:
@@ -134779,7 +134955,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id1003
+          headers: &id1007
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134802,7 +134978,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1003
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -134880,7 +135056,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id1004
+          headers: &id1008
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134894,9 +135070,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id1005
+        '401': &id1009
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1004
+          headers: *id1008
           content:
             application/json:
               schema:
@@ -134951,14 +135127,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id1004
+          headers: *id1008
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1004
+          headers: *id1008
           content:
             application/json:
               schema:
@@ -134984,10 +135160,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1005
+        '401': *id1009
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1004
+          headers: *id1008
           content:
             application/json:
               schema:
@@ -135032,7 +135208,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id1006
+          headers: &id1010
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135060,7 +135236,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1006
+          headers: *id1010
           content:
             application/json:
               schema:
@@ -135097,7 +135273,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id1007
+          headers: &id1011
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135111,9 +135287,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id1008
+        '401': &id1012
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1007
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -135131,9 +135307,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1009
+        '403': &id1013
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1007
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -135153,9 +135329,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1010
+        '404': &id1014
           description: Not found - The requested resource does not exist
-          headers: *id1007
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -135187,7 +135363,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id1007
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -135197,9 +135373,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id1008
-        '403': *id1009
-        '404': *id1010
+        '401': *id1012
+        '403': *id1013
+        '404': *id1014
       x-aragora-stability: stable
   /api/v1/workspaces/{workspace_id}/activity:
     get:
@@ -135412,7 +135588,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id1011
+          headers: &id1015
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135435,7 +135611,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1011
+          headers: *id1015
           content:
             application/json:
               schema:
@@ -135463,7 +135639,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1011
+          headers: *id1015
           content:
             application/json:
               schema:
@@ -135483,7 +135659,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1011
+          headers: *id1015
           content:
             application/json:
               schema:
@@ -135619,7 +135795,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id1012
+          headers: &id1016
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135642,7 +135818,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1012
+          headers: *id1016
           content:
             application/json:
               schema:
@@ -135670,7 +135846,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1012
+          headers: *id1016
           content:
             application/json:
               schema:
@@ -135690,7 +135866,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1012
+          headers: *id1016
           content:
             application/json:
               schema:
@@ -135712,7 +135888,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1012
+          headers: *id1016
           content:
             application/json:
               schema:
@@ -135764,7 +135940,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id1013
+          headers: &id1017
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135791,7 +135967,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1013
+          headers: *id1017
           content:
             application/json:
               schema:
@@ -135811,7 +135987,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1013
+          headers: *id1017
           content:
             application/json:
               schema:
@@ -135833,7 +136009,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1013
+          headers: *id1017
           content:
             application/json:
               schema:
@@ -136019,9 +136195,9 @@ paths:
                           type: integer
                   total:
                     type: integer
-        '401': &id1015
+        '401': &id1019
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1014
+          headers: &id1018
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136048,9 +136224,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1016
+        '403': &id1020
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1014
+          headers: *id1018
           content:
             application/json:
               schema:
@@ -136070,9 +136246,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id1017
+        '500': &id1021
           description: Internal server error - Unexpected error occurred
-          headers: *id1014
+          headers: *id1018
           content:
             application/json:
               schema:
@@ -136145,7 +136321,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1014
+          headers: *id1018
           content:
             application/json:
               schema:
@@ -136171,15 +136347,15 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1015
-        '403': *id1016
+        '401': *id1019
+        '403': *id1020
         '409':
           description: Another backup is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1017
+        '500': *id1021
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -136246,9 +136422,9 @@ paths:
                   expires_at:
                     type: string
                     format: date-time
-        '401': &id1019
+        '401': &id1023
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1018
+          headers: &id1022
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136275,9 +136451,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1020
+        '403': &id1024
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1018
+          headers: *id1022
           content:
             application/json:
               schema:
@@ -136297,9 +136473,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1021
+        '404': &id1025
           description: Not found - The requested resource does not exist
-          headers: *id1018
+          headers: *id1022
           content:
             application/json:
               schema:
@@ -136313,9 +136489,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1022
+        '500': &id1026
           description: Internal server error - Unexpected error occurred
-          headers: *id1018
+          headers: *id1022
           content:
             application/json:
               schema:
@@ -136357,16 +136533,16 @@ paths:
                     type: boolean
                   backup_id:
                     type: string
-        '401': *id1019
-        '403': *id1020
-        '404': *id1021
+        '401': *id1023
+        '403': *id1024
+        '404': *id1025
         '409':
           description: Cannot delete an in-progress backup
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1022
+        '500': *id1026
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -136435,7 +136611,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1023
+          headers: &id1027
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136464,7 +136640,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1023
+          headers: *id1027
           content:
             application/json:
               schema:
@@ -136486,7 +136662,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1023
+          headers: *id1027
           content:
             application/json:
               schema:
@@ -136565,7 +136741,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1024
+          headers: &id1028
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136594,7 +136770,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1024
+          headers: *id1028
           content:
             application/json:
               schema:
@@ -136616,7 +136792,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1024
+          headers: *id1028
           content:
             application/json:
               schema:
@@ -136632,7 +136808,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1024
+          headers: *id1028
           content:
             application/json:
               schema:
@@ -136717,7 +136893,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1025
+          headers: &id1029
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136746,7 +136922,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1025
+          headers: *id1029
           content:
             application/json:
               schema:
@@ -136768,7 +136944,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1025
+          headers: *id1029
           content:
             application/json:
               schema:
@@ -136861,9 +137037,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '401': &id1027
+        '401': &id1031
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1026
+          headers: &id1030
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136890,9 +137066,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1028
+        '403': &id1032
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1026
+          headers: *id1030
           content:
             application/json:
               schema:
@@ -136912,9 +137088,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1029
+        '404': &id1033
           description: Not found - The requested resource does not exist
-          headers: *id1026
+          headers: *id1030
           content:
             application/json:
               schema:
@@ -136928,9 +137104,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1030
+        '500': &id1034
           description: Internal server error - Unexpected error occurred
-          headers: *id1026
+          headers: *id1030
           content:
             application/json:
               schema:
@@ -137010,7 +137186,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1026
+          headers: *id1030
           content:
             application/json:
               schema:
@@ -137036,16 +137212,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1027
-        '403': *id1028
-        '404': *id1029
+        '401': *id1031
+        '403': *id1032
+        '404': *id1033
         '409':
           description: Another DR execution is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1030
+        '500': *id1034
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -137129,7 +137305,7 @@ paths:
                         type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1031
+          headers: &id1035
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137158,7 +137334,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1031
+          headers: *id1035
           content:
             application/json:
               schema:
@@ -137211,7 +137387,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1032
+          headers: &id1036
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137240,7 +137416,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1032
+          headers: *id1036
           content:
             application/json:
               schema:
@@ -137277,7 +137453,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1033
+          headers: &id1037
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137306,7 +137482,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1033
+          headers: *id1037
           content:
             application/json:
               schema:
@@ -137358,7 +137534,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1034
+          headers: &id1038
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137387,7 +137563,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1034
+          headers: *id1038
           content:
             application/json:
               schema:
@@ -137428,7 +137604,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1035
+          headers: &id1039
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137457,7 +137633,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1035
+          headers: *id1039
           content:
             application/json:
               schema:
@@ -137514,7 +137690,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1036
+          headers: &id1040
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137551,7 +137727,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1036
+          headers: *id1040
           content:
             application/json:
               schema:
@@ -137571,7 +137747,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1036
+          headers: *id1040
           content:
             application/json:
               schema:
@@ -137653,9 +137829,9 @@ paths:
                       type: object
                   health:
                     type: object
-        '400': &id1038
+        '400': &id1042
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1037
+          headers: &id1041
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137690,9 +137866,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id1039
+        '401': &id1043
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1037
+          headers: *id1041
           content:
             application/json:
               schema:
@@ -137710,9 +137886,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id1040
+        '404': &id1044
           description: Not found - The requested resource does not exist
-          headers: *id1037
+          headers: *id1041
           content:
             application/json:
               schema:
@@ -137726,9 +137902,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1041
+        '500': &id1045
           description: Internal server error - Unexpected error occurred
-          headers: *id1037
+          headers: *id1041
           content:
             application/json:
               schema:
@@ -137786,10 +137962,10 @@ paths:
                     type: string
                   workspace_id:
                     type: string
-        '400': *id1038
-        '401': *id1039
-        '404': *id1040
-        '500': *id1041
+        '400': *id1042
+        '401': *id1043
+        '404': *id1044
+        '500': *id1045
       x-aragora-stability: stable
   /api/v2/integrations/{type}/health:
     get:
@@ -137861,7 +138037,7 @@ paths:
                 - healthy
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1042
+          headers: &id1046
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137898,7 +138074,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1042
+          headers: *id1046
           content:
             application/json:
               schema:
@@ -137918,7 +138094,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1042
+          headers: *id1046
           content:
             application/json:
               schema:
@@ -137934,7 +138110,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1042
+          headers: *id1046
           content:
             application/json:
               schema:
@@ -138002,7 +138178,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1043
+          headers: &id1047
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138039,7 +138215,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1043
+          headers: *id1047
           content:
             application/json:
               schema:
@@ -138059,7 +138235,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1043
+          headers: *id1047
           content:
             application/json:
               schema:
@@ -138075,7 +138251,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1043
+          headers: *id1047
           content:
             application/json:
               schema:
@@ -138372,7 +138548,7 @@ paths:
       responses:
         '200':
           description: Marketplace categories.
-          headers: &id1044
+          headers: &id1048
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138393,7 +138569,7 @@ paths:
                       type: string
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1044
+          headers: *id1048
           content:
             application/json:
               schema:
@@ -138488,7 +138664,7 @@ paths:
       responses:
         '200':
           description: Marketplace templates.
-          headers: &id1045
+          headers: &id1049
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138513,9 +138689,9 @@ paths:
                     type: integer
                   offset:
                     type: integer
-        '400': &id1046
+        '400': &id1050
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1045
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -138541,9 +138717,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': &id1047
+        '500': &id1051
           description: Internal server error - Unexpected error occurred
-          headers: *id1045
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -138597,7 +138773,7 @@ paths:
       responses:
         '201':
           description: Template created.
-          headers: *id1045
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -138607,10 +138783,10 @@ paths:
                     type: string
                   success:
                     type: boolean
-        '400': *id1046
+        '400': *id1050
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1045
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -138630,7 +138806,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1045
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -138650,7 +138826,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id1047
+        '500': *id1051
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/import:
     post:
@@ -138693,7 +138869,7 @@ paths:
       responses:
         '201':
           description: Template imported.
-          headers: &id1048
+          headers: &id1052
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138714,7 +138890,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1048
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -138742,7 +138918,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1048
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -138762,7 +138938,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1048
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -138784,7 +138960,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1048
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -138810,13 +138986,13 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: &id1050
+        schema: &id1054
           type: string
         description: Marketplace template ID.
       responses:
         '200':
           description: Template details.
-          headers: &id1049
+          headers: &id1053
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138851,9 +139027,9 @@ paths:
                     type: integer
                   average_rating:
                     type: number
-        '400': &id1051
+        '400': &id1055
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1049
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -138879,9 +139055,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id1052
+        '404': &id1056
           description: Not found - The requested resource does not exist
-          headers: *id1049
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -138895,9 +139071,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1053
+        '500': &id1057
           description: Internal server error - Unexpected error occurred
-          headers: *id1049
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -138923,12 +139099,12 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: *id1050
+        schema: *id1054
         description: Marketplace template ID.
       responses:
         '200':
           description: Template deleted.
-          headers: *id1049
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -138938,10 +139114,10 @@ paths:
                     type: boolean
                   deleted:
                     type: string
-        '400': *id1051
+        '400': *id1055
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1049
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -138961,7 +139137,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1049
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -138981,8 +139157,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id1052
-        '500': *id1053
+        '404': *id1056
+        '500': *id1057
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/{template_id}/export:
     get:
@@ -139008,7 +139184,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1054
+          headers: &id1058
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139045,7 +139221,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1054
+          headers: *id1058
           content:
             application/json:
               schema:
@@ -139061,7 +139237,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1054
+          headers: *id1058
           content:
             application/json:
               schema:
@@ -139087,13 +139263,13 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: &id1056
+        schema: &id1060
           type: string
         description: Marketplace template ID.
       responses:
         '200':
           description: Template ratings.
-          headers: &id1055
+          headers: &id1059
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139126,9 +139302,9 @@ paths:
                     type: number
                   count:
                     type: integer
-        '400': &id1057
+        '400': &id1061
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1055
+          headers: *id1059
           content:
             application/json:
               schema:
@@ -139154,9 +139330,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id1058
+        '404': &id1062
           description: Not found - The requested resource does not exist
-          headers: *id1055
+          headers: *id1059
           content:
             application/json:
               schema:
@@ -139170,9 +139346,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1059
+        '500': &id1063
           description: Internal server error - Unexpected error occurred
-          headers: *id1055
+          headers: *id1059
           content:
             application/json:
               schema:
@@ -139198,7 +139374,7 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: *id1056
+        schema: *id1060
         description: Marketplace template ID.
       requestBody:
         required: true
@@ -139219,7 +139395,7 @@ paths:
       responses:
         '200':
           description: Template rating saved.
-          headers: *id1055
+          headers: *id1059
           content:
             application/json:
               schema:
@@ -139229,10 +139405,10 @@ paths:
                     type: boolean
                   average_rating:
                     type: number
-        '400': *id1057
+        '400': *id1061
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1055
+          headers: *id1059
           content:
             application/json:
               schema:
@@ -139252,7 +139428,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1055
+          headers: *id1059
           content:
             application/json:
               schema:
@@ -139272,8 +139448,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id1058
-        '500': *id1059
+        '404': *id1062
+        '500': *id1063
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/{template_id}/star:
     post:
@@ -139294,7 +139470,7 @@ paths:
       responses:
         '200':
           description: Template starred.
-          headers: &id1060
+          headers: &id1064
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139315,7 +139491,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1060
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -139343,7 +139519,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1060
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -139363,7 +139539,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1060
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -139385,7 +139561,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1060
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -139401,7 +139577,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1060
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -139569,7 +139745,7 @@ paths:
                       type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1061
+          headers: &id1065
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139606,7 +139782,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1061
+          headers: *id1065
           content:
             application/json:
               schema:
@@ -139626,7 +139802,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1061
+          headers: *id1065
           content:
             application/json:
               schema:
@@ -139648,7 +139824,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1061
+          headers: *id1065
           content:
             application/json:
               schema:
@@ -139806,7 +139982,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1062
+          headers: &id1066
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139843,7 +140019,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1062
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -139863,7 +140039,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1062
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -139885,7 +140061,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1062
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -139918,7 +140094,7 @@ paths:
       responses:
         '200':
           description: Deliberation status.
-          headers: &id1063
+          headers: &id1067
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139977,7 +140153,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1063
+          headers: *id1067
           content:
             application/json:
               schema:
@@ -139997,7 +140173,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1063
+          headers: *id1067
           content:
             application/json:
               schema:
@@ -140019,7 +140195,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1063
+          headers: *id1067
           content:
             application/json:
               schema:
@@ -140035,7 +140211,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1063
+          headers: *id1067
           content:
             application/json:
               schema:
@@ -140092,7 +140268,7 @@ paths:
       responses:
         '200':
           description: Orchestration template list.
-          headers: &id1064
+          headers: &id1068
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140138,7 +140314,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1064
+          headers: *id1068
           content:
             application/json:
               schema:
@@ -140158,7 +140334,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1064
+          headers: *id1068
           content:
             application/json:
               schema:
@@ -140180,7 +140356,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1064
+          headers: *id1068
           content:
             application/json:
               schema:
@@ -140206,7 +140382,7 @@ paths:
       responses:
         '200':
           description: Receipt list
-          headers: &id1065
+          headers: &id1069
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140241,7 +140417,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1065
+          headers: *id1069
           content:
             application/json:
               schema:
@@ -140261,7 +140437,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1065
+          headers: *id1069
           content:
             application/json:
               schema:
@@ -140288,7 +140464,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id1066
+          headers: &id1070
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140313,7 +140489,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1066
+          headers: *id1070
           content:
             application/json:
               schema:
@@ -140333,7 +140509,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1066
+          headers: *id1070
           content:
             application/json:
               schema:
@@ -140372,7 +140548,7 @@ paths:
       responses:
         '200':
           description: Shared receipt payload
-          headers: &id1067
+          headers: &id1071
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140395,7 +140571,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1067
+          headers: *id1071
           content:
             application/json:
               schema:
@@ -140413,7 +140589,7 @@ paths:
           description: Share link expired or access limit reached
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1067
+          headers: *id1071
           content:
             application/json:
               schema:
@@ -140440,7 +140616,7 @@ paths:
       responses:
         '200':
           description: Signing public key
-          headers: &id1068
+          headers: &id1072
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140463,7 +140639,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1068
+          headers: *id1072
           content:
             application/json:
               schema:
@@ -140479,7 +140655,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1068
+          headers: *id1072
           content:
             application/json:
               schema:
@@ -140506,7 +140682,7 @@ paths:
       responses:
         '200':
           description: Receipt stats
-          headers: &id1069
+          headers: &id1073
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140536,7 +140712,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1069
+          headers: *id1073
           content:
             application/json:
               schema:
@@ -140556,7 +140732,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1069
+          headers: *id1073
           content:
             application/json:
               schema:
@@ -140588,7 +140764,7 @@ paths:
       responses:
         '200':
           description: Receipt details
-          headers: &id1070
+          headers: &id1074
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140618,7 +140794,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1070
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -140638,7 +140814,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1070
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -140654,7 +140830,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1070
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -140687,7 +140863,7 @@ paths:
       responses:
         '200':
           description: Exported receipt
-          headers: &id1071
+          headers: &id1075
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140710,7 +140886,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1071
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -140730,7 +140906,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1071
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -140746,7 +140922,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1071
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -140809,7 +140985,7 @@ paths:
                     description: Channel-specific formatted content
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1072
+          headers: &id1076
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140846,7 +141022,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1072
+          headers: *id1076
           content:
             application/json:
               schema:
@@ -140866,7 +141042,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1072
+          headers: *id1076
           content:
             application/json:
               schema:
@@ -140882,7 +141058,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1072
+          headers: *id1076
           content:
             application/json:
               schema:
@@ -140964,7 +141140,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1073
+          headers: &id1077
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141001,7 +141177,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1073
+          headers: *id1077
           content:
             application/json:
               schema:
@@ -141021,7 +141197,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1073
+          headers: *id1077
           content:
             application/json:
               schema:
@@ -141037,7 +141213,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1073
+          headers: *id1077
           content:
             application/json:
               schema:
@@ -141078,7 +141254,7 @@ paths:
       responses:
         '200':
           description: Receipt shared
-          headers: &id1074
+          headers: &id1078
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141110,7 +141286,7 @@ paths:
                     - type: 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1074
+          headers: *id1078
           content:
             application/json:
               schema:
@@ -141130,7 +141306,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1074
+          headers: *id1078
           content:
             application/json:
               schema:
@@ -141152,7 +141328,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1074
+          headers: *id1078
           content:
             application/json:
               schema:
@@ -141168,7 +141344,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1074
+          headers: *id1078
           content:
             application/json:
               schema:
@@ -141190,7 +141366,7 @@ paths:
       summary: Verify receipt
       operationId: verifyReceiptById
       description: Verify receipt integrity.
-      security: &id1076
+      security: &id1080
       - bearerAuth: []
       parameters:
       - name: receipt_id
@@ -141201,7 +141377,7 @@ paths:
       responses:
         '200':
           description: Verification result
-          headers: &id1075
+          headers: &id1079
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141225,9 +141401,9 @@ paths:
                   verified_at:
                     type: string
                     format: date-time
-        '401': &id1077
+        '401': &id1081
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1075
+          headers: *id1079
           content:
             application/json:
               schema:
@@ -141245,9 +141421,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id1078
+        '404': &id1082
           description: Not found - The requested resource does not exist
-          headers: *id1075
+          headers: *id1079
           content:
             application/json:
               schema:
@@ -141261,9 +141437,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1079
+        '500': &id1083
           description: Internal server error - Unexpected error occurred
-          headers: *id1075
+          headers: *id1079
           content:
             application/json:
               schema:
@@ -141284,7 +141460,7 @@ paths:
       summary: Verify receipt integrity
       operationId: verifyReceiptIntegrity
       description: Verify receipt integrity with payload.
-      security: *id1076
+      security: *id1080
       parameters:
       - name: receipt_id
         in: path
@@ -141294,7 +141470,7 @@ paths:
       responses:
         '200':
           description: Integrity verification result
-          headers: *id1075
+          headers: *id1079
           content:
             application/json:
               schema:
@@ -141306,9 +141482,9 @@ paths:
                     type: boolean
                   integrity_verified:
                     type: boolean
-        '401': *id1077
-        '404': *id1078
-        '500': *id1079
+        '401': *id1081
+        '404': *id1082
+        '500': *id1083
       x-aragora-stability: experimental
   /api/v2/receipts/{receipt_id}/verify-signature:
     post:
@@ -141329,7 +141505,7 @@ paths:
       responses:
         '200':
           description: Signature verification result
-          headers: &id1080
+          headers: &id1084
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141354,7 +141530,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1080
+          headers: *id1084
           content:
             application/json:
               schema:
@@ -141374,7 +141550,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1080
+          headers: *id1084
           content:
             application/json:
               schema:
@@ -141390,7 +141566,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1080
+          headers: *id1084
           content:
             application/json:
               schema:
@@ -142030,9 +142206,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id1082
+        '404': &id1086
           description: Not found - The requested resource does not exist
-          headers: &id1081
+          headers: &id1085
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142093,7 +142269,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id1081
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -142105,7 +142281,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1081
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -142131,7 +142307,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1082
+        '404': *id1086
       security:
       - bearerAuth: []
       deprecated: true
@@ -142235,7 +142411,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id1083
+          headers: &id1087
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142258,7 +142434,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1083
+          headers: *id1087
           content:
             application/json:
               schema:
@@ -142311,7 +142487,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id1084
+          headers: &id1088
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142334,7 +142510,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1084
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -142362,7 +142538,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1084
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -142382,7 +142558,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1084
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -142460,7 +142636,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id1085
+          headers: &id1089
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142487,9 +142663,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id1086
+        '404': &id1090
           description: Not found - The requested resource does not exist
-          headers: *id1085
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142519,7 +142695,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id1085
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142531,7 +142707,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1085
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142557,7 +142733,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1086
+        '404': *id1090
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflow-templates:
@@ -142606,7 +142782,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id1087
+          headers: &id1091
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142622,7 +142798,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1087
+          headers: *id1091
           content:
             application/json:
               schema:
@@ -142741,7 +142917,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id1088
+          headers: &id1092
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142757,7 +142933,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1088
+          headers: *id1092
           content:
             application/json:
               schema:
@@ -142785,7 +142961,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1088
+          headers: *id1092
           content:
             application/json:
               schema:
@@ -142881,7 +143057,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id1089
+          headers: &id1093
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142897,7 +143073,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1089
+          headers: *id1093
           content:
             application/json:
               schema:
@@ -143079,7 +143255,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1090
+          headers: &id1094
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143116,7 +143292,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1090
+          headers: *id1094
           content:
             application/json:
               schema:
@@ -143173,7 +143349,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id1091
+          headers: &id1095
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143234,14 +143410,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id1091
+          headers: *id1095
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1091
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -143284,7 +143460,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id1092
+          headers: &id1096
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143298,9 +143474,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id1093
+        '404': &id1097
           description: Not found - The requested resource does not exist
-          headers: *id1092
+          headers: *id1096
           content:
             application/json:
               schema:
@@ -143336,14 +143512,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id1092
+          headers: *id1096
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1092
+          headers: *id1096
           content:
             application/json:
               schema:
@@ -143369,7 +143545,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1093
+        '404': *id1097
       deprecated: true
       x-aragora-stability: deprecated
     delete:
@@ -143386,7 +143562,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id1092
+          headers: *id1096
           content:
             application/json:
               schema:
@@ -143396,7 +143572,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id1093
+        '404': *id1097
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflows/{workflow_id}/execute:
@@ -143428,7 +143604,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id1094
+          headers: &id1098
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143451,7 +143627,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1094
+          headers: *id1098
           content:
             application/json:
               schema:
@@ -143479,7 +143655,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1094
+          headers: *id1098
           content:
             application/json:
               schema:
@@ -143495,7 +143671,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1094
+          headers: *id1098
           content:
             application/json:
               schema:
@@ -143530,7 +143706,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id1095
+          headers: &id1099
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143553,7 +143729,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1095
+          headers: *id1099
           content:
             application/json:
               schema:
@@ -143592,7 +143768,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id1096
+          headers: &id1100
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143606,9 +143782,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id1097
+        '401': &id1101
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1096
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143663,14 +143839,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id1096
+          headers: *id1100
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1096
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143696,10 +143872,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1097
+        '401': *id1101
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1096
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143744,7 +143920,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id1098
+          headers: &id1102
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143772,7 +143948,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1098
+          headers: *id1102
           content:
             application/json:
               schema:
@@ -143809,7 +143985,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id1099
+          headers: &id1103
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143823,9 +143999,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id1100
+        '401': &id1104
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1099
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143843,9 +144019,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1101
+        '403': &id1105
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1099
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143865,9 +144041,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1102
+        '404': &id1106
           description: Not found - The requested resource does not exist
-          headers: *id1099
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143899,7 +144075,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id1099
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143909,9 +144085,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id1100
-        '403': *id1101
-        '404': *id1102
+        '401': *id1104
+        '403': *id1105
+        '404': *id1106
       deprecated: true
       x-aragora-stability: deprecated
   /api/workspaces/{workspace_id}/members:
@@ -143949,7 +144125,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id1103
+          headers: &id1107
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143972,7 +144148,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1103
+          headers: *id1107
           content:
             application/json:
               schema:
@@ -144000,7 +144176,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1103
+          headers: *id1107
           content:
             application/json:
               schema:
@@ -144020,7 +144196,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1103
+          headers: *id1107
           content:
             application/json:
               schema:
@@ -144105,7 +144281,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id1104
+          headers: &id1108
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144128,7 +144304,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1104
+          headers: *id1108
           content:
             application/json:
               schema:
@@ -144156,7 +144332,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1104
+          headers: *id1108
           content:
             application/json:
               schema:
@@ -144176,7 +144352,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1104
+          headers: *id1108
           content:
             application/json:
               schema:
@@ -144198,7 +144374,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1104
+          headers: *id1108
           content:
             application/json:
               schema:
@@ -144250,7 +144426,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id1105
+          headers: &id1109
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144277,7 +144453,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1105
+          headers: *id1109
           content:
             application/json:
               schema:
@@ -144297,7 +144473,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1105
+          headers: *id1109
           content:
             application/json:
               schema:
@@ -144319,7 +144495,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1105
+          headers: *id1109
           content:
             application/json:
               schema:
@@ -144911,9 +145087,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id1107
+        '401': &id1111
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1106
+          headers: &id1110
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144940,9 +145116,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1108
+        '403': &id1112
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1106
+          headers: *id1110
           content:
             application/json:
               schema:
@@ -144962,9 +145138,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1109
+        '404': &id1113
           description: Not found - The requested resource does not exist
-          headers: *id1106
+          headers: *id1110
           content:
             application/json:
               schema:
@@ -145035,9 +145211,9 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': &id1110
+        '400': &id1114
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1106
+          headers: *id1110
           content:
             application/json:
               schema:
@@ -145063,9 +145239,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1107
-        '403': *id1108
-        '404': *id1109
+        '401': *id1111
+        '403': *id1112
+        '404': *id1113
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -145128,10 +145304,10 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': *id1110
-        '401': *id1107
-        '403': *id1108
-        '404': *id1109
+        '400': *id1114
+        '401': *id1111
+        '403': *id1112
+        '404': *id1113
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -145151,9 +145327,9 @@ paths:
       responses:
         '204':
           description: Group deleted successfully
-        '401': *id1107
-        '403': *id1108
-        '404': *id1109
+        '401': *id1111
+        '403': *id1112
+        '404': *id1113
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -145275,9 +145451,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id1112
+        '401': &id1116
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1111
+          headers: &id1115
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -145304,9 +145480,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1113
+        '403': &id1117
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1111
+          headers: *id1115
           content:
             application/json:
               schema:
@@ -145326,9 +145502,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1114
+        '404': &id1118
           description: Not found - The requested resource does not exist
-          headers: *id1111
+          headers: *id1115
           content:
             application/json:
               schema:
@@ -145413,9 +145589,9 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': &id1115
+        '400': &id1119
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1111
+          headers: *id1115
           content:
             application/json:
               schema:
@@ -145441,9 +145617,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1112
-        '403': *id1113
-        '404': *id1114
+        '401': *id1116
+        '403': *id1117
+        '404': *id1118
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -145508,10 +145684,10 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': *id1115
-        '401': *id1112
-        '403': *id1113
-        '404': *id1114
+        '400': *id1119
+        '401': *id1116
+        '403': *id1117
+        '404': *id1118
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -145531,9 +145707,9 @@ paths:
       responses:
         '204':
           description: User deleted successfully
-        '401': *id1112
-        '403': *id1113
-        '404': *id1114
+        '401': *id1116
+        '403': *id1117
+        '404': *id1118
       security:
       - bearerAuth: []
       x-aragora-stability: stable

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -12546,7 +12546,7 @@ export interface paths {
         /**
          * Get domain reputation scores
          * @deprecated
-         * @description Return domain-level reputation scores or reputation summaries.
+         * @description Return domain-level reputation scores or reputation summaries. Requires the critiques:read permission.
          */
         get: operations["listReputationDomain"];
         put?: never;
@@ -12567,7 +12567,7 @@ export interface paths {
         /**
          * Get reputation history
          * @deprecated
-         * @description List historical reputation events or score snapshots.
+         * @description List historical reputation events or score snapshots. Requires the critiques:read permission.
          */
         get: operations["listReputationHistory"];
         put?: never;
@@ -52338,7 +52338,7 @@ export interface paths {
         };
         /**
          * Get domain reputation scores
-         * @description Return domain-level reputation scores or reputation summaries.
+         * @description Return domain-level reputation scores or reputation summaries. Requires the critiques:read permission.
          */
         get: operations["getReputationDomain"];
         put?: never;
@@ -52358,7 +52358,7 @@ export interface paths {
         };
         /**
          * Get reputation history
-         * @description List historical reputation events or score snapshots.
+         * @description List historical reputation events or score snapshots. Requires the critiques:read permission.
          */
         get: operations["getReputationHistory"];
         put?: never;
@@ -82557,7 +82557,13 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        total_agents?: number;
+                        avg_elo?: number;
+                        max_elo?: number;
+                        min_elo?: number;
+                        total_matches?: number;
+                    };
                 };
             };
         };
@@ -87872,7 +87878,12 @@ export interface operations {
     };
     listReputationDomain: {
         parameters: {
-            query?: never;
+            query: {
+                /** @description Domain token matched against agent names. */
+                domain: string;
+                /** @description Maximum reputations to return. */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -87889,14 +87900,34 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        domain?: string;
+                        reputations?: {
+                            agent?: string;
+                            score?: number;
+                            vote_weight?: number;
+                            proposal_acceptance_rate?: number;
+                            critique_value?: number;
+                            debates_participated?: number;
+                        }[];
+                        count?: number;
+                    };
                 };
             };
         };
     };
     listReputationHistory: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Restrict snapshots to a single agent. */
+                agent?: string;
+                /** @description ISO-8601 lower bound; invalid values are a 400. */
+                start_date?: string;
+                /** @description ISO-8601 upper bound; invalid values are a 400. */
+                end_date?: string;
+                /** @description Maximum snapshots to return. */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -87913,7 +87944,15 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": {
+                        history?: {
+                            timestamp?: string;
+                            agent?: string;
+                            reputation?: number;
+                            event?: string;
+                        }[];
+                        count?: number;
+                    };
                 };
             };
         };
@@ -152150,7 +152189,13 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        total_agents?: number;
+                        avg_elo?: number;
+                        max_elo?: number;
+                        min_elo?: number;
+                        total_matches?: number;
+                    };
                 };
             };
         };
@@ -167911,7 +167956,12 @@ export interface operations {
     };
     getReputationDomain: {
         parameters: {
-            query?: never;
+            query: {
+                /** @description Domain token matched against agent names. */
+                domain: string;
+                /** @description Maximum reputations to return. */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -167928,14 +167978,34 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        domain?: string;
+                        reputations?: {
+                            agent?: string;
+                            score?: number;
+                            vote_weight?: number;
+                            proposal_acceptance_rate?: number;
+                            critique_value?: number;
+                            debates_participated?: number;
+                        }[];
+                        count?: number;
+                    };
                 };
             };
         };
     };
     getReputationHistory: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Restrict snapshots to a single agent. */
+                agent?: string;
+                /** @description ISO-8601 lower bound; invalid values are a 400. */
+                start_date?: string;
+                /** @description ISO-8601 upper bound; invalid values are a 400. */
+                end_date?: string;
+                /** @description Maximum snapshots to return. */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -167952,7 +168022,15 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": {
+                        history?: {
+                            timestamp?: string;
+                            agent?: string;
+                            reputation?: number;
+                            event?: string;
+                        }[];
+                        count?: number;
+                    };
                 };
             };
         };

--- a/tests/server/test_openapi.py
+++ b/tests/server/test_openapi.py
@@ -241,6 +241,93 @@ class TestSDKReferencedEndpointRegistrations:
         assert "/api/quotas/request-increase" not in schema["paths"]
 
 
+class TestSdkMissingRuntimeTrueBackfill:
+    """Runtime-true pins for the served sdk_missing.py charter entries.
+
+    Census follow-up to the quotas enrichment: of the 21 remaining charter
+    operations, exactly three are reachable through _try_modular_handler
+    (route-index/can_handle match into a handler method that serves the
+    documented path). These pins bind their spec entries to the handler
+    truth so a spec edit that drifts from the served contract fails here
+    before verify_sdk_contracts or sdk-parity see it.
+    """
+
+    def test_matches_stats_get_documents_runtime_contract(self):
+        """GET /api/matches/stats documents the served public stats shape.
+
+        MatchesStatsHandler.handle serves the exact version-stripped path with
+        no auth check (a public ranking read like the leaderboard), returning
+        EloSystem.get_stats(): total_agents/avg_elo/max_elo/min_elo/
+        total_matches, all always present (missing aggregates default).
+        """
+        op = ALL_ENDPOINTS["/api/matches/stats"]["get"]
+        assert "security" not in op
+        assert "requestBody" not in op
+        schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+        assert schema["type"] == "object"
+        assert set(schema["properties"]) == {
+            "total_agents",
+            "avg_elo",
+            "max_elo",
+            "min_elo",
+            "total_matches",
+        }
+        assert schema["properties"]["total_agents"]["type"] == "integer"
+        assert schema["properties"]["avg_elo"]["type"] == "number"
+        assert schema["properties"]["total_matches"]["type"] == "integer"
+
+    def test_reputation_history_get_documents_runtime_contract(self):
+        """GET /api/reputation/history documents the served snapshot timeline.
+
+        CritiqueHandler.handle sits behind require_permission("critiques:read"),
+        accepts agent/start_date/end_date filters plus a 1..1000-clamped limit,
+        and returns {history: [{timestamp, agent, reputation, event}], count}.
+        timestamp is AgentReputation.updated_at (str, default ""), never null.
+        """
+        op = ALL_ENDPOINTS["/api/reputation/history"]["get"]
+        assert op["security"] == [{"bearerAuth": []}]
+        params = {p["name"]: p for p in op["parameters"]}
+        assert set(params) == {"agent", "start_date", "end_date", "limit"}
+        assert all(p["in"] == "query" for p in params.values())
+        assert not any(p.get("required") for p in params.values())
+        assert params["limit"]["schema"]["type"] == "integer"
+        assert params["limit"]["schema"]["maximum"] == 1000
+        schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+        assert schema["type"] == "object"
+        assert set(schema["properties"]) == {"history", "count"}
+        item = schema["properties"]["history"]["items"]
+        assert set(item["properties"]) == {"timestamp", "agent", "reputation", "event"}
+        assert item["properties"]["timestamp"]["type"] == "string"
+        assert schema["properties"]["count"]["type"] == "integer"
+
+    def test_reputation_domain_get_documents_runtime_contract(self):
+        """GET /api/reputation/domain documents the served domain filter.
+
+        CritiqueHandler.handle (require_permission("critiques:read")) 400s
+        without ?domain= and returns {domain, reputations: [...], count} with
+        the six per-agent reputation fields _get_reputation_by_domain emits.
+        """
+        op = ALL_ENDPOINTS["/api/reputation/domain"]["get"]
+        assert op["security"] == [{"bearerAuth": []}]
+        params = {p["name"]: p for p in op["parameters"]}
+        assert set(params) == {"domain", "limit"}
+        assert params["domain"]["required"] is True
+        assert params["domain"]["in"] == "query"
+        assert not params["limit"].get("required")
+        schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+        assert set(schema["properties"]) == {"domain", "reputations", "count"}
+        item = schema["properties"]["reputations"]["items"]
+        assert set(item["properties"]) == {
+            "agent",
+            "score",
+            "vote_weight",
+            "proposal_acceptance_rate",
+            "critique_value",
+            "debates_participated",
+        }
+        assert item["properties"]["debates_participated"]["type"] == "integer"
+
+
 class TestGenerateOpenAPISchema:
     """Tests for schema generation function."""
 


### PR DESCRIPTION
## Summary

Census follow-up to #9838 (quotas enrichment, commit `b0be9f0d9796`, merged via `527c8fa4d74d`): the other 21 `sdk_missing.py` charter operations declared no security/requestBody/response truth. This PR enumerates every entry, maps each to its live handler through the actual dispatch machinery (`_try_modular_handler` route-index + `can_handle` fallback), and enriches ONLY the operations whose runtime contract is observable at the documented path. No handler/routing/behavior edits.

## Census (all 22 charter operations)

| # | Operation | Class | Evidence |
|---|-----------|-------|----------|
| 1 | POST /api/support/connect | B | SupportHandler exposes only `async handle_request()`; the modular dispatcher calls `handle_post`/`handle` (BaseHandler stubs return None) so requests end in the `handler_no_result` 500 branch. Contract unreachable at the documented path. |
| 2 | POST /api/support/triage | B | Same dispatch gap. |
| 3 | POST /api/support/auto-respond | B | Same dispatch gap. |
| 4 | DELETE /api/support/{support_id} | B | Same dispatch gap; additionally the handler's platform parsing only recognizes the `/api/v1/` prefix and a SUPPORTED_PLATFORMS enum, not an arbitrary `{support_id}`. |
| 5 | POST /api/support/{support_id}/tickets | B | Same dispatch gap (+ v1-only platform parsing). |
| 6 | PUT /api/support/{support_id}/tickets/{ticket_id} | B | Same dispatch gap (+ v1-only platform parsing). |
| 7 | POST /api/support/{support_id}/tickets/{ticket_id}/reply | B | Same dispatch gap (+ v1-only platform parsing). |
| 8 | GET /api/flips/{flip_id} | B | The flips dispatch in `handlers/agents/agents.py` serves only `/recent` and `/summary`; no branch serves `{flip_id}`. |
| 9 | POST /api/ecommerce/connect | B | EcommerceHandler is `handle_request()`-only; same dispatch gap as support. |
| 10 | POST /api/ecommerce/sync-inventory | B | Same dispatch gap. |
| 11 | POST /api/ecommerce/ship | B | Same dispatch gap. |
| 12 | DELETE /api/ecommerce/{integration_id} | B | Same dispatch gap. |
| 13 | POST /api/crm/connect | B | CRMHandler is `handle_request()`-only; same dispatch gap. |
| 14 | POST /api/crm/sync-lead | B | Same dispatch gap. |
| 15 | POST /api/crm/enrich | B | Same dispatch gap. |
| 16 | DELETE /api/crm/{integration_id} | B | Same dispatch gap. |
| 17 | GET /api/matches/stats | **A — enriched** | `MatchesStatsHandler.handle` exact-matches the version-stripped path; public read (no auth check, by design per handler docstring); returns `EloSystem.get_stats()` verbatim: `total_agents`/`avg_elo`/`max_elo`/`min_elo`/`total_matches`, all always present. |
| 18 | GET /api/matches/{match_id} | B | No handler claims the path (recent/stats belong to other handlers; no `{match_id}` branch exists). |
| 19 | POST /api/v1/quotas/request-increase | done (#9838) | Reference pattern; untouched here. |
| 20 | GET /api/reputation/domain | **A — enriched** | `CritiqueHandler.handle` lists the path in ROUTES behind `@require_permission("critiques:read")`; missing `?domain=` is a 400; `limit` clamped 1..1000 (default 100); response `{domain, reputations:[{agent,score,vote_weight,proposal_acceptance_rate,critique_value,debates_participated}], count}`. |
| 21 | GET /api/reputation/history | **A — enriched** | Same handler/permission; optional `agent`/`start_date`/`end_date`/`limit` (1..1000, default 100; invalid dates 400); response `{history:[{timestamp,agent,reputation,event}], count}`. `timestamp` is `AgentReputation.updated_at` (`str`, default `""`) — never null, so no nullable type array is warranted. This corrects the previous bare-array response the handler never returned. |
| 22 | GET /api/reputation/{agent_id} | B | `CritiqueHandler.can_handle` rejects it; the served per-agent shape lives at `/api/agent/{name}/reputation`. Documented path is unclaimed. |

Class B rationale (18 ops): enrichment must be RUNTIME-TRUE. For 15 support/crm/ecommerce entries the handlers' RBAC/body/response logic exists but is unreachable through the serving surface (their `handle_request()` is invoked by nothing; unit tests call it directly with fake request objects). For the other 3 no dispatch branch claims the documented path. Documenting security/requestBody/response for unserved paths would fabricate contract truth (documented-not-registered precedent from #9838's own census).

## Verification (battery-first, all before this PR was opened)

- Red-first pins: 3 new tests in `tests/server/test_openapi.py` (`TestSdkMissingRuntimeTrueBackfill`) confirmed RED against the unenriched spec, GREEN after
- `verify_sdk_contracts.py --strict --baseline ... --extra-spec` — PASS, **zero new strict keys** (`Baseline regressions: py=0 ts=0 stable=0`)
- `validate_openapi_routes.py --fail-on-missing --baseline` — PASS (0 new missing / 0 new orphaned)
- `check_sdk_parity.py --strict` (0/0, 31/36 within ceilings), `check_sdk_namespace_parity.py --strict` (0 regressions), `check_cross_sdk_parity.py --strict` — PASS
- CI-exact regen: `generate_openapi.py` (json+yaml) + operation-ids + param-descriptions + descriptions + `generate_sdk_types.py`; **double-regen byte-identical** (sha256-verified for all three artifacts); `generate_sdk_types.py --check` clean; `tests/test_openapi_regeneration.py` 2 passed
- `pytest tests/server/test_openapi*.py` — 209 passed; `make test-smoke` — passed
- `ruff check aragora/ tests/ scripts/` + `ruff format --check` (touched files) — clean; `preflight_mypy.sh` — no issues; TS `tsc --noEmit` (pinned 6.0.3) — clean
- Path-freeze census at PR time: no open PR touches `sdk_missing.py` or `tests/server/test_openapi.py`; stale #9033 (July harvest) overlaps only the mechanically regenerated artifacts

## Scope guarantees

- No handler/routing/behavior edits; spec module + test pins + mechanical regen only
- Hand-written diff: 234 changed lines (≤800 LOC)
