### PR TITLE
refactor(redis-config): repoint remaining rbac and handler importers to canonical path

### DIFF
--- a/aragora/rbac/emergency.py
+++ b/aragora/rbac/emergency.py
@@ -250,7 +250,7 @@ class BreakGlassAccess:
             return self._redis
 
         try:
-            from aragora.server.redis_config import get_redis_client
+            from aragora.utils.redis_config import get_redis_client
 
             self._redis = get_redis_client()
             self._redis_checked = True

--- a/aragora/rbac/emergency.py
+++ b/aragora/rbac/emergency.py
@@ -142,12 +142,14 @@ class EmergencyAccessRecord:
     @classmethod
     def from_storage_dict(cls, data: dict[str, Any]) -> EmergencyAccessRecord:
         """Reconstruct from storage dictionary."""
-        # Parse timestamps
-        activated_at = data.get("activated_at")
+        # Parse timestamps. Annotated Any: storage rows may legitimately lack
+        # these keys, and the historical contract passes that through unchanged
+        # rather than raising here.
+        activated_at: Any = data.get("activated_at")
         if isinstance(activated_at, str):
             activated_at = datetime.fromisoformat(activated_at.replace("Z", "+00:00"))
 
-        expires_at = data.get("expires_at")
+        expires_at: Any = data.get("expires_at")
         if isinstance(expires_at, str):
             expires_at = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
 

--- a/aragora/rbac/quotas.py
+++ b/aragora/rbac/quotas.py
@@ -222,7 +222,7 @@ class QuotaEnforcer:
         self._redis_checked = True
 
         try:
-            from aragora.server.redis_config import get_redis_client
+            from aragora.utils.redis_config import get_redis_client
 
             self._redis = get_redis_client()
             if self._redis:

--- a/aragora/server/handlers/explainability_store.py
+++ b/aragora/server/handlers/explainability_store.py
@@ -467,7 +467,7 @@ def get_batch_job_store() -> BatchJobStore:
     if backend_pref:
         if backend_pref == "redis":
             try:
-                from aragora.server.redis_config import get_redis_client, is_redis_available
+                from aragora.utils.redis_config import get_redis_client, is_redis_available
 
                 if is_redis_available():
                     redis_client = get_redis_client()
@@ -517,7 +517,7 @@ def get_batch_job_store() -> BatchJobStore:
 
     # Default behavior: try Redis first, then database backend
     try:
-        from aragora.server.redis_config import get_redis_client, is_redis_available
+        from aragora.utils.redis_config import get_redis_client, is_redis_available
 
         if is_redis_available():
             redis_client = get_redis_client()

--- a/aragora/server/handlers/public/status_page.py
+++ b/aragora/server/handlers/public/status_page.py
@@ -476,7 +476,7 @@ class StatusPageHandler(BaseHandler):
         """Check Redis health."""
         start = time.perf_counter()
         try:
-            from aragora.server.redis_config import get_redis_client, is_redis_available
+            from aragora.utils.redis_config import get_redis_client, is_redis_available
 
             if is_redis_available():
                 client = get_redis_client()

--- a/tests/handlers/public/test_status_page.py
+++ b/tests/handlers/public/test_status_page.py
@@ -694,11 +694,11 @@ class TestRedisHealth:
                 create=True,
             ) as _,
         ):
-            # The method imports from aragora.server.redis_config inside, so patch that module
+            # The method imports from aragora.utils.redis_config inside, so patch that module
             mock_redis_config = MagicMock()
             mock_redis_config.is_redis_available.return_value = True
             mock_redis_config.get_redis_client.return_value = mock_client
-            with patch.dict("sys.modules", {"aragora.server.redis_config": mock_redis_config}):
+            with patch.dict("sys.modules", {"aragora.utils.redis_config": mock_redis_config}):
                 result = handler._check_redis_health()
 
         assert result.status == ServiceStatus.OPERATIONAL
@@ -707,7 +707,7 @@ class TestRedisHealth:
     def test_redis_not_available(self, handler):
         mock_redis_config = MagicMock()
         mock_redis_config.is_redis_available.return_value = False
-        with patch.dict("sys.modules", {"aragora.server.redis_config": mock_redis_config}):
+        with patch.dict("sys.modules", {"aragora.utils.redis_config": mock_redis_config}):
             result = handler._check_redis_health()
         assert result.status == ServiceStatus.DEGRADED
         assert "unavailable" in result.message
@@ -716,7 +716,7 @@ class TestRedisHealth:
         mock_redis_config = MagicMock()
         mock_redis_config.is_redis_available.return_value = True
         mock_redis_config.get_redis_client.return_value = None
-        with patch.dict("sys.modules", {"aragora.server.redis_config": mock_redis_config}):
+        with patch.dict("sys.modules", {"aragora.utils.redis_config": mock_redis_config}):
             result = handler._check_redis_health()
         assert result.status == ServiceStatus.DEGRADED
 
@@ -724,7 +724,7 @@ class TestRedisHealth:
         # Remove the module so import fails
         import sys
 
-        saved = sys.modules.pop("aragora.server.redis_config", None)
+        saved = sys.modules.pop("aragora.utils.redis_config", None)
         try:
             import builtins
 
@@ -740,7 +740,7 @@ class TestRedisHealth:
             assert result.status == ServiceStatus.DEGRADED
         finally:
             if saved is not None:
-                sys.modules["aragora.server.redis_config"] = saved
+                sys.modules["aragora.utils.redis_config"] = saved
 
     def test_redis_ping_connection_error(self, handler):
         mock_client = MagicMock()
@@ -749,7 +749,7 @@ class TestRedisHealth:
         mock_redis_config = MagicMock()
         mock_redis_config.is_redis_available.return_value = True
         mock_redis_config.get_redis_client.return_value = mock_client
-        with patch.dict("sys.modules", {"aragora.server.redis_config": mock_redis_config}):
+        with patch.dict("sys.modules", {"aragora.utils.redis_config": mock_redis_config}):
             result = handler._check_redis_health()
         assert result.status == ServiceStatus.DEGRADED
 

--- a/tests/handlers/test_explainability_store.py
+++ b/tests/handlers/test_explainability_store.py
@@ -801,11 +801,11 @@ class TestGetBatchJobStore:
                 create=True,
             ),
             patch(
-                "aragora.server.redis_config.get_redis_client",
+                "aragora.utils.redis_config.get_redis_client",
                 return_value=mock_redis,
             ),
             patch(
-                "aragora.server.redis_config.is_redis_available",
+                "aragora.utils.redis_config.is_redis_available",
                 return_value=True,
             ),
         ):
@@ -818,11 +818,11 @@ class TestGetBatchJobStore:
         monkeypatch.setenv("ARAGORA_EXPLAINABILITY_DB", str(tmp_path / "fallback.db"))
         with (
             patch(
-                "aragora.server.redis_config.is_redis_available",
+                "aragora.utils.redis_config.is_redis_available",
                 return_value=False,
             ),
             patch(
-                "aragora.server.redis_config.get_redis_client",
+                "aragora.utils.redis_config.get_redis_client",
                 return_value=None,
             ),
         ):
@@ -885,11 +885,11 @@ class TestGetBatchJobStore:
         monkeypatch.setenv("ARAGORA_EXPLAINABILITY_DB", str(tmp_path / "auto.db"))
         with (
             patch(
-                "aragora.server.redis_config.is_redis_available",
+                "aragora.utils.redis_config.is_redis_available",
                 return_value=False,
             ),
             patch(
-                "aragora.server.redis_config.get_redis_client",
+                "aragora.utils.redis_config.get_redis_client",
                 return_value=None,
             ),
         ):
@@ -904,7 +904,7 @@ class TestGetBatchJobStore:
         monkeypatch.setenv("ARAGORA_EXPLAINABILITY_DB", str(tmp_path / "auto2.db"))
         with patch.dict(
             "sys.modules",
-            {"aragora.server.redis_config": None},
+            {"aragora.utils.redis_config": None},
         ):
             store = get_batch_job_store()
             assert store is not None

--- a/tests/rbac/test_quotas.py
+++ b/tests/rbac/test_quotas.py
@@ -714,7 +714,7 @@ class TestRedisPersistence:
         enforcer._redis_checked = False  # Reset for test
 
         # After calling _get_redis (will fail without actual Redis)
-        with patch("aragora.server.redis_config.get_redis_client", return_value=None):
+        with patch("aragora.utils.redis_config.get_redis_client", return_value=None):
             result = enforcer._get_redis()
 
         assert enforcer._redis_checked is True

--- a/tests/server/handlers/test_explainability_store.py
+++ b/tests/server/handlers/test_explainability_store.py
@@ -941,9 +941,9 @@ class TestSingletonManagement:
         mock_redis_client = MagicMock()
 
         with patch.dict(os.environ, {"ARAGORA_EXPLAINABILITY_STORE_BACKEND": "redis"}):
-            with patch("aragora.server.redis_config.is_redis_available", return_value=True):
+            with patch("aragora.utils.redis_config.is_redis_available", return_value=True):
                 with patch(
-                    "aragora.server.redis_config.get_redis_client", return_value=mock_redis_client
+                    "aragora.utils.redis_config.get_redis_client", return_value=mock_redis_client
                 ):
                     store = get_batch_job_store()
 
@@ -960,7 +960,7 @@ class TestSingletonManagement:
                 "ARAGORA_EXPLAINABILITY_DB": db_path,
             },
         ):
-            with patch("aragora.server.redis_config.is_redis_available", return_value=False):
+            with patch("aragora.utils.redis_config.is_redis_available", return_value=False):
                 with patch("aragora.storage.production_guards.require_distributed_store"):
                     store = get_batch_job_store()
 
@@ -1023,9 +1023,9 @@ class TestSingletonManagement:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ARAGORA_EXPLAINABILITY_STORE_BACKEND", None)
 
-            with patch("aragora.server.redis_config.is_redis_available", return_value=True):
+            with patch("aragora.utils.redis_config.is_redis_available", return_value=True):
                 with patch(
-                    "aragora.server.redis_config.get_redis_client", return_value=mock_redis_client
+                    "aragora.utils.redis_config.get_redis_client", return_value=mock_redis_client
                 ):
                     store = get_batch_job_store()
 

--- a/tests/server/test_redis_config_deprecation.py
+++ b/tests/server/test_redis_config_deprecation.py
@@ -217,3 +217,75 @@ class TestConsumersUseCanonicalPath:
         asyncio.run(_probe())
         """
         assert _run_shim_warning_probe(body) == 0
+
+
+class TestRbacAndHandlerConsumersUseCanonicalPath:
+    """Repointed rbac/ and server-handler consumers must not touch the shim.
+
+    Same fresh-interpreter call-time probe pattern as
+    TestConsumersUseCanonicalPath; every remaining consumer here imports the
+    Redis helpers lazily inside a method, so each probe exercises the actual
+    call path rather than mere module import.
+    """
+
+    def test_quota_enforcer_get_redis_emits_no_shim_warning(self):
+        body = """
+        from aragora.rbac.quotas import QuotaEnforcer
+
+        QuotaEnforcer(enable_persistence=False)._get_redis()
+        """
+        assert _run_shim_warning_probe(body) == 0
+
+    def test_break_glass_get_redis_emits_no_shim_warning(self):
+        body = """
+        from aragora.rbac.emergency import BreakGlassAccess
+
+        BreakGlassAccess(enable_persistence=False)._get_redis()
+        """
+        assert _run_shim_warning_probe(body) == 0
+
+    def test_batch_store_explicit_redis_backend_emits_no_shim_warning(self):
+        body = """
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["ARAGORA_EXPLAINABILITY_STORE_BACKEND"] = "redis"
+            os.environ["ARAGORA_EXPLAINABILITY_DB"] = os.path.join(tmp, "probe.db")
+            from aragora.server.handlers.explainability_store import (
+                get_batch_job_store,
+                reset_batch_job_store,
+            )
+
+            reset_batch_job_store()
+            get_batch_job_store()
+            reset_batch_job_store()
+        """
+        assert _run_shim_warning_probe(body) == 0
+
+    def test_batch_store_default_backend_emits_no_shim_warning(self):
+        body = """
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ.pop("ARAGORA_EXPLAINABILITY_STORE_BACKEND", None)
+            os.environ["ARAGORA_EXPLAINABILITY_DB"] = os.path.join(tmp, "probe.db")
+            from aragora.server.handlers.explainability_store import (
+                get_batch_job_store,
+                reset_batch_job_store,
+            )
+
+            reset_batch_job_store()
+            get_batch_job_store()
+            reset_batch_job_store()
+        """
+        assert _run_shim_warning_probe(body) == 0
+
+    def test_status_page_redis_health_emits_no_shim_warning(self):
+        body = """
+        from aragora.server.handlers.public.status_page import StatusPageHandler
+
+        StatusPageHandler()._check_redis_health()
+        """
+        assert _run_shim_warning_probe(body) == 0


### PR DESCRIPTION
## Summary

Tier-3 remainder of the redis_config shim repoint census (operator split ruling 2026-08-28, option (c); tier-1/2 subset merged in #9844). Repoints the 4 remaining runtime importers of deprecated `aragora.server.redis_config` to canonical `aragora.utils.redis_config`, retargets their 4 test seams patch-string-only, and extends the established call-time subprocess probe suite. Semantics identical; zero behavior change.

**Production repoints (5 sites, 4 files):**
- `aragora/rbac/quotas.py` — lazy import in `QuotaEnforcer._get_redis`
- `aragora/rbac/emergency.py` — lazy import in `BreakGlassAccess._get_redis`
- `aragora/server/handlers/explainability_store.py` — both lazy imports in `get_batch_job_store`
- `aragora/server/handlers/public/status_page.py` — lazy import in `StatusPageHandler._check_redis_health`

**Seam retargets (patch-string-only, byte-identical assertions, #9830 decoy-mock rule):**
- `tests/rbac/test_quotas.py` — 1 patch string
- `tests/handlers/test_explainability_store.py` — 6 patch strings + 1 `sys.modules` stub key
- `tests/server/handlers/test_explainability_store.py` — 5 patch strings
- `tests/handlers/public/test_status_page.py` — 4 `sys.modules` mock keys, pop/restore pair, and the directly-consequent comment line

**Probes (red-first):** new class `TestRbacAndHandlerConsumersUseCanonicalPath` in `tests/server/test_redis_config_deprecation.py` — 5 fresh-interpreter call-time probes (one per repointed call path, including both explainability-store backends). All 5 failed at base with exactly 1 shim DeprecationWarning each (`assert 1 == 0`); all pass after the repoint. The shim module and its deprecation-pin tests are untouched and still pass.

**Bounded pre-existing-debt fix (disclosed):** the mandatory changed-file mypy preflight surfaced 2 pre-existing `arg-type` errors in `EmergencyAccessRecord.from_storage_dict` (`aragora/rbac/emergency.py:171-172`, `"datetime | Any | None"` vs non-optional `datetime`). Both reproduce byte-identically at base `7043cfd41bea` in a clean worktree — latent main-side debt in a touched file, not introduced here. Fixed annotation-only (`: Any` on the two `.get()` intermediates, matching the actual storage contract); zero runtime change, verified by `tests/rbac/test_emergency.py` (51 passed). Same class and remedy as the metrics_data fix disclosed in #9844.

**Known gaps: none.** This is a pure mechanical repoint; no reviewer-visible gaps remain in-diff. Remaining `aragora.server.redis_config` references are all sanctioned: the shim itself, its deprecation-pin test, a historical prose pointer in `deploy/SHARED_STATE_SETUP.md`, and the shim's entry in the `scripts/check_sdk_parity.py` exclusion list (the shim module still exists; those references stay valid until shim removal).

## Validation

- Red-first: 5 new probes fail at base (`assert 1 == 0`, exactly 1 shim warning each), pass at head
- `python3 -m pytest tests/server/test_redis_config_deprecation.py` → 22 passed (17 prior + 5 new)
- 4 seam files → 333 passed, assertions unchanged
- 5-seed randomized sweep (1/42/100/2024/12345) over all 5 touched test files → 355 passed each
- `make lint`, `ruff format --check` → clean
- `scripts/preflight_mypy.sh --diff-base origin/main` → no issues in 9 files (after the disclosed debt fix); hook-variant mypy also clean
- `make test-smoke` and `scripts/test_tiers.sh smoke` (138 passed) → green
- `scripts/automation_pr_preflight.sh origin/main HEAD` → ok
- Diff: +102/−28 = 130 lines across 9 files

Census re-verified at push time on fresh origin/main: these were the only remaining runtime importers, and all 9 files are clean of foreign open-PR ownership (70 open PRs checked).

Paths under `aragora/rbac/` and `aragora/server/handlers/` — expected Tier 3 per merge-gate path rules; prepared for the parked prepare-only settlement flow.
