### PR TITLE
data(eval): add software decision corpus tranche

### DIFF
--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -26,6 +26,12 @@ two delayed missions that did not. Model-visible evidence is limited to
 official pre-cutoff NASA or NOAA material; the measured outcomes remain in the
 hash-bound sidecar.
 
+`software-engineering-holdout-1` contributes the two software-engineering
+holdout cases. One roadmap commitment was fulfilled and one announced language
+semantic change did not ship on schedule. Both cases use immutable upstream
+release or source-history evidence, and their outcomes remain in the separate
+hash-bound sidecar.
+
 Current canonical digests:
 
 - corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
@@ -46,13 +52,19 @@ Science/forecasting tranche:
 - corpus: `3f5ea13fac70579c8422b08f820a96a3ebd266e7cd2db174d381a24f47bc491e`
 - outcome sidecar: `f86c8ee9b8ee6694595ebdc11a758569262a20176771bf7f9d7067cdf323e090`
 
+Software-engineering holdout tranche:
+
+- corpus: `4d13fea53e1313c2db332bb932ab57abac5170a9779eba779cef4c3c712af2c6`
+- outcome sidecar: `bae34db3f7928ade185e2975849e609139c59d7c64b496909a6b4137c3d957d4`
+
 The tranche passes the decision-quality corpus validator with
 `--allow-partial`. That flag skips only the final 24-case balance requirement.
 It does not relax source cutoffs, outcome separation, digest binding, or
 per-case semantics.
 
-Together the four tranches provide sixteen of the planned 24 cases: four
-development cases in each required domain.
+Together the five tranches provide eighteen of the planned 24 cases: four
+development cases in each required domain and both software-engineering
+holdouts.
 
 Do not run model inference from a tranche. Counted inference begins only after
 all 24 cases, the scoring contract, prompts, roster, and both corpus digests are

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -8,15 +8,29 @@ cases required by the planned 24-case corpus. Every evidence URL is pinned to
 an immutable Git commit or release tag, and the outcome answer key remains in a
 separate hash-bound sidecar.
 
+`business-operations-1` contributes four business/operations development
+cases. Its acquisition scenarios deliberately balance two completed and two
+terminated transactions. Pre-cutoff packets combine the signed transaction
+with a public litigation or regulator signal; outcomes remain in the separate
+hash-bound sidecar.
+
 Current canonical digests:
 
 - corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
 - outcome sidecar: `dbce998d194fa3bb9fef6167902bc27a1445ab38e0d4d21378360503d8a97bb6`
 
+Business/operations tranche:
+
+- corpus: `734f515a6cff55e88faa8de2d4ff5bf32e42385bbe8ee109b68eb6df54ef8661`
+- outcome sidecar: `896a4e7f6b49c6cc7f0474e75a8b835619ef462fe142a53cd957e6e4d4ec9277`
+
 The tranche passes the decision-quality corpus validator with
 `--allow-partial`. That flag skips only the final 24-case balance requirement.
 It does not relax source cutoffs, outcome separation, digest binding, or
 per-case semantics.
+
+Together the two tranches provide eight of the planned 24 cases: eight
+development cases, four each in software engineering and business/operations.
 
 Do not run model inference from a tranche. Counted inference begins only after
 all 24 cases, the scoring contract, prompts, roster, and both corpus digests are

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -37,6 +37,11 @@ holdout cases. One regulatory return-to-service milestone was met and one
 aircraft delivery milestone was formally delayed. Both cases use immutable SEC
 filings, with the outcome answer key kept in the separate hash-bound sidecar.
 
+`policy-compliance-holdout-1` contributes the two policy/compliance holdout
+cases. One final rule was published within the stated readiness horizon and one
+was published just after it. Both cases use immutable GovInfo Federal Register
+documents, with the outcome answer key kept in the separate hash-bound sidecar.
+
 Current canonical digests:
 
 - corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
@@ -67,14 +72,19 @@ Business/operations holdout tranche:
 - corpus: `26473525c2ab4fbd7298d307292b42859540532aa62e24be08bf934208cd9b1d`
 - outcome sidecar: `e0e44873391ddd2836bc6f4158ed5a82f1c4b1900d132e228ca918eef2657a47`
 
+Policy/compliance holdout tranche:
+
+- corpus: `e52440953ce0c4b84f9f8ee5da69b278f4814af75971fe91c36279c555a4e5b6`
+- outcome sidecar: `fd3be3aea70c7008e27f9ae96b386726e6fa57c743a7bf4572b5cb41d656de8c`
+
 Each tranche passes the decision-quality corpus validator with
 `--allow-partial`. That flag skips only the final 24-case balance requirement.
 It does not relax source cutoffs, outcome separation, digest binding, or
 per-case semantics.
 
-Together the six tranches provide twenty of the planned 24 cases: four
-development cases in each required domain, both software-engineering holdouts,
-and both business/operations holdouts.
+Together the seven tranches provide twenty-two of the planned 24 cases: four
+development cases in each required domain, plus both holdouts in software
+engineering, business/operations, and policy/compliance.
 
 Do not run model inference from a tranche. Counted inference begins only after
 all 24 cases, the scoring contract, prompts, roster, and both corpus digests are

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -32,6 +32,11 @@ semantic change did not ship on schedule. Both cases use immutable upstream
 release or source-history evidence, and their outcomes remain in the separate
 hash-bound sidecar.
 
+`business-operations-holdout-1` contributes the two business/operations
+holdout cases. One regulatory return-to-service milestone was met and one
+aircraft delivery milestone was formally delayed. Both cases use immutable SEC
+filings, with the outcome answer key kept in the separate hash-bound sidecar.
+
 Current canonical digests:
 
 - corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
@@ -57,14 +62,19 @@ Software-engineering holdout tranche:
 - corpus: `4d13fea53e1313c2db332bb932ab57abac5170a9779eba779cef4c3c712af2c6`
 - outcome sidecar: `bae34db3f7928ade185e2975849e609139c59d7c64b496909a6b4137c3d957d4`
 
-The tranche passes the decision-quality corpus validator with
+Business/operations holdout tranche:
+
+- corpus: `26473525c2ab4fbd7298d307292b42859540532aa62e24be08bf934208cd9b1d`
+- outcome sidecar: `e0e44873391ddd2836bc6f4158ed5a82f1c4b1900d132e228ca918eef2657a47`
+
+Each tranche passes the decision-quality corpus validator with
 `--allow-partial`. That flag skips only the final 24-case balance requirement.
 It does not relax source cutoffs, outcome separation, digest binding, or
 per-case semantics.
 
-Together the five tranches provide eighteen of the planned 24 cases: four
-development cases in each required domain and both software-engineering
-holdouts.
+Together the six tranches provide twenty of the planned 24 cases: four
+development cases in each required domain, both software-engineering holdouts,
+and both business/operations holdouts.
 
 Do not run model inference from a tranche. Counted inference begins only after
 all 24 cases, the scoring contract, prompts, roster, and both corpus digests are

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -48,50 +48,63 @@ and one first-flight launch moved beyond its operating horizon. Both cases use
 official NASA publications, with the outcome answer key kept in the separate
 hash-bound sidecar.
 
-Current canonical digests:
+The forecast target is outcome-aligned in exactly 12 of the 24 cases. Each
+domain contributes three aligned and three non-aligned targets, split as two
+of four development cases and one of two holdout cases. Every question uses
+the same neutral forecast template, and each case's options are ordered
+lexicographically by `option_id` so wording polarity and option position do
+not disclose the answer key.
 
-- corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
-- outcome sidecar: `dbce998d194fa3bb9fef6167902bc27a1445ab38e0d4d21378360503d8a97bb6`
+Digests below are SHA-256 values over canonical JSON serialized with sorted
+keys, compact separators, and UTF-8 output (`ensure_ascii=False`). They are
+not hashes of the formatted file bytes.
+
+Software-engineering development tranche:
+
+- corpus: `e9ec5a9a62b6d2d9a6cd9664989d3be6e45b7cc7cbfe0d57919a4238e0770b27`
+- outcome sidecar: `cb3f1c0b7762b144142044a510f8c0cb489a15699ce6a7c6e262e2f35b17938d`
 
 Business/operations tranche:
 
-- corpus: `734f515a6cff55e88faa8de2d4ff5bf32e42385bbe8ee109b68eb6df54ef8661`
-- outcome sidecar: `896a4e7f6b49c6cc7f0474e75a8b835619ef462fe142a53cd957e6e4d4ec9277`
+- corpus: `ac9676ff9715b724a436ac3f697e3599aba8416e061fe009088eea4360ad8bba`
+- outcome sidecar: `ce281b2caab29f79b07d7784c3d19a08243ad914e1e384226dd17ff63f1452d4`
 
 Policy/compliance tranche:
 
-- corpus: `4247cf544b5c12f939517b2267f915559df85b059a164c457a40af74ffd88ea3`
-- outcome sidecar: `0972e27803a6b4b73ed15f553ba8847692c319ee2b882e7b50c84dcf5daea52e`
+- corpus: `17bce195c719c30c128b0ce86e906754c076e2c03da4a10f6421d9e80f57943b`
+- outcome sidecar: `171cb032ca3047305ecb2086ad0913417d5a95fcfaec8dc228ba1b4f1dcf197b`
 
 Science/forecasting tranche:
 
-- corpus: `3f5ea13fac70579c8422b08f820a96a3ebd266e7cd2db174d381a24f47bc491e`
-- outcome sidecar: `f86c8ee9b8ee6694595ebdc11a758569262a20176771bf7f9d7067cdf323e090`
+- corpus: `2fc5525c8b7a23c5f57faed12967cb170be1e83c6afcba58ac45b43cefa18445`
+- outcome sidecar: `061f6dc846889b01a22e3562b998d6b2b43f3bcf24efbe048f33b2089286de38`
 
 Software-engineering holdout tranche:
 
-- corpus: `4d13fea53e1313c2db332bb932ab57abac5170a9779eba779cef4c3c712af2c6`
-- outcome sidecar: `bae34db3f7928ade185e2975849e609139c59d7c64b496909a6b4137c3d957d4`
+- corpus: `97da356b5d70618c332e5fc52a0510996e28c6723aa00111206e663dc581295e`
+- outcome sidecar: `1db3bd542e913b09c820af98a9ce4237f7dbfe8bbfed53d77f35fcf7f0bce292`
 
 Business/operations holdout tranche:
 
-- corpus: `26473525c2ab4fbd7298d307292b42859540532aa62e24be08bf934208cd9b1d`
-- outcome sidecar: `e0e44873391ddd2836bc6f4158ed5a82f1c4b1900d132e228ca918eef2657a47`
+- corpus: `2036afb2a909e1ffd16d5764fefd1fbccbeb298dd29924222d6034ec30d7e855`
+- outcome sidecar: `05a6640cbee4878d0726d8dbbe92f6e9ebcb97a7eae7b0a03939cea2829358ff`
 
 Policy/compliance holdout tranche:
 
-- corpus: `e52440953ce0c4b84f9f8ee5da69b278f4814af75971fe91c36279c555a4e5b6`
-- outcome sidecar: `fd3be3aea70c7008e27f9ae96b386726e6fa57c743a7bf4572b5cb41d656de8c`
+- corpus: `318c209ccfc5d24b82f6083f284334fb89f752a9dfc6a8ab0ee68d6f5a5dbd4d`
+- outcome sidecar: `247848041189c398c20a57547901aafff6d30d51fd98206e5e5a5e0c4689e8a1`
 
 Science/forecasting holdout tranche:
 
-- corpus: `086c8edba8caae1da3c1478d7910c393bcd131f881ca2f93935cd5ac4d90808c`
-- outcome sidecar: `70c8f4f97affcb26c2b98f646f14f47b13149334e55297942bbb95fe7981c63b`
+- corpus: `503a5cc94a26fcd38f8c0bb264413ac82b2ae7a3489da8d22e6d646254702ed6`
+- outcome sidecar: `9d93b2f085b1c8586f67ee73538219bc1a98888ef0d4b3d11f196b9976b4e7d4`
 
-Each tranche passes the decision-quality corpus validator with
-`--allow-partial`. That flag skips only the final 24-case balance requirement.
-It does not relax source cutoffs, outcome separation, digest binding, or
-per-case semantics.
+These tranches are construction inputs, not frozen benchmark artifacts. This
+PR checks JSON structure, corpus/outcome case and option bindings, information
+cutoffs, source hashes, answer-key balance, and canonical digests. The
+automated decision-quality validator is not yet available on `origin/main`.
+Counted inference remains prohibited until a merged freeze contract and
+validator reproduce these checks across the assembled 24-case corpus.
 
 Together the eight tranches provide all 24 planned cases: four development and
 two holdout cases in each required domain.

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -42,6 +42,12 @@ cases. One final rule was published within the stated readiness horizon and one
 was published just after it. Both cases use immutable GovInfo Federal Register
 documents, with the outcome answer key kept in the separate hash-bound sidecar.
 
+`science-forecasting-holdout-1` contributes the two science/forecasting holdout
+cases. One sample-return milestone was completed within its recovery horizon
+and one first-flight launch moved beyond its operating horizon. Both cases use
+official NASA publications, with the outcome answer key kept in the separate
+hash-bound sidecar.
+
 Current canonical digests:
 
 - corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
@@ -77,14 +83,18 @@ Policy/compliance holdout tranche:
 - corpus: `e52440953ce0c4b84f9f8ee5da69b278f4814af75971fe91c36279c555a4e5b6`
 - outcome sidecar: `fd3be3aea70c7008e27f9ae96b386726e6fa57c743a7bf4572b5cb41d656de8c`
 
+Science/forecasting holdout tranche:
+
+- corpus: `086c8edba8caae1da3c1478d7910c393bcd131f881ca2f93935cd5ac4d90808c`
+- outcome sidecar: `70c8f4f97affcb26c2b98f646f14f47b13149334e55297942bbb95fe7981c63b`
+
 Each tranche passes the decision-quality corpus validator with
 `--allow-partial`. That flag skips only the final 24-case balance requirement.
 It does not relax source cutoffs, outcome separation, digest binding, or
 per-case semantics.
 
-Together the seven tranches provide twenty-two of the planned 24 cases: four
-development cases in each required domain, plus both holdouts in software
-engineering, business/operations, and policy/compliance.
+Together the eight tranches provide all 24 planned cases: four development and
+two holdout cases in each required domain.
 
 Do not run model inference from a tranche. Counted inference begins only after
 all 24 cases, the scoring contract, prompts, roster, and both corpus digests are

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -1,0 +1,23 @@
+# Decision Quality Corpus Tranches
+
+These files are construction inputs for the outcome-backed decision-quality
+benchmark. They are not independently eligible for a counted benchmark run.
+
+`software-development-1` contributes the four software-engineering development
+cases required by the planned 24-case corpus. Every evidence URL is pinned to
+an immutable Git commit or release tag, and the outcome answer key remains in a
+separate hash-bound sidecar.
+
+Current canonical digests:
+
+- corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
+- outcome sidecar: `dbce998d194fa3bb9fef6167902bc27a1445ab38e0d4d21378360503d8a97bb6`
+
+The tranche passes the decision-quality corpus validator with
+`--allow-partial`. That flag skips only the final 24-case balance requirement.
+It does not relax source cutoffs, outcome separation, digest binding, or
+per-case semantics.
+
+Do not run model inference from a tranche. Counted inference begins only after
+all 24 cases, the scoring contract, prompts, roster, and both corpus digests are
+merged and frozen together.

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -14,6 +14,12 @@ terminated transactions. Pre-cutoff packets combine the signed transaction
 with a public litigation or regulator signal; outcomes remain in the separate
 hash-bound sidecar.
 
+`policy-compliance-1` contributes four nonpartisan policy/compliance
+development cases. The tranche balances two rules published within the stated
+horizon and two standards or rules published after the stated horizon. All
+model-visible evidence is an official pre-cutoff publication; later outcome
+evidence remains in the hash-bound sidecar.
+
 Current canonical digests:
 
 - corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
@@ -24,13 +30,19 @@ Business/operations tranche:
 - corpus: `734f515a6cff55e88faa8de2d4ff5bf32e42385bbe8ee109b68eb6df54ef8661`
 - outcome sidecar: `896a4e7f6b49c6cc7f0474e75a8b835619ef462fe142a53cd957e6e4d4ec9277`
 
+Policy/compliance tranche:
+
+- corpus: `4247cf544b5c12f939517b2267f915559df85b059a164c457a40af74ffd88ea3`
+- outcome sidecar: `0972e27803a6b4b73ed15f553ba8847692c319ee2b882e7b50c84dcf5daea52e`
+
 The tranche passes the decision-quality corpus validator with
 `--allow-partial`. That flag skips only the final 24-case balance requirement.
 It does not relax source cutoffs, outcome separation, digest binding, or
 per-case semantics.
 
-Together the two tranches provide eight of the planned 24 cases: eight
-development cases, four each in software engineering and business/operations.
+Together the three tranches provide twelve of the planned 24 cases: twelve
+development cases, four each in software engineering, business/operations,
+and policy/compliance.
 
 Do not run model inference from a tranche. Counted inference begins only after
 all 24 cases, the scoring contract, prompts, roster, and both corpus digests are

--- a/docs/benchmarks/decision_quality/tranches/README.md
+++ b/docs/benchmarks/decision_quality/tranches/README.md
@@ -20,6 +20,12 @@ horizon and two standards or rules published after the stated horizon. All
 model-visible evidence is an official pre-cutoff publication; later outcome
 evidence remains in the hash-bound sidecar.
 
+`science-forecasting-1` contributes four science/forecasting development
+cases. It balances two observed outcomes that met the forecast threshold and
+two delayed missions that did not. Model-visible evidence is limited to
+official pre-cutoff NASA or NOAA material; the measured outcomes remain in the
+hash-bound sidecar.
+
 Current canonical digests:
 
 - corpus: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
@@ -35,14 +41,18 @@ Policy/compliance tranche:
 - corpus: `4247cf544b5c12f939517b2267f915559df85b059a164c457a40af74ffd88ea3`
 - outcome sidecar: `0972e27803a6b4b73ed15f553ba8847692c319ee2b882e7b50c84dcf5daea52e`
 
+Science/forecasting tranche:
+
+- corpus: `3f5ea13fac70579c8422b08f820a96a3ebd266e7cd2db174d381a24f47bc491e`
+- outcome sidecar: `f86c8ee9b8ee6694595ebdc11a758569262a20176771bf7f9d7067cdf323e090`
+
 The tranche passes the decision-quality corpus validator with
 `--allow-partial`. That flag skips only the final 24-case balance requirement.
 It does not relax source cutoffs, outcome separation, digest binding, or
 per-case semantics.
 
-Together the three tranches provide twelve of the planned 24 cases: twelve
-development cases, four each in software engineering, business/operations,
-and policy/compliance.
+Together the four tranches provide sixteen of the planned 24 cases: four
+development cases in each required domain.
 
 Do not run model inference from a tranche. Counted inference begins only after
 all 24 cases, the scoring contract, prompts, roster, and both corpus digests are

--- a/docs/benchmarks/decision_quality/tranches/business-operations-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-business-operations-tranche-1",
-  "frozen_at": "2026-08-30T02:03:00Z",
+  "revision": "draft-business-operations-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "biz-dev-twitter-merger-close",
@@ -10,18 +10,18 @@
       "split": "development",
       "title": "Twitter acquisition transition staffing after termination notice",
       "decision_prompt": "A business-operations lead supporting the announced Twitter acquisition must choose a primary staffing plan after the buyer purports to terminate and Twitter seeks specific performance. Choose the action that best fits whether the acquisition will still close by 2022-10-28.",
-      "forecast_question": "Will the Twitter acquisition close by 2022-10-28 despite the buyer's termination notice? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain close readiness\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_close_readiness",
       "options": [
-        {
-          "option_id": "retain_close_readiness",
-          "label": "Retain close readiness",
-          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2022-10-28."
-        },
         {
           "option_id": "demobilize_for_standalone",
           "label": "Demobilize for standalone operations",
           "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        },
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2022-10-28."
         }
       ],
       "information_cutoff": "2022-07-13T23:59:59Z",
@@ -48,18 +48,18 @@
       "split": "development",
       "title": "Microsoft-Activision integration readiness after the FTC challenge",
       "decision_prompt": "A business-operations lead supporting the Microsoft-Activision transaction must choose a primary staffing plan after the Federal Trade Commission moves to block the acquisition. Choose the action that best fits whether the transaction will close by 2023-10-18.",
-      "forecast_question": "Will Microsoft complete its acquisition of Activision Blizzard by 2023-10-18 despite the FTC challenge? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain close readiness\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_close_readiness",
       "options": [
-        {
-          "option_id": "retain_close_readiness",
-          "label": "Retain close readiness",
-          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2023-10-18."
-        },
         {
           "option_id": "demobilize_for_standalone",
           "label": "Demobilize for standalone operations",
           "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        },
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2023-10-18."
         }
       ],
       "information_cutoff": "2022-12-09T00:00:00Z",
@@ -86,18 +86,18 @@
       "split": "development",
       "title": "Adobe-Figma operating plan after UK phase-two referral",
       "decision_prompt": "A business-operations lead supporting Adobe's planned acquisition of Figma must choose a primary staffing plan after the UK Competition and Markets Authority refers the deal for an in-depth investigation. Choose the action that best fits whether the acquisition will close by 2024-03-31.",
-      "forecast_question": "Will Adobe complete its acquisition of Figma by 2024-03-31 rather than terminate the agreement? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain close readiness\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_close_readiness",
       "options": [
-        {
-          "option_id": "retain_close_readiness",
-          "label": "Retain close readiness",
-          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2024-03-31."
-        },
         {
           "option_id": "demobilize_for_standalone",
           "label": "Demobilize for standalone operations",
           "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        },
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2024-03-31."
         }
       ],
       "information_cutoff": "2023-07-14T00:00:00Z",
@@ -124,18 +124,18 @@
       "split": "development",
       "title": "JetBlue-Spirit operating plan after the DOJ challenge",
       "decision_prompt": "A business-operations lead supporting JetBlue's planned acquisition of Spirit must choose a primary staffing plan after the US Department of Justice sues to block the deal. Choose the action that best fits whether the acquisition will close by the agreement's 2024-07-24 outside date.",
-      "forecast_question": "Will JetBlue complete its acquisition of Spirit by 2024-07-24 despite the DOJ challenge? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain close readiness\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_close_readiness",
       "options": [
-        {
-          "option_id": "retain_close_readiness",
-          "label": "Retain close readiness",
-          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2024-07-24."
-        },
         {
           "option_id": "demobilize_for_standalone",
           "label": "Demobilize for standalone operations",
           "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        },
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2024-07-24."
         }
       ],
       "information_cutoff": "2023-03-08T00:00:00Z",

--- a/docs/benchmarks/decision_quality/tranches/business-operations-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-1.corpus.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-business-operations-tranche-1",
+  "frozen_at": "2026-08-30T02:03:00Z",
+  "cases": [
+    {
+      "case_id": "biz-dev-twitter-merger-close",
+      "domain": "business_operations",
+      "split": "development",
+      "title": "Twitter acquisition transition staffing after termination notice",
+      "decision_prompt": "A business-operations lead supporting the announced Twitter acquisition must choose a primary staffing plan after the buyer purports to terminate and Twitter seeks specific performance. Choose the action that best fits whether the acquisition will still close by 2022-10-28.",
+      "forecast_question": "Will the Twitter acquisition close by 2022-10-28 despite the buyer's termination notice? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_option_id": "retain_close_readiness",
+      "options": [
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2022-10-28."
+        },
+        {
+          "option_id": "demobilize_for_standalone",
+          "label": "Demobilize for standalone operations",
+          "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        }
+      ],
+      "information_cutoff": "2022-07-13T23:59:59Z",
+      "sources": [
+        {
+          "source_id": "twitter-musk-termination-letter-2022-07-08",
+          "title": "Musk parties' notice purporting to terminate the Twitter merger agreement",
+          "url": "https://www.sec.gov/Archives/edgar/data/1418091/000110465922078413/tm2220599d1_ex99-p.htm",
+          "published_at": "2022-07-08T00:00:00Z",
+          "content_sha256": "f8c6a9f980cf2b552e3f68148e88c3641b38b19104b514ecb3fd3028a71f4ed4"
+        },
+        {
+          "source_id": "twitter-specific-performance-complaint-2022-07-12",
+          "title": "Twitter complaint seeking specific performance of the merger agreement",
+          "url": "https://www.sec.gov/Archives/edgar/data/1418091/000119312522192993/d381911dex991.htm",
+          "published_at": "2022-07-12T00:00:00Z",
+          "content_sha256": "b96f17ab629f6bc2a07aafa150334de2c0356e2be2d7a2eda3b421c32a6a5ff3"
+        }
+      ]
+    },
+    {
+      "case_id": "biz-dev-microsoft-activision-close",
+      "domain": "business_operations",
+      "split": "development",
+      "title": "Microsoft-Activision integration readiness after the FTC challenge",
+      "decision_prompt": "A business-operations lead supporting the Microsoft-Activision transaction must choose a primary staffing plan after the Federal Trade Commission moves to block the acquisition. Choose the action that best fits whether the transaction will close by 2023-10-18.",
+      "forecast_question": "Will Microsoft complete its acquisition of Activision Blizzard by 2023-10-18 despite the FTC challenge? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_option_id": "retain_close_readiness",
+      "options": [
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2023-10-18."
+        },
+        {
+          "option_id": "demobilize_for_standalone",
+          "label": "Demobilize for standalone operations",
+          "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        }
+      ],
+      "information_cutoff": "2022-12-09T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "activision-microsoft-merger-agreement-2022-01-18",
+          "title": "Activision Blizzard filing for the Microsoft merger agreement",
+          "url": "https://www.sec.gov/Archives/edgar/data/718877/000110465922005156/tm223212d8_defa14a.htm",
+          "published_at": "2022-01-18T00:00:00Z",
+          "content_sha256": "44b5fb7c3c53aae9c372eaaa5a96fe949f74cdc26c78232f51ff77db32ba9d9b"
+        },
+        {
+          "source_id": "ftc-microsoft-activision-challenge-2022-12-08",
+          "title": "FTC administrative complaint challenging Microsoft's acquisition of Activision Blizzard",
+          "url": "https://www.ftc.gov/system/files/ftc_gov/pdf/D09412MicrosoftActivisionAdministrativeComplaintPublicVersionFinal.pdf",
+          "published_at": "2022-12-08T00:00:00Z",
+          "content_sha256": "580e0cfb2726facaedf5f896e80330702f4b45923b42053288068ef12fc3f18c"
+        }
+      ]
+    },
+    {
+      "case_id": "biz-dev-adobe-figma-close",
+      "domain": "business_operations",
+      "split": "development",
+      "title": "Adobe-Figma operating plan after UK phase-two referral",
+      "decision_prompt": "A business-operations lead supporting Adobe's planned acquisition of Figma must choose a primary staffing plan after the UK Competition and Markets Authority refers the deal for an in-depth investigation. Choose the action that best fits whether the acquisition will close by 2024-03-31.",
+      "forecast_question": "Will Adobe complete its acquisition of Figma by 2024-03-31 rather than terminate the agreement? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_option_id": "retain_close_readiness",
+      "options": [
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2024-03-31."
+        },
+        {
+          "option_id": "demobilize_for_standalone",
+          "label": "Demobilize for standalone operations",
+          "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        }
+      ],
+      "information_cutoff": "2023-07-14T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "adobe-figma-merger-agreement-2022-09-15",
+          "title": "Adobe filing for the Figma merger agreement",
+          "url": "https://www.sec.gov/Archives/edgar/data/796343/000114036122033413/ny20005310x2_8k.htm",
+          "published_at": "2022-09-15T00:00:00Z",
+          "content_sha256": "9fabd157d8ef34a41d5967bb83873f425f953fd10a679c39ff9bf1a12ce7f5de"
+        },
+        {
+          "source_id": "cma-adobe-figma-phase-two-referral-2023-07-13",
+          "title": "CMA decision to refer the Adobe-Figma acquisition for phase-two investigation",
+          "url": "https://assets.publishing.service.gov.uk/media/64aed1b4fe36e0000d6fa868/Decision_to_refer.pdf",
+          "published_at": "2023-07-13T00:00:00Z",
+          "content_sha256": "1104d3a28046c12a740ab92258a4a1f17c085d77c5cc5dc7cde50ef2a66f6219"
+        }
+      ]
+    },
+    {
+      "case_id": "biz-dev-jetblue-spirit-close",
+      "domain": "business_operations",
+      "split": "development",
+      "title": "JetBlue-Spirit operating plan after the DOJ challenge",
+      "decision_prompt": "A business-operations lead supporting JetBlue's planned acquisition of Spirit must choose a primary staffing plan after the US Department of Justice sues to block the deal. Choose the action that best fits whether the acquisition will close by the agreement's 2024-07-24 outside date.",
+      "forecast_question": "Will JetBlue complete its acquisition of Spirit by 2024-07-24 despite the DOJ challenge? Forecast the probability that retain_close_readiness is the correct action.",
+      "forecast_option_id": "retain_close_readiness",
+      "options": [
+        {
+          "option_id": "retain_close_readiness",
+          "label": "Retain close readiness",
+          "description": "Keep the transaction team staffed and maintain integration and closing readiness through 2024-07-24."
+        },
+        {
+          "option_id": "demobilize_for_standalone",
+          "label": "Demobilize for standalone operations",
+          "description": "Demobilize transaction execution and make independent operating plans the primary allocation."
+        }
+      ],
+      "information_cutoff": "2023-03-08T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "jetblue-spirit-merger-agreement-2022-07-28",
+          "title": "JetBlue-Spirit merger agreement",
+          "url": "https://www.sec.gov/Archives/edgar/data/1158463/000119312522204208/d319514dex21.htm",
+          "published_at": "2022-07-28T00:00:00Z",
+          "content_sha256": "4b7fccbb74369429c2b8f2ceaebf15f976e5998da3a4878fd504911171c7f2c5"
+        },
+        {
+          "source_id": "doj-jetblue-spirit-complaint-2023-03-07",
+          "title": "US and plaintiff states complaint to block JetBlue's acquisition of Spirit",
+          "url": "https://www.justice.gov/atr/case-document/file/1573131/dl",
+          "published_at": "2023-03-07T00:00:00Z",
+          "content_sha256": "028f0dce195758644d1ce2d0b77d069cf065a97daf5cc2c26acaf9aa88f280bb"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/business-operations-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "734f515a6cff55e88faa8de2d4ff5bf32e42385bbe8ee109b68eb6df54ef8661",
+  "corpus_sha256": "ac9676ff9715b724a436ac3f697e3599aba8416e061fe009088eea4360ad8bba",
   "outcomes": [
     {
       "case_id": "biz-dev-twitter-merger-close",

--- a/docs/benchmarks/decision_quality/tranches/business-operations-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-1.outcomes.json
@@ -1,0 +1,155 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "734f515a6cff55e88faa8de2d4ff5bf32e42385bbe8ee109b68eb6df54ef8661",
+  "outcomes": [
+    {
+      "case_id": "biz-dev-twitter-merger-close",
+      "resolved_at": "2022-10-27T00:00:00Z",
+      "correct_option_id": "retain_close_readiness",
+      "resolution_summary": "The Twitter acquisition closed on October 27, 2022, so maintaining transaction and integration readiness through the stated decision horizon was the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "twitter-merger-completion-2022-10-27",
+          "title": "Twitter Form 8-K reporting completion of the merger",
+          "url": "https://www.sec.gov/Archives/edgar/data/1418091/000119312522272772/d411753d8k.htm",
+          "published_at": "2022-10-27T00:00:00Z",
+          "content_sha256": "60bfc50d97605692296877358a8150695e9ec7ae13a2df2bed331ddd1f33a653"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "specific_performance_enforceability",
+          "description": "Whether Delaware law and the signed merger agreement made specific performance a credible remedy despite the termination notice.",
+          "aliases": ["contract enforceability", "specific performance remedy"]
+        },
+        {
+          "crux_id": "buyer_financing_availability",
+          "description": "Whether committed debt and equity financing remained available to fund the transaction.",
+          "aliases": ["financing certainty", "funding availability"]
+        },
+        {
+          "crux_id": "trial_timing_pressure",
+          "description": "Whether an expedited Delaware trial would force a decision before financing or agreement deadlines weakened Twitter's remedy.",
+          "aliases": ["expedited trial", "closing deadline pressure"]
+        },
+        {
+          "crux_id": "buyer_willingness_to_settle",
+          "description": "Whether the buyer would reverse course or settle rather than risk an adverse specific-performance judgment.",
+          "aliases": ["settlement incentive", "buyer follow-through"]
+        }
+      ]
+    },
+    {
+      "case_id": "biz-dev-microsoft-activision-close",
+      "resolved_at": "2023-10-13T00:00:00Z",
+      "correct_option_id": "retain_close_readiness",
+      "resolution_summary": "Microsoft completed the Activision Blizzard acquisition on October 13, 2023, before the forecast horizon, making continued transaction readiness the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "microsoft-activision-completion-2023-10-13",
+          "title": "Microsoft Form 8-K reporting completion of the Activision Blizzard acquisition",
+          "url": "https://www.sec.gov/Archives/edgar/data/789019/000119312523255762/d537928d8k.htm",
+          "published_at": "2023-10-13T00:00:00Z",
+          "content_sha256": "051d43e99ec522fc080e6c3e07e2ed4dae87e386cb9657c30e94b8f8599a525b"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "ftc_injunction_success",
+          "description": "Whether the FTC could obtain timely administrative or federal-court relief that prevented closing.",
+          "aliases": ["US antitrust injunction", "FTC litigation outcome"]
+        },
+        {
+          "crux_id": "uk_cloud_gaming_remedy",
+          "description": "Whether Microsoft could offer a cloud-gaming remedy acceptable to UK competition authorities.",
+          "aliases": ["CMA remedy", "cloud streaming concession"]
+        },
+        {
+          "crux_id": "outside_date_flexibility",
+          "description": "Whether the parties had enough contractual time and willingness to extend the closing timetable through regulatory litigation.",
+          "aliases": ["agreement extension", "closing timetable"]
+        },
+        {
+          "crux_id": "multijurisdiction_clearance",
+          "description": "Whether approvals outside the United States would leave the FTC challenge as a manageable rather than compounding obstacle.",
+          "aliases": ["global regulatory clearance", "jurisdictional approvals"]
+        }
+      ]
+    },
+    {
+      "case_id": "biz-dev-adobe-figma-close",
+      "resolved_at": "2023-12-17T00:00:00Z",
+      "correct_option_id": "demobilize_for_standalone",
+      "resolution_summary": "Adobe and Figma terminated their merger agreement after concluding that there was no clear path to required regulatory approvals, making standalone operating plans the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "adobe-figma-termination-2023-12-17",
+          "title": "Adobe Form 8-K reporting termination of the Figma merger agreement",
+          "url": "https://www.sec.gov/Archives/edgar/data/796343/000079634323000254/adbe-20231217.htm",
+          "published_at": "2023-12-18T00:00:00Z",
+          "content_sha256": "a984f09dbd8f10aaf08f6329442b047f168334fb5c5ba9e33f3d1641b74ef74b"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "uk_competition_remedy_scope",
+          "description": "Whether Adobe could offer a remedy that addressed UK concerns without destroying the transaction's strategic value.",
+          "aliases": ["CMA remedy viability", "UK competition concessions"]
+        },
+        {
+          "crux_id": "eu_regulatory_clearance",
+          "description": "Whether European regulators would accept the acquisition without incompatible or prohibitive conditions.",
+          "aliases": ["European approval", "EU competition clearance"]
+        },
+        {
+          "crux_id": "product_market_overlap",
+          "description": "Whether regulators would treat Adobe and Figma as current or potential close competitors in design software.",
+          "aliases": ["design software competition", "potential competition"]
+        },
+        {
+          "crux_id": "termination_fee_incentives",
+          "description": "Whether the cost of terminating was smaller than the operational and strategic cost of prolonged or heavily conditioned review.",
+          "aliases": ["break fee", "walk-away economics"]
+        }
+      ]
+    },
+    {
+      "case_id": "biz-dev-jetblue-spirit-close",
+      "resolved_at": "2024-03-01T00:00:00Z",
+      "correct_option_id": "demobilize_for_standalone",
+      "resolution_summary": "JetBlue and Spirit terminated their merger agreement after the transaction was blocked and the parties judged timely closing conditions unlikely to be met, making standalone operations the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "jetblue-spirit-termination-2024-03-01",
+          "title": "JetBlue Form 8-K reporting termination of the Spirit merger agreement",
+          "url": "https://www.sec.gov/Archives/edgar/data/1158463/000115846324000010/jblu-20240301.htm",
+          "published_at": "2024-03-04T00:00:00Z",
+          "content_sha256": "fa3497c69048456f37803c8ba619ad8c3b5ddf1dd9028c4a0dffead8b4a3f216"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "doj_injunction_success",
+          "description": "Whether the DOJ could prove that eliminating Spirit would substantially lessen competition and obtain an injunction.",
+          "aliases": ["antitrust injunction", "DOJ litigation outcome"]
+        },
+        {
+          "crux_id": "spirit_effect_evidence",
+          "description": "Whether evidence that Spirit independently lowered fares would make a structural remedy difficult to defend.",
+          "aliases": ["low-fare competition", "Spirit Effect"]
+        },
+        {
+          "crux_id": "remedy_feasibility",
+          "description": "Whether route, slot, or asset divestitures could preserve competition sufficiently for the transaction to proceed.",
+          "aliases": ["divestiture package", "antitrust remedy"]
+        },
+        {
+          "crux_id": "outside_date_headroom",
+          "description": "Whether litigation and any appeal could finish with enough time to close by the merger agreement's outside date.",
+          "aliases": ["appeal timing", "closing deadline"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-business-operations-holdout-tranche-1",
-  "frozen_at": "2026-08-30T03:03:00Z",
+  "revision": "draft-business-operations-holdout-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "biz-holdout-737-max-us-ungrounding-2020",
@@ -10,18 +10,18 @@
       "split": "holdout",
       "title": "Stage US 737 MAX return-to-service operations for Q4 2020",
       "decision_prompt": "A US airline operations team must decide whether to make 737 MAX return-to-service training, maintenance, and capacity preparation its primary fourth-quarter plan. Boeing's latest filing assumes regulatory approvals will enable deliveries to resume during Q4 2020, while emphasizing regulatory, customer, and pandemic uncertainty. Choose the action that best fits whether the FAA will rescind the US grounding order by 2020-12-31.",
-      "forecast_question": "Will the FAA rescind the US 737 MAX grounding order by 2020-12-31? Forecast the probability that stage_q4_return_plan is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Stage a Q4 return-to-service plan\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "stage_q4_return_plan",
       "options": [
-        {
-          "option_id": "stage_q4_return_plan",
-          "label": "Stage a Q4 return-to-service plan",
-          "description": "Prioritize the training, maintenance, and capacity work needed to restore US 737 MAX operations during Q4 2020."
-        },
         {
           "option_id": "defer_return_plan_to_2021",
           "label": "Defer the return plan to 2021",
           "description": "Keep alternate-fleet operations primary and defer material 737 MAX return-to-service preparation until 2021."
+        },
+        {
+          "option_id": "stage_q4_return_plan",
+          "label": "Stage a Q4 return-to-service plan",
+          "description": "Prioritize the training, maintenance, and capacity work needed to restore US 737 MAX operations during Q4 2020."
         }
       ],
       "information_cutoff": "2020-10-29T00:00:00Z",
@@ -41,7 +41,7 @@
       "split": "holdout",
       "title": "Plan 777X operations around a late-2023 first delivery",
       "decision_prompt": "An aerospace program operations team must set its primary supplier, staffing, and customer-readiness plan after Boeing forecasts the first 777X delivery in late 2023 and discloses certification, design-change, market, and production risks. Choose the action that best fits whether the first 777X delivery will occur by 2023-12-31.",
-      "forecast_question": "Will Boeing make the first 777X delivery by 2023-12-31? Forecast the probability that maintain_2023_delivery_readiness is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Maintain 2023 delivery readiness\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "maintain_2023_delivery_readiness",
       "options": [
         {

--- a/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.corpus.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-business-operations-holdout-tranche-1",
+  "frozen_at": "2026-08-30T03:03:00Z",
+  "cases": [
+    {
+      "case_id": "biz-holdout-737-max-us-ungrounding-2020",
+      "domain": "business_operations",
+      "split": "holdout",
+      "title": "Stage US 737 MAX return-to-service operations for Q4 2020",
+      "decision_prompt": "A US airline operations team must decide whether to make 737 MAX return-to-service training, maintenance, and capacity preparation its primary fourth-quarter plan. Boeing's latest filing assumes regulatory approvals will enable deliveries to resume during Q4 2020, while emphasizing regulatory, customer, and pandemic uncertainty. Choose the action that best fits whether the FAA will rescind the US grounding order by 2020-12-31.",
+      "forecast_question": "Will the FAA rescind the US 737 MAX grounding order by 2020-12-31? Forecast the probability that stage_q4_return_plan is the correct action.",
+      "forecast_option_id": "stage_q4_return_plan",
+      "options": [
+        {
+          "option_id": "stage_q4_return_plan",
+          "label": "Stage a Q4 return-to-service plan",
+          "description": "Prioritize the training, maintenance, and capacity work needed to restore US 737 MAX operations during Q4 2020."
+        },
+        {
+          "option_id": "defer_return_plan_to_2021",
+          "label": "Defer the return plan to 2021",
+          "description": "Keep alternate-fleet operations primary and defer material 737 MAX return-to-service preparation until 2021."
+        }
+      ],
+      "information_cutoff": "2020-10-29T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "boeing-2020-q3-max-delivery-assumption",
+          "title": "Boeing Form 10-Q for the quarter ended September 30, 2020",
+          "url": "https://www.sec.gov/Archives/edgar/data/12927/000001292720000076/ba-20200930.htm",
+          "published_at": "2020-10-28T00:00:00Z",
+          "content_sha256": "6ddd5438524acbda5b810dde2be19f7b1886c5662a074475b599842b9f5aa449"
+        }
+      ]
+    },
+    {
+      "case_id": "biz-holdout-777x-first-delivery-2023",
+      "domain": "business_operations",
+      "split": "holdout",
+      "title": "Plan 777X operations around a late-2023 first delivery",
+      "decision_prompt": "An aerospace program operations team must set its primary supplier, staffing, and customer-readiness plan after Boeing forecasts the first 777X delivery in late 2023 and discloses certification, design-change, market, and production risks. Choose the action that best fits whether the first 777X delivery will occur by 2023-12-31.",
+      "forecast_question": "Will Boeing make the first 777X delivery by 2023-12-31? Forecast the probability that maintain_2023_delivery_readiness is the correct action.",
+      "forecast_option_id": "maintain_2023_delivery_readiness",
+      "options": [
+        {
+          "option_id": "maintain_2023_delivery_readiness",
+          "label": "Maintain 2023 delivery readiness",
+          "description": "Keep suppliers, staffing, and customer-readiness milestones aligned to a first 777X delivery by the end of 2023."
+        },
+        {
+          "option_id": "rebaseline_beyond_2023",
+          "label": "Rebaseline beyond 2023",
+          "description": "Move the primary operations plan beyond 2023 and reduce commitments that depend on a first delivery by that date."
+        }
+      ],
+      "information_cutoff": "2021-02-02T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "boeing-2020-10k-777x-late-2023",
+          "title": "Boeing Form 10-K for the year ended December 31, 2020",
+          "url": "https://www.sec.gov/Archives/edgar/data/12927/000001292721000011/ba-20201231.htm",
+          "published_at": "2021-02-01T00:00:00Z",
+          "content_sha256": "aecdb6b6d0b9d4e54d1d903c9f180b905c8f20b83553e1181b41bbe104d64911"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "26473525c2ab4fbd7298d307292b42859540532aa62e24be08bf934208cd9b1d",
+  "corpus_sha256": "2036afb2a909e1ffd16d5764fefd1fbccbeb298dd29924222d6034ec30d7e855",
   "outcomes": [
     {
       "case_id": "biz-holdout-737-max-us-ungrounding-2020",

--- a/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/business-operations-holdout-1.outcomes.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "26473525c2ab4fbd7298d307292b42859540532aa62e24be08bf934208cd9b1d",
+  "outcomes": [
+    {
+      "case_id": "biz-holdout-737-max-us-ungrounding-2020",
+      "resolved_at": "2020-11-18T00:00:00Z",
+      "correct_option_id": "stage_q4_return_plan",
+      "resolution_summary": "The FAA rescinded the US 737 MAX grounding order during Q4 2020, and Boeing recorded that deliveries resumed in that quarter, making the staged Q4 return plan the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "boeing-2020-10k-max-us-ungrounding",
+          "title": "Boeing Form 10-K recording the FAA rescission and resumed deliveries",
+          "url": "https://www.sec.gov/Archives/edgar/data/12927/000001292721000011/ba-20201231.htm",
+          "published_at": "2021-02-01T00:00:00Z",
+          "content_sha256": "aecdb6b6d0b9d4e54d1d903c9f180b905c8f20b83553e1181b41bbe104d64911"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "faa_certification_completion",
+          "description": "Whether Boeing's design changes, documentation, and testing would satisfy the FAA before year-end.",
+          "aliases": ["FAA approval timing", "certification completion"]
+        },
+        {
+          "crux_id": "operator_training_readiness",
+          "description": "Whether required pilot training and airline program revisions could be approved quickly enough for a Q4 operating plan.",
+          "aliases": ["pilot training approval", "airline readiness"]
+        },
+        {
+          "crux_id": "parked_aircraft_maintenance",
+          "description": "Whether maintenance and modification work on parked aircraft could support a practical return after regulatory approval.",
+          "aliases": ["fleet maintenance readiness", "aircraft modification work"]
+        },
+        {
+          "crux_id": "pandemic_operational_disruption",
+          "description": "Whether pandemic-driven demand, staffing, and supply-chain disruption would make a Q4 return plan operationally impractical.",
+          "aliases": ["COVID operational risk", "demand and supply disruption"]
+        }
+      ]
+    },
+    {
+      "case_id": "biz-holdout-777x-first-delivery-2023",
+      "resolved_at": "2022-04-27T00:00:00Z",
+      "correct_option_id": "rebaseline_beyond_2023",
+      "resolution_summary": "Boeing revised the first 777X-9 delivery forecast from late 2023 to 2025, so rebaselining the operations plan beyond 2023 was the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "boeing-2022-q1-777x-delay-to-2025",
+          "title": "Boeing Form 10-Q delaying first 777X-9 delivery until 2025",
+          "url": "https://www.sec.gov/Archives/edgar/data/12927/000001292722000022/ba-20220331.htm",
+          "published_at": "2022-04-27T00:00:00Z",
+          "content_sha256": "5a5b8aa695adeff1974e1c22ce9c35c3bae2b578cc13b853dec964ab18ef381d"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "certification_schedule",
+          "description": "Whether the certification program would progress fast enough to support a first delivery in late 2023.",
+          "aliases": ["regulatory certification timing", "flight-test schedule"]
+        },
+        {
+          "crux_id": "design_change_scope",
+          "description": "Whether regulator-informed design modifications would remain bounded rather than cause another schedule reset.",
+          "aliases": ["required design modifications", "certification-driven rework"]
+        },
+        {
+          "crux_id": "production_system_readiness",
+          "description": "Whether Boeing and its suppliers could sustain the production and integration schedule required for a 2023 delivery.",
+          "aliases": ["supplier readiness", "production ramp"]
+        },
+        {
+          "crux_id": "market_and_customer_timing",
+          "description": "Whether pandemic-era market conditions and customer delivery discussions would preserve the late-2023 target.",
+          "aliases": ["customer schedule", "wide-body demand"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-policy-compliance-tranche-1",
-  "frozen_at": "2026-08-30T02:20:00Z",
+  "revision": "draft-policy-compliance-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "policy-dev-sec-cyber-disclosure-2023",
@@ -10,18 +10,18 @@
       "split": "development",
       "title": "SEC public-company cybersecurity disclosure rule timing",
       "decision_prompt": "A U.S. public company is deciding in early 2023 whether to fund implementation readiness for the SEC's proposed cybersecurity disclosure amendments before the fourth quarter. Choose the action that best protects compliance readiness if the Commission adopts a final rule by September 2023.",
-      "forecast_question": "Will the SEC adopt a final public-company cybersecurity disclosure rule on or before 2023-09-30? Forecast the probability that prepare_for_2023_rule is the correct action.",
-      "forecast_option_id": "prepare_for_2023_rule",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Defer implementation readiness\" is the outcome-aligned action at the stated horizon.",
+      "forecast_option_id": "defer_past_2023",
       "options": [
-        {
-          "option_id": "prepare_for_2023_rule",
-          "label": "Prepare for a 2023 final rule",
-          "description": "Fund bounded disclosure-process, incident-materiality, and governance readiness before the fourth quarter of 2023."
-        },
         {
           "option_id": "defer_past_2023",
           "label": "Defer implementation readiness",
           "description": "Wait until after 2023 before funding implementation readiness for the proposed requirements."
+        },
+        {
+          "option_id": "prepare_for_2023_rule",
+          "label": "Prepare for a 2023 final rule",
+          "description": "Fund bounded disclosure-process, incident-materiality, and governance readiness before the fourth quarter of 2023."
         }
       ],
       "information_cutoff": "2023-03-01T00:00:00Z",
@@ -41,18 +41,18 @@
       "split": "development",
       "title": "FDA food traceability final-rule readiness",
       "decision_prompt": "A food supply-chain operator covered by the FDA's proposed traceability rule must decide in spring 2022 whether to prepare its event-recording and data-sharing systems for a final rule during 2022. Choose the action that best protects compliance readiness.",
-      "forecast_question": "Will the FDA publish a final food traceability rule on or before 2022-12-31? Forecast the probability that prepare_for_2022_final_rule is the correct action.",
-      "forecast_option_id": "prepare_for_2022_final_rule",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Defer beyond 2022\" is the outcome-aligned action at the stated horizon.",
+      "forecast_option_id": "defer_until_after_2022",
       "options": [
-        {
-          "option_id": "prepare_for_2022_final_rule",
-          "label": "Prepare during 2022",
-          "description": "Begin bounded data-model and process readiness work for a final food traceability rule during 2022."
-        },
         {
           "option_id": "defer_until_after_2022",
           "label": "Defer beyond 2022",
           "description": "Wait until after 2022 before preparing systems for the proposed traceability requirements."
+        },
+        {
+          "option_id": "prepare_for_2022_final_rule",
+          "label": "Prepare during 2022",
+          "description": "Begin bounded data-model and process readiness work for a final food traceability rule during 2022."
         }
       ],
       "information_cutoff": "2022-05-01T00:00:00Z",
@@ -72,7 +72,7 @@
       "split": "development",
       "title": "SEC climate disclosure rule timing through 2023",
       "decision_prompt": "A U.S. public company is planning its 2023 reporting program after the SEC proposed climate-related disclosure rules. Choose whether to treat a 2023 final rule as the binding implementation baseline or preserve design readiness while waiting for final adoption.",
-      "forecast_question": "Will the SEC refrain from adopting a final climate-related disclosure rule through 2023-12-31? Forecast the probability that defer_binding_implementation is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Wait for the final rule\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "defer_binding_implementation",
       "options": [
         {
@@ -103,18 +103,18 @@
       "split": "development",
       "title": "NIST Cybersecurity Framework 2.0 draft timing",
       "decision_prompt": "A compliance program using NIST Cybersecurity Framework 1.1 must decide in January 2023 whether to switch its binding control baseline to CSF 2.0 before the end of July or wait for NIST to publish the initial public draft. Choose the action that best preserves an auditable baseline.",
-      "forecast_question": "Will NIST not publish the initial public draft of CSF 2.0 by 2023-07-31? Forecast the probability that wait_for_public_draft is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Keep CSF 1.1 until publication\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "wait_for_public_draft",
       "options": [
-        {
-          "option_id": "wait_for_public_draft",
-          "label": "Keep CSF 1.1 until publication",
-          "description": "Retain CSF 1.1 as the binding baseline until NIST publishes the CSF 2.0 initial public draft."
-        },
         {
           "option_id": "switch_before_publication",
           "label": "Switch before the draft is published",
           "description": "Replace the binding baseline with anticipated CSF 2.0 content before the initial public draft appears."
+        },
+        {
+          "option_id": "wait_for_public_draft",
+          "label": "Keep CSF 1.1 until publication",
+          "description": "Retain CSF 1.1 as the binding baseline until NIST publishes the CSF 2.0 initial public draft."
         }
       ],
       "information_cutoff": "2023-01-20T00:00:00Z",

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-1.corpus.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-policy-compliance-tranche-1",
+  "frozen_at": "2026-08-30T02:20:00Z",
+  "cases": [
+    {
+      "case_id": "policy-dev-sec-cyber-disclosure-2023",
+      "domain": "policy_compliance",
+      "split": "development",
+      "title": "SEC public-company cybersecurity disclosure rule timing",
+      "decision_prompt": "A U.S. public company is deciding in early 2023 whether to fund implementation readiness for the SEC's proposed cybersecurity disclosure amendments before the fourth quarter. Choose the action that best protects compliance readiness if the Commission adopts a final rule by September 2023.",
+      "forecast_question": "Will the SEC adopt a final public-company cybersecurity disclosure rule on or before 2023-09-30? Forecast the probability that prepare_for_2023_rule is the correct action.",
+      "forecast_option_id": "prepare_for_2023_rule",
+      "options": [
+        {
+          "option_id": "prepare_for_2023_rule",
+          "label": "Prepare for a 2023 final rule",
+          "description": "Fund bounded disclosure-process, incident-materiality, and governance readiness before the fourth quarter of 2023."
+        },
+        {
+          "option_id": "defer_past_2023",
+          "label": "Defer implementation readiness",
+          "description": "Wait until after 2023 before funding implementation readiness for the proposed requirements."
+        }
+      ],
+      "information_cutoff": "2023-03-01T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "sec-cyber-disclosure-proposal-2022-03-23",
+          "title": "Cybersecurity Risk Management, Strategy, Governance, and Incident Disclosure - Proposed Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2022-03-23/pdf/2022-05480.pdf",
+          "published_at": "2022-03-23T00:00:00Z",
+          "content_sha256": "0d4671d8b5c5435b943c13394d115074652cde0f151a939774b58f1e4d3c9ada"
+        }
+      ]
+    },
+    {
+      "case_id": "policy-dev-fda-food-traceability-2022",
+      "domain": "policy_compliance",
+      "split": "development",
+      "title": "FDA food traceability final-rule readiness",
+      "decision_prompt": "A food supply-chain operator covered by the FDA's proposed traceability rule must decide in spring 2022 whether to prepare its event-recording and data-sharing systems for a final rule during 2022. Choose the action that best protects compliance readiness.",
+      "forecast_question": "Will the FDA publish a final food traceability rule on or before 2022-12-31? Forecast the probability that prepare_for_2022_final_rule is the correct action.",
+      "forecast_option_id": "prepare_for_2022_final_rule",
+      "options": [
+        {
+          "option_id": "prepare_for_2022_final_rule",
+          "label": "Prepare during 2022",
+          "description": "Begin bounded data-model and process readiness work for a final food traceability rule during 2022."
+        },
+        {
+          "option_id": "defer_until_after_2022",
+          "label": "Defer beyond 2022",
+          "description": "Wait until after 2022 before preparing systems for the proposed traceability requirements."
+        }
+      ],
+      "information_cutoff": "2022-05-01T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "fda-food-traceability-proposal-2020-09-23",
+          "title": "Requirements for Additional Traceability Records for Certain Foods - Proposed Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2020-09-23/pdf/2020-20100.pdf",
+          "published_at": "2020-09-23T00:00:00Z",
+          "content_sha256": "2b0c4b5f70562dd91fe88d9832deab5704e0689874d4648cb6d7c10585f646c4"
+        }
+      ]
+    },
+    {
+      "case_id": "policy-dev-sec-climate-disclosure-2023",
+      "domain": "policy_compliance",
+      "split": "development",
+      "title": "SEC climate disclosure rule timing through 2023",
+      "decision_prompt": "A U.S. public company is planning its 2023 reporting program after the SEC proposed climate-related disclosure rules. Choose whether to treat a 2023 final rule as the binding implementation baseline or preserve design readiness while waiting for final adoption.",
+      "forecast_question": "Will the SEC refrain from adopting a final climate-related disclosure rule through 2023-12-31? Forecast the probability that defer_binding_implementation is the correct action.",
+      "forecast_option_id": "defer_binding_implementation",
+      "options": [
+        {
+          "option_id": "defer_binding_implementation",
+          "label": "Wait for the final rule",
+          "description": "Preserve design readiness but do not treat the proposal as a binding 2023 implementation baseline."
+        },
+        {
+          "option_id": "implement_as_2023_final",
+          "label": "Implement as a 2023 final rule",
+          "description": "Commit the reporting program to the proposed requirements on the assumption that a final rule will be adopted by year-end 2023."
+        }
+      ],
+      "information_cutoff": "2023-03-01T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "sec-climate-disclosure-proposal-2022-04-11",
+          "title": "The Enhancement and Standardization of Climate-Related Disclosures for Investors - Proposed Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2022-04-11/pdf/2022-06342.pdf",
+          "published_at": "2022-04-11T00:00:00Z",
+          "content_sha256": "88b8cce0fcd9a36e3bd5c40c9a095ea0ba4024c4f46819037a7a683fddb9ce8f"
+        }
+      ]
+    },
+    {
+      "case_id": "policy-dev-nist-csf2-july-2023",
+      "domain": "policy_compliance",
+      "split": "development",
+      "title": "NIST Cybersecurity Framework 2.0 draft timing",
+      "decision_prompt": "A compliance program using NIST Cybersecurity Framework 1.1 must decide in January 2023 whether to switch its binding control baseline to CSF 2.0 before the end of July or wait for NIST to publish the initial public draft. Choose the action that best preserves an auditable baseline.",
+      "forecast_question": "Will NIST not publish the initial public draft of CSF 2.0 by 2023-07-31? Forecast the probability that wait_for_public_draft is the correct action.",
+      "forecast_option_id": "wait_for_public_draft",
+      "options": [
+        {
+          "option_id": "wait_for_public_draft",
+          "label": "Keep CSF 1.1 until publication",
+          "description": "Retain CSF 1.1 as the binding baseline until NIST publishes the CSF 2.0 initial public draft."
+        },
+        {
+          "option_id": "switch_before_publication",
+          "label": "Switch before the draft is published",
+          "description": "Replace the binding baseline with anticipated CSF 2.0 content before the initial public draft appears."
+        }
+      ],
+      "information_cutoff": "2023-01-20T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "nist-csf2-concept-paper-2023-01-19",
+          "title": "NIST Cybersecurity Framework 2.0 Concept Paper",
+          "url": "https://www.nist.gov/system/files/documents/2023/01/19/CSF_2.0_Concept_Paper_01-18-23.pdf",
+          "published_at": "2023-01-19T00:00:00Z",
+          "content_sha256": "e3b6c8edb28b3cd77372b753cd58c842e7b75d58aca28891c6937cb3316094ea"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "4247cf544b5c12f939517b2267f915559df85b059a164c457a40af74ffd88ea3",
+  "corpus_sha256": "17bce195c719c30c128b0ce86e906754c076e2c03da4a10f6421d9e80f57943b",
   "outcomes": [
     {
       "case_id": "policy-dev-sec-cyber-disclosure-2023",

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-1.outcomes.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "4247cf544b5c12f939517b2267f915559df85b059a164c457a40af74ffd88ea3",
+  "outcomes": [
+    {
+      "case_id": "policy-dev-sec-cyber-disclosure-2023",
+      "resolved_at": "2023-07-26T00:00:00Z",
+      "correct_option_id": "prepare_for_2023_rule",
+      "resolution_summary": "The SEC adopted the final public-company cybersecurity disclosure rules on 2023-07-26, before the benchmark's September deadline.",
+      "authoritative_sources": [
+        {
+          "source_id": "sec-cyber-disclosure-final-2023-08-04",
+          "title": "Cybersecurity Risk Management, Strategy, Governance, and Incident Disclosure - Final Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2023-08-04/pdf/2023-16194.pdf",
+          "published_at": "2023-08-04T00:00:00Z",
+          "content_sha256": "ab846792ef65cd6884e9d53984e730582ee6865fcd25e04d28ecbfe3d15302c6"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "commission_rulemaking_followthrough",
+          "description": "Whether the Commission would advance the 2022 proposal to a final vote during 2023 rather than continue the comment process.",
+          "aliases": ["SEC adoption timing", "rulemaking follow-through"]
+        },
+        {
+          "crux_id": "material_incident_disclosure_scope",
+          "description": "Whether the material-incident and governance requirements could be narrowed enough to reach a final rule.",
+          "aliases": ["Form 8-K scope", "cyber disclosure scope"]
+        },
+        {
+          "crux_id": "issuer_implementation_feasibility",
+          "description": "Whether registrants could operationalize materiality, incident reporting, and governance disclosures on the contemplated schedule.",
+          "aliases": ["compliance readiness", "implementation burden"]
+        }
+      ]
+    },
+    {
+      "case_id": "policy-dev-fda-food-traceability-2022",
+      "resolved_at": "2022-11-21T00:00:00Z",
+      "correct_option_id": "prepare_for_2022_final_rule",
+      "resolution_summary": "The FDA published the final food traceability rule on 2022-11-21, establishing additional recordkeeping requirements for foods on the Food Traceability List.",
+      "authoritative_sources": [
+        {
+          "source_id": "fda-food-traceability-final-2022-11-21",
+          "title": "Requirements for Additional Traceability Records for Certain Foods - Final Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2022-11-21/pdf/2022-24417.pdf",
+          "published_at": "2022-11-21T00:00:00Z",
+          "content_sha256": "d4abaa56c3adef020e94e3898d32cc3a886575cf6bd496f61b8e4a829fd618d9"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "fsma_traceability_mandate",
+          "description": "Whether the statutory traceability mandate and food-safety objective would keep the rulemaking on an active path.",
+          "aliases": ["FSMA mandate", "traceability authority"]
+        },
+        {
+          "crux_id": "recordkeeping_scope_workability",
+          "description": "Whether FDA could define critical tracking events and key data elements that were workable across heterogeneous supply chains.",
+          "aliases": ["KDE and CTE scope", "recordkeeping feasibility"]
+        },
+        {
+          "crux_id": "compliance_burden_accommodations",
+          "description": "Whether exemptions, phase-in timing, and implementation accommodations could address burden concerns without delaying finalization beyond 2022.",
+          "aliases": ["industry burden", "phase-in design"]
+        }
+      ]
+    },
+    {
+      "case_id": "policy-dev-sec-climate-disclosure-2023",
+      "resolved_at": "2024-03-06T00:00:00Z",
+      "correct_option_id": "defer_binding_implementation",
+      "resolution_summary": "The SEC did not adopt the final climate-related disclosure rules during 2023; adoption occurred on 2024-03-06.",
+      "authoritative_sources": [
+        {
+          "source_id": "sec-climate-disclosure-final-2024-03-28",
+          "title": "The Enhancement and Standardization of Climate-Related Disclosures for Investors - Final Rules",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2024-03-28/pdf/2024-05137.pdf",
+          "published_at": "2024-03-28T00:00:00Z",
+          "content_sha256": "01406c70425ceda5d9d93ece86d34fc491f773bbcf11714379c4d50c08f50232"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "rule_scope_revision",
+          "description": "Whether the Commission could reconcile comments on emissions, financial metrics, attestation, and phase-in requirements in time for a 2023 vote.",
+          "aliases": ["final rule scope", "proposal revision complexity"]
+        },
+        {
+          "crux_id": "statutory_authority_risk",
+          "description": "Whether legal-authority and litigation concerns would delay or materially narrow final adoption.",
+          "aliases": ["legal challenge risk", "SEC authority"]
+        },
+        {
+          "crux_id": "commission_schedule_capacity",
+          "description": "Whether the Commission's rulemaking schedule had enough capacity to complete this complex rule before year-end 2023.",
+          "aliases": ["agenda timing", "adoption schedule"]
+        }
+      ]
+    },
+    {
+      "case_id": "policy-dev-nist-csf2-july-2023",
+      "resolved_at": "2023-08-08T00:00:00Z",
+      "correct_option_id": "wait_for_public_draft",
+      "resolution_summary": "NIST released the CSF 2.0 initial public draft on 2023-08-08, after the benchmark's July 31 deadline.",
+      "authoritative_sources": [
+        {
+          "source_id": "nist-csf2-withdrawn-draft-release-record-2024-02-26",
+          "title": "Public Draft: The NIST Cybersecurity Framework 2.0 - withdrawal and publication record",
+          "url": "https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.29.ipd.pdf",
+          "published_at": "2024-02-26T00:00:00Z",
+          "content_sha256": "bf0e108a8af79f3db741e4da9ba9cd2d2876c97e89f9d02d894eedfc506bfee5"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "public_feedback_processing",
+          "description": "Whether NIST could incorporate concept-paper and workshop feedback quickly enough to publish before the end of July.",
+          "aliases": ["comment synthesis", "feedback processing time"]
+        },
+        {
+          "crux_id": "framework_scope_changes",
+          "description": "Whether proposed changes to scope, governance, profiles, and implementation resources would require additional drafting time.",
+          "aliases": ["CSF 2.0 design breadth", "scope complexity"]
+        },
+        {
+          "crux_id": "summer_schedule_precision",
+          "description": "Whether NIST's stated intent to issue a draft during summer implied publication by July rather than later in the season.",
+          "aliases": ["draft schedule credibility", "summer release timing"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.corpus.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-policy-compliance-holdout-tranche-1",
+  "frozen_at": "2026-08-30T03:17:26Z",
+  "cases": [
+    {
+      "case_id": "policy-holdout-ftc-noncompete-rule-2024",
+      "domain": "policy_compliance",
+      "split": "holdout",
+      "title": "FTC non-compete final-rule readiness by May 2024",
+      "decision_prompt": "A national employer is planning its 2024 employment-contract compliance program after the FTC proposed a rule governing non-compete clauses. Choose whether to fund bounded contract-inventory, notice, and policy-readiness work on the expectation that the FTC will publish a final Non-Compete Clause Rule by the end of May 2024, or defer that implementation work beyond the stated horizon.",
+      "forecast_question": "Will the FTC publish a final Non-Compete Clause Rule on or before 2024-05-31? Forecast the probability that prepare_for_may_2024_rule is the correct action.",
+      "forecast_option_id": "prepare_for_may_2024_rule",
+      "options": [
+        {
+          "option_id": "prepare_for_may_2024_rule",
+          "label": "Prepare for a rule by May 2024",
+          "description": "Fund bounded contract inventory, worker-notice, and policy readiness for a final rule published by the end of May 2024."
+        },
+        {
+          "option_id": "defer_beyond_may_2024",
+          "label": "Defer beyond May 2024",
+          "description": "Preserve monitoring but defer material implementation readiness beyond May 2024."
+        }
+      ],
+      "information_cutoff": "2023-01-20T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "ftc-noncompete-proposal-2023-01-19",
+          "title": "Non-Compete Clause Rule - Notice of Proposed Rulemaking",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2023-01-19/pdf/2023-00414.pdf",
+          "published_at": "2023-01-19T00:00:00Z",
+          "content_sha256": "eb6aa67a3da592cbbaba21282bf0e89308fb9cc6278590b84e705f672af587b3"
+        }
+      ]
+    },
+    {
+      "case_id": "policy-holdout-dol-independent-contractor-2023",
+      "domain": "policy_compliance",
+      "split": "holdout",
+      "title": "DOL independent-contractor final-rule timing through 2023",
+      "decision_prompt": "A multi-state business is planning worker-classification compliance after the Department of Labor proposed replacing the 2021 independent-contractor analysis under the Fair Labor Standards Act. Choose whether to treat a final replacement rule as a binding 2023 implementation baseline or preserve readiness while deferring the binding rollout until 2024.",
+      "forecast_question": "Will the Department of Labor refrain from publishing the final independent-contractor rule through 2023-12-31? Forecast the probability that defer_binding_rollout_to_2024 is the correct action.",
+      "forecast_option_id": "defer_binding_rollout_to_2024",
+      "options": [
+        {
+          "option_id": "defer_binding_rollout_to_2024",
+          "label": "Defer the binding rollout to 2024",
+          "description": "Preserve classification-analysis readiness but do not treat the proposal as a final 2023 compliance baseline."
+        },
+        {
+          "option_id": "implement_as_2023_final",
+          "label": "Implement as a 2023 final rule",
+          "description": "Commit the worker-classification program to the proposed replacement on the assumption that the final rule will publish during 2023."
+        }
+      ],
+      "information_cutoff": "2022-10-14T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "dol-independent-contractor-proposal-2022-10-13",
+          "title": "Employee or Independent Contractor Classification Under the Fair Labor Standards Act - Proposed Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2022-10-13/pdf/2022-21454.pdf",
+          "published_at": "2022-10-13T00:00:00Z",
+          "content_sha256": "fb2fa5404e1c154790411363415d149186f11c76907570d496a67291d68206f0"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-policy-compliance-holdout-tranche-1",
-  "frozen_at": "2026-08-30T03:17:26Z",
+  "revision": "draft-policy-compliance-holdout-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "policy-holdout-ftc-noncompete-rule-2024",
@@ -10,18 +10,18 @@
       "split": "holdout",
       "title": "FTC non-compete final-rule readiness by May 2024",
       "decision_prompt": "A national employer is planning its 2024 employment-contract compliance program after the FTC proposed a rule governing non-compete clauses. Choose whether to fund bounded contract-inventory, notice, and policy-readiness work on the expectation that the FTC will publish a final Non-Compete Clause Rule by the end of May 2024, or defer that implementation work beyond the stated horizon.",
-      "forecast_question": "Will the FTC publish a final Non-Compete Clause Rule on or before 2024-05-31? Forecast the probability that prepare_for_may_2024_rule is the correct action.",
-      "forecast_option_id": "prepare_for_may_2024_rule",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Defer beyond May 2024\" is the outcome-aligned action at the stated horizon.",
+      "forecast_option_id": "defer_beyond_may_2024",
       "options": [
-        {
-          "option_id": "prepare_for_may_2024_rule",
-          "label": "Prepare for a rule by May 2024",
-          "description": "Fund bounded contract inventory, worker-notice, and policy readiness for a final rule published by the end of May 2024."
-        },
         {
           "option_id": "defer_beyond_may_2024",
           "label": "Defer beyond May 2024",
           "description": "Preserve monitoring but defer material implementation readiness beyond May 2024."
+        },
+        {
+          "option_id": "prepare_for_may_2024_rule",
+          "label": "Prepare for a rule by May 2024",
+          "description": "Fund bounded contract inventory, worker-notice, and policy readiness for a final rule published by the end of May 2024."
         }
       ],
       "information_cutoff": "2023-01-20T00:00:00Z",
@@ -41,7 +41,7 @@
       "split": "holdout",
       "title": "DOL independent-contractor final-rule timing through 2023",
       "decision_prompt": "A multi-state business is planning worker-classification compliance after the Department of Labor proposed replacing the 2021 independent-contractor analysis under the Fair Labor Standards Act. Choose whether to treat a final replacement rule as a binding 2023 implementation baseline or preserve readiness while deferring the binding rollout until 2024.",
-      "forecast_question": "Will the Department of Labor refrain from publishing the final independent-contractor rule through 2023-12-31? Forecast the probability that defer_binding_rollout_to_2024 is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Defer the binding rollout to 2024\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "defer_binding_rollout_to_2024",
       "options": [
         {

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "e52440953ce0c4b84f9f8ee5da69b278f4814af75971fe91c36279c555a4e5b6",
+  "corpus_sha256": "318c209ccfc5d24b82f6083f284334fb89f752a9dfc6a8ab0ee68d6f5a5dbd4d",
   "outcomes": [
     {
       "case_id": "policy-holdout-ftc-noncompete-rule-2024",

--- a/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/policy-compliance-holdout-1.outcomes.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "e52440953ce0c4b84f9f8ee5da69b278f4814af75971fe91c36279c555a4e5b6",
+  "outcomes": [
+    {
+      "case_id": "policy-holdout-ftc-noncompete-rule-2024",
+      "resolved_at": "2024-05-07T00:00:00Z",
+      "correct_option_id": "prepare_for_may_2024_rule",
+      "resolution_summary": "The FTC published the final Non-Compete Clause Rule on 2024-05-07, within the benchmark's May 2024 publication horizon, making bounded readiness the outcome-aligned action for this timing question.",
+      "authoritative_sources": [
+        {
+          "source_id": "ftc-noncompete-final-2024-05-07",
+          "title": "Non-Compete Clause Rule - Final Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2024-05-07/pdf/2024-09171.pdf",
+          "published_at": "2024-05-07T00:00:00Z",
+          "content_sha256": "6059e0245c85d0d70ffef048b32bd3def7cd9889c1d5b0d0bb92d8cf1e5e495b"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "ftc_rulemaking_authority",
+          "description": "Whether the Commission would maintain its asserted authority to issue a generally applicable non-compete rule through final adoption.",
+          "aliases": ["FTC statutory authority", "rulemaking authority"]
+        },
+        {
+          "crux_id": "comment_record_processing",
+          "description": "Whether the Commission could process the rulemaking record and revise the proposal without pushing publication beyond May 2024.",
+          "aliases": ["public comment volume", "record review timing"]
+        },
+        {
+          "crux_id": "final_rule_scope",
+          "description": "Whether exemptions, treatment of existing agreements, and notice obligations could be bounded enough for a final vote.",
+          "aliases": ["rule scope revisions", "senior executive treatment"]
+        },
+        {
+          "crux_id": "commission_adoption_schedule",
+          "description": "Whether the Commission would place and approve the rule on a schedule that supported publication by the benchmark deadline.",
+          "aliases": ["commission vote timing", "publication schedule"]
+        }
+      ]
+    },
+    {
+      "case_id": "policy-holdout-dol-independent-contractor-2023",
+      "resolved_at": "2024-01-10T00:00:00Z",
+      "correct_option_id": "defer_binding_rollout_to_2024",
+      "resolution_summary": "The Department of Labor published the final independent-contractor rule on 2024-01-10, after the benchmark's 2023 deadline, so deferring the binding rollout to 2024 was the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "dol-independent-contractor-final-2024-01-10",
+          "title": "Employee or Independent Contractor Classification Under the Fair Labor Standards Act - Final Rule",
+          "url": "https://www.govinfo.gov/content/pkg/FR-2024-01-10/pdf/2024-00067.pdf",
+          "published_at": "2024-01-10T00:00:00Z",
+          "content_sha256": "e41e1ce14d83576a0fc5d81fa902bd8ff94299dac459e10e1716f155f9203330"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "economic_reality_test_design",
+          "description": "Whether the Department could finalize a totality-of-the-circumstances test that reconciled judicial precedent with the proposed regulatory text.",
+          "aliases": ["classification test design", "factor weighting"]
+        },
+        {
+          "crux_id": "2021_rule_baseline",
+          "description": "Whether litigation and enforcement surrounding the 2021 rule would complicate replacement-rule timing.",
+          "aliases": ["existing rule litigation", "regulatory baseline"]
+        },
+        {
+          "crux_id": "stakeholder_comment_resolution",
+          "description": "Whether the Department could resolve comments from workers and businesses without extending finalization beyond 2023.",
+          "aliases": ["comment review", "stakeholder objections"]
+        },
+        {
+          "crux_id": "department_publication_schedule",
+          "description": "Whether the Department's rulemaking and Federal Register schedule would support publication before the end of 2023.",
+          "aliases": ["regulatory agenda timing", "Federal Register schedule"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-1.corpus.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-science-forecasting-tranche-1",
+  "frozen_at": "2026-08-30T02:34:27Z",
+  "cases": [
+    {
+      "case_id": "science-dev-dart-orbit-change",
+      "domain": "science_forecasting",
+      "split": "development",
+      "title": "DART post-impact orbit-measurement campaign",
+      "decision_prompt": "A planetary-defense observation team has telescope time reserved around NASA's September 2022 DART impact. Choose the action that best preserves the ability to determine whether the kinetic impact achieved a measurable deflection of Dimorphos.",
+      "forecast_question": "Will DART change Dimorphos's orbital period by at least 73 seconds by 2022-10-31? Forecast the probability that retain_measurement_campaign is the correct action.",
+      "forecast_option_id": "retain_measurement_campaign",
+      "options": [
+        {
+          "option_id": "retain_measurement_campaign",
+          "label": "Retain the post-impact campaign",
+          "description": "Keep coordinated telescope capacity through October to measure the post-impact orbital period."
+        },
+        {
+          "option_id": "release_measurement_slots",
+          "label": "Release the observing slots",
+          "description": "Return the reserved telescope capacity before impact and do not maintain a coordinated post-impact measurement campaign."
+        }
+      ],
+      "information_cutoff": "2022-08-26T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "nasa-dart-fact-sheet-2022-08-25",
+          "title": "NASA Planetary Defense: Double Asteroid Redirection Test fact sheet",
+          "url": "https://www.nasa.gov/wp-content/uploads/2023/08/pd-dart-fact-sheet.pdf",
+          "published_at": "2022-08-25T19:59:45Z",
+          "content_sha256": "a43dcce04cddc836a504a96138f8133220afc4b5d130e6fb3ddce7da0df6a731"
+        }
+      ]
+    },
+    {
+      "case_id": "science-dev-atlantic-2023-storm-count",
+      "domain": "science_forecasting",
+      "split": "development",
+      "title": "Atlantic hurricane-season surge capacity",
+      "decision_prompt": "An emergency-science operations team is allocating seasonal analysis and response capacity after NOAA's May 2023 Atlantic outlook. Choose the action that best fits whether the final named-storm count will exceed the 1991-2020 average of 14.",
+      "forecast_question": "Will the 2023 Atlantic hurricane season produce more than 14 named storms by 2023-12-07? Forecast the probability that retain_high_activity_contingency is the correct action.",
+      "forecast_option_id": "retain_high_activity_contingency",
+      "options": [
+        {
+          "option_id": "retain_high_activity_contingency",
+          "label": "Retain high-activity contingency capacity",
+          "description": "Keep surge analysis and response capacity available for a named-storm count above the recent climatological average."
+        },
+        {
+          "option_id": "plan_for_at_most_average_count",
+          "label": "Plan for an at-most-average count",
+          "description": "Size the seasonal allocation on the assumption that no more than 14 named storms will form."
+        }
+      ],
+      "information_cutoff": "2023-05-26T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "noaa-2023-hurricane-outlook-2023-05-25",
+          "title": "NOAA 2023 Hurricane Season Outlook Interagency Congressional Briefing",
+          "url": "https://www.noaa.gov/sites/default/files/2023-05/2023HurricaneSeasonOutlookBriefing.pdf",
+          "published_at": "2023-05-25T20:37:21Z",
+          "content_sha256": "5bb6aebbc42ad25cde7941529c1cba588456a7a00e2175acd62f3cdf7f47faeb"
+        }
+      ]
+    },
+    {
+      "case_id": "science-dev-psyche-2022-launch",
+      "domain": "science_forecasting",
+      "split": "development",
+      "title": "Psyche 2022 launch-operations plan",
+      "decision_prompt": "A deep-space science operations group is allocating staffing in March 2022 for the Psyche mission's planned late-2022 departure. Choose the action that best fits whether Psyche will launch before the end of 2022.",
+      "forecast_question": "Will NASA's Psyche spacecraft launch on or before 2022-12-31? Forecast the probability that retain_2022_launch_readiness is the correct action.",
+      "forecast_option_id": "retain_2022_launch_readiness",
+      "options": [
+        {
+          "option_id": "retain_2022_launch_readiness",
+          "label": "Retain 2022 launch readiness",
+          "description": "Keep the mission-operations allocation committed to a launch before the end of 2022."
+        },
+        {
+          "option_id": "rebaseline_after_2022",
+          "label": "Rebaseline beyond 2022",
+          "description": "Move the primary mission-operations allocation beyond 2022 while preserving bounded contingency support."
+        }
+      ],
+      "information_cutoff": "2022-03-06T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "nasa-psyche-flight-rule-design-2022-03-05",
+          "title": "Flight Rule Design, Implementation, Verification, and Validation for the Psyche Mission",
+          "url": "https://ntrs.nasa.gov/api/citations/20230007023",
+          "published_at": "2022-03-05T00:00:00Z",
+          "content_sha256": "ffe2d076ff51afd010f5c0f875db18fb3279b70342f913a7068368caebdbcec6"
+        }
+      ]
+    },
+    {
+      "case_id": "science-dev-starliner-cft-july-2023",
+      "domain": "science_forecasting",
+      "split": "development",
+      "title": "Starliner July 2023 crew-test operations plan",
+      "decision_prompt": "An ISS science-operations team must allocate integration staffing after NASA reports a July 21 target for Boeing's first Starliner crewed flight test while technical issues remain open. Choose the action that best fits whether the flight will launch by the end of July 2023.",
+      "forecast_question": "Will Boeing's Starliner Crew Flight Test launch on or before 2023-07-31? Forecast the probability that retain_july_integration_readiness is the correct action.",
+      "forecast_option_id": "retain_july_integration_readiness",
+      "options": [
+        {
+          "option_id": "retain_july_integration_readiness",
+          "label": "Retain July integration readiness",
+          "description": "Keep the July launch and ISS integration staffing allocation intact."
+        },
+        {
+          "option_id": "rebaseline_after_july",
+          "label": "Rebaseline beyond July",
+          "description": "Move the primary integration staffing allocation beyond July while retaining bounded contingency coverage."
+        }
+      ],
+      "information_cutoff": "2023-06-01T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "nasa-commercial-programs-briefing-2023-05-31",
+          "title": "NASA Advisory Committee Commercial Programs briefing",
+          "url": "https://www.nasa.gov/wp-content/uploads/2023/10/csd-nac-briefing-may-2023-tagged.pdf",
+          "published_at": "2023-05-31T14:18:56Z",
+          "content_sha256": "95c51c157d3050cdfbd4d2b8b4551286e18f8661e82ee6207673fc17f5028713"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-science-forecasting-tranche-1",
-  "frozen_at": "2026-08-30T02:34:27Z",
+  "revision": "draft-science-forecasting-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "science-dev-dart-orbit-change",
@@ -10,18 +10,18 @@
       "split": "development",
       "title": "DART post-impact orbit-measurement campaign",
       "decision_prompt": "A planetary-defense observation team has telescope time reserved around NASA's September 2022 DART impact. Choose the action that best preserves the ability to determine whether the kinetic impact achieved a measurable deflection of Dimorphos.",
-      "forecast_question": "Will DART change Dimorphos's orbital period by at least 73 seconds by 2022-10-31? Forecast the probability that retain_measurement_campaign is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain the post-impact campaign\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_measurement_campaign",
       "options": [
-        {
-          "option_id": "retain_measurement_campaign",
-          "label": "Retain the post-impact campaign",
-          "description": "Keep coordinated telescope capacity through October to measure the post-impact orbital period."
-        },
         {
           "option_id": "release_measurement_slots",
           "label": "Release the observing slots",
           "description": "Return the reserved telescope capacity before impact and do not maintain a coordinated post-impact measurement campaign."
+        },
+        {
+          "option_id": "retain_measurement_campaign",
+          "label": "Retain the post-impact campaign",
+          "description": "Keep coordinated telescope capacity through October to measure the post-impact orbital period."
         }
       ],
       "information_cutoff": "2022-08-26T00:00:00Z",
@@ -41,18 +41,18 @@
       "split": "development",
       "title": "Atlantic hurricane-season surge capacity",
       "decision_prompt": "An emergency-science operations team is allocating seasonal analysis and response capacity after NOAA's May 2023 Atlantic outlook. Choose the action that best fits whether the final named-storm count will exceed the 1991-2020 average of 14.",
-      "forecast_question": "Will the 2023 Atlantic hurricane season produce more than 14 named storms by 2023-12-07? Forecast the probability that retain_high_activity_contingency is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain high-activity contingency capacity\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_high_activity_contingency",
       "options": [
-        {
-          "option_id": "retain_high_activity_contingency",
-          "label": "Retain high-activity contingency capacity",
-          "description": "Keep surge analysis and response capacity available for a named-storm count above the recent climatological average."
-        },
         {
           "option_id": "plan_for_at_most_average_count",
           "label": "Plan for an at-most-average count",
           "description": "Size the seasonal allocation on the assumption that no more than 14 named storms will form."
+        },
+        {
+          "option_id": "retain_high_activity_contingency",
+          "label": "Retain high-activity contingency capacity",
+          "description": "Keep surge analysis and response capacity available for a named-storm count above the recent climatological average."
         }
       ],
       "information_cutoff": "2023-05-26T00:00:00Z",
@@ -72,18 +72,18 @@
       "split": "development",
       "title": "Psyche 2022 launch-operations plan",
       "decision_prompt": "A deep-space science operations group is allocating staffing in March 2022 for the Psyche mission's planned late-2022 departure. Choose the action that best fits whether Psyche will launch before the end of 2022.",
-      "forecast_question": "Will NASA's Psyche spacecraft launch on or before 2022-12-31? Forecast the probability that retain_2022_launch_readiness is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain 2022 launch readiness\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_2022_launch_readiness",
       "options": [
-        {
-          "option_id": "retain_2022_launch_readiness",
-          "label": "Retain 2022 launch readiness",
-          "description": "Keep the mission-operations allocation committed to a launch before the end of 2022."
-        },
         {
           "option_id": "rebaseline_after_2022",
           "label": "Rebaseline beyond 2022",
           "description": "Move the primary mission-operations allocation beyond 2022 while preserving bounded contingency support."
+        },
+        {
+          "option_id": "retain_2022_launch_readiness",
+          "label": "Retain 2022 launch readiness",
+          "description": "Keep the mission-operations allocation committed to a launch before the end of 2022."
         }
       ],
       "information_cutoff": "2022-03-06T00:00:00Z",
@@ -103,18 +103,18 @@
       "split": "development",
       "title": "Starliner July 2023 crew-test operations plan",
       "decision_prompt": "An ISS science-operations team must allocate integration staffing after NASA reports a July 21 target for Boeing's first Starliner crewed flight test while technical issues remain open. Choose the action that best fits whether the flight will launch by the end of July 2023.",
-      "forecast_question": "Will Boeing's Starliner Crew Flight Test launch on or before 2023-07-31? Forecast the probability that retain_july_integration_readiness is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain July integration readiness\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "retain_july_integration_readiness",
       "options": [
-        {
-          "option_id": "retain_july_integration_readiness",
-          "label": "Retain July integration readiness",
-          "description": "Keep the July launch and ISS integration staffing allocation intact."
-        },
         {
           "option_id": "rebaseline_after_july",
           "label": "Rebaseline beyond July",
           "description": "Move the primary integration staffing allocation beyond July while retaining bounded contingency coverage."
+        },
+        {
+          "option_id": "retain_july_integration_readiness",
+          "label": "Retain July integration readiness",
+          "description": "Keep the July launch and ISS integration staffing allocation intact."
         }
       ],
       "information_cutoff": "2023-06-01T00:00:00Z",

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-1.outcomes.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "3f5ea13fac70579c8422b08f820a96a3ebd266e7cd2db174d381a24f47bc491e",
+  "outcomes": [
+    {
+      "case_id": "science-dev-dart-orbit-change",
+      "resolved_at": "2022-10-11T00:00:00Z",
+      "correct_option_id": "retain_measurement_campaign",
+      "resolution_summary": "DART successfully impacted Dimorphos, and NASA measured an orbital-period reduction of roughly 32 minutes, far exceeding the 73-second minimum success criterion.",
+      "authoritative_sources": [
+        {
+          "source_id": "nasa-dart-final-report-2023-10-01",
+          "title": "Final Technical Report for the Double Asteroid Redirection Test Mission",
+          "url": "https://ntrs.nasa.gov/api/citations/20230015804/downloads/DART%20Final%20Technical%20Report.pdf",
+          "published_at": "2023-10-01T00:00:00Z",
+          "content_sha256": "c7fb2ac0011a5fab5a3a369ea9937dca09dfddfd9050244408143212b299bc44"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "autonomous_targeting_success",
+          "description": "Whether DART's autonomous navigation could identify and strike Dimorphos accurately enough to execute the experiment.",
+          "aliases": ["SMART Nav performance", "impact targeting accuracy"]
+        },
+        {
+          "crux_id": "momentum_transfer_magnitude",
+          "description": "Whether the impact and ejecta would transfer enough momentum to exceed the minimum measurable orbital-period change.",
+          "aliases": ["kinetic coupling", "deflection magnitude"]
+        },
+        {
+          "crux_id": "ground_observation_precision",
+          "description": "Whether the observing campaign could determine the post-impact binary period precisely enough to verify the threshold.",
+          "aliases": ["light-curve precision", "telescope measurement readiness"]
+        }
+      ]
+    },
+    {
+      "case_id": "science-dev-atlantic-2023-storm-count",
+      "resolved_at": "2023-12-07T00:00:00Z",
+      "correct_option_id": "retain_high_activity_contingency",
+      "resolution_summary": "NOAA's post-season monitoring recorded 20 Atlantic named storms in 2023, above the 1991-2020 average of 14.",
+      "authoritative_sources": [
+        {
+          "source_id": "noaa-global-ocean-monitoring-2023-12-11",
+          "title": "NOAA Global Ocean Monitoring: Recent Evolution, Current Status, and Predictions",
+          "url": "https://www.cpc.ncep.noaa.gov/products/GODAS/ocean_briefing_gif/global_ocean_monitoring_2023_12.pdf",
+          "published_at": "2023-12-11T03:13:10Z",
+          "content_sha256": "7d1b277db5571b7fdbf6043e41ad8ef4bd82dda93e319e03a257bbf6f4c3de09"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "el_nino_shear_suppression",
+          "description": "Whether developing El Nino wind shear would suppress Atlantic storm formation strongly enough to cap the seasonal count.",
+          "aliases": ["ENSO suppression", "vertical wind shear"]
+        },
+        {
+          "crux_id": "atlantic_sst_amplification",
+          "description": "Whether exceptionally warm tropical Atlantic sea-surface temperatures would offset the expected El Nino suppression.",
+          "aliases": ["warm Atlantic", "main development region temperatures"]
+        },
+        {
+          "crux_id": "short_lived_storm_frequency",
+          "description": "Whether environmental conditions would support numerous named storms even without an unusually high major-hurricane count.",
+          "aliases": ["storm count versus intensity", "short-duration systems"]
+        }
+      ]
+    },
+    {
+      "case_id": "science-dev-psyche-2022-launch",
+      "resolved_at": "2022-06-24T00:00:00Z",
+      "correct_option_id": "rebaseline_after_2022",
+      "resolution_summary": "NASA stood down from Psyche's 2022 launch opportunity after late flight-software delivery, immature testbeds, incomplete verification, and operations-readiness concerns.",
+      "authoritative_sources": [
+        {
+          "source_id": "nasa-psyche-independent-review-2022-11-04",
+          "title": "Psyche Independent Review Board Report and NASA-JPL Response",
+          "url": "https://www.nasa.gov/wp-content/uploads/2022/11/psyche_irb_report_and_response_nov_2022.pdf",
+          "published_at": "2022-11-04T00:00:00Z",
+          "content_sha256": "b13961ae0ffa2c18ae8a29c2515e8eb19cfc69b80e01605c05666973fe879535"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "flight_software_delivery",
+          "description": "Whether guidance, navigation, control, and fault-protection software would reach a testable flight configuration with sufficient margin.",
+          "aliases": ["GNC software maturity", "flight software schedule"]
+        },
+        {
+          "crux_id": "testbed_verification_readiness",
+          "description": "Whether the spacecraft simulators and verification program were mature enough to complete required validation before the launch window.",
+          "aliases": ["testbed maturity", "verification and validation"]
+        },
+        {
+          "crux_id": "experienced_staff_capacity",
+          "description": "Whether the project and institution had enough experienced personnel to close technical and operations-readiness work safely.",
+          "aliases": ["workforce capacity", "operations staffing"]
+        }
+      ]
+    },
+    {
+      "case_id": "science-dev-starliner-cft-july-2023",
+      "resolved_at": "2023-08-01T00:00:00Z",
+      "correct_option_id": "rebaseline_after_july",
+      "resolution_summary": "Starliner's first crewed flight test did not launch by July 2023; after additional delays, it launched in June 2024.",
+      "authoritative_sources": [
+        {
+          "source_id": "nasa-oig-iss-operations-risk-2024-09-26",
+          "title": "NASA's Management of Risks to Sustaining ISS Operations through 2030",
+          "url": "https://oig.nasa.gov/wp-content/uploads/2024/09/ig-24-020.pdf",
+          "published_at": "2024-09-26T00:00:00Z",
+          "content_sha256": "61059ffef51f599e0426868db370f4d69335a8f1bf6f9f358363a803c21d3006"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "open_technical_issue_closure",
+          "description": "Whether the remaining spacecraft technical issues could be resolved before fueling and final flight-readiness decisions.",
+          "aliases": ["technical closure", "hardware readiness"]
+        },
+        {
+          "crux_id": "certification_schedule_margin",
+          "description": "Whether the July target retained enough schedule margin for NASA and Boeing certification work without accepting excess crew risk.",
+          "aliases": ["flight-readiness margin", "certification timing"]
+        },
+        {
+          "crux_id": "iss_manifest_integration",
+          "description": "Whether ISS traffic and mission-integration constraints would still support the targeted crew-flight window after technical slips.",
+          "aliases": ["station schedule", "launch manifest integration"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "3f5ea13fac70579c8422b08f820a96a3ebd266e7cd2db174d381a24f47bc491e",
+  "corpus_sha256": "2fc5525c8b7a23c5f57faed12967cb170be1e83c6afcba58ac45b43cefa18445",
   "outcomes": [
     {
       "case_id": "science-dev-dart-orbit-change",

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.corpus.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-science-forecasting-holdout-tranche-1",
+  "frozen_at": "2026-08-30T03:26:16Z",
+  "cases": [
+    {
+      "case_id": "science-holdout-osiris-rex-return-september-2023",
+      "domain": "science_forecasting",
+      "split": "holdout",
+      "title": "OSIRIS-REx sample-return operations through September 2023",
+      "decision_prompt": "A sample-return operations team is allocating its September 2023 recovery, curation, and communications capacity after NASA publishes the OSIRIS-REx return press kit. Choose whether to retain the full September recovery plan on the expectation that the Bennu sample capsule will land successfully by month-end, or rebaseline the primary operations plan beyond September.",
+      "forecast_question": "Will the OSIRIS-REx sample capsule land successfully on Earth on or before 2023-09-30? Forecast the probability that retain_september_recovery_plan is the correct action.",
+      "forecast_option_id": "retain_september_recovery_plan",
+      "options": [
+        {
+          "option_id": "retain_september_recovery_plan",
+          "label": "Retain the September recovery plan",
+          "description": "Keep recovery, curation, and communications capacity committed to a successful sample landing by the end of September."
+        },
+        {
+          "option_id": "rebaseline_beyond_september",
+          "label": "Rebaseline beyond September",
+          "description": "Move the primary recovery and curation plan beyond September and reduce commitments tied to a September landing."
+        }
+      ],
+      "information_cutoff": "2023-09-02T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "nasa-osiris-rex-return-press-kit-2023-09",
+          "title": "OSIRIS-REx Asteroid Sample Return Mission Press Kit",
+          "url": "https://science.nasa.gov/wp-content/uploads/2023/09/osirisrexpresskit-2023.pdf",
+          "published_at": "2023-09-01T00:00:00Z",
+          "content_sha256": "8aa4fbd6c843ff6a2ade524791a3c15e51d4e6031b4b9e4e1bbf35ad25bbecae"
+        }
+      ]
+    },
+    {
+      "case_id": "science-holdout-artemis-i-launch-september-2022",
+      "domain": "science_forecasting",
+      "split": "holdout",
+      "title": "Artemis I launch operations through September 2022",
+      "decision_prompt": "NASA has completed the Artemis I flight-readiness review and declared the uncrewed mission go for an August 29 launch attempt. A launch-operations team must decide whether to keep September staffing, range, and mission-support capacity committed to a launch by month-end or rebaseline the primary plan beyond September.",
+      "forecast_question": "Will Artemis I fail to launch through 2022-09-30? Forecast the probability that rebaseline_launch_beyond_september is the correct action.",
+      "forecast_option_id": "rebaseline_launch_beyond_september",
+      "options": [
+        {
+          "option_id": "rebaseline_launch_beyond_september",
+          "label": "Rebaseline beyond September",
+          "description": "Move the primary launch-operations plan beyond September while preserving bounded readiness for earlier attempts."
+        },
+        {
+          "option_id": "retain_september_launch_plan",
+          "label": "Retain the September launch plan",
+          "description": "Keep staffing, range, and mission-support commitments centered on an Artemis I launch by the end of September."
+        }
+      ],
+      "information_cutoff": "2022-08-23T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "nasa-artemis-i-flight-readiness-go-2022-08-22",
+          "title": "Artemis I Flight Readiness Concludes; NASA Go for August 29 Launch",
+          "url": "https://www.nasa.gov/blogs/missions/2022/08/22/artemis-i-flight-readiness-concludes-nasa-go-for-august-29-launch-briefing-set-for-8-p-m/",
+          "published_at": "2022-08-22T00:00:00Z",
+          "content_sha256": "878b32d5aeb61e0d23834163f90026f3675f9558aab8326f2c7929323701a106"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-science-forecasting-holdout-tranche-1",
-  "frozen_at": "2026-08-30T03:26:16Z",
+  "revision": "draft-science-forecasting-holdout-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "science-holdout-osiris-rex-return-september-2023",
@@ -10,18 +10,18 @@
       "split": "holdout",
       "title": "OSIRIS-REx sample-return operations through September 2023",
       "decision_prompt": "A sample-return operations team is allocating its September 2023 recovery, curation, and communications capacity after NASA publishes the OSIRIS-REx return press kit. Choose whether to retain the full September recovery plan on the expectation that the Bennu sample capsule will land successfully by month-end, or rebaseline the primary operations plan beyond September.",
-      "forecast_question": "Will the OSIRIS-REx sample capsule land successfully on Earth on or before 2023-09-30? Forecast the probability that retain_september_recovery_plan is the correct action.",
-      "forecast_option_id": "retain_september_recovery_plan",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Rebaseline beyond September\" is the outcome-aligned action at the stated horizon.",
+      "forecast_option_id": "rebaseline_beyond_september",
       "options": [
-        {
-          "option_id": "retain_september_recovery_plan",
-          "label": "Retain the September recovery plan",
-          "description": "Keep recovery, curation, and communications capacity committed to a successful sample landing by the end of September."
-        },
         {
           "option_id": "rebaseline_beyond_september",
           "label": "Rebaseline beyond September",
           "description": "Move the primary recovery and curation plan beyond September and reduce commitments tied to a September landing."
+        },
+        {
+          "option_id": "retain_september_recovery_plan",
+          "label": "Retain the September recovery plan",
+          "description": "Keep recovery, curation, and communications capacity committed to a successful sample landing by the end of September."
         }
       ],
       "information_cutoff": "2023-09-02T00:00:00Z",
@@ -41,7 +41,7 @@
       "split": "holdout",
       "title": "Artemis I launch operations through September 2022",
       "decision_prompt": "NASA has completed the Artemis I flight-readiness review and declared the uncrewed mission go for an August 29 launch attempt. A launch-operations team must decide whether to keep September staffing, range, and mission-support capacity committed to a launch by month-end or rebaseline the primary plan beyond September.",
-      "forecast_question": "Will Artemis I fail to launch through 2022-09-30? Forecast the probability that rebaseline_launch_beyond_september is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Rebaseline beyond September\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "rebaseline_launch_beyond_september",
       "options": [
         {

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "086c8edba8caae1da3c1478d7910c393bcd131f881ca2f93935cd5ac4d90808c",
+  "corpus_sha256": "503a5cc94a26fcd38f8c0bb264413ac82b2ae7a3489da8d22e6d646254702ed6",
   "outcomes": [
     {
       "case_id": "science-holdout-osiris-rex-return-september-2023",

--- a/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/science-forecasting-holdout-1.outcomes.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "086c8edba8caae1da3c1478d7910c393bcd131f881ca2f93935cd5ac4d90808c",
+  "outcomes": [
+    {
+      "case_id": "science-holdout-osiris-rex-return-september-2023",
+      "resolved_at": "2023-09-24T00:00:00Z",
+      "correct_option_id": "retain_september_recovery_plan",
+      "resolution_summary": "The OSIRIS-REx sample-return capsule landed safely in Utah on 2023-09-24, making the retained September recovery plan the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "nasa-ntrs-osiris-rex-earth-return-performance-2024",
+          "title": "OSIRIS-REx Earth Return and Entry: Targeting Strategy and Maneuver Performance",
+          "url": "https://ntrs.nasa.gov/api/citations/20240000803/downloads/OREx_ER_Entry_Targeting_Strategy_and_Man_Perf_v3.pdf",
+          "published_at": "2024-02-01T00:00:00Z",
+          "content_sha256": "cfeee4f9b5c6c0431a76e5a6d012ef7f515d29318b57d4a3e8b3ffce4a11aecd"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "earth_return_targeting_accuracy",
+          "description": "Whether trajectory correction and navigation would place the capsule inside the atmospheric-entry corridor.",
+          "aliases": ["entry targeting", "trajectory accuracy"]
+        },
+        {
+          "crux_id": "capsule_release_execution",
+          "description": "Whether the spacecraft would release the sample capsule at the planned state while diverting the carrier safely past Earth.",
+          "aliases": ["sample capsule release", "spacecraft divert maneuver"]
+        },
+        {
+          "crux_id": "entry_descent_landing_system",
+          "description": "Whether the heat shield, parachutes, and landing sequence would perform through atmospheric entry and descent.",
+          "aliases": ["EDL performance", "parachute and heat shield"]
+        },
+        {
+          "crux_id": "recovery_and_curation_readiness",
+          "description": "Whether weather, range coordination, recovery teams, and clean-room handling would support immediate retrieval and curation.",
+          "aliases": ["Utah recovery readiness", "sample curation operations"]
+        }
+      ]
+    },
+    {
+      "case_id": "science-holdout-artemis-i-launch-september-2022",
+      "resolved_at": "2022-11-16T00:00:00Z",
+      "correct_option_id": "rebaseline_launch_beyond_september",
+      "resolution_summary": "Artemis I did not launch during August or September 2022; SLS and Orion launched on 2022-11-16, so rebaselining the primary launch plan beyond September was the outcome-aligned action.",
+      "authoritative_sources": [
+        {
+          "source_id": "nasa-artemis-i-liftoff-2022-11-16",
+          "title": "Liftoff! NASA's Artemis I Mega Rocket Launches Orion to Moon",
+          "url": "https://www.nasa.gov/news-release/liftoff-nasas-artemis-i-mega-rocket-launches-orion-to-moon/",
+          "published_at": "2022-11-16T00:00:00Z",
+          "content_sha256": "859da16fbf6c4783d4632c1e3fc214cb548f6fb03a89cb83c5cc4f4cb5b1e89e"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "first_flight_integration_readiness",
+          "description": "Whether the first integrated SLS, Orion, and ground-systems stack would remain flight-ready through final countdown operations.",
+          "aliases": ["integrated stack readiness", "first-flight risk"]
+        },
+        {
+          "crux_id": "cryogenic_loading_and_engine_conditioning",
+          "description": "Whether propellant loading, thermal conditioning, and engine-start constraints could be satisfied during the available launch windows.",
+          "aliases": ["hydrogen loading", "engine conditioning"]
+        },
+        {
+          "crux_id": "weather_and_range_availability",
+          "description": "Whether weather, range, and pad constraints would leave a usable launch opportunity before the end of September.",
+          "aliases": ["launch weather", "range availability"]
+        },
+        {
+          "crux_id": "turnaround_between_attempts",
+          "description": "Whether teams could diagnose issues, service the vehicle, and recycle between attempts within the September horizon.",
+          "aliases": ["launch attempt turnaround", "pad recycle time"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/software-development-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/software-development-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-software-development-tranche-1",
-  "frozen_at": "2026-08-30T01:50:00Z",
+  "revision": "draft-software-development-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "se-dev-k8s-dockershim-1-24",
@@ -10,7 +10,7 @@
       "split": "development",
       "title": "Kubernetes dockershim removal planning",
       "decision_prompt": "A platform team operates Kubernetes clusters whose nodes rely on the in-tree dockershim integration. Choose the action that best protects the team's ability to adopt Kubernetes 1.24 while maintaining a supported container runtime.",
-      "forecast_question": "Will Kubernetes 1.24 ship without the in-tree dockershim integration? Forecast the probability that migrate_runtime_before_1_24 is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Migrate before Kubernetes 1.24\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "migrate_runtime_before_1_24",
       "options": [
         {
@@ -41,18 +41,18 @@
       "split": "development",
       "title": "Prepare for optional no-GIL CPython",
       "decision_prompt": "A CPython-dependent platform team must decide whether to reserve engineering capacity for free-threaded compatibility prototypes while PEP 703 is still a draft. Choose the action that best positions the platform if the proposal is accepted for CPython.",
-      "forecast_question": "Will the Python Steering Council accept PEP 703 in a form that places optional no-GIL CPython on the Python 3.13 roadmap? Forecast the probability that prepare_for_acceptance is the correct action.",
-      "forecast_option_id": "prepare_for_acceptance",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Defer until formal acceptance\" is the outcome-aligned action at the stated horizon.",
+      "forecast_option_id": "defer_until_formal_acceptance",
       "options": [
-        {
-          "option_id": "prepare_for_acceptance",
-          "label": "Prepare for acceptance",
-          "description": "Reserve bounded engineering capacity now for compatibility testing and a free-threaded prototype."
-        },
         {
           "option_id": "defer_until_formal_acceptance",
           "label": "Defer until formal acceptance",
           "description": "Do not reserve engineering capacity until the Steering Council formally accepts the proposal."
+        },
+        {
+          "option_id": "prepare_for_acceptance",
+          "label": "Prepare for acceptance",
+          "description": "Reserve bounded engineering capacity now for compatibility testing and a free-threaded prototype."
         }
       ],
       "information_cutoff": "2023-05-12T00:00:00Z",
@@ -72,18 +72,18 @@
       "split": "development",
       "title": "Node.js 16 accelerated end-of-life response",
       "decision_prompt": "A production service runs on Node.js 16 after the official release schedule moves its end-of-life date to September 2023. Choose the action that best preserves security support without depending on a later schedule extension.",
-      "forecast_question": "Will the official Node.js schedule end Node.js 16 support on or before 2023-09-11 without a later extension? Forecast the probability that upgrade_before_eol is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Upgrade before the revised end-of-life date\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "upgrade_before_eol",
       "options": [
-        {
-          "option_id": "upgrade_before_eol",
-          "label": "Upgrade before the revised end-of-life date",
-          "description": "Move the service to a supported Node.js LTS line before 2023-09-11."
-        },
         {
           "option_id": "defer_beyond_eol",
           "label": "Defer beyond the revised end-of-life date",
           "description": "Keep Node.js 16 in production beyond 2023-09-11 while expecting support or the schedule to be extended."
+        },
+        {
+          "option_id": "upgrade_before_eol",
+          "label": "Upgrade before the revised end-of-life date",
+          "description": "Move the service to a supported Node.js LTS line before 2023-09-11."
         }
       ],
       "information_cutoff": "2022-06-16T00:00:00Z",
@@ -103,8 +103,8 @@
       "split": "development",
       "title": "Migrate away from standard-library distutils",
       "decision_prompt": "A Python build tool imports distutils from the standard library. PEP 632 has been accepted and describes removal in Python 3.12. Choose the action that best preserves compatibility with that release.",
-      "forecast_question": "Will Python 3.12 omit distutils from the standard library as PEP 632 specifies? Forecast the probability that migrate_before_python312 is the correct action.",
-      "forecast_option_id": "migrate_before_python312",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Retain the standard-library dependency\" is the outcome-aligned action at the stated horizon.",
+      "forecast_option_id": "retain_stdlib_distutils",
       "options": [
         {
           "option_id": "migrate_before_python312",

--- a/docs/benchmarks/decision_quality/tranches/software-development-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/software-development-1.corpus.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-software-development-tranche-1",
+  "frozen_at": "2026-08-30T01:50:00Z",
+  "cases": [
+    {
+      "case_id": "se-dev-k8s-dockershim-1-24",
+      "domain": "software_engineering",
+      "split": "development",
+      "title": "Kubernetes dockershim removal planning",
+      "decision_prompt": "A platform team operates Kubernetes clusters whose nodes rely on the in-tree dockershim integration. Choose the action that best protects the team's ability to adopt Kubernetes 1.24 while maintaining a supported container runtime.",
+      "forecast_question": "Will Kubernetes 1.24 ship without the in-tree dockershim integration? Forecast the probability that migrate_runtime_before_1_24 is the correct action.",
+      "forecast_option_id": "migrate_runtime_before_1_24",
+      "options": [
+        {
+          "option_id": "migrate_runtime_before_1_24",
+          "label": "Migrate before Kubernetes 1.24",
+          "description": "Move nodes to a CRI-compatible runtime, or to a supported external Docker adapter, before adopting Kubernetes 1.24."
+        },
+        {
+          "option_id": "retain_in_tree_dockershim",
+          "label": "Retain the in-tree dockershim dependency",
+          "description": "Defer runtime migration and plan to keep using the in-tree dockershim integration through Kubernetes 1.24."
+        }
+      ],
+      "information_cutoff": "2022-01-08T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "k8s-dockershim-commitment-2022-01-07",
+          "title": "Kubernetes is Moving on From Dockershim: Commitments and Next Steps",
+          "url": "https://raw.githubusercontent.com/kubernetes/website/147fd1c21bb2838d0aca5cff6cb4a2c887c3f369/content/en/blog/_posts/2022/kubernetes-is-moving-on-from-dockershim.md",
+          "published_at": "2022-01-07T00:00:00Z",
+          "content_sha256": "b610d69a329e163828b5faa7c9fd1350b407aaf3aa3b0dcde75899ae6bd320a0"
+        }
+      ]
+    },
+    {
+      "case_id": "se-dev-pep703-acceptance",
+      "domain": "software_engineering",
+      "split": "development",
+      "title": "Prepare for optional no-GIL CPython",
+      "decision_prompt": "A CPython-dependent platform team must decide whether to reserve engineering capacity for free-threaded compatibility prototypes while PEP 703 is still a draft. Choose the action that best positions the platform if the proposal is accepted for CPython.",
+      "forecast_question": "Will the Python Steering Council accept PEP 703 in a form that places optional no-GIL CPython on the Python 3.13 roadmap? Forecast the probability that prepare_for_acceptance is the correct action.",
+      "forecast_option_id": "prepare_for_acceptance",
+      "options": [
+        {
+          "option_id": "prepare_for_acceptance",
+          "label": "Prepare for acceptance",
+          "description": "Reserve bounded engineering capacity now for compatibility testing and a free-threaded prototype."
+        },
+        {
+          "option_id": "defer_until_formal_acceptance",
+          "label": "Defer until formal acceptance",
+          "description": "Do not reserve engineering capacity until the Steering Council formally accepts the proposal."
+        }
+      ],
+      "information_cutoff": "2023-05-12T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "pep703-draft-2023-05-11",
+          "title": "PEP 703 draft: Making the Global Interpreter Lock Optional in CPython",
+          "url": "https://raw.githubusercontent.com/python/peps/cf1649c9d2cae038d1d7e51db32c0ab1b912e2f6/pep-0703.rst",
+          "published_at": "2023-05-11T18:11:40Z",
+          "content_sha256": "60e7e8dd33c92bacef31470cf91cff5f93e3937ab385a58c2c36ce2961cadbd7"
+        }
+      ]
+    },
+    {
+      "case_id": "se-dev-node16-eol",
+      "domain": "software_engineering",
+      "split": "development",
+      "title": "Node.js 16 accelerated end-of-life response",
+      "decision_prompt": "A production service runs on Node.js 16 after the official release schedule moves its end-of-life date to September 2023. Choose the action that best preserves security support without depending on a later schedule extension.",
+      "forecast_question": "Will the official Node.js schedule end Node.js 16 support on or before 2023-09-11 without a later extension? Forecast the probability that upgrade_before_eol is the correct action.",
+      "forecast_option_id": "upgrade_before_eol",
+      "options": [
+        {
+          "option_id": "upgrade_before_eol",
+          "label": "Upgrade before the revised end-of-life date",
+          "description": "Move the service to a supported Node.js LTS line before 2023-09-11."
+        },
+        {
+          "option_id": "defer_beyond_eol",
+          "label": "Defer beyond the revised end-of-life date",
+          "description": "Keep Node.js 16 in production beyond 2023-09-11 while expecting support or the schedule to be extended."
+        }
+      ],
+      "information_cutoff": "2022-06-16T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "node-release-schedule-2022-06-15",
+          "title": "Node.js release schedule with revised Node.js 16 end date",
+          "url": "https://raw.githubusercontent.com/nodejs/Release/e7851ec7281ffa0f71fcd849cce72dbbbe89f85d/schedule.json",
+          "published_at": "2022-06-15T19:37:05Z",
+          "content_sha256": "aa4742bc87b63d816aa962b6d2a164986be3c78973d6c8cf9c0444dc6e15f55b"
+        }
+      ]
+    },
+    {
+      "case_id": "se-dev-python312-distutils-removal",
+      "domain": "software_engineering",
+      "split": "development",
+      "title": "Migrate away from standard-library distutils",
+      "decision_prompt": "A Python build tool imports distutils from the standard library. PEP 632 has been accepted and describes removal in Python 3.12. Choose the action that best preserves compatibility with that release.",
+      "forecast_question": "Will Python 3.12 omit distutils from the standard library as PEP 632 specifies? Forecast the probability that migrate_before_python312 is the correct action.",
+      "forecast_option_id": "migrate_before_python312",
+      "options": [
+        {
+          "option_id": "migrate_before_python312",
+          "label": "Migrate before Python 3.12",
+          "description": "Replace standard-library distutils imports with maintained packaging interfaces before adopting Python 3.12."
+        },
+        {
+          "option_id": "retain_stdlib_distutils",
+          "label": "Retain the standard-library dependency",
+          "description": "Keep importing standard-library distutils and defer migration until after Python 3.12 ships."
+        }
+      ],
+      "information_cutoff": "2021-01-26T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "pep632-accepted-2021-01-25",
+          "title": "PEP 632 accepted: Deprecate distutils module",
+          "url": "https://raw.githubusercontent.com/python/peps/0b7e157a540ccc553998d9e7a5911e1b709671fd/pep-0632.rst",
+          "published_at": "2021-01-25T17:44:41Z",
+          "content_sha256": "9114a72afaa11fe7a4dfa74a96e33e6e53bc03793d999acde32c7e6bf1c822cb"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/software-development-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/software-development-1.outcomes.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c",
+  "outcomes": [
+    {
+      "case_id": "se-dev-k8s-dockershim-1-24",
+      "resolved_at": "2022-05-03T00:00:00Z",
+      "correct_option_id": "migrate_runtime_before_1_24",
+      "resolution_summary": "Kubernetes 1.24 shipped with dockershim removed from kubelet, requiring a CRI-compatible runtime or an external adapter for Docker Engine.",
+      "authoritative_sources": [
+        {
+          "source_id": "k8s-1-24-release-2022-05-03",
+          "title": "Kubernetes 1.24: Stargazer release announcement",
+          "url": "https://raw.githubusercontent.com/kubernetes/website/147fd1c21bb2838d0aca5cff6cb4a2c887c3f369/content/en/blog/_posts/2022/kubernetes-release-1.24.md",
+          "published_at": "2022-05-03T00:00:00Z",
+          "content_sha256": "893189a25ee629211b84c2b60a2813b114cc906b658d5aa88e78e9c61ae848ef"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "removal_schedule_credibility",
+          "description": "Whether Kubernetes maintainers would follow through on the announced 1.24 removal schedule rather than postpone it again.",
+          "aliases": ["dockershim removal timing", "release schedule credibility"]
+        },
+        {
+          "crux_id": "replacement_runtime_readiness",
+          "description": "Whether containerd, CRI-O, or cri-dockerd provided a viable migration target before Kubernetes 1.24.",
+          "aliases": ["CRI runtime readiness", "migration alternative availability"]
+        },
+        {
+          "crux_id": "uncontrolled_docker_dependencies",
+          "description": "Whether node tooling and workloads depended on Docker Engine behavior beyond the kubelet integration.",
+          "aliases": ["Docker socket dependencies", "ecosystem migration blockers"]
+        }
+      ]
+    },
+    {
+      "case_id": "se-dev-pep703-acceptance",
+      "resolved_at": "2023-10-24T00:00:00Z",
+      "correct_option_id": "prepare_for_acceptance",
+      "resolution_summary": "The Python Steering Council accepted PEP 703 with a gradual, reversible rollout, targeting an optional no-GIL build for Python 3.13.",
+      "authoritative_sources": [
+        {
+          "source_id": "pep703-accepted-2023-10-28",
+          "title": "PEP 703 marked Accepted",
+          "url": "https://raw.githubusercontent.com/python/peps/1d09abe70138f530d7dd3307e5cbc053a929b923/peps/pep-0703.rst",
+          "published_at": "2023-10-28T23:23:10Z",
+          "content_sha256": "9ca62cc097c11a0ca33b7e5cddb074133bbbe2217a27ddaf9edad29b83b170c9"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "steering_council_risk_tolerance",
+          "description": "Whether the Steering Council would accept the implementation risk if rollout could remain optional and reversible.",
+          "aliases": ["acceptance appetite", "reversibility proviso"]
+        },
+        {
+          "crux_id": "single_thread_performance",
+          "description": "Whether the proposal's single-threaded performance cost was small enough for a gradual CPython roadmap.",
+          "aliases": ["performance regression", "nogil overhead"]
+        },
+        {
+          "crux_id": "extension_compatibility",
+          "description": "Whether the C-extension ecosystem could transition without making the proposal operationally untenable.",
+          "aliases": ["C API compatibility", "extension migration cost"]
+        }
+      ]
+    },
+    {
+      "case_id": "se-dev-node16-eol",
+      "resolved_at": "2023-09-11T00:00:00Z",
+      "correct_option_id": "upgrade_before_eol",
+      "resolution_summary": "The official Node.js schedule retained 2023-09-11 as the Node.js 16 end-of-life date; the line was not extended beyond that date.",
+      "authoritative_sources": [
+        {
+          "source_id": "node-release-schedule-2023-10-24",
+          "title": "Node.js release schedule after Node.js 16 end-of-life",
+          "url": "https://raw.githubusercontent.com/nodejs/Release/2562cb2310658085f3042a5b2f745d8ee015c447/schedule.json",
+          "published_at": "2023-10-24T15:02:59Z",
+          "content_sha256": "d4f6de8e87616401d217aab5a190f06d99e4da16ad08c80133a41f2c14c8de83"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "openssl_support_deadline",
+          "description": "Whether OpenSSL 1.1.1 support constraints made the accelerated Node.js 16 end date difficult to extend.",
+          "aliases": ["OpenSSL dependency", "security support deadline"]
+        },
+        {
+          "crux_id": "release_schedule_followthrough",
+          "description": "Whether Node.js release governance would preserve the revised date after publicly updating the schedule.",
+          "aliases": ["schedule credibility", "EOL follow-through"]
+        },
+        {
+          "crux_id": "successor_lts_availability",
+          "description": "Whether a supported successor LTS line was available early enough to make migration practical.",
+          "aliases": ["Node.js 18 readiness", "upgrade path availability"]
+        }
+      ]
+    },
+    {
+      "case_id": "se-dev-python312-distutils-removal",
+      "resolved_at": "2023-10-02T00:00:00Z",
+      "correct_option_id": "migrate_before_python312",
+      "resolution_summary": "Python 3.12 removed distutils from the standard library and directed projects that still needed it to install setuptools separately.",
+      "authoritative_sources": [
+        {
+          "source_id": "python312-whatsnew-distutils-2023-10-02",
+          "title": "What's New In Python 3.12",
+          "url": "https://raw.githubusercontent.com/python/cpython/v3.12.0/Doc/whatsnew/3.12.rst",
+          "published_at": "2023-10-02T00:00:00Z",
+          "content_sha256": "4a0da7af729f2ba5d6f34d257f440d1700245531aad9cb2bf18bb78af24cfab9"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "setuptools_replacement_viability",
+          "description": "Whether setuptools and maintained packaging interfaces covered the practical distutils migration path.",
+          "aliases": ["packaging replacement", "setuptools compatibility"]
+        },
+        {
+          "crux_id": "cpython_build_decoupling",
+          "description": "Whether CPython could remove its own build-time dependence on distutils before Python 3.12.",
+          "aliases": ["CPython bootstrap dependency", "stdlib removal feasibility"]
+        },
+        {
+          "crux_id": "ecosystem_migration_cost",
+          "description": "Whether downstream packages could update imports before removal without prohibitive disruption.",
+          "aliases": ["downstream compatibility", "package migration burden"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/software-development-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/software-development-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c",
+  "corpus_sha256": "e9ec5a9a62b6d2d9a6cd9664989d3be6e45b7cc7cbfe0d57919a4238e0770b27",
   "outcomes": [
     {
       "case_id": "se-dev-k8s-dockershim-1-24",

--- a/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.corpus.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "decision-quality-corpus/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "revision": "draft-software-engineering-holdout-tranche-1",
-  "frozen_at": "2026-08-30T02:50:00Z",
+  "revision": "draft-software-engineering-holdout-tranche-2",
+  "frozen_at": "2026-08-30T03:52:00Z",
   "cases": [
     {
       "case_id": "se-holdout-k8s-psp-removal-1-25",
@@ -10,7 +10,7 @@
       "split": "holdout",
       "title": "Migrate from Kubernetes PodSecurityPolicy before 1.25",
       "decision_prompt": "A platform team relies on the built-in Kubernetes PodSecurityPolicy admission plugin. Upstream lifecycle metadata marks that API deprecated in 1.21 and removed in 1.25. Choose the action that best preserves enforceable workload-security policy through a Kubernetes 1.25 upgrade.",
-      "forecast_question": "Will Kubernetes 1.25 remove the built-in PodSecurityPolicy admission plugin? Forecast the probability that migrate_before_1_25 is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Migrate before Kubernetes 1.25\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "migrate_before_1_25",
       "options": [
         {
@@ -41,7 +41,7 @@
       "split": "holdout",
       "title": "Commit to PEP 563 runtime changes for Python 3.10",
       "decision_prompt": "A Python framework introspects annotations at runtime. The accepted PEP 563 text says postponed annotation evaluation will become the default in Python 3.10. Choose whether to make an irreversible compatibility break for that release now or preserve current behavior until the release semantics are confirmed.",
-      "forecast_question": "Will Python 3.10 make PEP 563 postponed annotation evaluation the default? Forecast the probability that commit_breaking_migration_for_3_10 is the correct action.",
+      "forecast_question": "Using only information available at the cutoff, forecast the probability that \"Commit the breaking migration for Python 3.10\" is the outcome-aligned action at the stated horizon.",
       "forecast_option_id": "commit_breaking_migration_for_3_10",
       "options": [
         {

--- a/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.corpus.json
+++ b/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.corpus.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "decision-quality-corpus/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "draft-software-engineering-holdout-tranche-1",
+  "frozen_at": "2026-08-30T02:50:00Z",
+  "cases": [
+    {
+      "case_id": "se-holdout-k8s-psp-removal-1-25",
+      "domain": "software_engineering",
+      "split": "holdout",
+      "title": "Migrate from Kubernetes PodSecurityPolicy before 1.25",
+      "decision_prompt": "A platform team relies on the built-in Kubernetes PodSecurityPolicy admission plugin. Upstream lifecycle metadata marks that API deprecated in 1.21 and removed in 1.25. Choose the action that best preserves enforceable workload-security policy through a Kubernetes 1.25 upgrade.",
+      "forecast_question": "Will Kubernetes 1.25 remove the built-in PodSecurityPolicy admission plugin? Forecast the probability that migrate_before_1_25 is the correct action.",
+      "forecast_option_id": "migrate_before_1_25",
+      "options": [
+        {
+          "option_id": "migrate_before_1_25",
+          "label": "Migrate before Kubernetes 1.25",
+          "description": "Replace PodSecurityPolicy with Pod Security Admission or another supported policy controller before upgrading to Kubernetes 1.25."
+        },
+        {
+          "option_id": "retain_psp_through_1_25",
+          "label": "Retain PodSecurityPolicy through 1.25",
+          "description": "Keep the built-in PodSecurityPolicy dependency and defer migration until after Kubernetes 1.25 ships."
+        }
+      ],
+      "information_cutoff": "2021-02-10T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "k8s-psp-lifecycle-metadata-2020-12-18",
+          "title": "Kubernetes PodSecurityPolicy prerelease lifecycle metadata",
+          "url": "https://raw.githubusercontent.com/kubernetes/kubernetes/979c644df2ad051015a8ccf6475e3476eda0cea0/staging/src/k8s.io/api/policy/v1beta1/types.go",
+          "published_at": "2020-12-18T06:16:25Z",
+          "content_sha256": "2f41de7da96e53301706db39158038ed395106ee6c8cdbb30961cb31247e0157"
+        }
+      ]
+    },
+    {
+      "case_id": "se-holdout-pep563-python310-default",
+      "domain": "software_engineering",
+      "split": "holdout",
+      "title": "Commit to PEP 563 runtime changes for Python 3.10",
+      "decision_prompt": "A Python framework introspects annotations at runtime. The accepted PEP 563 text says postponed annotation evaluation will become the default in Python 3.10. Choose whether to make an irreversible compatibility break for that release now or preserve current behavior until the release semantics are confirmed.",
+      "forecast_question": "Will Python 3.10 make PEP 563 postponed annotation evaluation the default? Forecast the probability that commit_breaking_migration_for_3_10 is the correct action.",
+      "forecast_option_id": "commit_breaking_migration_for_3_10",
+      "options": [
+        {
+          "option_id": "commit_breaking_migration_for_3_10",
+          "label": "Commit the breaking migration for Python 3.10",
+          "description": "Ship framework changes that assume annotations are strings by default in Python 3.10."
+        },
+        {
+          "option_id": "preserve_behavior_until_confirmed",
+          "label": "Preserve compatibility until confirmed",
+          "description": "Keep runtime annotation behavior compatible and gate any breaking migration on confirmed Python 3.10 release semantics."
+        }
+      ],
+      "information_cutoff": "2021-01-01T00:00:00Z",
+      "sources": [
+        {
+          "source_id": "pep563-python310-default-2020-05-19",
+          "title": "PEP 563 accepted text targeting default adoption in Python 3.10",
+          "url": "https://raw.githubusercontent.com/python/peps/f1c3a99ad5df574489e877c0456c0c714b507357/pep-0563.rst",
+          "published_at": "2020-05-19T16:19:55Z",
+          "content_sha256": "5e302adcdc7e195497a408ee283b08e173d6348275a752532a1b351b3cc1294e"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.outcomes.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "decision-quality-outcomes/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "corpus_sha256": "4d13fea53e1313c2db332bb932ab57abac5170a9779eba779cef4c3c712af2c6",
+  "outcomes": [
+    {
+      "case_id": "se-holdout-k8s-psp-removal-1-25",
+      "resolved_at": "2022-08-23T00:00:00Z",
+      "correct_option_id": "migrate_before_1_25",
+      "resolution_summary": "Kubernetes 1.25 removed the beta PodSecurityPolicy admission plugin and directed users to migrate before upgrading.",
+      "authoritative_sources": [
+        {
+          "source_id": "k8s-1-25-psp-removal-2022-08-23",
+          "title": "Kubernetes 1.25 changelog",
+          "url": "https://raw.githubusercontent.com/kubernetes/kubernetes/v1.25.0/CHANGELOG/CHANGELOG-1.25.md",
+          "published_at": "2022-08-23T00:00:00Z",
+          "content_sha256": "f9c6508923abc8fa7bf4a0a7ee61be571e083caad3c21522dff724c580f4c334"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "lifecycle_schedule_followthrough",
+          "description": "Whether Kubernetes maintainers would enforce the prerelease lifecycle metadata and remove PSP in 1.25 rather than postpone removal.",
+          "aliases": ["removal schedule credibility", "1.25 lifecycle follow-through"]
+        },
+        {
+          "crux_id": "replacement_policy_readiness",
+          "description": "Whether Pod Security Admission or external policy controllers would provide a usable migration path by Kubernetes 1.25.",
+          "aliases": ["PSA readiness", "policy replacement availability"]
+        },
+        {
+          "crux_id": "backward_compatibility_pressure",
+          "description": "Whether installed-base compatibility pressure would outweigh the project's beta API lifecycle policy.",
+          "aliases": ["PSP installed base", "compatibility-driven delay"]
+        }
+      ]
+    },
+    {
+      "case_id": "se-holdout-pep563-python310-default",
+      "resolved_at": "2021-09-25T15:53:47Z",
+      "correct_option_id": "preserve_behavior_until_confirmed",
+      "resolution_summary": "The authoritative PEP 563 text removed its Python 3.10 default-adoption claim and recorded that default behavior remained unresolved pending PEP 649.",
+      "authoritative_sources": [
+        {
+          "source_id": "pep563-python310-default-correction-2021-09-25",
+          "title": "PEP 563 correction removing Python 3.10 default adoption",
+          "url": "https://raw.githubusercontent.com/python/peps/b9b44c4eb7819553f293ff222a476f44c682714c/pep-0563.rst",
+          "published_at": "2021-09-25T15:53:47Z",
+          "content_sha256": "21122a48e4f04712826c039741f26c46b4dff103bdb7948a29fddcd5efe1652e"
+        }
+      ],
+      "cruxes": [
+        {
+          "crux_id": "runtime_compatibility_risk",
+          "description": "Whether default stringized annotations would break enough runtime-introspection libraries to force a schedule change.",
+          "aliases": ["annotation compatibility", "runtime introspection breakage"]
+        },
+        {
+          "crux_id": "pep649_alternative_viability",
+          "description": "Whether PEP 649 offered a credible alternative with better runtime semantics before Python 3.10 finalized.",
+          "aliases": ["deferred annotation alternative", "PEP 649 competition"]
+        },
+        {
+          "crux_id": "steering_council_schedule_tolerance",
+          "description": "Whether Python governance would preserve the announced 3.10 schedule despite unresolved semantic and compatibility concerns.",
+          "aliases": ["release schedule rigidity", "governance willingness to defer"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.outcomes.json
+++ b/docs/benchmarks/decision_quality/tranches/software-engineering-holdout-1.outcomes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "decision-quality-outcomes/1.0",
   "benchmark_id": "outcome-backed-decision-quality-v1",
-  "corpus_sha256": "4d13fea53e1313c2db332bb932ab57abac5170a9779eba779cef4c3c712af2c6",
+  "corpus_sha256": "97da356b5d70618c332e5fc52a0510996e28c6723aa00111206e663dc581295e",
   "outcomes": [
     {
       "case_id": "se-holdout-k8s-psp-removal-1-25",


### PR DESCRIPTION
## Summary

Adds the first construction tranche for the Outcome-Backed Decision Quality benchmark:

- four software-engineering development cases;
- immutable commit/tag-pinned pre-cutoff evidence;
- separate hash-bound outcome sidecar with authoritative resolution sources;
- three preregistered cruxes per case;
- explicit construction-only documentation that forbids counted inference before the complete 24-case freeze.

Corpus SHA-256: `aae58206475930742377b9a75f2f62f7e394e52f127fa97960d00eb8a651dd9c`
Outcome SHA-256: `dbce998d194fa3bb9fef6167902bc27a1445ab38e0d4d21378360503d8a97bb6`

## Validation

- decision-quality validator from #9878 with `--allow-partial` and the expected outcome digest: 4 cases, 4 software development, zero issues
- all eight immutable source URLs fetched and matched their recorded SHA-256 values
- four pre-cutoff source assertions passed
- JSON parse checks passed
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- pre-commit and pre-push hooks
- `git diff --check`

## Dependency

The validator contract currently lives in parked draft PR #9878. Keep this PR draft until that contract or a clean successor is merged and validates this tranche from current main. No model inference has been run and no benchmark result is claimed.