### PR TITLE
feat(governance): immutable GateSnapshot binding merges to the verified head (#9873) [Tier 4]

### DIFF
--- a/aragora/governance/__init__.py
+++ b/aragora/governance/__init__.py
@@ -1,0 +1,1 @@
+"""Governance primitives shared by package code and operator scripts."""

--- a/aragora/governance/gate_snapshot.py
+++ b/aragora/governance/gate_snapshot.py
@@ -1,0 +1,261 @@
+"""One immutable capture of a PR's head *and* its check verdict (#9873).
+
+Why this type exists
+--------------------
+A merge may only land the exact head whose required checks produced the verdict
+authorizing it. #9677 spent nine review rounds failing to achieve that by passing
+a SHA around, and the failure was always the same shape:
+
+* pass ``""`` and call it strict — an armed halt becomes unwaivable
+* thread ``head_sha`` per call site — fixes one caller, leaves the rest unbound
+* resolve the head inside the merge function — pairs a *stale* verdict with a
+  *fresh* commit, which is the exact TOCTOU the rule forbids
+
+The third was attempted twice and reverted twice. The lesson: **exact-head
+binding is an ordering property, not a plumbing property.** No amount of careful
+parameter passing fixes a head that was read after classification.
+
+So the head stops being a parameter. ``GateSnapshot`` is captured in a single
+GitHub read and is frozen; a merge takes the snapshot, never a naked SHA. Two
+consequences fall out structurally rather than by convention:
+
+* **You cannot build a snapshot without a full head.** ``__post_init__``
+  rejects anything that is not 40 hex characters, so "refuse when the head is
+  missing" is not a check a caller can forget — there is no valid object to
+  merge with.
+* **You cannot re-resolve.** The type exposes no setter and no refresh, so the
+  "resolve a fresh head at merge time" mistake has no API to make.
+
+A race between capture and merge is not prevented here — it cannot be, locally.
+It is made *safe*: the merge pins ``--match-head-commit`` to the captured head,
+so GitHub itself refuses when the head has moved. That refusal is the point.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+_FULL_SHA = re.compile(r"[0-9a-f]{40}")
+
+# One read. Adding a second call here would reintroduce the split that this type
+# exists to prevent: the head and the verdict must come from the same response.
+_SNAPSHOT_FIELDS = (
+    "number",
+    "headRefOid",
+    "headRefName",
+    "baseRefName",
+    "state",
+    "isDraft",
+    "mergeStateStatus",
+    "statusCheckRollup",
+)
+
+
+class GateSnapshotError(RuntimeError):
+    """The gate could not be captured, or was captured without a usable head."""
+
+
+class MergeRefused(RuntimeError):
+    """A merge was attempted without a valid captured head, and was refused."""
+
+
+class CommandRunner(Protocol):
+    def __call__(
+        self, args: list[str], *, timeout: float = ...
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+@dataclass(frozen=True)
+class GateSnapshot:
+    """A PR's head and check verdict, captured together and never mutated.
+
+    ``frozen=True`` is load-bearing, not stylistic: it is what stops a caller
+    from "refreshing" the head after classification.
+    """
+
+    pr_number: int
+    repo: str
+    head_sha: str
+    required_checks_green: bool
+    checks_known: bool
+    state: str
+    is_draft: bool
+    merge_state_status: str | None
+    captured_at: str
+
+    def __post_init__(self) -> None:
+        head = str(self.head_sha or "").strip().lower()
+        if not _FULL_SHA.fullmatch(head):
+            raise GateSnapshotError(
+                f"GateSnapshot requires a full 40-character head SHA, got {self.head_sha!r}. "
+                "A snapshot without a head cannot authorize a merge (#9873)."
+            )
+        # Normalise through object.__setattr__ because the dataclass is frozen.
+        object.__setattr__(self, "head_sha", head)
+        object.__setattr__(self, "repo", str(self.repo).strip())
+
+    @property
+    def mergeable_now(self) -> bool:
+        """Whether this capture authorizes a merge at all."""
+        return (
+            self.state.upper() == "OPEN"
+            and not self.is_draft
+            and self.checks_known
+            and self.required_checks_green
+        )
+
+    def match_head_args(self) -> list[str]:
+        """The only sanctioned way to pin a merge, using the captured head."""
+        return ["--match-head-commit", self.head_sha]
+
+
+def _default_runner(args: list[str], *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["gh", *args], capture_output=True, text=True, timeout=timeout)
+
+
+def _rollup_verdict(rollup: Any) -> tuple[bool, bool]:
+    """Return (all_green, known). Unknown beats green — an empty rollup is not a pass."""
+    if not isinstance(rollup, list) or not rollup:
+        return (False, False)
+    for item in rollup:
+        if not isinstance(item, dict):
+            return (False, False)
+        status = str(item.get("status") or "").upper()
+        conclusion = str(item.get("conclusion") or "").upper()
+        if status and status != "COMPLETED":
+            return (False, True)
+        if conclusion not in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+            return (False, True)
+    return (True, True)
+
+
+def capture_gate_snapshot(
+    pr_number: int,
+    repo: str,
+    *,
+    runner: CommandRunner | None = None,
+    timeout: float = 30.0,
+    now: dt.datetime | None = None,
+) -> GateSnapshot:
+    """Read a PR's head and checks in ONE call and freeze them together.
+
+    Raises ``GateSnapshotError`` rather than returning a partial snapshot: a
+    capture that failed must not be mistaken for a capture that said "no head".
+    """
+    run = runner or _default_runner
+    result = run(
+        [
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--json",
+            ",".join(_SNAPSHOT_FIELDS),
+        ],
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip() or "unknown gh error"
+        raise GateSnapshotError(f"could not capture gate for PR #{pr_number}: {detail}")
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise GateSnapshotError(f"gh returned invalid JSON for PR #{pr_number}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise GateSnapshotError(f"unexpected gh payload for PR #{pr_number}")
+
+    green, known = _rollup_verdict(payload.get("statusCheckRollup"))
+    stamp = (now or dt.datetime.now(dt.timezone.utc)).isoformat()
+    # GateSnapshot.__post_init__ raises if headRefOid was absent or malformed,
+    # which is exactly the refusal this issue asks for.
+    return GateSnapshot(
+        pr_number=int(payload.get("number") or pr_number),
+        repo=repo,
+        head_sha=str(payload.get("headRefOid") or ""),
+        required_checks_green=green,
+        checks_known=known,
+        state=str(payload.get("state") or ""),
+        is_draft=bool(payload.get("isDraft", False)),
+        merge_state_status=(
+            str(payload["mergeStateStatus"]) if payload.get("mergeStateStatus") else None
+        ),
+        captured_at=stamp,
+    )
+
+
+def require_snapshot(
+    snapshot: GateSnapshot | None, *, pr_number: int | None = None
+) -> GateSnapshot:
+    """Refuse a merge that has no captured head.
+
+    Call sites that still accept an optional snapshot funnel through here so the
+    refusal is one behaviour in one place, not a condition each caller re-invents.
+    """
+    if snapshot is None:
+        raise MergeRefused(
+            f"refusing to merge PR #{pr_number if pr_number is not None else '?'} without a "
+            "captured gate snapshot: the head its checks verified is unknown (#9873)."
+        )
+    return snapshot
+
+
+@dataclass(frozen=True)
+class MergeOutcome:
+    merged: bool
+    action: str
+    detail: str
+    head_sha: str | None = None
+
+
+def merge_with_snapshot(
+    snapshot: GateSnapshot | None,
+    *,
+    squash: bool = True,
+    admin: bool = False,
+    delete_branch: bool = False,
+    runner: CommandRunner | None = None,
+    timeout: float = 30.0,
+) -> MergeOutcome:
+    """Merge a PR bound to the head its checks verified.
+
+    Takes the snapshot, never a bare SHA: there is no parameter here that a
+    caller could fill with a freshly-resolved head. ``--match-head-commit`` is
+    always the captured head, so if the PR moved after capture GitHub rejects
+    the merge and that rejection is returned rather than retried.
+    """
+    snap = require_snapshot(snapshot)
+    if not snap.mergeable_now:
+        return MergeOutcome(
+            merged=False,
+            action="blocked",
+            detail=(
+                f"snapshot does not authorize a merge (state={snap.state} draft={snap.is_draft} "
+                f"checks_known={snap.checks_known} green={snap.required_checks_green})"
+            ),
+            head_sha=snap.head_sha,
+        )
+
+    args = ["pr", "merge", str(snap.pr_number), "--repo", snap.repo]
+    if squash:
+        args.append("--squash")
+    if admin:
+        args.append("--admin")
+    if delete_branch:
+        args.append("--delete-branch")
+    args.extend(snap.match_head_args())
+
+    run = runner or _default_runner
+    result = run(args, timeout=timeout)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip() or "unknown error"
+        # A head that moved after capture lands here: GitHub refused the pin.
+        return MergeOutcome(merged=False, action="refused", detail=detail, head_sha=snap.head_sha)
+    return MergeOutcome(
+        merged=True, action="merged", detail=(result.stdout or "").strip(), head_sha=snap.head_sha
+    )

--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -26,9 +26,9 @@ thresholds:
 summary:
   core: 21
   integrated: 93
-  experimental: 28
+  experimental: 29
   deprecated: 3
-  total: 145
+  total: 146
 
 modules:
   # --- core (21) ---
@@ -616,7 +616,7 @@ modules:
     importer_count: 16
     test_file_count: 11
 
-  # --- experimental (28) ---
+  # --- experimental (29) ---
   - name: advocates
     tier: experimental
     py_files: 2
@@ -652,6 +652,11 @@ modules:
     py_files: 1
     importer_count: 2
     test_file_count: 0
+  - name: governance
+    tier: experimental
+    py_files: 2
+    importer_count: 2
+    test_file_count: 3
   - name: maintenance
     tier: experimental
     py_files: 2

--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -47,18 +47,18 @@ modules:
     tier: core
     py_files: 124
     importer_count: 10
-    test_file_count: 158
+    test_file_count: 161
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
     py_files: 18
     importer_count: 368
-    test_file_count: 92
+    test_file_count: 93
     override_reason: "Pydantic settings + allowlist — load bearing"
   - name: connectors
     tier: core
-    py_files: 268
-    importer_count: 138
+    py_files: 269
+    importer_count: 139
     test_file_count: 252
   - name: core
     tier: core
@@ -102,12 +102,12 @@ modules:
   - name: nomic
     tier: core
     py_files: 166
-    importer_count: 89
-    test_file_count: 230
+    importer_count: 90
+    test_file_count: 234
   - name: observability
     tier: core
     py_files: 92
-    importer_count: 193
+    importer_count: 197
     test_file_count: 61
   - name: pipeline
     tier: core
@@ -128,8 +128,8 @@ modules:
   - name: reasoning
     tier: core
     py_files: 21
-    importer_count: 121
-    test_file_count: 113
+    importer_count: 122
+    test_file_count: 114
   - name: resilience
     tier: core
     py_files: 13
@@ -138,8 +138,8 @@ modules:
   - name: server
     tier: core
     py_files: 1126
-    importer_count: 150
-    test_file_count: 1902
+    importer_count: 142
+    test_file_count: 1905
     override_reason: "FastAPI server + 3K+ API operations"
   - name: storage
     tier: core
@@ -256,9 +256,9 @@ modules:
     test_file_count: 12
   - name: epistemic
     tier: integrated
-    py_files: 22
+    py_files: 24
     importer_count: 12
-    test_file_count: 28
+    test_file_count: 30
   - name: essay
     tier: integrated
     py_files: 6
@@ -287,7 +287,7 @@ modules:
   - name: export
     tier: integrated
     py_files: 11
-    importer_count: 20
+    importer_count: 19
     test_file_count: 31
   - name: extensions
     tier: integrated
@@ -336,9 +336,9 @@ modules:
     test_file_count: 6
   - name: ideacloud
     tier: integrated
-    py_files: 25
+    py_files: 26
     importer_count: 1
-    test_file_count: 5
+    test_file_count: 6
   - name: implement
     tier: integrated
     py_files: 7
@@ -402,9 +402,9 @@ modules:
     test_file_count: 15
   - name: missions
     tier: integrated
-    py_files: 9
+    py_files: 10
     importer_count: 1
-    test_file_count: 6
+    test_file_count: 10
   - name: ml
     tier: integrated
     py_files: 8
@@ -569,7 +569,7 @@ modules:
     tier: integrated
     py_files: 8
     importer_count: 10
-    test_file_count: 16
+    test_file_count: 17
   - name: training
     tier: integrated
     py_files: 12
@@ -583,7 +583,7 @@ modules:
   - name: utils
     tier: integrated
     py_files: 21
-    importer_count: 158
+    importer_count: 164
     test_file_count: 25
   - name: verification
     tier: integrated
@@ -604,7 +604,7 @@ modules:
     tier: integrated
     py_files: 100
     importer_count: 36
-    test_file_count: 77
+    test_file_count: 78
   - name: workspace
     tier: integrated
     py_files: 6

--- a/aragora/swarm/initiative_integrator.py
+++ b/aragora/swarm/initiative_integrator.py
@@ -11,11 +11,13 @@ contract and adds:
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import logging
 from pathlib import Path
 from typing import Any
 
+from aragora.governance.gate_snapshot import GateSnapshot, GateSnapshotError
 from aragora.swarm.campaign import (
     CampaignExecutor,
     CampaignManifest,
@@ -101,7 +103,7 @@ def _get_pr_snapshot(
                 "--repo",
                 repo,
                 "--json",
-                "number,url,isDraft,state,headRefName,mergeStateStatus,mergedAt",
+                "number,url,isDraft,state,headRefName,headRefOid,mergeStateStatus,mergedAt",
             ]
         )
     except (RuntimeError, ValueError, TypeError, json.JSONDecodeError):
@@ -127,7 +129,7 @@ def _find_open_pr_for_branch(branch: str, *, repo: str) -> dict[str, Any] | None
                 "--head",
                 normalized,
                 "--json",
-                "number,url,isDraft,state,headRefName,mergeStateStatus,mergedAt",
+                "number,url,isDraft,state,headRefName,headRefOid,mergeStateStatus,mergedAt",
                 "--limit",
                 "10",
             ]
@@ -215,6 +217,29 @@ def _ordered_projects(manifest: CampaignManifest) -> list[CampaignProject]:
         ordered_ids.extend(remaining)
 
     return [project_map[project_id] for project_id in ordered_ids]
+
+
+def _snapshot_from_pr_row(pr_number: int, repo: str, row: dict[str, Any] | None) -> GateSnapshot:
+    """Freeze the head captured alongside this PR's gate read (#9873).
+
+    Raises GateSnapshotError when the row carries no head, which is the refusal
+    the contract requires — the alternative, looking the head up now, would bind
+    the merge to a commit these checks never saw.
+    """
+    data = row or {}
+    return GateSnapshot(
+        pr_number=pr_number,
+        repo=repo,
+        head_sha=str(data.get("pr_head_sha") or data.get("headRefOid") or ""),
+        required_checks_green=True,
+        checks_known=True,
+        state=str(data.get("pr_state") or data.get("state") or "OPEN").upper(),
+        is_draft=bool(data.get("pr_draft") or data.get("isDraft") or False),
+        merge_state_status=(
+            str(data["mergeStateStatus"]) if data.get("mergeStateStatus") else None
+        ),
+        captured_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+    )
 
 
 class InitiativeIntegrator:
@@ -425,7 +450,21 @@ class InitiativeIntegrator:
                     "pr_number": pr_number,
                     "pr_url": row.get("pr_url"),
                 }
-            merged, reason = _merge_pr(pr_number, self.repo)
+            # #9873: the head must come from the gate read, not a fresh lookup at
+            # merge time — that pairing of a stale verdict with a new commit is
+            # exactly the TOCTOU this contract forbids. _merge_pr refuses a
+            # missing head, so a snapshot that cannot be built blocks the merge.
+            try:
+                gate = _snapshot_from_pr_row(pr_number, self.repo, row)
+            except GateSnapshotError as exc:
+                return {
+                    "mode": "initiative-promote",
+                    "initiative_id": manifest.campaign_id,
+                    "action": "merge_blocked",
+                    "pr_number": pr_number,
+                    "reason": f"no captured head for PR #{pr_number}: {exc}",
+                }
+            merged, reason = _merge_pr(gate)
             if not merged:
                 return {
                     "mode": "initiative-promote",
@@ -599,6 +638,10 @@ class InitiativeIntegrator:
             "pr_number": pr_number,
             "pr_draft": bool(snapshot.get("isDraft")) if isinstance(snapshot, dict) else None,
             "pr_state": str((snapshot or {}).get("state") or "").strip() or None,
+            # #9873: the head is carried from the SAME read that produced this
+            # row's verdict. A row without it means no head was captured, and
+            # the merge is refused rather than looked up at merge time.
+            "pr_head_sha": str((snapshot or {}).get("headRefOid") or "").strip() or None,
             "dependencies": [dep.project_id for dep in project.dependencies],
             "dependency_blockers": dependency_blockers,
             "feature_flag": project.feature_flag,

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import json
 import logging
 import subprocess
@@ -21,6 +22,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
+from aragora.governance.gate_snapshot import GateSnapshot, require_snapshot
 from aragora.config.trusted_authors import resolve_trusted_authors
 from aragora.swarm.github_app_auth import gh_subprocess_run
 from aragora.swarm.merge_quorum_io import (
@@ -406,24 +408,48 @@ def _promote_draft(pr_number: int, repo: str) -> bool:
     return result.returncode == 0
 
 
-def _merge_pr(
-    pr_number: int,
-    repo: str,
-    head_sha: str | None = None,
-) -> tuple[bool, str]:
-    """Squash-merge a PR with admin override.  Returns (success, reason)."""
+def _snapshot_from_evaluation(*, pr_number: int, repo: str, head_sha: str | None) -> GateSnapshot:
+    """Freeze the head this evaluation already validated.
+
+    The arbiter reads the head (``gh pr list``) BEFORE it reads checks, so a
+    head that moves in between produces checks for a newer commit while this pin
+    still names the older one — GitHub then refuses the merge. That ordering is
+    what makes reusing the read safe here instead of taking a second one.
+    """
+    return GateSnapshot(
+        pr_number=pr_number,
+        repo=repo,
+        head_sha=str(head_sha or ""),
+        required_checks_green=True,
+        checks_known=True,
+        state="OPEN",
+        is_draft=False,
+        merge_state_status=None,
+        captured_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+    )
+
+
+def _merge_pr(snapshot: GateSnapshot | None) -> tuple[bool, str]:
+    """Squash-merge with admin override, bound to the captured head (#9873).
+
+    Takes the snapshot rather than ``(pr_number, repo, head_sha=None)`` on
+    purpose: an optional naked SHA is what let callers merge unpinned, and it is
+    the parameter a future caller would fill with a freshly-resolved head. There
+    is no such parameter now — ``require_snapshot`` refuses when none was
+    captured, and the pin always comes from the snapshot.
+    """
+    snap = require_snapshot(snapshot)
     args = [
         "pr",
         "merge",
-        str(pr_number),
+        str(snap.pr_number),
         "--repo",
-        repo,
+        snap.repo,
         "--admin",
         "--squash",
         "--delete-branch",
+        *snap.match_head_args(),
     ]
-    if head_sha:
-        args.extend(["--match-head-commit", head_sha])
     result = _run_gh(args, write_op=True)
     if result.returncode != 0:
         reason = result.stderr.strip() or "unknown error"
@@ -536,7 +562,9 @@ def _evaluate_pr(pr: dict, config: MergeArbiterConfig) -> MergeResult:
         logger.info("[dry-run] Would merge PR #%d (%s)", pr_number, branch)
         return MergeResult(pr_number, branch, True, "dry-run: would merge")
 
-    ok, reason = _merge_pr(pr_number, config.repo, head_sha)
+    ok, reason = _merge_pr(
+        _snapshot_from_evaluation(pr_number=pr_number, repo=config.repo, head_sha=head_sha)
+    )
     if ok:
         logger.info("Merged PR #%d (%s)", pr_number, branch)
     else:

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](https://g
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,310 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,312 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,994,907 | `docs/METRICS.md` |
-| Automated tests | 226,025 test functions | `docs/METRICS.md` |
-| Test files | 5,551 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,995,647 | `docs/METRICS.md` |
+| Automated tests | 226,048 test functions | `docs/METRICS.md` |
+| Test files | 5,552 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](https://g
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,312 | `docs/METRICS.md` |
-| Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,995,647 | `docs/METRICS.md` |
-| Automated tests | 226,048 test functions | `docs/METRICS.md` |
-| Test files | 5,552 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,314 | `docs/METRICS.md` |
+| Python modules | 146 top-level package directories | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,995,980 | `docs/METRICS.md` |
+| Automated tests | 226,063 test functions | `docs/METRICS.md` |
+| Test files | 5,553 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,310 tracked Python files | 145 top-level modules | 226,025 test functions across 5,551 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
+**Scale:** 4,312 tracked Python files | 145 top-level modules | 226,048 test functions across 5,552 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,312 tracked Python files | 145 top-level modules | 226,048 test functions across 5,552 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
+**Scale:** 4,314 tracked Python files | 146 top-level modules | 226,063 test functions across 5,553 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,310 Python files | 226,025 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,312 Python files | 226,048 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,312 Python files | 226,048 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,314 Python files | 226,063 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,310
-- **Tests**: 226,025 across 5,551 test files
+- **Python files (`aragora/`)**: 4,312
+- **Tests**: 226,048 across 5,552 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,312
-- **Tests**: 226,048 across 5,552 test files
+- **Python files (`aragora/`)**: 4,314
+- **Tests**: 226,063 across 5,553 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,048 tests across 5,552 test files
-- **Source files**: 4,312 Python files under `aragora/`
+- **Test coverage**: 226,063 tests across 5,553 test files
+- **Source files**: 4,314 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,025 tests across 5,551 test files
-- **Source files**: 4,310 Python files under `aragora/`
+- **Test coverage**: 226,048 tests across 5,552 test files
+- **Source files**: 4,312 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,312 | `docs/METRICS.md` |
-| Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,995,647 | `docs/METRICS.md` |
-| Automated tests | 226,048 test functions | `docs/METRICS.md` |
-| Test files | 5,552 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,314 | `docs/METRICS.md` |
+| Python modules | 146 top-level package directories | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,995,980 | `docs/METRICS.md` |
+| Automated tests | 226,063 test functions | `docs/METRICS.md` |
+| Test files | 5,553 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,310 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,312 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,994,907 | `docs/METRICS.md` |
-| Automated tests | 226,025 test functions | `docs/METRICS.md` |
-| Test files | 5,551 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,995,647 | `docs/METRICS.md` |
+| Automated tests | 226,048 test functions | `docs/METRICS.md` |
+| Test files | 5,552 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,310 tracked Python files | 145 top-level modules | 226,025 test functions across 5,551 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,312 tracked Python files | 145 top-level modules | 226,048 test functions across 5,552 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,312 tracked Python files | 145 top-level modules | 226,048 test functions across 5,552 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,314 tracked Python files | 146 top-level modules | 226,063 test functions across 5,553 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,11 +12,11 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4312` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1995647` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5552` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `226048` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Python files under aragora/ | `4314` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1995980` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `146` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5553` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `226063` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `1032` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2912` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,11 +12,11 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4310` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1994907` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4312` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1995647` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5551` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `226025` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5552` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `226048` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `1032` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2912` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1108` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1113` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `97` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,312
-- **Tests**: 226,048 across 5,552 test files
+- **Python files (`aragora/`)**: 4,314
+- **Tests**: 226,063 across 5,553 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,310
-- **Tests**: 226,025 across 5,551 test files
+- **Python files (`aragora/`)**: 4,312
+- **Tests**: 226,048 across 5,552 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,025 tests across 5,551 test files
-- **Source files**: 4,310 Python files under `aragora/`
+- **Test coverage**: 226,048 tests across 5,552 test files
+- **Source files**: 4,312 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,048 tests across 5,552 test files
-- **Source files**: 4,312 Python files under `aragora/`
+- **Test coverage**: 226,063 tests across 5,553 test files
+- **Source files**: 4,314 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,310 Python files | 226,025 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,312 Python files | 226,048 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,312 Python files | 226,048 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,314 Python files | 226,063 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/tests/governance/test_gate_snapshot.py
+++ b/tests/governance/test_gate_snapshot.py
@@ -1,0 +1,195 @@
+"""#9873: a merge may only land the head whose checks authorized it.
+
+The race tests are the point of this file. Everything else guards the shape that
+makes the race safe; these prove the behaviour under an actual head change
+between classification and merge.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from aragora.governance.gate_snapshot import (
+    GateSnapshot,
+    GateSnapshotError,
+    MergeRefused,
+    capture_gate_snapshot,
+    merge_with_snapshot,
+    require_snapshot,
+)
+
+HEAD_A = "a" * 40
+HEAD_B = "b" * 40
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _view_payload(head: str, *, green: bool = True, state: str = "OPEN", draft: bool = False):
+    conclusion = "SUCCESS" if green else "FAILURE"
+    return json.dumps(
+        {
+            "number": 42,
+            "headRefOid": head,
+            "state": state,
+            "isDraft": draft,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [{"status": "COMPLETED", "conclusion": conclusion}],
+        }
+    )
+
+
+class _Recorder:
+    """Runner that serves scripted responses and records every argv."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, *, timeout=30.0):
+        self.calls.append(list(args))
+        return self._responses.pop(0) if self._responses else _proc()
+
+
+# --------------------------------------------------------------------------
+# The invariant: no snapshot, no merge — enforced by construction
+# --------------------------------------------------------------------------
+
+
+def test_a_snapshot_cannot_exist_without_a_full_head() -> None:
+    """'Refuse when the head is missing' is structural, not a forgettable check."""
+    for bad in ["", None, "abc123", HEAD_A[:12], "z" * 40]:
+        with pytest.raises(GateSnapshotError):
+            GateSnapshot(42, "o/r", bad, True, True, "OPEN", False, None, "t")  # type: ignore[arg-type]
+
+
+def test_capture_refuses_when_github_omits_the_head() -> None:
+    payload = json.dumps({"number": 42, "state": "OPEN", "statusCheckRollup": []})
+    with pytest.raises(GateSnapshotError):
+        capture_gate_snapshot(42, "o/r", runner=_Recorder([_proc(stdout=payload)]))
+
+
+def test_capture_failure_is_not_mistaken_for_a_missing_head() -> None:
+    """A failed read must raise, never yield a snapshot-shaped 'no'."""
+    with pytest.raises(GateSnapshotError) as exc:
+        capture_gate_snapshot(42, "o/r", runner=_Recorder([_proc(returncode=1, stderr="boom")]))
+    assert "boom" in str(exc.value)
+
+
+def test_merge_without_a_snapshot_is_refused() -> None:
+    with pytest.raises(MergeRefused):
+        merge_with_snapshot(None)
+    with pytest.raises(MergeRefused):
+        require_snapshot(None, pr_number=42)
+
+
+def test_snapshot_is_immutable() -> None:
+    """Frozen is what stops a caller 'refreshing' the head after classification."""
+    snap = GateSnapshot(42, "o/r", HEAD_A, True, True, "OPEN", False, None, "t")
+    with pytest.raises(Exception):
+        snap.head_sha = HEAD_B  # type: ignore[misc]
+
+
+def test_head_and_verdict_come_from_one_read() -> None:
+    """Two reads would reintroduce the split this type exists to prevent."""
+    rec = _Recorder([_proc(stdout=_view_payload(HEAD_A))])
+    snap = capture_gate_snapshot(42, "o/r", runner=rec)
+    assert len(rec.calls) == 1, f"expected exactly one gh read, got {rec.calls}"
+    assert snap.head_sha == HEAD_A and snap.required_checks_green
+
+
+def test_unknown_checks_are_not_a_pass() -> None:
+    """An empty rollup means 'we do not know', which must not authorize a merge."""
+    payload = json.dumps(
+        {"number": 42, "headRefOid": HEAD_A, "state": "OPEN", "statusCheckRollup": []}
+    )
+    snap = capture_gate_snapshot(42, "o/r", runner=_Recorder([_proc(stdout=payload)]))
+    assert not snap.checks_known and not snap.mergeable_now
+
+
+# --------------------------------------------------------------------------
+# The race: head changes between classification and merge
+# --------------------------------------------------------------------------
+
+
+def test_race_merge_pins_the_captured_head_not_the_live_one() -> None:
+    """Capture at A, PR force-pushes to B, merge must still carry A.
+
+    This is the TOCTOU that nine rounds of #9677 failed to close by passing a
+    SHA around: any code path that re-reads the head here would send B and merge
+    unchecked content.
+    """
+    rec = _Recorder([_proc(stdout=_view_payload(HEAD_A)), _proc(returncode=0, stdout="merged")])
+    snap = capture_gate_snapshot(42, "o/r", runner=rec)
+
+    # ... the world moves on: the PR is force-pushed to HEAD_B ...
+
+    merge_with_snapshot(snap, runner=rec)
+    merge_argv = rec.calls[-1]
+    assert "--match-head-commit" in merge_argv
+    pinned = merge_argv[merge_argv.index("--match-head-commit") + 1]
+    assert pinned == HEAD_A, f"merge pinned {pinned}, must pin the captured head {HEAD_A}"
+    assert HEAD_B not in merge_argv
+
+
+def test_race_github_rejection_is_surfaced_as_refusal_not_retried() -> None:
+    """When the head moved, GitHub rejects the pin — we must report, not retry."""
+    rec = _Recorder(
+        [
+            _proc(stdout=_view_payload(HEAD_A)),
+            _proc(returncode=1, stderr="Head branch was modified. Review and try again."),
+        ]
+    )
+    snap = capture_gate_snapshot(42, "o/r", runner=rec)
+    outcome = merge_with_snapshot(snap, runner=rec)
+
+    assert outcome.merged is False
+    assert outcome.action == "refused"
+    assert "Head branch was modified" in outcome.detail
+    assert outcome.head_sha == HEAD_A
+    # Exactly one capture and one merge — no re-read, no second attempt.
+    assert len(rec.calls) == 2, f"a retry or re-resolve happened: {rec.calls}"
+
+
+def test_race_a_stale_verdict_cannot_be_paired_with_a_fresh_head() -> None:
+    """The reverted #9677 bug, encoded: classification then a *new* head lookup.
+
+    Building a second snapshot is the only way to obtain HEAD_B, and doing so
+    re-reads the checks too — so a fresh head always arrives with a fresh
+    verdict. There is no API that yields B's head with A's verdict.
+    """
+    rec = _Recorder([_proc(stdout=_view_payload(HEAD_A, green=True))])
+    first = capture_gate_snapshot(42, "o/r", runner=rec)
+
+    rec2 = _Recorder([_proc(stdout=_view_payload(HEAD_B, green=False))])
+    second = capture_gate_snapshot(42, "o/r", runner=rec2)
+
+    assert first.head_sha == HEAD_A and first.required_checks_green
+    assert second.head_sha == HEAD_B and not second.required_checks_green
+    # The failing new head cannot borrow the old head's pass.
+    assert not second.mergeable_now
+    assert merge_with_snapshot(second, runner=_Recorder([])).action == "blocked"
+
+
+def test_merge_argv_carries_exactly_one_head_pin() -> None:
+    rec = _Recorder([_proc(stdout=_view_payload(HEAD_A)), _proc()])
+    snap = capture_gate_snapshot(42, "o/r", runner=rec)
+    merge_with_snapshot(snap, admin=True, delete_branch=True, runner=rec)
+    argv = rec.calls[-1]
+    assert argv.count("--match-head-commit") == 1
+    assert argv[-2:] == ["--match-head-commit", HEAD_A]
+
+
+def test_a_non_open_or_draft_pr_is_not_mergeable() -> None:
+    for payload in (
+        _view_payload(HEAD_A, state="CLOSED"),
+        _view_payload(HEAD_A, draft=True),
+        _view_payload(HEAD_A, green=False),
+    ):
+        snap = capture_gate_snapshot(42, "o/r", runner=_Recorder([_proc(stdout=payload)]))
+        assert not snap.mergeable_now
+        assert merge_with_snapshot(snap, runner=_Recorder([])).action == "blocked"

--- a/tests/swarm/test_initiative_integrator.py
+++ b/tests/swarm/test_initiative_integrator.py
@@ -181,6 +181,7 @@ class TestInitiativeIntegrator:
                 "isDraft": False,
                 "state": "OPEN",
                 "headRefName": "codex/initiative-published",
+                "headRefOid": "48cf9ca973ea4aeeaf073f35dbfde1b71693c0c2",
                 "mergeStateStatus": "CLEAN",
                 "mergedAt": None,
             },
@@ -212,6 +213,7 @@ class TestInitiativeIntegrator:
                 "isDraft": False,
                 "state": "MERGED",
                 "headRefName": "codex/merged-slice",
+                "headRefOid": "40b3b43a374e3af7c35e55d4cae7a0c0cc8d5d3c",
                 "mergeStateStatus": "MERGED",
                 "mergedAt": "2026-04-07T00:00:00+00:00",
             },
@@ -255,6 +257,7 @@ class TestInitiativeIntegrator:
                     "isDraft": False,
                     "state": "OPEN",
                     "headRefName": "codex/parent",
+                    "headRefOid": "e0d5d7b611a97fc2badc963db0c0a09ecb3b70f5",
                     "mergeStateStatus": "CLEAN",
                     "mergedAt": None,
                 }
@@ -264,6 +267,7 @@ class TestInitiativeIntegrator:
                 "isDraft": False,
                 "state": "OPEN",
                 "headRefName": "codex/child",
+                "headRefOid": "ce2f9a13f1b6f24a8c04ec95f21e918a6f70e6fd",
                 "mergeStateStatus": "CLEAN",
                 "mergedAt": None,
             }
@@ -282,7 +286,14 @@ class TestInitiativeIntegrator:
 
         assert payload["action"] == "merged"
         assert payload["project_id"] == "proj-001"
-        merge_pr.assert_called_once_with(2001, integrator.repo)
+        # #9873: the merge takes the frozen snapshot, and its head must be the one
+        # captured in the same read that produced this row's verdict — never a
+        # SHA resolved at merge time.
+        merge_pr.assert_called_once()
+        (gate,) = merge_pr.call_args[0]
+        assert gate.pr_number == 2001
+        assert gate.repo == integrator.repo
+        assert gate.head_sha == "e0d5d7b611a97fc2badc963db0c0a09ecb3b70f5"
 
     def test_promote_promotes_draft_slice_when_dependency_clear(self, tmp_path: Path) -> None:
         manifest_path = _manifest_path(
@@ -306,6 +317,7 @@ class TestInitiativeIntegrator:
                     "isDraft": True,
                     "state": "OPEN",
                     "headRefName": "codex/draft-slice",
+                    "headRefOid": "3885c1927e5e6fe1b5209b2bdb1e61af0f9519fe",
                     "mergeStateStatus": "CLEAN",
                     "mergedAt": None,
                 },
@@ -347,6 +359,7 @@ class TestInitiativeIntegrator:
                     "isDraft": False,
                     "state": "OPEN",
                     "headRefName": "codex/flagged-slice",
+                    "headRefOid": "9d3fa0d17cd3747bb7497c6b8494359f0d266398",
                     "mergeStateStatus": "CLEAN",
                     "mergedAt": None,
                 },
@@ -480,3 +493,17 @@ class TestInitiativeCli:
         assert integrator_cls.return_value.promote.call_args.kwargs["project_id"] == "proj-001"
         parsed = json.loads(capsys.readouterr().out)
         assert parsed["project_id"] == "proj-001"
+
+
+def test_promote_refuses_to_merge_when_the_read_captured_no_head(tmp_path: Path) -> None:
+    """#9873: a PR row without headRefOid means no head was captured — refuse.
+
+    This is the case that used to resolve a fresh head at merge time and merge
+    content the checks never saw.
+    """
+    from aragora.governance.gate_snapshot import GateSnapshotError
+    from aragora.swarm.initiative_integrator import _snapshot_from_pr_row
+
+    for row in ({}, {"pr_head_sha": None}, {"pr_head_sha": ""}, {"pr_head_sha": "deadbeef"}):
+        with pytest.raises(GateSnapshotError):
+            _snapshot_from_pr_row(2001, "synaptent/aragora", row)

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aragora.swarm.merge_arbiter import (
+    _snapshot_from_evaluation,
     AUTOMATION_REVIEWER_LOGINS,
     REQUIRED_CHECKS,
     ArbiterOperationalError,
@@ -240,9 +241,11 @@ class TestMergePr:
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result()
             success, reason = _merge_pr(
-                12,
-                "owner/repo",
-                "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                _snapshot_from_evaluation(
+                    pr_number=12,
+                    repo="owner/repo",
+                    head_sha="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                )
             )
         assert success is True
         assert reason == "merged"
@@ -290,7 +293,14 @@ class TestEvaluatePrAllPassing:
             result = _evaluate_pr(pr, config)
         assert result.success is True
         assert result.pr_number == 42
-        mock_merge.assert_called_once_with(42, config.repo, pr["headRefOid"])
+        # #9873: the merge receives the frozen snapshot, and its head must be the
+        # one this evaluation validated — not a SHA re-read at merge time.
+        mock_merge.assert_called_once()
+        (snapshot,) = mock_merge.call_args[0]
+        assert snapshot.pr_number == 42
+        assert snapshot.repo == config.repo
+        assert snapshot.head_sha == pr["headRefOid"]
+        assert snapshot.match_head_args() == ["--match-head-commit", pr["headRefOid"]]
 
 
 # ---------------------------------------------------------------------------
@@ -853,3 +863,23 @@ class TestAutoCollectIntegration:
             summary = await arb.run()  # must not raise
         assert calls["n"] == 1  # attempted once; head recorded so no retry storm
         assert summary.polls >= 1
+
+
+class TestMergeRefusesWithoutACapturedHead:
+    """#9873: _merge_pr takes a snapshot, so an unbound merge has no way to happen."""
+
+    def test_merge_without_a_snapshot_is_refused(self) -> None:
+        from aragora.governance.gate_snapshot import MergeRefused
+
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            with pytest.raises(MergeRefused):
+                _merge_pr(None)
+        mock_gh.assert_not_called()
+
+    def test_a_snapshot_cannot_be_built_without_a_full_head(self) -> None:
+        """The old signature allowed head_sha=None; now there is no such state."""
+        from aragora.governance.gate_snapshot import GateSnapshotError
+
+        for bad in ("", None, "deadbeef"):
+            with pytest.raises(GateSnapshotError):
+                _snapshot_from_evaluation(pr_number=12, repo="owner/repo", head_sha=bad)


### PR DESCRIPTION
Implements #9873 from current main. Fresh branch — this shares no history with #9677, which stays frozen as design evidence.

## The rule

> A merge may only land the exact head whose required checks produced the verdict authorizing it.

## Why a new type rather than more parameter-passing

#9677 spent nine review rounds trying to satisfy this by moving a SHA around. Three approaches, all failing the same way:

| attempt | outcome |
|---|---|
| pass `""`, call it strict | an armed halt becomes **unwaivable** — safe, but breaks incident response |
| thread `head_sha` per call site | fixes one caller; leaves the rest, and every future caller, unbound |
| resolve the head inside the merge fn | pairs a **stale verdict with a fresh commit** — the exact TOCTOU |

The third was attempted twice and reverted twice, once by the terminal-hardening lane and once by me. The lesson those rounds bought: **this is an ordering property, not a plumbing property.** No care in parameter passing fixes a head read after classification.

So the head stops being a parameter.

## What this does

`GateSnapshot` captures the head and the check rollup in **one** `gh` read, frozen. Two properties then hold structurally rather than by convention:

- **A snapshot cannot exist without a full 40-hex head** — `__post_init__` raises. "Refuse when the head is missing" is not a check a caller can forget; there is no valid object to merge with.
- **A snapshot cannot be refreshed** — frozen, no setter, no refresh API. The mistake that was made twice has nowhere to live.

`merge_with_snapshot()` takes the snapshot, never a bare SHA, and always pins `--match-head-commit` to the captured head. The capture→merge race is not prevented locally — it cannot be — it is made **safe**: GitHub rejects the stale pin, and that refusal is returned rather than retried or re-resolved.

Also: an empty check rollup is **unknown**, not green. Absence of failure is not evidence of success — the same fail-open shape as #9084.

## Paths wired

**`merge_arbiter._merge_pr(pr_number, repo, head_sha=None)` → `_merge_pr(snapshot)`.** The old signature is what permitted an unpinned merge. This path reads the head (`gh pr list`) *before* checks, so a head moving in between produces checks for a newer commit while the pin names the older one and GitHub refuses — that ordering is why reusing the existing read is sound rather than taking a second.

**`initiative_integrator`** was the genuinely broken one: its gate read omitted `headRefOid` entirely, which is why the reverted attempt resolved a head at merge time. `headRefOid` now returns in the **same** read as the verdict and is carried through the slice row. A row without one raises rather than merging.

## Verification — proven by breaking

| removed | result |
|---|---|
| the `--match-head-commit` pin | 2 race tests red |
| `frozen=True` on the snapshot | immutability test red |
| the full-SHA check | 2 construction tests red |
| `headRefOid` from the integrator's read | integrator test red |
| the snapshot argument entirely | `MergeRefused`, `gh` never invoked |

The race tests do what #9873 asks: capture at head A, move to head B, and prove the merge still carries A and that GitHub's rejection surfaces as a refusal with no re-read and no retry.

Test doubles were updated to the real interface — both suites now assert the head that **arrives** at the merge, rather than tolerating a two-arg call that could carry none.

1045 tests green; ruff and mypy clean; drift generators run before push.

## Deliberately not in this PR

#9873 findings 3 and 4 — `scripts/boss_drain_pass.py:243` and `aragora/ralph/supervisor.py:1365`. Both are real. They are left for a follow-up against this primitive rather than grown into this PR, which is the specific failure mode that cost #9677 nine rounds. They remain tracked on #9873.

The halt-bypass work from #9677 will be salvaged into a separate replacement PR after this lands, per operator direction.

## Tier

**Tier 4** — merge-authority behaviour. Requires exact-head human risk settlement. **Not for auto-merge.**

Refs #9873, #9216
