### PR TITLE
ops(hetzner): one-shot workflow to rejoin the tailnet (#9391) [Tier 4]

### DIFF
--- a/.github/workflows/hetzner-tailscale-rejoin.yml
+++ b/.github/workflows/hetzner-tailscale-rejoin.yml
@@ -1,0 +1,102 @@
+# One-shot repair: bring the Hetzner nodes back onto the tailnet (#9391).
+#
+# Those three hosts are alive — their runners are online and executing jobs —
+# but they left the tailnet 61 days ago, so SSH (which is Tailscale-only) cannot
+# reach them. This uses the one channel that still works, the runner agent, to
+# restore the channel that does not.
+#
+# Deliberately narrow: it authenticates Tailscale and reports. It does not
+# deploy, does not read repository secrets other than the auth key, and does not
+# touch production. Once SSH is back, everything else happens over SSH where it
+# belongs.
+name: Hetzner Tailscale Rejoin
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type REJOIN to proceed'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  rejoin:
+    name: Rejoin tailnet
+    if: github.event.inputs.confirm == 'REJOIN'
+    runs-on: [self-hosted, aragora, Linux, X64, hetzner]
+    timeout-minutes: 10
+    strategy:
+      # Three identical jobs so the scheduler places one on each of the three
+      # runners. They share the same labels, so there is no way to address a
+      # specific host; running the set in parallel is what reaches all of them.
+      fail-fast: false
+      matrix:
+        slot: [1, 2, 3]
+    steps:
+      - name: Identify this host
+        shell: bash
+        run: |
+          echo "runner=${RUNNER_NAME}  host=$(hostname)  slot=${{ matrix.slot }}"
+
+      - name: Report current tailscale state
+        shell: bash
+        run: |
+          if command -v tailscale >/dev/null 2>&1; then
+            echo "installed: $(tailscale version | head -1)"
+            tailscale status --peers=false 2>&1 | head -5 || echo "not connected"
+          else
+            echo "tailscale is NOT installed on $(hostname)"
+          fi
+
+      - name: Install tailscale if absent
+        shell: bash
+        run: |
+          if ! command -v tailscale >/dev/null 2>&1; then
+            echo "installing tailscale"
+            curl -fsSL https://tailscale.com/install.sh | sudo sh
+          else
+            echo "already installed"
+          fi
+
+      - name: Authenticate and come up
+        shell: bash
+        env:
+          TS_AUTHKEY: ${{ secrets.TAILSCALE_AUTHKEY }}
+        run: |
+          if [ -z "${TS_AUTHKEY}" ]; then
+            echo "::error::TAILSCALE_AUTHKEY secret is not set. Add it before running."
+            exit 1
+          fi
+          sudo systemctl enable --now tailscaled || true
+
+          # Pass the key via a 0600 file rather than on the command line: argv is
+          # world-readable through `ps`, so any other process on this shared box
+          # could read the key mid-run. Removed in a trap so it does not survive
+          # a failure either.
+          keyfile="$(mktemp)"
+          trap 'rm -f "$keyfile"' EXIT
+          chmod 600 "$keyfile"
+          printf '%s' "${TS_AUTHKEY}" > "$keyfile"
+
+          sudo tailscale up \
+            --authkey="file:${keyfile}" \
+            --hostname="$(hostname)" \
+            --accept-routes \
+            --ssh=false
+          echo "tailscale up completed"
+
+      - name: Confirm it joined
+        shell: bash
+        run: |
+          ip="$(tailscale ip -4 2>/dev/null || true)"
+          if [ -z "$ip" ]; then
+            echo "::error::no tailscale IPv4 assigned — the node did not join"
+            tailscale status 2>&1 | head -10
+            exit 1
+          fi
+          echo "joined: $(hostname) -> ${ip}"
+          # Persist across reboot, which is the likeliest reason it dropped off.
+          sudo systemctl is-enabled tailscaled || sudo systemctl enable tailscaled


### PR DESCRIPTION
Restores SSH access to the three Hetzner hosts so production can be rebuilt there (#9882).

**The situation:** those hosts are alive — runners online, one executed a probe today — but Tailscale shows all three `offline, last seen 61d ago`. Your SSH config points only at Tailscale IPs (`100.94.174.19` etc., `User root`, no public IP), so there is currently no route to them. The runner agent is the only working channel.

This workflow uses that channel to fix the other one, then gets out of the way — everything else happens over SSH.

**Scope:** authenticate Tailscale and report. No deploy, no production access, no secret other than `TAILSCALE_AUTHKEY`.

- dispatch-only, gated on typing `REJOIN`
- 3-way matrix: all three runners share identical labels, so there is no way to address one specific host; running the set in parallel is what reaches all three
- installs tailscale if absent; enables `tailscaled` so the node survives the reboot that most likely dropped it
- fails if no IPv4 is assigned, rather than reporting success on a node that did not join
- auth key goes to a `0600` temp file passed as `--authkey=file:...`, not on the command line — argv is readable via `ps` and these are shared boxes

**Requires** a `TAILSCALE_AUTHKEY` repository secret (reusable, pre-authorized, from the Tailscale admin console) before dispatch.

**Alternative worth preferring:** if the Hetzner web console is to hand, bringing the nodes up from there needs no CI change and no key in GitHub at all. This exists for when that is not convenient.

**Tier 4** — workflow change. Requires settlement. Not for auto-merge.

Refs #9391