### PR TITLE
feat(eval): validate outcome-backed decision corpus

### DIFF
--- a/aragora/evaluation/decision_quality_corpus.py
+++ b/aragora/evaluation/decision_quality_corpus.py
@@ -61,6 +61,24 @@ _OUTCOME_KEYS = {
 _CRUX_KEYS = {"crux_id", "description", "aliases"}
 
 
+class _DuplicateObjectKeyError(ValueError):
+    """Raised when a JSON object repeats a key."""
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        super().__init__(f"duplicate JSON object key: {key!r}")
+
+
+def _reject_duplicate_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build a JSON object while rejecting ambiguous duplicate keys."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateObjectKeyError(key)
+        result[key] = value
+    return result
+
+
 @dataclass(frozen=True)
 class ValidationIssue:
     """One fail-closed corpus validation issue."""
@@ -690,9 +708,21 @@ def validate_corpus_files(
     documents: list[Any] = []
     for label, path in (("corpus", corpus_path), ("outcomes", outcomes_path)):
         try:
-            documents.append(json.loads(path.read_text(encoding="utf-8")))
+            documents.append(
+                json.loads(
+                    path.read_text(encoding="utf-8"),
+                    object_pairs_hook=_reject_duplicate_object_keys,
+                )
+            )
         except OSError as exc:
             _issue(report, f"${label}", "read_error", f"cannot read {path}: {exc}")
+        except _DuplicateObjectKeyError as exc:
+            _issue(
+                report,
+                f"${label}",
+                "duplicate_json_key",
+                f"{path}: duplicate object key {exc.key!r}",
+            )
         except json.JSONDecodeError as exc:
             _issue(
                 report,

--- a/aragora/evaluation/decision_quality_corpus.py
+++ b/aragora/evaluation/decision_quality_corpus.py
@@ -1,0 +1,719 @@
+"""Validation for the outcome-backed decision-quality benchmark corpus.
+
+The model-visible corpus and resolved-outcome sidecar are deliberately
+separate. The sidecar binds to the canonical corpus hash so answer keys cannot
+be changed silently after inference starts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+CORPUS_SCHEMA_VERSION = "decision-quality-corpus/1.0"
+OUTCOMES_SCHEMA_VERSION = "decision-quality-outcomes/1.0"
+DOMAINS = (
+    "software_engineering",
+    "business_operations",
+    "policy_compliance",
+    "science_forecasting",
+)
+SPLITS = ("development", "holdout")
+
+_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+_CORPUS_KEYS = {"schema_version", "benchmark_id", "revision", "frozen_at", "cases"}
+_CASE_KEYS = {
+    "case_id",
+    "domain",
+    "split",
+    "title",
+    "decision_prompt",
+    "forecast_question",
+    "forecast_option_id",
+    "options",
+    "information_cutoff",
+    "sources",
+}
+_OPTION_KEYS = {"option_id", "label", "description"}
+_SOURCE_KEYS = {"source_id", "title", "url", "published_at", "content_sha256"}
+_OUTCOMES_KEYS = {
+    "schema_version",
+    "benchmark_id",
+    "corpus_sha256",
+    "outcomes",
+}
+_OUTCOME_KEYS = {
+    "case_id",
+    "resolved_at",
+    "correct_option_id",
+    "resolution_summary",
+    "authoritative_sources",
+    "cruxes",
+}
+_CRUX_KEYS = {"crux_id", "description", "aliases"}
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """One fail-closed corpus validation issue."""
+
+    path: str
+    code: str
+    message: str
+
+
+@dataclass
+class CorpusValidationReport:
+    """Structured result returned by corpus validation."""
+
+    corpus_sha256: str | None = None
+    case_count: int = 0
+    domain_counts: dict[str, int] = field(default_factory=dict)
+    split_counts: dict[str, int] = field(default_factory=dict)
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "corpus_sha256": self.corpus_sha256,
+            "case_count": self.case_count,
+            "domain_counts": self.domain_counts,
+            "split_counts": self.split_counts,
+            "issues": [asdict(issue) for issue in self.issues],
+        }
+
+
+def canonical_json_bytes(document: Any) -> bytes:
+    """Return the stable JSON representation used by the corpus hash."""
+    return json.dumps(
+        document,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def corpus_sha256(corpus: Any) -> str:
+    """Return the canonical SHA-256 digest of a model-visible corpus."""
+    return hashlib.sha256(canonical_json_bytes(corpus)).hexdigest()
+
+
+def _issue(
+    report: CorpusValidationReport,
+    path: str,
+    code: str,
+    message: str,
+) -> None:
+    report.issues.append(ValidationIssue(path=path, code=code, message=message))
+
+
+def _as_object(
+    value: Any,
+    *,
+    path: str,
+    report: CorpusValidationReport,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        _issue(report, path, "invalid_type", "must be a JSON object")
+        return None
+    return value
+
+
+def _check_keys(
+    value: dict[str, Any],
+    *,
+    allowed: set[str],
+    path: str,
+    report: CorpusValidationReport,
+) -> None:
+    for key in sorted(allowed - value.keys()):
+        _issue(report, f"{path}.{key}", "missing_field", "field is required")
+    for key in sorted(value.keys() - allowed):
+        _issue(
+            report,
+            f"{path}.{key}",
+            "unknown_field",
+            "field is not permitted by the frozen corpus contract",
+        )
+
+
+def _nonempty_string(
+    value: Any,
+    *,
+    path: str,
+    report: CorpusValidationReport,
+) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        _issue(report, path, "invalid_string", "must be a non-empty string")
+        return None
+    return value
+
+
+def _identifier(
+    value: Any,
+    *,
+    path: str,
+    report: CorpusValidationReport,
+) -> str | None:
+    text = _nonempty_string(value, path=path, report=report)
+    if text is not None and _ID_PATTERN.fullmatch(text) is None:
+        _issue(
+            report,
+            path,
+            "invalid_identifier",
+            "must use lowercase letters, digits, dots, underscores, or hyphens",
+        )
+        return None
+    return text
+
+
+def _timestamp(
+    value: Any,
+    *,
+    path: str,
+    report: CorpusValidationReport,
+) -> datetime | None:
+    text = _nonempty_string(value, path=path, report=report)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        _issue(report, path, "invalid_timestamp", "must be an ISO-8601 timestamp")
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _issue(report, path, "naive_timestamp", "must include a UTC offset")
+        return None
+    return parsed
+
+
+def _sha256(
+    value: Any,
+    *,
+    path: str,
+    report: CorpusValidationReport,
+) -> str | None:
+    text = _nonempty_string(value, path=path, report=report)
+    if text is not None and _SHA256_PATTERN.fullmatch(text) is None:
+        _issue(report, path, "invalid_sha256", "must be a lowercase 64-character SHA-256")
+        return None
+    return text
+
+
+def _https_url(
+    value: Any,
+    *,
+    path: str,
+    report: CorpusValidationReport,
+) -> str | None:
+    text = _nonempty_string(value, path=path, report=report)
+    if text is not None and not text.startswith("https://"):
+        _issue(report, path, "non_public_url", "must use an https:// public source URL")
+        return None
+    return text
+
+
+def _validate_source(
+    value: Any,
+    *,
+    path: str,
+    report: CorpusValidationReport,
+    cutoff: datetime | None = None,
+) -> tuple[str | None, datetime | None]:
+    source = _as_object(value, path=path, report=report)
+    if source is None:
+        return None, None
+    _check_keys(source, allowed=_SOURCE_KEYS, path=path, report=report)
+    source_id = _identifier(source.get("source_id"), path=f"{path}.source_id", report=report)
+    _nonempty_string(source.get("title"), path=f"{path}.title", report=report)
+    _https_url(source.get("url"), path=f"{path}.url", report=report)
+    published_at = _timestamp(
+        source.get("published_at"),
+        path=f"{path}.published_at",
+        report=report,
+    )
+    _sha256(source.get("content_sha256"), path=f"{path}.content_sha256", report=report)
+    if cutoff is not None and published_at is not None and published_at > cutoff:
+        _issue(
+            report,
+            f"{path}.published_at",
+            "outcome_leakage",
+            "model-visible evidence must not be published after the information cutoff",
+        )
+    return source_id, published_at
+
+
+def _validate_case(
+    value: Any,
+    *,
+    index: int,
+    report: CorpusValidationReport,
+) -> tuple[str | None, set[str], datetime | None, str | None, str | None]:
+    path = f"$.cases[{index}]"
+    case = _as_object(value, path=path, report=report)
+    if case is None:
+        return None, set(), None, None, None
+    _check_keys(case, allowed=_CASE_KEYS, path=path, report=report)
+
+    case_id = _identifier(case.get("case_id"), path=f"{path}.case_id", report=report)
+    domain = _nonempty_string(case.get("domain"), path=f"{path}.domain", report=report)
+    if domain is not None and domain not in DOMAINS:
+        _issue(report, f"{path}.domain", "invalid_domain", f"must be one of {DOMAINS}")
+    split = _nonempty_string(case.get("split"), path=f"{path}.split", report=report)
+    if split is not None and split not in SPLITS:
+        _issue(report, f"{path}.split", "invalid_split", f"must be one of {SPLITS}")
+    _nonempty_string(case.get("title"), path=f"{path}.title", report=report)
+    _nonempty_string(
+        case.get("decision_prompt"),
+        path=f"{path}.decision_prompt",
+        report=report,
+    )
+    _nonempty_string(
+        case.get("forecast_question"),
+        path=f"{path}.forecast_question",
+        report=report,
+    )
+    cutoff = _timestamp(
+        case.get("information_cutoff"),
+        path=f"{path}.information_cutoff",
+        report=report,
+    )
+
+    option_ids: set[str] = set()
+    options = case.get("options")
+    if not isinstance(options, list) or len(options) != 2:
+        _issue(report, f"{path}.options", "invalid_options", "must contain exactly two options")
+    else:
+        for option_index, raw_option in enumerate(options):
+            option_path = f"{path}.options[{option_index}]"
+            option = _as_object(raw_option, path=option_path, report=report)
+            if option is None:
+                continue
+            _check_keys(option, allowed=_OPTION_KEYS, path=option_path, report=report)
+            option_id = _identifier(
+                option.get("option_id"),
+                path=f"{option_path}.option_id",
+                report=report,
+            )
+            _nonempty_string(option.get("label"), path=f"{option_path}.label", report=report)
+            _nonempty_string(
+                option.get("description"),
+                path=f"{option_path}.description",
+                report=report,
+            )
+            if option_id in option_ids:
+                _issue(
+                    report,
+                    f"{option_path}.option_id",
+                    "duplicate_option_id",
+                    "option identifiers must be unique within a case",
+                )
+            elif option_id is not None:
+                option_ids.add(option_id)
+
+    forecast_option_id = _identifier(
+        case.get("forecast_option_id"),
+        path=f"{path}.forecast_option_id",
+        report=report,
+    )
+    if forecast_option_id is not None and forecast_option_id not in option_ids:
+        _issue(
+            report,
+            f"{path}.forecast_option_id",
+            "unknown_forecast_option",
+            "must reference one of the case option identifiers",
+        )
+
+    sources = case.get("sources")
+    if not isinstance(sources, list) or not sources:
+        _issue(report, f"{path}.sources", "missing_sources", "must contain public evidence")
+    else:
+        source_ids: set[str] = set()
+        for source_index, source in enumerate(sources):
+            source_path = f"{path}.sources[{source_index}]"
+            source_id, _ = _validate_source(
+                source,
+                path=source_path,
+                report=report,
+                cutoff=cutoff,
+            )
+            if source_id in source_ids:
+                _issue(
+                    report,
+                    f"{source_path}.source_id",
+                    "duplicate_source_id",
+                    "source identifiers must be unique within a case",
+                )
+            elif source_id is not None:
+                source_ids.add(source_id)
+
+    return case_id, option_ids, cutoff, domain, split
+
+
+def _validate_outcome(
+    value: Any,
+    *,
+    index: int,
+    case_options: dict[str, set[str]],
+    case_cutoffs: dict[str, datetime],
+    report: CorpusValidationReport,
+) -> tuple[str | None, datetime | None]:
+    path = f"$.outcomes[{index}]"
+    outcome = _as_object(value, path=path, report=report)
+    if outcome is None:
+        return None, None
+    _check_keys(outcome, allowed=_OUTCOME_KEYS, path=path, report=report)
+
+    case_id = _identifier(outcome.get("case_id"), path=f"{path}.case_id", report=report)
+    resolved_at = _timestamp(
+        outcome.get("resolved_at"),
+        path=f"{path}.resolved_at",
+        report=report,
+    )
+    correct_option_id = _identifier(
+        outcome.get("correct_option_id"),
+        path=f"{path}.correct_option_id",
+        report=report,
+    )
+    _nonempty_string(
+        outcome.get("resolution_summary"),
+        path=f"{path}.resolution_summary",
+        report=report,
+    )
+
+    if case_id is not None:
+        if case_id not in case_options:
+            _issue(report, f"{path}.case_id", "unknown_case", "has no matching corpus case")
+        elif correct_option_id not in case_options[case_id]:
+            _issue(
+                report,
+                f"{path}.correct_option_id",
+                "unknown_correct_option",
+                "must reference one of the matching case options",
+            )
+        cutoff = case_cutoffs.get(case_id)
+        if cutoff is not None and resolved_at is not None and resolved_at <= cutoff:
+            _issue(
+                report,
+                f"{path}.resolved_at",
+                "invalid_resolution_time",
+                "must be later than the model-visible information cutoff",
+            )
+
+    sources = outcome.get("authoritative_sources")
+    if not isinstance(sources, list) or not sources:
+        _issue(
+            report,
+            f"{path}.authoritative_sources",
+            "missing_outcome_sources",
+            "must contain authoritative outcome evidence",
+        )
+    else:
+        source_ids: set[str] = set()
+        for source_index, source in enumerate(sources):
+            source_path = f"{path}.authoritative_sources[{source_index}]"
+            source_id, published_at = _validate_source(
+                source,
+                path=source_path,
+                report=report,
+            )
+            if source_id in source_ids:
+                _issue(
+                    report,
+                    f"{source_path}.source_id",
+                    "duplicate_source_id",
+                    "source identifiers must be unique within an outcome",
+                )
+            elif source_id is not None:
+                source_ids.add(source_id)
+            if resolved_at is not None and published_at is not None and published_at < resolved_at:
+                _issue(
+                    report,
+                    f"{source_path}.published_at",
+                    "premature_outcome_source",
+                    "authoritative outcome evidence must not predate resolution",
+                )
+
+    cruxes = outcome.get("cruxes")
+    if not isinstance(cruxes, list) or not 3 <= len(cruxes) <= 5:
+        _issue(report, f"{path}.cruxes", "invalid_crux_count", "must contain 3 to 5 cruxes")
+    else:
+        crux_ids: set[str] = set()
+        for crux_index, raw_crux in enumerate(cruxes):
+            crux_path = f"{path}.cruxes[{crux_index}]"
+            crux = _as_object(raw_crux, path=crux_path, report=report)
+            if crux is None:
+                continue
+            _check_keys(crux, allowed=_CRUX_KEYS, path=crux_path, report=report)
+            crux_id = _identifier(
+                crux.get("crux_id"),
+                path=f"{crux_path}.crux_id",
+                report=report,
+            )
+            _nonempty_string(
+                crux.get("description"),
+                path=f"{crux_path}.description",
+                report=report,
+            )
+            aliases = crux.get("aliases")
+            if not isinstance(aliases, list) or not all(
+                isinstance(alias, str) and alias.strip() for alias in aliases
+            ):
+                _issue(
+                    report,
+                    f"{crux_path}.aliases",
+                    "invalid_aliases",
+                    "must be a list of non-empty strings",
+                )
+            if crux_id in crux_ids:
+                _issue(
+                    report,
+                    f"{crux_path}.crux_id",
+                    "duplicate_crux_id",
+                    "crux identifiers must be unique within an outcome",
+                )
+            elif crux_id is not None:
+                crux_ids.add(crux_id)
+
+    return case_id, resolved_at
+
+
+def validate_corpus_documents(
+    corpus: Any,
+    outcomes: Any,
+    *,
+    allow_partial: bool = False,
+) -> CorpusValidationReport:
+    """Validate the model-visible corpus and hash-bound outcome sidecar."""
+    report = CorpusValidationReport()
+    corpus_object = _as_object(corpus, path="$", report=report)
+    outcomes_object = _as_object(outcomes, path="$", report=report)
+    if corpus_object is None or outcomes_object is None:
+        return report
+
+    report.corpus_sha256 = corpus_sha256(corpus_object)
+    _check_keys(corpus_object, allowed=_CORPUS_KEYS, path="$", report=report)
+    _check_keys(outcomes_object, allowed=_OUTCOMES_KEYS, path="$", report=report)
+
+    if corpus_object.get("schema_version") != CORPUS_SCHEMA_VERSION:
+        _issue(
+            report,
+            "$.schema_version",
+            "unsupported_schema",
+            f"must equal {CORPUS_SCHEMA_VERSION!r}",
+        )
+    if outcomes_object.get("schema_version") != OUTCOMES_SCHEMA_VERSION:
+        _issue(
+            report,
+            "$.schema_version",
+            "unsupported_outcomes_schema",
+            f"must equal {OUTCOMES_SCHEMA_VERSION!r}",
+        )
+
+    benchmark_id = _identifier(
+        corpus_object.get("benchmark_id"),
+        path="$.benchmark_id",
+        report=report,
+    )
+    outcomes_benchmark_id = _identifier(
+        outcomes_object.get("benchmark_id"),
+        path="$.benchmark_id",
+        report=report,
+    )
+    if benchmark_id is not None and outcomes_benchmark_id != benchmark_id:
+        _issue(
+            report,
+            "$.benchmark_id",
+            "benchmark_id_mismatch",
+            "outcome sidecar must name the same benchmark",
+        )
+    _identifier(corpus_object.get("revision"), path="$.revision", report=report)
+    frozen_at = _timestamp(
+        corpus_object.get("frozen_at"),
+        path="$.frozen_at",
+        report=report,
+    )
+
+    declared_hash = _sha256(
+        outcomes_object.get("corpus_sha256"),
+        path="$.corpus_sha256",
+        report=report,
+    )
+    if declared_hash is not None and declared_hash != report.corpus_sha256:
+        _issue(
+            report,
+            "$.corpus_sha256",
+            "corpus_hash_mismatch",
+            "outcome sidecar is not bound to the canonical corpus document",
+        )
+
+    cases = corpus_object.get("cases")
+    if not isinstance(cases, list):
+        _issue(report, "$.cases", "invalid_type", "must be a JSON array")
+        cases = []
+    report.case_count = len(cases)
+    if report.case_count == 0:
+        _issue(report, "$.cases", "empty_corpus", "must contain at least one resolved case")
+
+    case_options: dict[str, set[str]] = {}
+    case_cutoffs: dict[str, datetime] = {}
+    domains: list[str] = []
+    splits: list[str] = []
+    domain_splits: Counter[tuple[str, str]] = Counter()
+    for index, case in enumerate(cases):
+        case_id, options, cutoff, domain, split = _validate_case(
+            case,
+            index=index,
+            report=report,
+        )
+        if case_id in case_options:
+            _issue(
+                report,
+                f"$.cases[{index}].case_id",
+                "duplicate_case_id",
+                "case identifiers must be unique",
+            )
+        elif case_id is not None:
+            case_options[case_id] = options
+            if cutoff is not None:
+                case_cutoffs[case_id] = cutoff
+        if domain in DOMAINS:
+            domains.append(domain)
+        if split in SPLITS:
+            splits.append(split)
+        if domain in DOMAINS and split in SPLITS:
+            domain_splits[(domain, split)] += 1
+
+    report.domain_counts = dict(sorted(Counter(domains).items()))
+    report.split_counts = dict(sorted(Counter(splits).items()))
+    if not allow_partial:
+        if report.case_count != 24:
+            _issue(report, "$.cases", "wrong_case_count", "must contain exactly 24 cases")
+        for domain in DOMAINS:
+            if report.domain_counts.get(domain, 0) != 6:
+                _issue(
+                    report,
+                    "$.cases",
+                    "wrong_domain_count",
+                    f"domain {domain!r} must contain exactly 6 cases",
+                )
+            if domain_splits[(domain, "development")] != 4:
+                _issue(
+                    report,
+                    "$.cases",
+                    "wrong_development_count",
+                    f"domain {domain!r} must contain exactly 4 development cases",
+                )
+            if domain_splits[(domain, "holdout")] != 2:
+                _issue(
+                    report,
+                    "$.cases",
+                    "wrong_holdout_count",
+                    f"domain {domain!r} must contain exactly 2 holdout cases",
+                )
+
+    raw_outcomes = outcomes_object.get("outcomes")
+    if not isinstance(raw_outcomes, list):
+        _issue(report, "$.outcomes", "invalid_type", "must be a JSON array")
+        raw_outcomes = []
+    if not raw_outcomes:
+        _issue(report, "$.outcomes", "empty_outcomes", "must contain at least one outcome")
+    outcome_ids: set[str] = set()
+    resolution_times: list[datetime] = []
+    for index, outcome in enumerate(raw_outcomes):
+        case_id, resolved_at = _validate_outcome(
+            outcome,
+            index=index,
+            case_options=case_options,
+            case_cutoffs=case_cutoffs,
+            report=report,
+        )
+        if case_id in outcome_ids:
+            _issue(
+                report,
+                f"$.outcomes[{index}].case_id",
+                "duplicate_outcome",
+                "each corpus case must have exactly one outcome",
+            )
+        elif case_id is not None:
+            outcome_ids.add(case_id)
+        if resolved_at is not None:
+            resolution_times.append(resolved_at)
+
+    missing_outcomes = sorted(case_options.keys() - outcome_ids)
+    extra_outcomes = sorted(outcome_ids - case_options.keys())
+    if missing_outcomes:
+        _issue(
+            report,
+            "$.outcomes",
+            "missing_outcomes",
+            f"missing outcomes for cases: {', '.join(missing_outcomes)}",
+        )
+    if extra_outcomes:
+        _issue(
+            report,
+            "$.outcomes",
+            "extra_outcomes",
+            f"outcomes reference unknown cases: {', '.join(extra_outcomes)}",
+        )
+    if frozen_at is not None and any(resolved_at > frozen_at for resolved_at in resolution_times):
+        _issue(
+            report,
+            "$.frozen_at",
+            "premature_freeze",
+            "must be at or after every authoritative outcome resolution",
+        )
+
+    return report
+
+
+def validate_corpus_files(
+    corpus_path: Path,
+    outcomes_path: Path,
+    *,
+    allow_partial: bool = False,
+) -> CorpusValidationReport:
+    """Load and validate corpus files without raising on malformed input."""
+    report = CorpusValidationReport()
+    documents: list[Any] = []
+    for label, path in (("corpus", corpus_path), ("outcomes", outcomes_path)):
+        try:
+            documents.append(json.loads(path.read_text(encoding="utf-8")))
+        except OSError as exc:
+            _issue(report, f"${label}", "read_error", f"cannot read {path}: {exc}")
+        except json.JSONDecodeError as exc:
+            _issue(
+                report,
+                f"${label}",
+                "invalid_json",
+                f"{path}:{exc.lineno}:{exc.colno}: {exc.msg}",
+            )
+    if report.issues:
+        return report
+    return validate_corpus_documents(documents[0], documents[1], allow_partial=allow_partial)
+
+
+__all__ = [
+    "CORPUS_SCHEMA_VERSION",
+    "OUTCOMES_SCHEMA_VERSION",
+    "DOMAINS",
+    "SPLITS",
+    "ValidationIssue",
+    "CorpusValidationReport",
+    "canonical_json_bytes",
+    "corpus_sha256",
+    "validate_corpus_documents",
+    "validate_corpus_files",
+]

--- a/aragora/evaluation/decision_quality_corpus.py
+++ b/aragora/evaluation/decision_quality_corpus.py
@@ -1,13 +1,14 @@
 """Validation for the outcome-backed decision-quality benchmark corpus.
 
 The model-visible corpus and resolved-outcome sidecar are deliberately
-separate. The sidecar binds to the canonical corpus hash so answer keys cannot
-be changed silently after inference starts.
+separate. Validation reports canonical digests for both documents so a frozen
+benchmark manifest can pin the question set and answer key before inference.
 """
 
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import re
 from collections import Counter
@@ -15,6 +16,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 CORPUS_SCHEMA_VERSION = "decision-quality-corpus/1.0"
 OUTCOMES_SCHEMA_VERSION = "decision-quality-outcomes/1.0"
@@ -28,6 +30,8 @@ SPLITS = ("development", "holdout")
 
 _ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_HOST_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_NON_PUBLIC_HOST_SUFFIXES = (".home", ".internal", ".lan", ".local", ".localhost")
 
 _CORPUS_KEYS = {"schema_version", "benchmark_id", "revision", "frozen_at", "cases"}
 _CASE_KEYS = {
@@ -93,6 +97,7 @@ class CorpusValidationReport:
     """Structured result returned by corpus validation."""
 
     corpus_sha256: str | None = None
+    outcomes_sha256: str | None = None
     case_count: int = 0
     domain_counts: dict[str, int] = field(default_factory=dict)
     split_counts: dict[str, int] = field(default_factory=dict)
@@ -106,6 +111,7 @@ class CorpusValidationReport:
         return {
             "ok": self.ok,
             "corpus_sha256": self.corpus_sha256,
+            "outcomes_sha256": self.outcomes_sha256,
             "case_count": self.case_count,
             "domain_counts": self.domain_counts,
             "split_counts": self.split_counts,
@@ -126,6 +132,11 @@ def canonical_json_bytes(document: Any) -> bytes:
 def corpus_sha256(corpus: Any) -> str:
     """Return the canonical SHA-256 digest of a model-visible corpus."""
     return hashlib.sha256(canonical_json_bytes(corpus)).hexdigest()
+
+
+def outcomes_sha256(outcomes: Any) -> str:
+    """Return the canonical SHA-256 digest of a resolved-outcome sidecar."""
+    return hashlib.sha256(canonical_json_bytes(outcomes)).hexdigest()
 
 
 def _issue(
@@ -237,10 +248,46 @@ def _https_url(
     report: CorpusValidationReport,
 ) -> str | None:
     text = _nonempty_string(value, path=path, report=report)
-    if text is not None and not text.startswith("https://"):
+    if text is not None and not _is_public_https_url(text):
         _issue(report, path, "non_public_url", "must use an https:// public source URL")
         return None
     return text
+
+
+def _is_public_https_url(text: str) -> bool:
+    """Return whether a URL has a syntactically public HTTPS authority."""
+    try:
+        parsed = urlsplit(text)
+        host = parsed.hostname
+        parsed.port
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or host is None
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return False
+
+    normalized_host = host.rstrip(".").lower()
+    if not normalized_host:
+        return False
+    try:
+        address = ipaddress.ip_address(normalized_host)
+    except ValueError:
+        try:
+            ascii_host = normalized_host.encode("idna").decode("ascii")
+        except UnicodeError:
+            return False
+        if (
+            "." not in ascii_host
+            or ascii_host == "localhost"
+            or ascii_host.endswith(_NON_PUBLIC_HOST_SUFFIXES)
+        ):
+            return False
+        return all(_HOST_LABEL_PATTERN.fullmatch(label) for label in ascii_host.split("."))
+    return address.is_global
 
 
 def _validate_source(
@@ -513,6 +560,7 @@ def validate_corpus_documents(
     outcomes: Any,
     *,
     allow_partial: bool = False,
+    expected_outcomes_sha256: str | None = None,
 ) -> CorpusValidationReport:
     """Validate the model-visible corpus and hash-bound outcome sidecar."""
     report = CorpusValidationReport()
@@ -522,6 +570,20 @@ def validate_corpus_documents(
         return report
 
     report.corpus_sha256 = corpus_sha256(corpus_object)
+    report.outcomes_sha256 = outcomes_sha256(outcomes_object)
+    if expected_outcomes_sha256 is not None:
+        expected_hash = _sha256(
+            expected_outcomes_sha256,
+            path="$expected_outcomes_sha256",
+            report=report,
+        )
+        if expected_hash is not None and expected_hash != report.outcomes_sha256:
+            _issue(
+                report,
+                "$expected_outcomes_sha256",
+                "outcomes_hash_mismatch",
+                "outcome sidecar does not match the frozen expected digest",
+            )
     _check_keys(corpus_object, allowed=_CORPUS_KEYS, path="$", report=report)
     _check_keys(outcomes_object, allowed=_OUTCOMES_KEYS, path="$", report=report)
 
@@ -702,6 +764,7 @@ def validate_corpus_files(
     outcomes_path: Path,
     *,
     allow_partial: bool = False,
+    expected_outcomes_sha256: str | None = None,
 ) -> CorpusValidationReport:
     """Load and validate corpus files without raising on malformed input."""
     report = CorpusValidationReport()
@@ -732,7 +795,12 @@ def validate_corpus_files(
             )
     if report.issues:
         return report
-    return validate_corpus_documents(documents[0], documents[1], allow_partial=allow_partial)
+    return validate_corpus_documents(
+        documents[0],
+        documents[1],
+        allow_partial=allow_partial,
+        expected_outcomes_sha256=expected_outcomes_sha256,
+    )
 
 
 __all__ = [
@@ -744,6 +812,7 @@ __all__ = [
     "CorpusValidationReport",
     "canonical_json_bytes",
     "corpus_sha256",
+    "outcomes_sha256",
     "validate_corpus_documents",
     "validate_corpus_files",
 ]

--- a/docs/benchmarks/decision_quality/README.md
+++ b/docs/benchmarks/decision_quality/README.md
@@ -17,7 +17,11 @@ without claiming that a benchmark result exists yet.
 - Resolution evidence and three to five preregistered cruxes live only in the
   outcome sidecar.
 - The sidecar names the canonical SHA-256 of the model-visible corpus.
-- Any correction produces a new corpus revision and invalidates affected runs.
+- Validation reports a canonical SHA-256 for the outcome sidecar. The frozen
+  benchmark manifest must record both digests before inference.
+- Any correction produces a new corpus revision and invalidates affected runs;
+  later validation must pass the recorded digest with
+  `--expected-outcomes-sha256`.
 
 The JSON Schema at `corpus.schema.json` describes both documents. The CLI adds
 cross-document checks, timestamp ordering, unique identifiers, exact domain
@@ -33,6 +37,12 @@ During corpus construction, `--allow-partial` skips only the final 24-case
 domain/split count gate. It does not relax source cutoffs, outcome separation,
 hash binding, or per-case semantics. A partial corpus must never be used for a
 counted benchmark run.
+
+The canonical representation is the UTF-8 JSON encoding produced by
+`canonical_json_bytes`; it is the benchmark's explicit digest contract rather
+than an implicit cross-language JCS claim. URL validation is deterministic and
+offline: it requires a parsed HTTPS URL with a syntactically public host and
+rejects local/reserved hosts and non-global IP addresses without resolving DNS.
 
 The future runner must load the model-visible corpus independently from the
 outcome sidecar. Outcomes, correct options, resolution summaries, and

--- a/docs/benchmarks/decision_quality/README.md
+++ b/docs/benchmarks/decision_quality/README.md
@@ -1,0 +1,39 @@
+# Outcome-Backed Decision Quality Corpus
+
+This directory holds the frozen public-case contract for the outcome-backed
+decision-quality benchmark. It extends the existing
+[`DECISION_QUALITY_DELTA_BENCHMARK_SPEC.md`](../../plans/DECISION_QUALITY_DELTA_BENCHMARK_SPEC.md)
+without claiming that a benchmark result exists yet.
+
+## Contract
+
+- 24 already-resolved public cases.
+- Six cases in each domain: software engineering, business/operations,
+  nonpartisan policy/compliance, and science/forecasting.
+- Four development and two holdout cases per domain, for a 16/8 split.
+- Exactly two explicit options per case and one named option whose probability
+  is forecast.
+- Model-visible evidence was public at or before the case information cutoff.
+- Resolution evidence and three to five preregistered cruxes live only in the
+  outcome sidecar.
+- The sidecar names the canonical SHA-256 of the model-visible corpus.
+- Any correction produces a new corpus revision and invalidates affected runs.
+
+The JSON Schema at `corpus.schema.json` describes both documents. The CLI adds
+cross-document checks, timestamp ordering, unique identifiers, exact domain
+balance, and hash binding:
+
+```bash
+python3 scripts/debate_quality_benchmark.py validate-corpus \
+  --corpus docs/benchmarks/decision_quality/corpus.json \
+  --outcomes docs/benchmarks/decision_quality/outcomes.json
+```
+
+During corpus construction, `--allow-partial` skips only the final 24-case
+domain/split count gate. It does not relax source cutoffs, outcome separation,
+hash binding, or per-case semantics. A partial corpus must never be used for a
+counted benchmark run.
+
+The future runner must load the model-visible corpus independently from the
+outcome sidecar. Outcomes, correct options, resolution summaries, and
+preregistered cruxes must never enter model prompts.

--- a/docs/benchmarks/decision_quality/corpus.schema.json
+++ b/docs/benchmarks/decision_quality/corpus.schema.json
@@ -40,7 +40,8 @@
         },
         "url": {
           "type": "string",
-          "pattern": "^https://"
+          "format": "uri",
+          "pattern": "^https://(?!(?:localhost|[^/?#]*\\.(?:localhost|local|internal|lan|home))(?::[0-9]+)?(?:[/?#]|$))(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?|\\[[0-9A-Fa-f:.]+\\]|(?:[0-9]{1,3}\\.){3}[0-9]{1,3})(?::[0-9]+)?(?:[/?#]|$)"
         },
         "published_at": {
           "type": "string",

--- a/docs/benchmarks/decision_quality/corpus.schema.json
+++ b/docs/benchmarks/decision_quality/corpus.schema.json
@@ -1,0 +1,275 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aragora.ai/schemas/decision-quality-corpus-1.0.json",
+  "title": "Outcome-Backed Decision Quality Corpus",
+  "description": "Schema for either the model-visible corpus or its hash-bound outcome sidecar. Cross-document and balance invariants are enforced by debate_quality_benchmark.py validate-corpus.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/corpus"
+    },
+    {
+      "$ref": "#/$defs/outcomes"
+    }
+  ],
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "title",
+        "url",
+        "published_at",
+        "content_sha256"
+      ],
+      "properties": {
+        "source_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "pattern": "^https://"
+        },
+        "published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "content_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "option": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "option_id",
+        "label",
+        "description"
+      ],
+      "properties": {
+        "option_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "domain",
+        "split",
+        "title",
+        "decision_prompt",
+        "forecast_question",
+        "forecast_option_id",
+        "options",
+        "information_cutoff",
+        "sources"
+      ],
+      "properties": {
+        "case_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "domain": {
+          "enum": [
+            "software_engineering",
+            "business_operations",
+            "policy_compliance",
+            "science_forecasting"
+          ]
+        },
+        "split": {
+          "enum": [
+            "development",
+            "holdout"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_prompt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "forecast_question": {
+          "type": "string",
+          "minLength": 1
+        },
+        "forecast_option_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "options": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/$defs/option"
+          }
+        },
+        "information_cutoff": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/source"
+          }
+        }
+      }
+    },
+    "corpus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "benchmark_id",
+        "revision",
+        "frozen_at",
+        "cases"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "decision-quality-corpus/1.0"
+        },
+        "benchmark_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "revision": {
+          "$ref": "#/$defs/identifier"
+        },
+        "frozen_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "cases": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/case"
+          }
+        }
+      }
+    },
+    "crux": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "crux_id",
+        "description",
+        "aliases"
+      ],
+      "properties": {
+        "crux_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "resolved_at",
+        "correct_option_id",
+        "resolution_summary",
+        "authoritative_sources",
+        "cruxes"
+      ],
+      "properties": {
+        "case_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "resolved_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "correct_option_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "resolution_summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authoritative_sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/source"
+          }
+        },
+        "cruxes": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/$defs/crux"
+          }
+        }
+      }
+    },
+    "outcomes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "benchmark_id",
+        "corpus_sha256",
+        "outcomes"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "decision-quality-outcomes/1.0"
+        },
+        "benchmark_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "corpus_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "outcomes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/outcome"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/debate_quality_benchmark.py
+++ b/scripts/debate_quality_benchmark.py
@@ -17,6 +17,11 @@ Usage:
 
     # Full run with subset
     python scripts/debate_quality_benchmark.py --prompts 6
+
+    # Validate a frozen outcome-backed corpus and answer-key sidecar
+    python scripts/debate_quality_benchmark.py validate-corpus \
+        --corpus docs/benchmarks/decision_quality/corpus.json \
+        --outcomes docs/benchmarks/decision_quality/outcomes.json
 """
 
 from __future__ import annotations
@@ -47,6 +52,10 @@ from aragora.evaluation.llm_judge import (  # noqa: E402
     LLMJudge,
     PairwiseResult,
     WEIGHT_PROFILES,
+)
+from aragora.evaluation.decision_quality_corpus import (  # noqa: E402
+    CorpusValidationReport,
+    validate_corpus_files,
 )
 
 logging.basicConfig(
@@ -958,8 +967,61 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-async def main() -> None:
-    args = parse_args()
+def parse_validate_corpus_args(argv: list[str]) -> argparse.Namespace:
+    """Parse the additive outcome-backed corpus validation command."""
+    parser = argparse.ArgumentParser(
+        prog="debate_quality_benchmark.py validate-corpus",
+        description="Validate a frozen decision corpus and its hash-bound outcome sidecar.",
+    )
+    parser.add_argument("--corpus", type=Path, required=True, help="Model-visible corpus JSON")
+    parser.add_argument(
+        "--outcomes",
+        type=Path,
+        required=True,
+        help="Outcome and preregistered-crux sidecar JSON",
+    )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Skip only the final 24-case domain/split count gate during corpus construction.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser.parse_args(argv)
+
+
+def print_corpus_validation(report: CorpusValidationReport, *, as_json: bool) -> None:
+    """Print a deterministic corpus validation result."""
+    if as_json:
+        print(json.dumps(report.to_dict(), sort_keys=True))
+        return
+    verdict = "PASS" if report.ok else "FAIL"
+    print(f"Decision-quality corpus validation: {verdict}")
+    print(f"Corpus SHA-256: {report.corpus_sha256 or 'unavailable'}")
+    print(f"Cases: {report.case_count}")
+    print(f"Domains: {json.dumps(report.domain_counts, sort_keys=True)}")
+    print(f"Splits: {json.dumps(report.split_counts, sort_keys=True)}")
+    for issue in report.issues:
+        print(f"- {issue.path} [{issue.code}] {issue.message}")
+
+
+def run_validate_corpus(argv: list[str]) -> int:
+    """Run the corpus validator and return a process-style status code."""
+    args = parse_validate_corpus_args(argv)
+    report = validate_corpus_files(
+        args.corpus,
+        args.outcomes,
+        allow_partial=args.allow_partial,
+    )
+    print_corpus_validation(report, as_json=args.json)
+    return 0 if report.ok else 1
+
+
+async def main(argv: list[str] | None = None) -> None:
+    raw_argv = sys.argv[1:] if argv is None else argv
+    if raw_argv and raw_argv[0] == "validate-corpus":
+        raise SystemExit(run_validate_corpus(raw_argv[1:]))
+
+    args = parse_args(raw_argv)
 
     selected = select_prompts(args.prompts)
 

--- a/scripts/debate_quality_benchmark.py
+++ b/scripts/debate_quality_benchmark.py
@@ -985,6 +985,10 @@ def parse_validate_corpus_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Skip only the final 24-case domain/split count gate during corpus construction.",
     )
+    parser.add_argument(
+        "--expected-outcomes-sha256",
+        help="Require the outcome sidecar to match this frozen canonical SHA-256 digest.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     return parser.parse_args(argv)
 
@@ -997,6 +1001,7 @@ def print_corpus_validation(report: CorpusValidationReport, *, as_json: bool) ->
     verdict = "PASS" if report.ok else "FAIL"
     print(f"Decision-quality corpus validation: {verdict}")
     print(f"Corpus SHA-256: {report.corpus_sha256 or 'unavailable'}")
+    print(f"Outcomes SHA-256: {report.outcomes_sha256 or 'unavailable'}")
     print(f"Cases: {report.case_count}")
     print(f"Domains: {json.dumps(report.domain_counts, sort_keys=True)}")
     print(f"Splits: {json.dumps(report.split_counts, sort_keys=True)}")
@@ -1011,6 +1016,7 @@ def run_validate_corpus(argv: list[str]) -> int:
         args.corpus,
         args.outcomes,
         allow_partial=args.allow_partial,
+        expected_outcomes_sha256=args.expected_outcomes_sha256,
     )
     print_corpus_validation(report, as_json=args.json)
     return 0 if report.ok else 1

--- a/tests/evaluation/test_decision_quality_corpus.py
+++ b/tests/evaluation/test_decision_quality_corpus.py
@@ -4,12 +4,14 @@ import copy
 import json
 from pathlib import Path
 
+import pytest
 from jsonschema import Draft202012Validator
 
 from aragora.evaluation.decision_quality_corpus import (
     DOMAINS,
     corpus_sha256,
     validate_corpus_documents,
+    validate_corpus_files,
 )
 
 
@@ -216,3 +218,35 @@ def test_mutating_corpus_requires_new_sidecar_hash() -> None:
     report = validate_corpus_documents(mutated, outcomes, allow_partial=True)
 
     assert "corpus_hash_mismatch" in _issue_codes(report)
+
+
+@pytest.mark.parametrize("duplicate_in", ["corpus", "outcomes"])
+def test_file_loader_rejects_duplicate_object_keys_at_any_depth(
+    tmp_path: Path,
+    duplicate_in: str,
+) -> None:
+    corpus, outcomes = _documents()
+    corpus_text = json.dumps(corpus)
+    outcomes_text = json.dumps(outcomes)
+    if duplicate_in == "corpus":
+        corpus_text = corpus_text.replace(
+            '"revision": "v1"',
+            '"revision": "v1", "revision": "v2"',
+            1,
+        )
+    else:
+        outcomes_text = outcomes_text.replace(
+            '"case_id": "software-development-1"',
+            '"case_id": "software-development-1", "case_id": "other"',
+            1,
+        )
+    corpus_path = tmp_path / "corpus.json"
+    outcomes_path = tmp_path / "outcomes.json"
+    corpus_path.write_text(corpus_text)
+    outcomes_path.write_text(outcomes_text)
+
+    report = validate_corpus_files(corpus_path, outcomes_path, allow_partial=True)
+
+    assert not report.ok
+    assert _issue_codes(report) == {"duplicate_json_key"}
+    assert report.issues[0].path == f"${duplicate_in}"

--- a/tests/evaluation/test_decision_quality_corpus.py
+++ b/tests/evaluation/test_decision_quality_corpus.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from aragora.evaluation.decision_quality_corpus import (
+    DOMAINS,
+    corpus_sha256,
+    validate_corpus_documents,
+)
+
+
+def _case(case_id: str, domain: str, split: str) -> dict[str, object]:
+    return {
+        "case_id": case_id,
+        "domain": domain,
+        "split": split,
+        "title": f"Resolved public decision {case_id}",
+        "decision_prompt": "Choose the more likely outcome using only the supplied evidence.",
+        "forecast_question": "What is the probability that option yes is correct?",
+        "forecast_option_id": "yes",
+        "options": [
+            {"option_id": "yes", "label": "Yes", "description": "The event occurs."},
+            {"option_id": "no", "label": "No", "description": "The event does not occur."},
+        ],
+        "information_cutoff": "2025-01-01T00:00:00Z",
+        "sources": [
+            {
+                "source_id": "evidence-1",
+                "title": "Public evidence snapshot",
+                "url": "https://example.com/evidence",
+                "published_at": "2024-12-31T00:00:00Z",
+                "content_sha256": "1" * 64,
+            }
+        ],
+    }
+
+
+def _outcome(case_id: str) -> dict[str, object]:
+    return {
+        "case_id": case_id,
+        "resolved_at": "2025-02-01T00:00:00Z",
+        "correct_option_id": "yes",
+        "resolution_summary": "The authoritative record confirms the event occurred.",
+        "authoritative_sources": [
+            {
+                "source_id": "outcome-1",
+                "title": "Authoritative outcome record",
+                "url": "https://example.com/outcome",
+                "published_at": "2025-02-01T00:00:00Z",
+                "content_sha256": "2" * 64,
+            }
+        ],
+        "cruxes": [
+            {"crux_id": "crux-1", "description": "First crux", "aliases": []},
+            {"crux_id": "crux-2", "description": "Second crux", "aliases": ["two"]},
+            {"crux_id": "crux-3", "description": "Third crux", "aliases": []},
+        ],
+    }
+
+
+def _documents(
+    cases: list[dict[str, object]] | None = None,
+) -> tuple[dict[str, object], dict[str, object]]:
+    selected_cases = cases or [_case("software-development-1", DOMAINS[0], "development")]
+    corpus: dict[str, object] = {
+        "schema_version": "decision-quality-corpus/1.0",
+        "benchmark_id": "outcome-backed-decision-quality",
+        "revision": "v1",
+        "frozen_at": "2025-03-01T00:00:00Z",
+        "cases": selected_cases,
+    }
+    outcomes: dict[str, object] = {
+        "schema_version": "decision-quality-outcomes/1.0",
+        "benchmark_id": "outcome-backed-decision-quality",
+        "corpus_sha256": corpus_sha256(corpus),
+        "outcomes": [_outcome(str(case["case_id"])) for case in selected_cases],
+    }
+    return corpus, outcomes
+
+
+def _full_documents() -> tuple[dict[str, object], dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    for domain in DOMAINS:
+        for index in range(4):
+            cases.append(_case(f"{domain}-development-{index + 1}", domain, "development"))
+        for index in range(2):
+            cases.append(_case(f"{domain}-holdout-{index + 1}", domain, "holdout"))
+    return _documents(cases)
+
+
+def _issue_codes(report: object) -> set[str]:
+    return {issue.code for issue in report.issues}  # type: ignore[attr-defined]
+
+
+def test_partial_corpus_accepts_hash_bound_resolved_case() -> None:
+    corpus, outcomes = _documents()
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert report.ok
+    assert report.case_count == 1
+    assert report.corpus_sha256 == corpus_sha256(corpus)
+
+
+def test_complete_corpus_requires_six_cases_and_four_two_split_per_domain() -> None:
+    corpus, outcomes = _full_documents()
+
+    report = validate_corpus_documents(corpus, outcomes)
+
+    assert report.ok
+    assert report.case_count == 24
+    assert report.domain_counts == dict.fromkeys(DOMAINS, 6)
+    assert report.split_counts == {"development": 16, "holdout": 8}
+
+
+def test_incomplete_corpus_fails_without_explicit_partial_mode() -> None:
+    corpus, outcomes = _documents()
+
+    report = validate_corpus_documents(corpus, outcomes)
+
+    assert not report.ok
+    assert "wrong_case_count" in _issue_codes(report)
+    assert "wrong_domain_count" in _issue_codes(report)
+
+
+def test_partial_mode_does_not_allow_an_empty_benchmark() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"] = []
+    outcomes["corpus_sha256"] = corpus_sha256(corpus)
+    outcomes["outcomes"] = []
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert {"empty_corpus", "empty_outcomes"} <= _issue_codes(report)
+
+
+def test_model_visible_source_after_cutoff_is_rejected_as_leakage() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["sources"][0]["published_at"] = "2025-01-02T00:00:00Z"  # type: ignore[index]
+    outcomes["corpus_sha256"] = corpus_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "outcome_leakage" in _issue_codes(report)
+
+
+def test_answer_key_field_in_model_visible_case_is_rejected() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["correct_option_id"] = "yes"  # type: ignore[index]
+    outcomes["corpus_sha256"] = corpus_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "unknown_field" in _issue_codes(report)
+
+
+def test_outcome_sidecar_must_match_canonical_corpus_hash() -> None:
+    corpus, outcomes = _documents()
+    outcomes["corpus_sha256"] = "0" * 64
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "corpus_hash_mismatch" in _issue_codes(report)
+
+
+def test_every_case_requires_exactly_one_outcome() -> None:
+    corpus, outcomes = _documents()
+    outcomes["outcomes"] = []
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "missing_outcomes" in _issue_codes(report)
+
+
+def test_outcome_must_resolve_after_information_cutoff() -> None:
+    corpus, outcomes = _documents()
+    outcomes["outcomes"][0]["resolved_at"] = "2025-01-01T00:00:00Z"  # type: ignore[index]
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "invalid_resolution_time" in _issue_codes(report)
+
+
+def test_canonical_hash_is_independent_of_object_key_order() -> None:
+    corpus, _ = _documents()
+    reordered = {key: corpus[key] for key in reversed(corpus)}
+
+    assert corpus_sha256(corpus) == corpus_sha256(reordered)
+
+
+def test_json_schema_accepts_both_documents() -> None:
+    corpus, outcomes = _documents()
+    schema_path = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "benchmarks"
+        / "decision_quality"
+        / "corpus.schema.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    validator = Draft202012Validator(schema)
+
+    assert not list(validator.iter_errors(corpus))
+    assert not list(validator.iter_errors(outcomes))
+
+
+def test_mutating_corpus_requires_new_sidecar_hash() -> None:
+    corpus, outcomes = _documents()
+    mutated = copy.deepcopy(corpus)
+    mutated["cases"][0]["title"] = "Silently changed title"  # type: ignore[index]
+
+    report = validate_corpus_documents(mutated, outcomes, allow_partial=True)
+
+    assert "corpus_hash_mismatch" in _issue_codes(report)

--- a/tests/evaluation/test_decision_quality_corpus.py
+++ b/tests/evaluation/test_decision_quality_corpus.py
@@ -10,6 +10,7 @@ from jsonschema import Draft202012Validator
 from aragora.evaluation.decision_quality_corpus import (
     DOMAINS,
     corpus_sha256,
+    outcomes_sha256,
     validate_corpus_documents,
     validate_corpus_files,
 )
@@ -106,6 +107,7 @@ def test_partial_corpus_accepts_hash_bound_resolved_case() -> None:
     assert report.ok
     assert report.case_count == 1
     assert report.corpus_sha256 == corpus_sha256(corpus)
+    assert report.outcomes_sha256 == outcomes_sha256(outcomes)
 
 
 def test_complete_corpus_requires_six_cases_and_four_two_split_per_domain() -> None:
@@ -218,6 +220,70 @@ def test_mutating_corpus_requires_new_sidecar_hash() -> None:
     report = validate_corpus_documents(mutated, outcomes, allow_partial=True)
 
     assert "corpus_hash_mismatch" in _issue_codes(report)
+
+
+def test_mutating_answer_key_fails_against_frozen_outcomes_hash() -> None:
+    corpus, outcomes = _documents()
+    frozen_hash = outcomes_sha256(outcomes)
+    mutated = copy.deepcopy(outcomes)
+    mutated["outcomes"][0]["correct_option_id"] = "no"  # type: ignore[index]
+
+    report = validate_corpus_documents(
+        corpus,
+        mutated,
+        allow_partial=True,
+        expected_outcomes_sha256=frozen_hash,
+    )
+
+    assert report.outcomes_sha256 == outcomes_sha256(mutated)
+    assert report.outcomes_sha256 != frozen_hash
+    assert "outcomes_hash_mismatch" in _issue_codes(report)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/evidence",
+        "https://",
+        "https://localhost/internal",
+        "https://service.internal/evidence",
+        "https://127.0.0.1/evidence",
+        "https://[::1]/evidence",
+        "https://bad host/evidence",
+        "https://example.com:invalid/evidence",
+    ],
+)
+def test_runtime_rejects_non_public_source_urls(url: str) -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["sources"][0]["url"] = url  # type: ignore[index]
+    outcomes["corpus_sha256"] = corpus_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "non_public_url" in _issue_codes(report)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://",
+        "https://localhost/internal",
+        "https://service.internal/evidence",
+    ],
+)
+def test_json_schema_rejects_non_public_source_urls(url: str) -> None:
+    corpus, _ = _documents()
+    corpus["cases"][0]["sources"][0]["url"] = url  # type: ignore[index]
+    schema_path = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "benchmarks"
+        / "decision_quality"
+        / "corpus.schema.json"
+    )
+    validator = Draft202012Validator(json.loads(schema_path.read_text()))
+
+    assert list(validator.iter_errors(corpus))
 
 
 @pytest.mark.parametrize("duplicate_in", ["corpus", "outcomes"])

--- a/tests/scripts/test_debate_quality_benchmark.py
+++ b/tests/scripts/test_debate_quality_benchmark.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from aragora.evaluation.decision_quality_corpus import corpus_sha256
+from aragora.evaluation.decision_quality_corpus import corpus_sha256, outcomes_sha256
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -135,6 +135,49 @@ def test_validate_corpus_command_emits_structured_json(
     assert exit_code == 0
     assert payload["ok"] is True
     assert payload["case_count"] == 1
+    assert payload["outcomes_sha256"] == outcomes_sha256(outcomes)
+
+
+def test_validate_corpus_command_enforces_frozen_outcomes_digest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+    corpus = {
+        "schema_version": "decision-quality-corpus/1.0",
+        "benchmark_id": "cli-test",
+        "revision": "v1",
+        "frozen_at": "2025-03-01T00:00:00Z",
+        "cases": [],
+    }
+    outcomes = {
+        "schema_version": "decision-quality-outcomes/1.0",
+        "benchmark_id": "cli-test",
+        "corpus_sha256": corpus_sha256(corpus),
+        "outcomes": [],
+    }
+    corpus_path = tmp_path / "corpus.json"
+    outcomes_path = tmp_path / "outcomes.json"
+    corpus_path.write_text(json.dumps(corpus))
+    outcomes_path.write_text(json.dumps(outcomes))
+
+    exit_code = module.run_validate_corpus(
+        [
+            "--corpus",
+            str(corpus_path),
+            "--outcomes",
+            str(outcomes_path),
+            "--allow-partial",
+            "--expected-outcomes-sha256",
+            "0" * 64,
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["outcomes_sha256"] == outcomes_sha256(outcomes)
+    assert any(issue["code"] == "outcomes_hash_mismatch" for issue in payload["issues"])
 
 
 def test_legacy_parser_does_not_consume_validate_corpus_command() -> None:

--- a/tests/scripts/test_debate_quality_benchmark.py
+++ b/tests/scripts/test_debate_quality_benchmark.py
@@ -1,9 +1,12 @@
 import asyncio
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
 import pytest
+
+from aragora.evaluation.decision_quality_corpus import corpus_sha256
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -47,3 +50,97 @@ def test_select_prompts_positive_limit_returns_prefix() -> None:
     module = _load_module()
 
     assert module.select_prompts(2) == module.PROMPTS[:2]
+
+
+def test_validate_corpus_command_emits_structured_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+    corpus = {
+        "schema_version": "decision-quality-corpus/1.0",
+        "benchmark_id": "cli-test",
+        "revision": "v1",
+        "frozen_at": "2025-03-01T00:00:00Z",
+        "cases": [
+            {
+                "case_id": "case-1",
+                "domain": "software_engineering",
+                "split": "development",
+                "title": "CLI validation case",
+                "decision_prompt": "Choose one option.",
+                "forecast_question": "What is the probability of yes?",
+                "forecast_option_id": "yes",
+                "options": [
+                    {"option_id": "yes", "label": "Yes", "description": "Occurs."},
+                    {"option_id": "no", "label": "No", "description": "Does not occur."},
+                ],
+                "information_cutoff": "2025-01-01T00:00:00Z",
+                "sources": [
+                    {
+                        "source_id": "evidence",
+                        "title": "Evidence",
+                        "url": "https://example.com/evidence",
+                        "published_at": "2024-12-31T00:00:00Z",
+                        "content_sha256": "1" * 64,
+                    }
+                ],
+            }
+        ],
+    }
+    outcomes = {
+        "schema_version": "decision-quality-outcomes/1.0",
+        "benchmark_id": "cli-test",
+        "corpus_sha256": corpus_sha256(corpus),
+        "outcomes": [
+            {
+                "case_id": "case-1",
+                "resolved_at": "2025-02-01T00:00:00Z",
+                "correct_option_id": "yes",
+                "resolution_summary": "Yes occurred.",
+                "authoritative_sources": [
+                    {
+                        "source_id": "outcome",
+                        "title": "Outcome",
+                        "url": "https://example.com/outcome",
+                        "published_at": "2025-02-01T00:00:00Z",
+                        "content_sha256": "2" * 64,
+                    }
+                ],
+                "cruxes": [
+                    {"crux_id": "one", "description": "One", "aliases": []},
+                    {"crux_id": "two", "description": "Two", "aliases": []},
+                    {"crux_id": "three", "description": "Three", "aliases": []},
+                ],
+            }
+        ],
+    }
+    corpus_path = tmp_path / "corpus.json"
+    outcomes_path = tmp_path / "outcomes.json"
+    corpus_path.write_text(json.dumps(corpus))
+    outcomes_path.write_text(json.dumps(outcomes))
+
+    exit_code = module.run_validate_corpus(
+        [
+            "--corpus",
+            str(corpus_path),
+            "--outcomes",
+            str(outcomes_path),
+            "--allow-partial",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["case_count"] == 1
+
+
+def test_legacy_parser_does_not_consume_validate_corpus_command() -> None:
+    module = _load_module()
+
+    args = module.parse_args(["--dry-run", "--prompts", "1"])
+
+    assert args.dry_run is True
+    assert args.prompts == 1


### PR DESCRIPTION
## Summary
- extend the canonical debate-quality benchmark with a `validate-corpus` operation
- define a strict 24-case, four-domain corpus and hash-bound outcome-sidecar contract
- fail closed on post-cutoff evidence, answer-key leakage, hash drift, missing outcomes, and invalid domain/split balance
- preserve the legacy benchmark CLI and document partial corpus construction without relaxing semantic gates

## Validation
- `python3 -m pytest tests/evaluation/test_decision_quality_corpus.py tests/scripts/test_debate_quality_benchmark.py -q` (18 passed)
- `python3 -m ruff check aragora/evaluation/decision_quality_corpus.py scripts/debate_quality_benchmark.py tests/evaluation/test_decision_quality_corpus.py tests/scripts/test_debate_quality_benchmark.py`
- `python3 -m ruff format --check aragora/evaluation/decision_quality_corpus.py scripts/debate_quality_benchmark.py tests/evaluation/test_decision_quality_corpus.py tests/scripts/test_debate_quality_benchmark.py`
- `python3 -m mypy aragora/evaluation/decision_quality_corpus.py`
- `bash scripts/test_tiers.sh typecheck`
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff origin/main...HEAD --check`

## Boundaries
This is the first bounded slice of the outcome-backed decision-quality convergence program. It does not add the corpus itself, run models, score outcomes, or publish a quality claim.