### PR TITLE
docs(research-intake): ranking re-run receipt, claude proposal, #9872 linkage

### DIFF
--- a/docs/research/2026-08-26-x-bookmarks-triage.md
+++ b/docs/research/2026-08-26-x-bookmarks-triage.md
@@ -137,15 +137,15 @@ The outcome was a **failed consensus, and the receipt says so**:
 Consequence: the per-candidate verdicts in this brief remain **analyst verdicts, not
 debate-settled ones** — exactly what the receipt-preserving posture requires us to say.
 
-**Re-run (2026-08-29, same day):** claude CLI auth recovered on its own (the 401 was the known
-transient refresh-rotation race) and the debate re-ran cleanly — and failed consensus *again*,
-honestly, for a different reason: the codex proposer timed out at 240s on the 14-candidate topic,
+**Re-run (2026-08-29, same day):** claude CLI auth was available again; the cause of the first
+run's 401 remains unverified. The debate re-ran and failed consensus *again*, this time because
+the codex proposer timed out at 240s on the 14-candidate topic,
 leaving claude's full grounded proposal (it verified candidate 11's code claim against `grok.py`
 itself) with no second perspective. Claude's own critique flagged that this mirrors candidate 1's
 collaboration-vs-independence failure mode. Artifacts:
 
 - Re-run receipt: [`receipts/2026-08-29-x-intake-ranking-rerun-receipt.json`](receipts/2026-08-29-x-intake-ranking-rerun-receipt.json) (verdict `FAIL`, cause only visible in `agent_responses`)
-- Claude's single-model ranking: [`receipts/2026-08-29-claude-ranking-proposal.md`](receipts/2026-08-29-claude-ranking-proposal.md) — promotes the DeepMind verifier-metric audit (#9868) to rank 1; otherwise broadly concordant with the analyst ordering
+- Claude's single-model ranking: [`receipts/2026-08-29-claude-ranking-proposal.md`](receipts/2026-08-29-claude-ranking-proposal.md) — promotes the DeepMind verifier-metric audit (#9868) to rank 1 and diverges from the analyst verdicts by rejecting candidates #3, #7, and #8
 - Defect filed: [#9872](https://github.com/synaptent/aragora/issues/9872) — MetaPlanner degrades silently when a proposer times out; fix that, then re-run for a true consensus receipt.
 
 ## Rules of the road for this brief

--- a/docs/research/2026-08-26-x-bookmarks-triage.md
+++ b/docs/research/2026-08-26-x-bookmarks-triage.md
@@ -135,12 +135,18 @@ The outcome was a **failed consensus, and the receipt says so**:
   [`receipts/2026-08-29-x-intake-ranking-run.json`](receipts/2026-08-29-x-intake-ranking-run.json).
 
 Consequence: the per-candidate verdicts in this brief remain **analyst verdicts, not
-debate-settled ones** — exactly what the receipt-preserving posture requires us to say. Re-run
-after restoring claude CLI auth (`claude login`, or once API-key agents are reachable again):
+debate-settled ones** — exactly what the receipt-preserving posture requires us to say.
 
-```bash
-python3 scripts/rank_research_candidates.py docs/research/2026-08-26-x-bookmarks-triage.md --agents claude,codex --max-goals 10
-```
+**Re-run (2026-08-29, same day):** claude CLI auth recovered on its own (the 401 was the known
+transient refresh-rotation race) and the debate re-ran cleanly — and failed consensus *again*,
+honestly, for a different reason: the codex proposer timed out at 240s on the 14-candidate topic,
+leaving claude's full grounded proposal (it verified candidate 11's code claim against `grok.py`
+itself) with no second perspective. Claude's own critique flagged that this mirrors candidate 1's
+collaboration-vs-independence failure mode. Artifacts:
+
+- Re-run receipt: [`receipts/2026-08-29-x-intake-ranking-rerun-receipt.json`](receipts/2026-08-29-x-intake-ranking-rerun-receipt.json) (verdict `FAIL`, cause only visible in `agent_responses`)
+- Claude's single-model ranking: [`receipts/2026-08-29-claude-ranking-proposal.md`](receipts/2026-08-29-claude-ranking-proposal.md) — promotes the DeepMind verifier-metric audit (#9868) to rank 1; otherwise broadly concordant with the analyst ordering
+- Defect filed: [#9872](https://github.com/synaptent/aragora/issues/9872) — MetaPlanner degrades silently when a proposer times out; fix that, then re-run for a true consensus receipt.
 
 ## Rules of the road for this brief
 

--- a/docs/research/receipts/2026-08-29-claude-ranking-proposal.md
+++ b/docs/research/receipts/2026-08-29-claude-ranking-proposal.md
@@ -1,0 +1,54 @@
+Candidate 11's codebase claim checks out: `grok.py:77-84` treats the xAI Live Search 410 deprecation as a fallback trigger, and `GrokAgent` has no search-tool support — it's a plain OpenAI-compatible chat agent. That's the only candidate I can verify internally; here is my proposal.
+
+# Proposal: Ranking of the 14 Research Candidates + Improvement Goals
+
+## Epistemic status (stated up front, per task rules)
+
+All 14 candidates cite X posts dated July–August 2026, **after my January 2026 knowledge cutoff**. I cannot verify any of these posts, papers, or products from training knowledge — not the Anthropic multiagent report, not Simile, QM, Prime Intellect's verifiers v1, buzz, Not Diamond Code, OmniRoute, Open-Kritt, the DeepMind verifier paper, Recuris, or RSI-Exam. I am ranking the *supplied claims* by their fit to the decision-integrity roadmap, conditional on those claims being accurate. Every high-ranked candidate therefore gets a "verify the source first" step baked into its goal. The one exception is candidate 11, whose codebase-side claim I verified directly (above). I also cannot verify issue numbers (#8233, #9695, #9709) beyond what the prompt supplies.
+
+## Ranking (highest expected impact first)
+
+**Tier 1 — direct hits on the integrity of receipts themselves**
+
+1. **#12 DeepMind: verifiers score the wrong metric.** Highest expected impact *if the paper says what the summary claims*. Aragora ships `enable_truth_ratio_weighting`, a cross-verification phase, and receipt confidence values. If verifier scores are systematically misaligned with correctness, that bias flows straight into decision receipts — the product's core artifact. Even a partial confirmation forces a calibration audit. Risk: the summary is second-hand ("via marfinxx", "reportedly showing"); the claim must be read from the actual paper before any roadmap change.
+2. **#1 Anthropic: patterns and problems in multiagent systems.** Primary published evidence bearing on Aragora's foundational claim (heterogeneous adversarial review > independent review). The 266-vs-21 finding cuts both ways: collaboration finds more, but "low unique/validated rates" is exactly the hollow-consensus failure mode the Trickster feature exists for. The concrete, cheap deliverable — a *reviewer-independence attribute* in receipts — is a genuinely good idea regardless of which way the evidence points, because it lets customers see whether findings were independently derived or cross-contaminated.
+3. **#2 Simile: trained confidence model.** A dedicated model predicting when the primary model is trustworthy is a concrete architecture for calibrated receipt confidence, and it pairs naturally with #12 (if verifiers are miscalibrated, a trained meta-model is one remedy). Ranked below #12/#1 because it's one company's product post, not evidence — it's a design pattern to evaluate, not a result to act on.
+
+**Tier 2 — strengthens the proof/benchmark lane**
+
+4. **#14 RSI-Exam.** 88 executable tasks is exactly the class of external, falsifiable yardstick the Nomic loop's proof-first gate needs — self-improvement claims are currently self-graded, which is a credibility gap. Executable benchmarks are cheap to pilot and hard to game. Contingent on the benchmark actually existing and being runnable.
+5. **#11 Grok x_search / xAI Agent Tools API.** The only candidate with an internally verified premise: the code already routes *around* the deprecated Live Search API but never adopted its replacement. Bounded scope, real capability gain (live X-corpus evidence for debates), and it strengthens evidence attribution in receipts. Ranked mid-tier because it's a single-agent capability, not a roadmap-level shift.
+6. **#13 Google skill-library paper + Recuris.** The traces/wiki/skills three-way split is a useful external reference model for auditing Knowledge Mound tiering and the skills registry. Value is diagnostic (benchmark our design against it), not a feature. Fold candidate #9 into this.
+
+**Tier 3 — relevant but conditional or premature**
+
+7. **#6 Not Diamond Code.** Adjacent to dormant decision-stakes routing (#8233). But "20–65% cost reduction" is a vendor claim, and routing is a cost/quality concern, not a decision-integrity concern — it only earns priority if it funds more heterogeneous quorum coverage per dollar. Watch-and-evaluate, not build.
+8. **#5 buzz (jack).** Cryptographic identity for people + agents is squarely relevant to ODR-2 signing and claim-to-identity binding (#9695/#9709). But a weeks-old open-source workspace is a risky dependency for an identity layer; the right move is to study its identity *model*, not adopt the project. Survives scrutiny as a design input only.
+9. **#4 Prime Intellect.** The governance angle is the real content: a receipt should attest *what changed in a self-modifying harness and who approved it*. That's a genuinely Aragora-shaped idea (it's what the Nomic loop's protected-files/approval machinery already gestures at). The harness itself is not something to chase. Keep the governance requirement, drop the rest.
+10. **#9 Alibaba structured context.** Reasonable pattern, but "context assembly as code, permissioned and attributable" is directionally what the memory coordinator and RLM work already do. Merge into #13's benchmark-comparison exercise rather than tracking separately.
+11. **#10 Open-weight quorum candidates (Apodex 1.1, GLM-5.3).** Routine model-evaluation work, already covered by the existing OpenRouter path and agent registry. Low ceiling; the GLM governance anecdote is a marketing narrative, not evidence.
+
+**Rejected (do not survive scrutiny)**
+
+12. **#3 YC QM.** Competitive/market context, not a roadmap input. "Closest public artifact to our Chief-of-Staff stages" tells us the space is validated, but yields no testable design decision, no receipt improvement, no verifiable claim. Reading it is a 30-minute analyst task, not a goal. **Reject as a ranked candidate.**
+13. **#7 OmniRoute.** "Free MIT gateway, 340 providers" from a trending-repos aggregator account is precisely the profile of an unvetted supply-chain risk — routing production API keys and debate traffic through an unaudited proxy contradicts the security pillar. OpenRouter fallback already exists. **Reject; revisit only if it accrues independent adoption evidence.**
+14. **#8 Open-Kritt (+ pentest-harness, V12).** AGPL is a hard licensing problem for a commercial platform's integration path, the V12 vuln claims (QEMU escape, LPEs) are unverified hype-profile claims, and the comparables are competitive context, not inputs. The one salvageable idea — using an external finding-set as a *benchmark* for grounded-finding quality — is folded into the benchmark goal below. **Reject as an integration candidate; retain only as benchmark material.**
+
+## Proposed improvement goals (ordered by priority)
+
+**1. Verifier-calibration audit of the truth scorer and cross-verification phase** — *Track: Core* (requires approval) — **Impact: High.**
+First read the actual DeepMind paper (#12) and Anthropic report (#1) to confirm the claims; then measure Aragora's own verifier/truth-scorer outputs against ground-truth outcomes on debates with known-correct answers, and report where receipt confidence is miscalibrated. This is prioritized first because it tests whether the product's central artifact — receipt confidence — is trustworthy, and every other candidate (Simile-style confidence models included) is downstream of knowing the answer. Deliverable is a calibration report plus a go/no-go on a Simile-style trained confidence model (#2).
+
+**2. Reviewer-independence attribute in decision receipts** — *Track: Core* (requires approval; receipt schema surface) — **Impact: High.**
+Add a receipt field recording whether each finding was independently derived or produced under cross-agent visibility, per the collaboration-vs-independence distinction in #1. Small schema change, large differentiation value: it operationalizes the one robust lesson from the Anthropic data (collaboration inflates volume but contaminates independence) and lets customers weight findings accordingly. Depends on goal 1 only for framing, not for code — can proceed in parallel.
+
+**3. External executable benchmark lane for self-improvement and finding-quality claims** — *Track: QA* — **Impact: Medium-High.**
+Pilot RSI-Exam (#14) as an external yardstick for Nomic-loop improvement claims, and evaluate one external vulnerability finding-set (from #8's ecosystem, as data — not an AGPL code integration) as a grounded-finding quality benchmark for the audit/bug-detector modules. Rationale: the proof-first gate currently lacks any yardstick Aragora doesn't grade itself; this is the cheapest credibility win in the list. First step is verifying RSI-Exam exists and runs.
+
+**4. Grok Agent Tools API adoption for evidence-grade search** — *Track: Core* (agent change; small blast radius) — **Impact: Medium.**
+Replace the routed-around Live Search path with xAI's Agent Tools / x_search support in `GrokAgent` (`aragora/agents/api_agents/grok.py`), wiring results into evidence collection with source attribution. This is the only candidate with a verified internal premise and a bounded scope; it converts a dead code path into live-corpus evidence for debates.
+
+**5. Identity-and-provenance design study: harness-change attestation + agent identity binding** — *Track: Security* — **Impact: Medium.**
+A design-only spike (no dependency adoption) combining the two governance ideas that survived scrutiny: (a) receipts that attest what changed in a self-modifying harness and who approved it (#4), and (b) an evaluation of buzz's identity model (#5) against the ODR-2 signing and claim-to-identity work (#9695/#9709). Ranked last because it's forward-looking design rather than a measurable near-term integrity gain, but it's the right preparation for Tier-4 claims.
+
+**Anticipated objections.** (a) *"Three of five goals lean on unverified posts"* — correct, which is why goals 1, 3, and 5 each begin with source verification and are scoped to fail cheap if the source doesn't hold up; goal 4 rests on verified code, and goal 2 is a good schema change even if the Anthropic numbers shift. (b) *"Two Core goals need approval"* — yes, but decision-integrity is a Core property; a ranking that avoided Core to dodge approval would optimize for convenience over the stated objective. (c) *"Why reject OmniRoute when quorum diversity is a pillar?"* — because candidate #10's open-weight models achieve the same diversity through the already-trusted OpenRouter path without inserting an unaudited proxy into the key path.

--- a/docs/research/receipts/2026-08-29-x-intake-ranking-rerun-receipt.json
+++ b/docs/research/receipts/2026-08-29-x-intake-ranking-rerun-receipt.json
@@ -1,0 +1,114 @@
+{
+  "receipt_id": "cd15c51e-8635-4ee8-9ca3-aa2723b2aae6",
+  "gauntlet_id": "dcd06781-fcb6-456e-bcba-abe55bead4fe",
+  "timestamp": "2026-08-29T22:07:15.591211+00:00",
+  "input_summary": "You are planning improvements for the Aragora project.\n\nOBJECTIVE: Rank these externally sourced research candidates by expected impact on the decision-integrity roadmap; reject any that do not survive scrutiny\n\nAVAILABLE TRACKS (domains you can work on):\nsme, developer, self_hosted, qa, core, security\n\nTrack descriptions:\n- SME: Small business features, dashboard, user workspace\n- Developer: SDKs, API, documentation\n- Self-Hosted: Docker, deployment, backup/restore\n- QA: Tests, CI/CD, code qual",
+  "input_hash": "c6e68960a9849d37647447574862b1aab292f7d2a7481ce173c6776e671a3142",
+  "risk_summary": {
+    "critical": 1,
+    "high": 0,
+    "medium": 0,
+    "low": 0,
+    "total": 1
+  },
+  "attacks_attempted": 0,
+  "attacks_successful": 0,
+  "probes_run": 1,
+  "vulnerabilities_found": 0,
+  "vulnerability_details": [],
+  "verdict": "FAIL",
+  "confidence": 0.0,
+  "robustness_score": 0.0,
+  "verdict_reasoning": "No consensus reached",
+  "dissenting_views": [],
+  "consensus_proof": {
+    "reached": false,
+    "confidence": 0.0,
+    "supporting_agents": [
+      "claude",
+      "codex"
+    ],
+    "dissenting_agents": [],
+    "method": "majority",
+    "evidence_hash": "",
+    "tainted_proposals": [],
+    "trust_score": 1.0
+  },
+  "provenance_chain": [
+    {
+      "timestamp": "2026-08-29T16:58:41.038592",
+      "event_type": "message",
+      "agent": "claude",
+      "description": "[proposer] Candidate 11's codebase claim checks out: `grok.py",
+      "evidence_hash": "50b242823eab64ae"
+    },
+    {
+      "timestamp": "2026-08-29T17:03:35.076665",
+      "event_type": "message",
+      "agent": "codex",
+      "description": "[proposer] [Error generating proposal: Agent codex timed out ",
+      "evidence_hash": "0d7b4a3106ea691f"
+    },
+    {
+      "timestamp": "2026-08-29T17:04:05.523309",
+      "event_type": "message",
+      "agent": "claude",
+      "description": "[critic] Critique from claude (severity: 10.0):\nIssues:\n\nSu",
+      "evidence_hash": "42aee0ea0763838f"
+    },
+    {
+      "timestamp": "2026-08-29T22:07:15.591211+00:00",
+      "event_type": "verdict",
+      "agent": null,
+      "description": "Consensus: not reached (0.0% confidence)",
+      "evidence_hash": ""
+    }
+  ],
+  "agent_responses": [
+    {
+      "agent": "claude",
+      "response": "Candidate 11's codebase claim checks out: `grok.py:77-84` treats the xAI Live Search 410 deprecation as a fallback trigger, and `GrokAgent` has no search-tool support \u2014 it's a plain OpenAI-compatible chat agent. That's the only candidate I can verify internally; here is my proposal.\n\n# Proposal: Ranking of the 14 Research Candidates + Improvement Goals\n\n## Epistemic status (stated up front, per task rules)\n\nAll 14 candidates cite X posts dated July\u2013August 2026, **after my January 2026 knowledge cutoff**. I cannot verify any of these posts, papers, or products from training knowledge \u2014 not the Anthropic multiagent report, not Simile, QM, Prime Intellect's verifiers v1, buzz, Not Diamond Code, OmniRoute, Open-Kritt, the DeepMind verifier paper, Recuris, or RSI-Exam. I am ranking the *supplied claims* by their fit to the decision-integrity roadmap, conditional on those claims being accurate. Every high-ranked candidate therefore gets a \"verify the source first\" step baked into its goal. The one exception is candidate 11, whose codebase-side claim I verified directly (above). I also cannot verify issue numbers (#8233, #9695, #9709) beyond what the prompt supplies.\n\n## Ranking (highest expected impact first)\n\n**Tier 1 \u2014 direct hits on the integrity of receipts themselves**\n\n1. **#12 DeepMind: verifiers score the wrong metric.** Highest expected impact *if the paper says what the summary claims*. Aragora ships `enable_truth_ratio_weighting`, a cross-verification phase, and receipt confidence values. If verifier scores are systematically misaligned with correctness, that bias flows straight into decision receipts \u2014 the product's core artifact. Even a partial confirmation forces a calibration audit. Risk: the summary is second-hand (\"via marfinxx\", \"reportedly showing\"); the claim must be read from the actual paper before any roadmap change.\n2. **#1 Anthropic: patterns and problems in multiagent systems.** Primary published evidence bearing on Aragora's foundational claim (heterogeneous adversarial review > independent review). The 266-vs-21 finding cuts both ways: collaboration finds more, but \"low unique/validated rates\" is exactly the hollow-consensus failure mode the Trickster feature exists for. The concrete, cheap deliverable \u2014 a *reviewer-independence attribute* in receipts \u2014 is a genuinely good idea regardless of which way the evidence points, because it lets customers see whether findings were independently derived or cross-contaminated.\n3. **#2 Simile: trained confidence model.** A dedicated model predicting when the primary model is trustworthy is a concrete architecture for calibrated receipt confidence, and it pairs naturally with #12 (if verifiers are miscalibrated, a trained meta-model is one remedy). Ranked below #12/#1 because it's one company's product post, not evidence \u2014 it's a design pattern to evaluate, not a result to act on.\n\n**Tier 2 \u2014 strengthens the proof/benchmark lane**\n\n4. **#14 RSI-Exam.** 88 executable tasks is exactly the class of external, falsifiable yardstick the Nomic loop's proof-first gate needs \u2014 self-improvement claims are currently self-graded, which is a credibility gap. Executable benchmarks are cheap to pilot and hard to game. Contingent on the benchmark actually existing and being runnable.\n5. **#11 Grok x_search / xAI Agent Tools API.** The only candidate with an internally verified premise: the code already routes *around* the deprecated Live Search API but never adopted its replacement. Bounded scope, real capability gain (live X-corpus evidence for debates), and it strengthens evidence attribution in receipts. Ranked mid-tier because it's a single-agent capability, not a roadmap-level shift.\n6. **#13 Google skill-library paper + Recuris.** The traces/wiki/skills three-way split is a useful external reference model for auditing Knowledge Mound tiering and the skills registry. Value is diagnostic (benchmark our design against it), not a feature. Fold candidate #9 into this.\n\n**Tier 3 \u2014 relevant but conditional or premature**\n\n7. **#6 Not Diamond Code.** Adjacent to dormant decision-stakes routing (#8233). But \"20\u201365% cost reduction\" is a vendor claim, and routing is a cost/quality concern, not a decision-integrity concern \u2014 it only earns priority if it funds more heterogeneous quorum coverage per dollar. Watch-and-evaluate, not build.\n8. **#5 buzz (jack).** Cryptographic identity for people + agents is squarely relevant to ODR-2 signing and claim-to-identity binding (#9695/#9709). But a weeks-old open-source workspace is a risky dependency for an identity layer; the right move is to study its identity *model*, not adopt the project. Survives scrutiny as a design input only.\n9. **#4 Prime Intellect.** The governance angle is the real content: a receipt should attest *what changed in a self-modifying harness and who approved it*. That's a genuinely Aragora-shaped idea (it's what the Nomic loop's protected-files/approval machinery already gestures at). The harness itself is not something to chase. Keep the governance requirement, drop the rest.\n10. **#9 Alibaba structured context.** Reasonable pattern, but \"context assembly as code, permissioned and attributable\" is directionally what the memory coordinator and RLM work already do. Merge into #13's benchmark-comparison exercise rather than tracking separately.\n11. **#10 Open-weight quorum candidates (Apodex 1.1, GLM-5.3).** Routine model-evaluation work, already covered by the existing OpenRouter path and agent registry. Low ceiling; the GLM governance anecdote is a marketing narrative, not evidence.\n\n**Rejected (do not survive scrutiny)**\n\n12. **#3 YC QM.** Competitive/market context, not a roadmap input. \"Closest public artifact to our Chief-of-Staff stages\" tells us the space is validated, but yields no testable design decision, no receipt improvement, no verifiable claim. Reading it is a 30-minute analyst task, not a goal. **Reject as a ranked candidate.**\n13. **#7 OmniRoute.** \"Free MIT gateway, 340 providers\" from a trending-repos aggregator account is precisely the profile of an unvetted supply-chain risk \u2014 routing production API keys and debate traffic through an unaudited proxy contradicts the security pillar. OpenRouter fallback already exists. **Reject; revisit only if it accrues independent adoption evidence.**\n14. **#8 Open-Kritt (+ pentest-harness, V12).** AGPL is a hard licensing problem for a commercial platform's integration path, the V12 vuln claims (QEMU escape, LPEs) are unverified hype-profile claims, and the comparables are competitive context, not inputs. The one salvageable idea \u2014 using an external finding-set as a *benchmark* for grounded-finding quality \u2014 is folded into the benchmark goal below. **Reject as an integration candidate; retain only as benchmark material.**\n\n## Proposed improvement goals (ordered by priority)\n\n**1. Verifier-calibration audit of the truth scorer and cross-verification phase** \u2014 *Track: Core* (requires approval) \u2014 **Impact: High.**\nFirst read the actual DeepMind paper (#12) and Anthropic report (#1) to confirm the claims; then measure Aragora's own verifier/truth-scorer outputs against ground-truth outcomes on debates with known-correct answers, and report where receipt confidence is miscalibrated. This is prioritized first because it tests whether the product's central artifact \u2014 receipt confidence \u2014 is trustworthy, and every other candidate (Simile-style confidence models included) is downstream of knowing the answer. Deliverable is a calibration report plus a go/no-go on a Simile-style trained confidence model (#2).\n\n**2. Reviewer-independence attribute in decision receipts** \u2014 *Track: Core* (requires approval; receipt schema surface) \u2014 **Impact: High.**\nAdd a receipt field recording whether each finding was independently derived or produced under cross-agent visibility, per the collaboration-vs-independence distinction in #1. Small schema change, large differentiation value: it operationalizes the one robust lesson from the Anthropic data (collaboration inflates volume but contaminates independence) and lets customers weight findings accordingly. Depends on goal 1 only for framing, not for code \u2014 can proceed in parallel.\n\n**3. External executable benchmark lane for self-improvement and finding-quality claims** \u2014 *Track: QA* \u2014 **Impact: Medium-High.**\nPilot RSI-Exam (#14) as an external yardstick for Nomic-loop improvement claims, and evaluate one external vulnerability finding-set (from #8's ecosystem, as data \u2014 not an AGPL code integration) as a grounded-finding quality benchmark for the audit/bug-detector modules. Rationale: the proof-first gate currently lacks any yardstick Aragora doesn't grade itself; this is the cheapest credibility win in the list. First step is verifying RSI-Exam exists and runs.\n\n**4. Grok Agent Tools API adoption for evidence-grade search** \u2014 *Track: Core* (agent change; small blast radius) \u2014 **Impact: Medium.**\nReplace the routed-around Live Search path with xAI's Agent Tools / x_search support in `GrokAgent` (`aragora/agents/api_agents/grok.py`), wiring results into evidence collection with source attribution. This is the only candidate with a verified internal premise and a bounded scope; it converts a dead code path into live-corpus evidence for debates.\n\n**5. Identity-and-provenance design study: harness-change attestation + agent identity binding** \u2014 *Track: Security* \u2014 **Impact: Medium.**\nA design-only spike (no dependency adoption) combining the two governance ideas that survived scrutiny: (a) receipts that attest what changed in a self-modifying harness and who approved it (#4), and (b) an evaluation of buzz's identity model (#5) against the ODR-2 signing and claim-to-identity work (#9695/#9709). Ranked last because it's forward-looking design rather than a measurable near-term integrity gain, but it's the right preparation for Tier-4 claims.\n\n**Anticipated objections.** (a) *\"Three of five goals lean on unverified posts\"* \u2014 correct, which is why goals 1, 3, and 5 each begin with source verification and are scoped to fail cheap if the source doesn't hold up; goal 4 rests on verified code, and goal 2 is a good schema change even if the Anthropic numbers shift. (b) *\"Two Core goals need approval\"* \u2014 yes, but decision-integrity is a Core property; a ranking that avoided Core to dodge approval would optimize for convenience over the stated objective. (c) *\"Why reject OmniRoute when quorum diversity is a pillar?\"* \u2014 because candidate #10's open-weight models achieve the same diversity through the already-trusted OpenRouter path without inserting an unaudited proxy into the key path.",
+      "role": "proposer",
+      "round": 0,
+      "provider": "",
+      "provider_display": "",
+      "model": "",
+      "llm_label": ""
+    },
+    {
+      "agent": "codex",
+      "response": "[Error generating proposal: Agent codex timed out after 240.0s]",
+      "role": "proposer",
+      "round": 0,
+      "provider": "",
+      "provider_display": "",
+      "model": "",
+      "llm_label": ""
+    },
+    {
+      "agent": "claude",
+      "response": "Critique from claude (severity: 10.0):\nIssues:\n\nSuggestions:\n  - Because it contributes nothing, it also cannot serve its structural role in the debate: there is no second independent perspective to test the claude proposal against. Notably, this is exactly the failure mode candidate #1 (collaboration vs. independence) warns about \u2014 the surviving proposal will now advance without independent adversarial pressure, and any consensus reached is effectively single-sourced.\n  - Treat the claude proposal as the sole substantive submission this round, but have the consensus phase explicitly record that it was unopposed \u2014 ideally as a lowered confidence attribute rather than silently proceeding. (The claude proposal's own goal 2, a reviewer-independence attribute in receipts, is precisely the mechanism that should capture this.)\n  - Re-run or replace the codex proposer with a longer timeout or a lighter prompt (the candidate list is large; a staged prompt \u2014 rank first, goals second \u2014 would likely fit the budget).\n  - If a re-run isn't possible, the critique rounds should compensate by stress-testing the claude proposal harder than usual. Two points worth pressure-testing there: (a) its top-ranked candidate (#12) rests on a second-hand summary of an unverifiable post-cutoff paper, and the proposal's mitigation (\"read the paper first\") makes goal 1's priority contingent in a way the ranking itself doesn't reflect; (b) rejecting #3 (QM) as \"not a roadmap input\" is defensible but slightly overconfident \u2014 competitive artifacts have historically informed the Chief-of-Staff staging, and a 30-minute analyst task could simply be goal 5's first step rather than a rejection.\nReasoning: The proposal under review is the codex agent's output, which is a timeout error rather than a proposal. There is no content to evaluate on the merits, so my feedback addresses that failure directly, with reference to the claude proposal in Round 0 as the standing alternative.\n\n**ISSUES:**\n- The proposal is empty \u2014 `[Error generating proposal: Agent codex timed out after 240.0s]` contains no ranking, no rejections, and no improvement goals. It satisfies none of the task requirements (rank all 14",
+      "role": "critic",
+      "round": 1,
+      "provider": "",
+      "provider_display": "",
+      "model": "",
+      "llm_label": ""
+    }
+  ],
+  "cost_summary": null,
+  "settlement_metadata": null,
+  "settlement_status": null,
+  "explainability": null,
+  "thinking_traces": null,
+  "schema_version": "1.1",
+  "artifact_hash": "66eaacc3f2ebeb1923b6e8244d0809422e9351eafa25f7a73c6241c25f386430",
+  "config_used": {
+    "rounds": 1,
+    "participants": [
+      "claude",
+      "codex"
+    ],
+    "duration_seconds": 600.0791471004486
+  }
+}

--- a/docs/research/receipts/2026-08-29-x-intake-ranking-rerun-receipt.json
+++ b/docs/research/receipts/2026-08-29-x-intake-ranking-rerun-receipt.json
@@ -25,8 +25,7 @@
     "reached": false,
     "confidence": 0.0,
     "supporting_agents": [
-      "claude",
-      "codex"
+      "claude"
     ],
     "dissenting_agents": [],
     "method": "majority",


### PR DESCRIPTION
Follow-up to #9859: preserves the second honest-FAIL ranking receipt (codex proposer 240s timeout — the defect filed as #9872), claude's grounded single-model ranking of the 14 intake candidates (promotes the DeepMind verifier-metric audit #9868 to rank 1), and updates the triage brief's ranking-outcome section. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)