### PR TITLE
feat(evaluation): freeze outcome-backed decision quality harness

### DIFF
--- a/aragora/evaluation/decision_quality_corpus.py
+++ b/aragora/evaluation/decision_quality_corpus.py
@@ -1,0 +1,685 @@
+"""Frozen corpus validation for the outcome-backed decision-quality benchmark.
+
+The model-visible corpus and resolved outcomes remain separate.  Tranche files
+are immutable construction inputs; the benchmark manifest binds their canonical
+digests and the aggregate corpus/outcome digests before any inference occurs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+CORPUS_SCHEMA_VERSION = "decision-quality-corpus/1.0"
+OUTCOMES_SCHEMA_VERSION = "decision-quality-outcomes/1.0"
+DOMAINS = (
+    "software_engineering",
+    "business_operations",
+    "policy_compliance",
+    "science_forecasting",
+)
+SPLITS = ("development", "holdout")
+
+_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_HOST_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_NON_PUBLIC_SUFFIXES = (".home", ".internal", ".lan", ".local", ".localhost")
+
+_CORPUS_KEYS = {"schema_version", "benchmark_id", "revision", "frozen_at", "cases"}
+_CASE_KEYS = {
+    "case_id",
+    "domain",
+    "split",
+    "title",
+    "decision_prompt",
+    "forecast_question",
+    "forecast_option_id",
+    "options",
+    "information_cutoff",
+    "sources",
+}
+_OPTION_KEYS = {"option_id", "label", "description"}
+_SOURCE_KEYS = {"source_id", "title", "url", "published_at", "content_sha256"}
+_OUTCOMES_KEYS = {"schema_version", "benchmark_id", "corpus_sha256", "outcomes"}
+_OUTCOME_KEYS = {
+    "case_id",
+    "resolved_at",
+    "correct_option_id",
+    "resolution_summary",
+    "authoritative_sources",
+    "cruxes",
+}
+_CRUX_KEYS = {"crux_id", "description", "aliases"}
+
+
+class DuplicateObjectKeyError(ValueError):
+    """Raised when a JSON object repeats a key."""
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        super().__init__(f"duplicate JSON object key: {key!r}")
+
+
+def _reject_duplicate_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateObjectKeyError(key)
+        result[key] = value
+    return result
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """One fail-closed corpus validation issue."""
+
+    path: str
+    code: str
+    message: str
+
+
+@dataclass
+class CorpusValidationReport:
+    """Structured corpus validation result."""
+
+    corpus_sha256: str | None = None
+    outcomes_sha256: str | None = None
+    case_count: int = 0
+    domain_counts: dict[str, int] = field(default_factory=dict)
+    split_counts: dict[str, int] = field(default_factory=dict)
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "corpus_sha256": self.corpus_sha256,
+            "outcomes_sha256": self.outcomes_sha256,
+            "case_count": self.case_count,
+            "domain_counts": self.domain_counts,
+            "split_counts": self.split_counts,
+            "issues": [asdict(issue) for issue in self.issues],
+        }
+
+
+@dataclass(frozen=True)
+class TrancheInput:
+    """One manifest-pinned corpus/outcome tranche pair."""
+
+    corpus_path: Path
+    outcomes_path: Path
+    corpus_sha256: str
+    outcomes_sha256: str
+
+
+def canonical_json_bytes(document: Any) -> bytes:
+    """Return the benchmark's documented Python canonical JSON encoding."""
+    return json.dumps(
+        document,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_sha256(document: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(document)).hexdigest()
+
+
+def _issue(report: CorpusValidationReport, path: str, code: str, message: str) -> None:
+    report.issues.append(ValidationIssue(path, code, message))
+
+
+def load_json_document(path: Path) -> tuple[Any | None, ValidationIssue | None]:
+    """Load JSON with duplicate-key and encoding failures returned as data."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        return json.loads(raw, object_pairs_hook=_reject_duplicate_object_keys), None
+    except OSError as exc:
+        return None, ValidationIssue(str(path), "read_error", str(exc))
+    except UnicodeError as exc:
+        return None, ValidationIssue(str(path), "invalid_utf8", str(exc))
+    except DuplicateObjectKeyError as exc:
+        return None, ValidationIssue(str(path), "duplicate_json_key", str(exc))
+    except json.JSONDecodeError as exc:
+        return None, ValidationIssue(
+            str(path),
+            "invalid_json",
+            f"line {exc.lineno}, column {exc.colno}: {exc.msg}",
+        )
+
+
+def _object(value: Any, path: str, report: CorpusValidationReport) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        _issue(report, path, "invalid_type", "must be a JSON object")
+        return None
+    return value
+
+
+def _keys(
+    value: dict[str, Any], allowed: set[str], path: str, report: CorpusValidationReport
+) -> None:
+    for key in sorted(allowed - value.keys()):
+        _issue(report, f"{path}.{key}", "missing_field", "field is required")
+    for key in sorted(value.keys() - allowed):
+        _issue(report, f"{path}.{key}", "unknown_field", "field is not permitted")
+
+
+def _text(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        _issue(report, path, "invalid_string", "must be a non-empty string")
+        return None
+    return value
+
+
+def _identifier(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    text = _text(value, path, report)
+    if text is not None and _ID_PATTERN.fullmatch(text) is None:
+        _issue(report, path, "invalid_identifier", "must be a lowercase benchmark identifier")
+        return None
+    return text
+
+
+def _timestamp(value: Any, path: str, report: CorpusValidationReport) -> datetime | None:
+    text = _text(value, path, report)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        _issue(report, path, "invalid_timestamp", "must be an ISO-8601 timestamp")
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _issue(report, path, "naive_timestamp", "must include a UTC offset")
+        return None
+    return parsed
+
+
+def _sha256(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    text = _text(value, path, report)
+    if text is not None and _SHA256_PATTERN.fullmatch(text) is None:
+        _issue(report, path, "invalid_sha256", "must be a lowercase 64-character SHA-256")
+        return None
+    return text
+
+
+def _public_https(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    text = _text(value, path, report)
+    if text is not None and not is_public_https_url(text):
+        _issue(report, path, "non_public_url", "must use a syntactically public HTTPS URL")
+        return None
+    return text
+
+
+def is_public_https_url(text: str) -> bool:
+    """Fail closed for local, credential-bearing, or malformed source URLs."""
+    try:
+        parsed = urlsplit(text)
+        host = parsed.hostname
+        parsed.port
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or host is None
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return False
+    normalized = host.rstrip(".").lower()
+    if not normalized:
+        return False
+    try:
+        return ipaddress.ip_address(normalized).is_global
+    except ValueError:
+        try:
+            ascii_host = normalized.encode("idna").decode("ascii")
+        except UnicodeError:
+            return False
+        if "." not in ascii_host or ascii_host.endswith(_NON_PUBLIC_SUFFIXES):
+            return False
+        return all(_HOST_LABEL_PATTERN.fullmatch(label) for label in ascii_host.split("."))
+
+
+def _source(
+    value: Any,
+    path: str,
+    report: CorpusValidationReport,
+    *,
+    cutoff: datetime | None = None,
+    not_before: datetime | None = None,
+) -> str | None:
+    source = _object(value, path, report)
+    if source is None:
+        return None
+    _keys(source, _SOURCE_KEYS, path, report)
+    source_id = _identifier(source.get("source_id"), f"{path}.source_id", report)
+    _text(source.get("title"), f"{path}.title", report)
+    _public_https(source.get("url"), f"{path}.url", report)
+    published_at = _timestamp(source.get("published_at"), f"{path}.published_at", report)
+    _sha256(source.get("content_sha256"), f"{path}.content_sha256", report)
+    if cutoff is not None and published_at is not None and published_at > cutoff:
+        _issue(
+            report,
+            f"{path}.published_at",
+            "outcome_leakage",
+            "model-visible evidence must not postdate the information cutoff",
+        )
+    if not_before is not None and published_at is not None and published_at < not_before:
+        _issue(
+            report,
+            f"{path}.published_at",
+            "premature_outcome_source",
+            "authoritative outcome evidence must not predate resolution",
+        )
+    return source_id
+
+
+def _case(
+    value: Any, index: int, report: CorpusValidationReport
+) -> tuple[str | None, set[str], datetime | None, str | None, str | None, str | None]:
+    path = f"$.cases[{index}]"
+    case = _object(value, path, report)
+    if case is None:
+        return None, set(), None, None, None, None
+    _keys(case, _CASE_KEYS, path, report)
+    case_id = _identifier(case.get("case_id"), f"{path}.case_id", report)
+    domain = _text(case.get("domain"), f"{path}.domain", report)
+    split = _text(case.get("split"), f"{path}.split", report)
+    if domain is not None and domain not in DOMAINS:
+        _issue(report, f"{path}.domain", "invalid_domain", f"must be one of {DOMAINS}")
+    if split is not None and split not in SPLITS:
+        _issue(report, f"{path}.split", "invalid_split", f"must be one of {SPLITS}")
+    for key in ("title", "decision_prompt", "forecast_question"):
+        _text(case.get(key), f"{path}.{key}", report)
+    cutoff = _timestamp(case.get("information_cutoff"), f"{path}.information_cutoff", report)
+
+    option_ids: set[str] = set()
+    option_id_order: list[str] = []
+    options = case.get("options")
+    if not isinstance(options, list) or len(options) != 2:
+        _issue(report, f"{path}.options", "invalid_options", "must contain exactly two options")
+    else:
+        for option_index, raw in enumerate(options):
+            option_path = f"{path}.options[{option_index}]"
+            option = _object(raw, option_path, report)
+            if option is None:
+                continue
+            _keys(option, _OPTION_KEYS, option_path, report)
+            option_id = _identifier(option.get("option_id"), f"{option_path}.option_id", report)
+            _text(option.get("label"), f"{option_path}.label", report)
+            _text(option.get("description"), f"{option_path}.description", report)
+            if option_id in option_ids:
+                _issue(report, f"{option_path}.option_id", "duplicate_option_id", "must be unique")
+            elif option_id is not None:
+                option_ids.add(option_id)
+                option_id_order.append(option_id)
+        if len(option_id_order) == 2 and option_id_order != sorted(option_id_order):
+            _issue(
+                report,
+                f"{path}.options",
+                "unsorted_options",
+                "option IDs must be in lexicographic order to prevent position leakage",
+            )
+    forecast_option = _identifier(
+        case.get("forecast_option_id"), f"{path}.forecast_option_id", report
+    )
+    if forecast_option is not None and forecast_option not in option_ids:
+        _issue(report, f"{path}.forecast_option_id", "unknown_forecast_option", "unknown option")
+
+    sources = case.get("sources")
+    if not isinstance(sources, list) or not sources:
+        _issue(report, f"{path}.sources", "missing_sources", "must contain public evidence")
+    else:
+        source_ids: set[str] = set()
+        for source_index, raw in enumerate(sources):
+            source_path = f"{path}.sources[{source_index}]"
+            source_id = _source(raw, source_path, report, cutoff=cutoff)
+            if source_id in source_ids:
+                _issue(report, f"{source_path}.source_id", "duplicate_source_id", "must be unique")
+            elif source_id is not None:
+                source_ids.add(source_id)
+    return case_id, option_ids, cutoff, domain, split, forecast_option
+
+
+def _outcome(
+    value: Any,
+    index: int,
+    case_options: dict[str, set[str]],
+    case_cutoffs: dict[str, datetime],
+    report: CorpusValidationReport,
+) -> tuple[str | None, datetime | None, str | None]:
+    path = f"$.outcomes[{index}]"
+    outcome = _object(value, path, report)
+    if outcome is None:
+        return None, None, None
+    _keys(outcome, _OUTCOME_KEYS, path, report)
+    case_id = _identifier(outcome.get("case_id"), f"{path}.case_id", report)
+    resolved_at = _timestamp(outcome.get("resolved_at"), f"{path}.resolved_at", report)
+    correct_option = _identifier(
+        outcome.get("correct_option_id"), f"{path}.correct_option_id", report
+    )
+    _text(outcome.get("resolution_summary"), f"{path}.resolution_summary", report)
+    if case_id is not None:
+        if case_id not in case_options:
+            _issue(report, f"{path}.case_id", "unknown_case", "has no matching corpus case")
+        elif correct_option not in case_options[case_id]:
+            _issue(report, f"{path}.correct_option_id", "unknown_correct_option", "unknown option")
+        cutoff = case_cutoffs.get(case_id)
+        if cutoff is not None and resolved_at is not None and resolved_at <= cutoff:
+            _issue(
+                report,
+                f"{path}.resolved_at",
+                "invalid_resolution_time",
+                "must be later than the information cutoff",
+            )
+
+    sources = outcome.get("authoritative_sources")
+    if not isinstance(sources, list) or not sources:
+        _issue(report, f"{path}.authoritative_sources", "missing_outcome_sources", "required")
+    else:
+        source_ids: set[str] = set()
+        for source_index, raw in enumerate(sources):
+            source_path = f"{path}.authoritative_sources[{source_index}]"
+            source_id = _source(raw, source_path, report, not_before=resolved_at)
+            if source_id in source_ids:
+                _issue(report, f"{source_path}.source_id", "duplicate_source_id", "must be unique")
+            elif source_id is not None:
+                source_ids.add(source_id)
+
+    cruxes = outcome.get("cruxes")
+    if not isinstance(cruxes, list) or not 3 <= len(cruxes) <= 5:
+        _issue(report, f"{path}.cruxes", "invalid_crux_count", "must contain 3 to 5 cruxes")
+    else:
+        crux_ids: set[str] = set()
+        for crux_index, raw in enumerate(cruxes):
+            crux_path = f"{path}.cruxes[{crux_index}]"
+            crux = _object(raw, crux_path, report)
+            if crux is None:
+                continue
+            _keys(crux, _CRUX_KEYS, crux_path, report)
+            crux_id = _identifier(crux.get("crux_id"), f"{crux_path}.crux_id", report)
+            _text(crux.get("description"), f"{crux_path}.description", report)
+            aliases = crux.get("aliases")
+            if not isinstance(aliases, list) or not all(
+                isinstance(alias, str) and alias.strip() for alias in aliases
+            ):
+                _issue(report, f"{crux_path}.aliases", "invalid_aliases", "must be strings")
+            if crux_id in crux_ids:
+                _issue(report, f"{crux_path}.crux_id", "duplicate_crux_id", "must be unique")
+            elif crux_id is not None:
+                crux_ids.add(crux_id)
+    return case_id, resolved_at, correct_option
+
+
+def validate_corpus_documents(
+    corpus: Any,
+    outcomes: Any,
+    *,
+    allow_partial: bool = False,
+    expected_outcomes_sha256: str | None = None,
+) -> CorpusValidationReport:
+    """Validate model-visible cases and their hash-bound outcome sidecar."""
+    report = CorpusValidationReport()
+    corpus_object = _object(corpus, "$corpus", report)
+    outcomes_object = _object(outcomes, "$outcomes", report)
+    if corpus_object is None or outcomes_object is None:
+        return report
+    try:
+        report.corpus_sha256 = canonical_sha256(corpus_object)
+        report.outcomes_sha256 = canonical_sha256(outcomes_object)
+    except (TypeError, ValueError) as exc:
+        _issue(report, "$", "non_canonical_json", str(exc))
+        return report
+    _keys(corpus_object, _CORPUS_KEYS, "$corpus", report)
+    _keys(outcomes_object, _OUTCOMES_KEYS, "$outcomes", report)
+    if corpus_object.get("schema_version") != CORPUS_SCHEMA_VERSION:
+        _issue(report, "$corpus.schema_version", "unsupported_schema", CORPUS_SCHEMA_VERSION)
+    if outcomes_object.get("schema_version") != OUTCOMES_SCHEMA_VERSION:
+        _issue(
+            report,
+            "$outcomes.schema_version",
+            "unsupported_schema",
+            OUTCOMES_SCHEMA_VERSION,
+        )
+    benchmark_id = _identifier(corpus_object.get("benchmark_id"), "$corpus.benchmark_id", report)
+    outcome_benchmark = _identifier(
+        outcomes_object.get("benchmark_id"), "$outcomes.benchmark_id", report
+    )
+    if benchmark_id is not None and outcome_benchmark != benchmark_id:
+        _issue(report, "$outcomes.benchmark_id", "benchmark_id_mismatch", "must match corpus")
+    _identifier(corpus_object.get("revision"), "$corpus.revision", report)
+    frozen_at = _timestamp(corpus_object.get("frozen_at"), "$corpus.frozen_at", report)
+    declared_corpus_hash = _sha256(
+        outcomes_object.get("corpus_sha256"), "$outcomes.corpus_sha256", report
+    )
+    if declared_corpus_hash is not None and declared_corpus_hash != report.corpus_sha256:
+        _issue(report, "$outcomes.corpus_sha256", "corpus_hash_mismatch", "must bind corpus")
+    if expected_outcomes_sha256 is not None:
+        if _SHA256_PATTERN.fullmatch(expected_outcomes_sha256) is None:
+            _issue(report, "$expected_outcomes_sha256", "invalid_sha256", "invalid digest")
+        elif expected_outcomes_sha256 != report.outcomes_sha256:
+            _issue(report, "$expected_outcomes_sha256", "outcomes_hash_mismatch", "digest drift")
+
+    cases = corpus_object.get("cases")
+    if not isinstance(cases, list):
+        _issue(report, "$corpus.cases", "invalid_type", "must be an array")
+        cases = []
+    report.case_count = len(cases)
+    if not cases:
+        _issue(report, "$corpus.cases", "empty_corpus", "must contain cases")
+    case_options: dict[str, set[str]] = {}
+    case_cutoffs: dict[str, datetime] = {}
+    case_domains: dict[str, str] = {}
+    case_splits: dict[str, str] = {}
+    case_forecast_options: dict[str, str] = {}
+    domains: list[str] = []
+    splits: list[str] = []
+    domain_splits: Counter[tuple[str, str]] = Counter()
+    for index, raw in enumerate(cases):
+        case_id, options, cutoff, domain, split, forecast_option = _case(raw, index, report)
+        if case_id in case_options:
+            _issue(report, f"$corpus.cases[{index}].case_id", "duplicate_case_id", "must be unique")
+        elif case_id is not None:
+            case_options[case_id] = options
+            if cutoff is not None:
+                case_cutoffs[case_id] = cutoff
+            if domain in DOMAINS:
+                case_domains[case_id] = domain
+            if split in SPLITS:
+                case_splits[case_id] = split
+            if forecast_option is not None:
+                case_forecast_options[case_id] = forecast_option
+        if domain in DOMAINS:
+            domains.append(domain)
+        if split in SPLITS:
+            splits.append(split)
+        if domain in DOMAINS and split in SPLITS:
+            domain_splits[(domain, split)] += 1
+    report.domain_counts = dict(sorted(Counter(domains).items()))
+    report.split_counts = dict(sorted(Counter(splits).items()))
+    if not allow_partial:
+        if len(cases) != 24:
+            _issue(report, "$corpus.cases", "wrong_case_count", "must contain exactly 24 cases")
+        for domain in DOMAINS:
+            if report.domain_counts.get(domain, 0) != 6:
+                _issue(report, "$corpus.cases", "wrong_domain_count", f"{domain} must have 6")
+            if domain_splits[(domain, "development")] != 4:
+                _issue(report, "$corpus.cases", "wrong_development_count", f"{domain} must have 4")
+            if domain_splits[(domain, "holdout")] != 2:
+                _issue(report, "$corpus.cases", "wrong_holdout_count", f"{domain} must have 2")
+
+    raw_outcomes = outcomes_object.get("outcomes")
+    if not isinstance(raw_outcomes, list):
+        _issue(report, "$outcomes.outcomes", "invalid_type", "must be an array")
+        raw_outcomes = []
+    if not raw_outcomes:
+        _issue(report, "$outcomes.outcomes", "empty_outcomes", "must contain outcomes")
+    outcome_ids: set[str] = set()
+    positive_targets: list[str] = []
+    for index, raw in enumerate(raw_outcomes):
+        case_id, resolved_at, correct_option = _outcome(
+            raw, index, case_options, case_cutoffs, report
+        )
+        if case_id in outcome_ids:
+            _issue(
+                report,
+                f"$outcomes.outcomes[{index}].case_id",
+                "duplicate_outcome",
+                "must be unique",
+            )
+        elif case_id is not None:
+            outcome_ids.add(case_id)
+            if correct_option == case_forecast_options.get(case_id):
+                positive_targets.append(case_id)
+        if frozen_at is not None and resolved_at is not None and frozen_at < resolved_at:
+            _issue(
+                report,
+                f"$outcomes.outcomes[{index}].resolved_at",
+                "premature_freeze",
+                "corpus freeze must not predate any resolved outcome",
+            )
+    missing = sorted(case_options.keys() - outcome_ids)
+    extra = sorted(outcome_ids - case_options.keys())
+    if missing:
+        _issue(report, "$outcomes.outcomes", "missing_outcomes", ", ".join(missing))
+    if extra:
+        _issue(report, "$outcomes.outcomes", "extra_outcomes", ", ".join(extra))
+    if not allow_partial:
+        if len(positive_targets) != 12:
+            _issue(
+                report,
+                "$outcomes.outcomes",
+                "wrong_target_balance",
+                "exactly 12 of 24 outcomes must match the forecast option",
+            )
+        target_domain_splits = Counter(
+            (case_domains.get(case_id), case_splits.get(case_id)) for case_id in positive_targets
+        )
+        for domain in DOMAINS:
+            if sum(target_domain_splits[(domain, split)] for split in SPLITS) != 3:
+                _issue(
+                    report,
+                    "$outcomes.outcomes",
+                    "wrong_domain_target_balance",
+                    f"{domain} must contain exactly 3 positive targets",
+                )
+            if target_domain_splits[(domain, "development")] != 2:
+                _issue(
+                    report,
+                    "$outcomes.outcomes",
+                    "wrong_development_target_balance",
+                    f"{domain} development must contain exactly 2 positive targets",
+                )
+            if target_domain_splits[(domain, "holdout")] != 1:
+                _issue(
+                    report,
+                    "$outcomes.outcomes",
+                    "wrong_holdout_target_balance",
+                    f"{domain} holdout must contain exactly 1 positive target",
+                )
+    return report
+
+
+def validate_corpus_files(
+    corpus_path: Path,
+    outcomes_path: Path,
+    *,
+    allow_partial: bool = False,
+    expected_outcomes_sha256: str | None = None,
+) -> CorpusValidationReport:
+    """Load and validate two files without raising on malformed input."""
+    corpus, corpus_issue = load_json_document(corpus_path)
+    outcomes, outcomes_issue = load_json_document(outcomes_path)
+    if corpus_issue is not None or outcomes_issue is not None:
+        return CorpusValidationReport(
+            issues=[issue for issue in (corpus_issue, outcomes_issue) if issue is not None]
+        )
+    return validate_corpus_documents(
+        corpus,
+        outcomes,
+        allow_partial=allow_partial,
+        expected_outcomes_sha256=expected_outcomes_sha256,
+    )
+
+
+def assemble_tranches(
+    inputs: list[TrancheInput],
+    *,
+    benchmark_id: str,
+    revision: str,
+    frozen_at: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, CorpusValidationReport]:
+    """Assemble manifest-pinned tranche inputs into one canonical benchmark."""
+    report = CorpusValidationReport()
+    cases: list[dict[str, Any]] = []
+    outcomes: list[dict[str, Any]] = []
+    for index, item in enumerate(inputs):
+        corpus_doc, corpus_issue = load_json_document(item.corpus_path)
+        outcomes_doc, outcomes_issue = load_json_document(item.outcomes_path)
+        for issue in (corpus_issue, outcomes_issue):
+            if issue is not None:
+                report.issues.append(issue)
+        if corpus_doc is None or outcomes_doc is None:
+            continue
+        try:
+            actual_corpus = canonical_sha256(corpus_doc)
+            actual_outcomes = canonical_sha256(outcomes_doc)
+        except (TypeError, ValueError) as exc:
+            _issue(report, f"$tranches[{index}]", "non_canonical_json", str(exc))
+            continue
+        if actual_corpus != item.corpus_sha256:
+            _issue(report, f"$tranches[{index}].corpus", "tranche_hash_mismatch", actual_corpus)
+        if actual_outcomes != item.outcomes_sha256:
+            _issue(report, f"$tranches[{index}].outcomes", "tranche_hash_mismatch", actual_outcomes)
+        partial = validate_corpus_documents(corpus_doc, outcomes_doc, allow_partial=True)
+        report.issues.extend(partial.issues)
+        if partial.ok:
+            cases.extend(corpus_doc["cases"])
+            outcomes.extend(outcomes_doc["outcomes"])
+    if report.issues:
+        return None, None, report
+    corpus = {
+        "schema_version": CORPUS_SCHEMA_VERSION,
+        "benchmark_id": benchmark_id,
+        "revision": revision,
+        "frozen_at": frozen_at,
+        "cases": sorted(cases, key=lambda item: item["case_id"]),
+    }
+    outcome_sidecar = {
+        "schema_version": OUTCOMES_SCHEMA_VERSION,
+        "benchmark_id": benchmark_id,
+        "corpus_sha256": canonical_sha256(corpus),
+        "outcomes": sorted(outcomes, key=lambda item: item["case_id"]),
+    }
+    return corpus, outcome_sidecar, validate_corpus_documents(corpus, outcome_sidecar)
+
+
+__all__ = [
+    "CORPUS_SCHEMA_VERSION",
+    "OUTCOMES_SCHEMA_VERSION",
+    "DOMAINS",
+    "SPLITS",
+    "CorpusValidationReport",
+    "TrancheInput",
+    "ValidationIssue",
+    "assemble_tranches",
+    "canonical_json_bytes",
+    "canonical_sha256",
+    "is_public_https_url",
+    "load_json_document",
+    "validate_corpus_documents",
+    "validate_corpus_files",
+]

--- a/aragora/evaluation/outcome_decision_quality.py
+++ b/aragora/evaluation/outcome_decision_quality.py
@@ -435,7 +435,11 @@ def request_contains_outcome_data(request: dict[str, Any], outcome: dict[str, An
         forbidden.extend(source.values())
     for crux in outcome.get("cruxes", []):
         forbidden.extend((crux.get("crux_id"), crux.get("description")))
-        forbidden.extend(crux.get("aliases", []))
+        # Aliases are intentionally lexical and can occur naturally in the
+        # pre-cutoff packet (for example, "compliance readiness").  Treating
+        # those coincidences as sidecar disclosure makes valid frozen cases
+        # un-runnable.  Stable IDs and full preregistered descriptions remain
+        # forbidden and provide the fail-closed structural markers.
     return any(isinstance(value, str) and value and value in request_text for value in forbidden)
 
 

--- a/aragora/evaluation/outcome_decision_quality.py
+++ b/aragora/evaluation/outcome_decision_quality.py
@@ -488,6 +488,13 @@ def _member_index(condition: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {member["family"]: member for member in condition["members"]}
 
 
+def _nonnegative_finite_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) and number >= 0 else None
+
+
 def validate_runner_response(response: dict[str, Any], condition: dict[str, Any]) -> list[str]:
     """Validate result shape and exact family/model/transport integrity."""
     errors: list[str] = []
@@ -514,15 +521,18 @@ def validate_runner_response(response: dict[str, Any], condition: dict[str, Any]
             errors.append(f"calls[{index}] transport drift")
         if call.get("billing_class") != member["billing_class"]:
             errors.append(f"calls[{index}] billing class drift")
-        latency = call.get("latency_ms")
-        cost = call.get("cost_usd")
-        if not isinstance(latency, (int, float)) or latency < 0:
+        latency = _nonnegative_finite_number(call.get("latency_ms"))
+        cost = _nonnegative_finite_number(call.get("cost_usd"))
+        if latency is None:
             errors.append(f"calls[{index}] invalid latency")
-        if not isinstance(cost, (int, float)) or not math.isfinite(float(cost)) or cost < 0:
+        if cost is None:
             errors.append(f"calls[{index}] invalid cost")
     for family in expected:
-        if observed[family] == 0:
+        count = observed[family]
+        if count == 0:
             errors.append(f"incomplete roster: missing {family}")
+        elif count != 1:
+            errors.append(f"duplicate family {family}: expected exactly one call, observed {count}")
     output = response.get("output")
     if not isinstance(output, dict):
         errors.append("output must be an object")
@@ -680,10 +690,22 @@ def execute_batch(
             if condition_name == "aragora_team" and receipt_verification != "verified":
                 errors.append(f"team receipt {receipt_verification}")
             raw_calls = response.get("calls")
-            calls: list[Any] = raw_calls if isinstance(raw_calls, list) else []
+            call_items: list[Any] = raw_calls if isinstance(raw_calls, list) else []
+            calls: list[dict[str, Any]] = []
             cost_entries: list[CostEntry] = []
-            for call in calls:
+            unknown_paid_cost = False
+            for call in call_items:
                 if not isinstance(call, dict):
+                    continue
+                latency = _nonnegative_finite_number(call.get("latency_ms"))
+                cost = _nonnegative_finite_number(call.get("cost_usd"))
+                recorded_call = dict(call)
+                recorded_call["latency_ms"] = latency if latency is not None else 0.0
+                recorded_call["cost_usd"] = cost if cost is not None else 0.0
+                calls.append(recorded_call)
+                billing_class = str(call.get("billing_class", ""))
+                if cost is None and billing_class == "paid_api":
+                    unknown_paid_cost = True
                     continue
                 cost_entries.append(
                     CostEntry(
@@ -694,8 +716,25 @@ def execute_batch(
                         family=str(call.get("family", "")),
                         model=str(call.get("resolved_model", "")),
                         transport=str(call.get("transport", "")),
-                        billing_class=str(call.get("billing_class", "")),
-                        cost_usd=float(call.get("cost_usd", 0.0)),
+                        billing_class=billing_class,
+                        cost_usd=cost if cost is not None else 0.0,
+                    )
+                )
+            if unknown_paid_cost:
+                cost_entries = [
+                    entry for entry in cost_entries if entry.billing_class != "paid_api"
+                ]
+                cost_entries.append(
+                    CostEntry(
+                        recorded_at=now.isoformat().replace("+00:00", "Z"),
+                        run_id=run_id,
+                        case_id=case["case_id"],
+                        condition=condition_name,
+                        family="unknown",
+                        model="unknown",
+                        transport="unknown",
+                        billing_class="paid_api",
+                        cost_usd=max_paid,
                     )
                 )
             actual_paid = sum(
@@ -724,9 +763,7 @@ def execute_batch(
                 "transport": primary_call.get("transport"),
                 "calls": calls,
                 "output": response.get("output"),
-                "latency_ms": sum(
-                    float(call.get("latency_ms", 0.0)) for call in calls if isinstance(call, dict)
-                ),
+                "latency_ms": sum(float(call["latency_ms"]) for call in calls),
                 "cost_usd": sum(entry.cost_usd for entry in cost_entries),
                 "errors": sorted(set(errors)),
                 "attempt_count": attempts,
@@ -813,8 +850,33 @@ def load_results(paths: Iterable[Path]) -> tuple[list[dict[str, Any]], list[str]
     return results, errors
 
 
-def score_results(bundle: BenchmarkBundle, results: list[dict[str, Any]]) -> dict[str, Any]:
+def _require_result_bindings(
+    bundle: BenchmarkBundle,
+    results: list[dict[str, Any]],
+    implementation_sha: str,
+) -> None:
+    if _SHA_PATTERN.fullmatch(implementation_sha) is None:
+        raise ValueError("implementation_sha must be a full lowercase git SHA")
+    expected = {
+        "benchmark_id": bundle.manifest["benchmark_id"],
+        "revision": bundle.manifest["revision"],
+        "manifest_sha256": bundle.manifest_sha256,
+        "implementation_sha": implementation_sha,
+    }
+    for index, result in enumerate(results):
+        for field_name, expected_value in expected.items():
+            if result.get(field_name) != expected_value:
+                raise ValueError(f"result binding mismatch at result {index}: {field_name}")
+
+
+def score_results(
+    bundle: BenchmarkBundle,
+    results: list[dict[str, Any]],
+    *,
+    implementation_sha: str,
+) -> dict[str, Any]:
     """Produce deterministic per-condition metrics and best-single deltas."""
+    _require_result_bindings(bundle, results, implementation_sha)
     case_by_id = {case["case_id"]: case for case in bundle.cases}
     outcome_by_id = {outcome["case_id"]: outcome for outcome in bundle.outcomes["outcomes"]}
     per_condition: dict[str, list[dict[str, float]]] = defaultdict(list)
@@ -915,6 +977,7 @@ def score_results(bundle: BenchmarkBundle, results: list[dict[str, Any]]) -> dic
         "benchmark_id": bundle.manifest["benchmark_id"],
         "revision": bundle.manifest["revision"],
         "manifest_sha256": bundle.manifest_sha256,
+        "implementation_sha": implementation_sha,
         "result_count": len(results),
         "incomplete_results": sorted(set(incomplete)),
         "conditions": summaries,

--- a/aragora/evaluation/outcome_decision_quality.py
+++ b/aragora/evaluation/outcome_decision_quality.py
@@ -1,0 +1,1043 @@
+"""Outcome-backed decision-quality benchmark harness and deterministic scorer.
+
+The harness is intentionally transport-neutral.  A runner receives one
+model-visible case packet and must return a structured response.  This module
+owns corpus freezing, family/roster integrity, retry and budget policy,
+append-only result recording, independent receipt verification, and scoring.
+Outcome sidecars are never passed to the runner.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import statistics
+import subprocess
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from aragora.evaluation.decision_quality_corpus import (
+    CorpusValidationReport,
+    TrancheInput,
+    assemble_tranches,
+    canonical_json_bytes,
+    canonical_sha256,
+    load_json_document,
+)
+from aragora.evaluation.manifold_brier import brier_score
+
+MANIFEST_SCHEMA_VERSION = "decision-quality-benchmark/1.0"
+ROSTER_SCHEMA_VERSION = "decision-quality-roster/1.0"
+RESULT_SCHEMA_VERSION = "decision-quality-result/1.0"
+SCORE_SCHEMA_VERSION = "decision-quality-score/1.0"
+HOLDOUT_LOCK_SCHEMA_VERSION = "decision-quality-holdout-lock/1.0"
+SCORER_CONTRACT_VERSION = "outcome-decision-quality-scorer/1.0"
+CANONICAL_JSON_CONVENTION = "python-json-sort-keys-compact-utf8-no-nan-v1"
+REQUIRED_CONDITIONS = (
+    "single_claude",
+    "single_openai",
+    "single_gemini",
+    "aragora_team",
+)
+
+_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class ContractIssue:
+    path: str
+    code: str
+    message: str
+
+
+@dataclass
+class BenchmarkContractReport:
+    manifest_sha256: str | None = None
+    corpus_sha256: str | None = None
+    outcomes_sha256: str | None = None
+    case_count: int = 0
+    issues: list[ContractIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "manifest_sha256": self.manifest_sha256,
+            "corpus_sha256": self.corpus_sha256,
+            "outcomes_sha256": self.outcomes_sha256,
+            "case_count": self.case_count,
+            "issues": [asdict(issue) for issue in self.issues],
+        }
+
+
+@dataclass(frozen=True)
+class BenchmarkBundle:
+    manifest_path: Path
+    manifest: dict[str, Any]
+    manifest_sha256: str
+    corpus: dict[str, Any]
+    outcomes: dict[str, Any]
+    prompt_contract: str
+    roster: dict[str, Any]
+
+    @property
+    def cases(self) -> list[dict[str, Any]]:
+        return list(self.corpus["cases"])
+
+
+@dataclass(frozen=True)
+class CostEntry:
+    recorded_at: str
+    run_id: str
+    case_id: str
+    condition: str
+    family: str
+    model: str
+    transport: str
+    billing_class: str
+    cost_usd: float
+
+
+@dataclass
+class CostLedger:
+    """Append-only paid-API budget ledger grouped by UTC day."""
+
+    path: Path
+    daily_cap_usd: float
+    entries: list[CostEntry] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, path: Path, daily_cap_usd: float) -> CostLedger:
+        ledger = cls(path=path, daily_cap_usd=daily_cap_usd)
+        if not path.exists():
+            return ledger
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            raise ValueError(f"cannot read cost ledger {path}: {exc}") from exc
+        for line_number, line in enumerate(lines, start=1):
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+                ledger.entries.append(CostEntry(**payload))
+            except (json.JSONDecodeError, TypeError) as exc:
+                raise ValueError(f"invalid cost ledger line {line_number}: {exc}") from exc
+        return ledger
+
+    def paid_total(self, utc_day: str) -> float:
+        return sum(
+            entry.cost_usd
+            for entry in self.entries
+            if entry.billing_class == "paid_api" and entry.recorded_at[:10] == utc_day
+        )
+
+    def require_capacity(self, utc_day: str, projected_cost_usd: float) -> None:
+        if projected_cost_usd < 0:
+            raise ValueError("projected cost must not be negative")
+        projected = self.paid_total(utc_day) + projected_cost_usd
+        if projected > self.daily_cap_usd + 1e-9:
+            raise RuntimeError(
+                f"paid API budget exhausted for {utc_day}: "
+                f"projected ${projected:.4f} > ${self.daily_cap_usd:.4f}"
+            )
+
+    def append(self, entries: Iterable[CostEntry]) -> None:
+        new_entries = list(entries)
+        if not new_entries:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as stream:
+            for entry in new_entries:
+                stream.write(json.dumps(asdict(entry), sort_keys=True, separators=(",", ":")))
+                stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        self.entries.extend(new_entries)
+
+
+Runner = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+def _contract_issue(report: BenchmarkContractReport, path: str, code: str, message: str) -> None:
+    report.issues.append(ContractIssue(path, code, message))
+
+
+def _safe_artifact_path(manifest_dir: Path, relative: Any) -> Path | None:
+    if not isinstance(relative, str) or not relative or Path(relative).is_absolute():
+        return None
+    resolved = (manifest_dir / relative).resolve()
+    try:
+        resolved.relative_to(manifest_dir.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _read_text(path: Path) -> tuple[str | None, ContractIssue | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except OSError as exc:
+        return None, ContractIssue(str(path), "read_error", str(exc))
+    except UnicodeError as exc:
+        return None, ContractIssue(str(path), "invalid_utf8", str(exc))
+
+
+def load_benchmark_bundle(
+    manifest_path: Path,
+) -> tuple[BenchmarkBundle | None, BenchmarkContractReport]:
+    """Load and verify every file pinned by the frozen benchmark manifest."""
+    report = BenchmarkContractReport()
+    manifest_doc, manifest_issue = load_json_document(manifest_path)
+    if manifest_issue is not None:
+        report.issues.append(ContractIssue(**asdict(manifest_issue)))
+        return None, report
+    if not isinstance(manifest_doc, dict):
+        _contract_issue(report, "$", "invalid_manifest", "manifest must be a JSON object")
+        return None, report
+    try:
+        report.manifest_sha256 = canonical_sha256(manifest_doc)
+    except (TypeError, ValueError) as exc:
+        _contract_issue(report, "$", "non_canonical_json", str(exc))
+        return None, report
+    if manifest_doc.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        _contract_issue(report, "$.schema_version", "unsupported_schema", MANIFEST_SCHEMA_VERSION)
+    if manifest_doc.get("canonical_json") != CANONICAL_JSON_CONVENTION:
+        _contract_issue(report, "$.canonical_json", "canonicalization_mismatch", "unsupported")
+    if tuple(manifest_doc.get("conditions", ())) != REQUIRED_CONDITIONS:
+        _contract_issue(
+            report,
+            "$.conditions",
+            "condition_roster_mismatch",
+            f"must equal {REQUIRED_CONDITIONS}",
+        )
+
+    manifest_dir = manifest_path.resolve().parent
+    prompt_spec = manifest_doc.get("prompt")
+    roster_spec = manifest_doc.get("roster")
+    if not isinstance(prompt_spec, dict) or not isinstance(roster_spec, dict):
+        _contract_issue(report, "$", "missing_contract_artifact", "prompt and roster are required")
+        return None, report
+    prompt_path = _safe_artifact_path(manifest_dir, prompt_spec.get("path"))
+    roster_path = _safe_artifact_path(manifest_dir, roster_spec.get("path"))
+    if prompt_path is None or roster_path is None:
+        _contract_issue(report, "$", "unsafe_artifact_path", "artifact paths must stay local")
+        return None, report
+    prompt_text, prompt_issue = _read_text(prompt_path)
+    roster_doc, roster_issue = load_json_document(roster_path)
+    if prompt_issue is not None:
+        report.issues.append(prompt_issue)
+    if roster_issue is not None:
+        report.issues.append(ContractIssue(**asdict(roster_issue)))
+    if roster_doc is not None and not isinstance(roster_doc, dict):
+        _contract_issue(report, "$.roster", "invalid_roster", "must be a JSON object")
+    if prompt_text is None or not isinstance(roster_doc, dict):
+        return None, report
+    prompt_digest = hashlib.sha256(prompt_text.encode("utf-8")).hexdigest()
+    if prompt_digest != prompt_spec.get("sha256"):
+        _contract_issue(report, "$.prompt.sha256", "artifact_hash_mismatch", prompt_digest)
+    roster_digest = canonical_sha256(roster_doc)
+    if roster_digest != roster_spec.get("sha256"):
+        _contract_issue(report, "$.roster.sha256", "artifact_hash_mismatch", roster_digest)
+    _validate_roster(roster_doc, report)
+
+    tranches = manifest_doc.get("tranches")
+    tranche_inputs: list[TrancheInput] = []
+    if not isinstance(tranches, list) or len(tranches) != 8:
+        _contract_issue(report, "$.tranches", "invalid_tranche_count", "must contain eight")
+    else:
+        for index, raw in enumerate(tranches):
+            if not isinstance(raw, dict):
+                _contract_issue(report, f"$.tranches[{index}]", "invalid_tranche", "must be object")
+                continue
+            corpus_path = _safe_artifact_path(manifest_dir, raw.get("corpus_path"))
+            outcomes_path = _safe_artifact_path(manifest_dir, raw.get("outcomes_path"))
+            corpus_digest = raw.get("corpus_sha256")
+            outcomes_digest = raw.get("outcomes_sha256")
+            if corpus_path is None or outcomes_path is None:
+                _contract_issue(
+                    report, f"$.tranches[{index}]", "unsafe_artifact_path", "invalid path"
+                )
+            elif not all(
+                isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value)
+                for value in (corpus_digest, outcomes_digest)
+            ):
+                _contract_issue(
+                    report, f"$.tranches[{index}]", "invalid_sha256", "digests required"
+                )
+            else:
+                tranche_inputs.append(
+                    TrancheInput(
+                        corpus_path, outcomes_path, str(corpus_digest), str(outcomes_digest)
+                    )
+                )
+
+    corpus: dict[str, Any] | None = None
+    outcomes: dict[str, Any] | None = None
+    if len(tranche_inputs) == 8:
+        corpus, outcomes, corpus_report = assemble_tranches(
+            tranche_inputs,
+            benchmark_id=str(manifest_doc.get("benchmark_id", "")),
+            revision=str(manifest_doc.get("revision", "")),
+            frozen_at=str(manifest_doc.get("frozen_at", "")),
+        )
+        _copy_corpus_issues(corpus_report, report)
+        report.corpus_sha256 = corpus_report.corpus_sha256
+        report.outcomes_sha256 = corpus_report.outcomes_sha256
+        report.case_count = corpus_report.case_count
+    aggregate = manifest_doc.get("aggregate")
+    if not isinstance(aggregate, dict):
+        _contract_issue(report, "$.aggregate", "missing_aggregate", "required")
+    else:
+        for key, actual in (
+            ("corpus_sha256", report.corpus_sha256),
+            ("outcomes_sha256", report.outcomes_sha256),
+            ("case_count", report.case_count),
+        ):
+            if aggregate.get(key) != actual:
+                _contract_issue(report, f"$.aggregate.{key}", "aggregate_mismatch", str(actual))
+    scorer = manifest_doc.get("scorer")
+    if not isinstance(scorer, dict) or scorer.get("contract_version") != SCORER_CONTRACT_VERSION:
+        _contract_issue(report, "$.scorer", "scorer_contract_mismatch", SCORER_CONTRACT_VERSION)
+    budget = manifest_doc.get("budget")
+    if (
+        not isinstance(budget, dict)
+        or budget.get("paid_api_daily_usd") != 25.0
+        or budget.get("infrastructure_retries_per_call") != 1
+    ):
+        _contract_issue(report, "$.budget", "budget_contract_mismatch", "must be $25 and one retry")
+    holdout = manifest_doc.get("holdout")
+    if not isinstance(holdout, dict) or holdout.get("repetitions") != 2:
+        _contract_issue(
+            report, "$.holdout", "holdout_contract_mismatch", "two repetitions required"
+        )
+    if report.issues or corpus is None or outcomes is None:
+        return None, report
+    return (
+        BenchmarkBundle(
+            manifest_path=manifest_path.resolve(),
+            manifest=manifest_doc,
+            manifest_sha256=report.manifest_sha256 or "",
+            corpus=corpus,
+            outcomes=outcomes,
+            prompt_contract=prompt_text,
+            roster=roster_doc,
+        ),
+        report,
+    )
+
+
+def _copy_corpus_issues(source: CorpusValidationReport, target: BenchmarkContractReport) -> None:
+    for issue in source.issues:
+        target.issues.append(ContractIssue(issue.path, issue.code, issue.message))
+
+
+def _validate_roster(roster: dict[str, Any], report: BenchmarkContractReport) -> None:
+    if roster.get("schema_version") != ROSTER_SCHEMA_VERSION:
+        _contract_issue(
+            report, "$.roster.schema_version", "unsupported_schema", ROSTER_SCHEMA_VERSION
+        )
+    conditions = roster.get("conditions")
+    if not isinstance(conditions, dict) or set(conditions) != set(REQUIRED_CONDITIONS):
+        _contract_issue(
+            report, "$.roster.conditions", "incomplete_roster", "four conditions required"
+        )
+        return
+    for condition_name, condition in conditions.items():
+        if not isinstance(condition, dict):
+            _contract_issue(report, f"$.roster.{condition_name}", "invalid_condition", "object")
+            continue
+        members = condition.get("members")
+        if not isinstance(members, list) or not members:
+            _contract_issue(
+                report, f"$.roster.{condition_name}.members", "incomplete_roster", "required"
+            )
+            continue
+        families: set[str] = set()
+        for index, member in enumerate(members):
+            path = f"$.roster.{condition_name}.members[{index}]"
+            if not isinstance(member, dict):
+                _contract_issue(report, path, "invalid_member", "must be object")
+                continue
+            family = member.get("family")
+            if family in families:
+                _contract_issue(report, f"{path}.family", "duplicate_family", str(family))
+            elif isinstance(family, str):
+                families.add(family)
+            for key in ("requested_model", "transport", "billing_class"):
+                if not isinstance(member.get(key), str) or not member[key]:
+                    _contract_issue(report, f"{path}.{key}", "missing_field", "required")
+            resolved = member.get("allowed_resolved_models")
+            if (
+                not isinstance(resolved, list)
+                or not resolved
+                or not all(isinstance(model, str) and model for model in resolved)
+            ):
+                _contract_issue(
+                    report, f"{path}.allowed_resolved_models", "missing_field", "required"
+                )
+        expected = {condition_name.removeprefix("single_")}
+        if condition_name == "aragora_team":
+            expected = {"claude", "openai", "gemini"}
+            if condition.get("adversarial_rounds") != 1:
+                _contract_issue(report, f"$.roster.{condition_name}", "round_contract", "one round")
+        if families != expected:
+            _contract_issue(
+                report,
+                f"$.roster.{condition_name}.members",
+                "family_roster_mismatch",
+                f"expected {sorted(expected)}",
+            )
+
+
+def build_model_visible_request(
+    bundle: BenchmarkBundle,
+    case: dict[str, Any],
+    condition: str,
+    *,
+    repetition: int,
+    implementation_sha: str,
+) -> dict[str, Any]:
+    """Build one request packet with no outcome-sidecar content."""
+    roster_condition = bundle.roster["conditions"][condition]
+    return {
+        "schema_version": "decision-quality-request/1.0",
+        "benchmark_id": bundle.manifest["benchmark_id"],
+        "revision": bundle.manifest["revision"],
+        "manifest_sha256": bundle.manifest_sha256,
+        "implementation_sha": implementation_sha,
+        "repetition": repetition,
+        "condition": condition,
+        "prompt_contract": bundle.prompt_contract,
+        "case": json.loads(json.dumps(case)),
+        "roster": json.loads(json.dumps(roster_condition)),
+    }
+
+
+def request_contains_outcome_data(request: dict[str, Any], outcome: dict[str, Any]) -> bool:
+    """Conservatively detect answer-sidecar strings in a model request."""
+    request_text = canonical_json_bytes(request).decode("utf-8")
+    forbidden: list[Any] = [
+        outcome.get("resolved_at"),
+        outcome.get("resolution_summary"),
+    ]
+    for source in outcome.get("authoritative_sources", []):
+        forbidden.extend(source.values())
+    for crux in outcome.get("cruxes", []):
+        forbidden.extend((crux.get("crux_id"), crux.get("description")))
+        forbidden.extend(crux.get("aliases", []))
+    return any(isinstance(value, str) and value and value in request_text for value in forbidden)
+
+
+def run_subprocess_runner(
+    command: list[str], request: dict[str, Any], timeout: float
+) -> dict[str, Any]:
+    """Invoke a JSON-in/JSON-out runner command with a hard timeout."""
+    try:
+        completed = subprocess.run(
+            command,
+            input=json.dumps(request),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "infrastructure_failure": True, "error_class": "runner_timeout"}
+    except OSError:
+        return {
+            "ok": False,
+            "infrastructure_failure": True,
+            "error_class": "runner_spawn_failed",
+        }
+    if completed.returncode != 0:
+        return {
+            "ok": False,
+            "infrastructure_failure": True,
+            "error_class": "runner_nonzero_exit",
+        }
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "infrastructure_failure": True,
+            "error_class": "runner_invalid_json",
+            "error": f"invalid JSON at line {exc.lineno}, column {exc.colno}",
+        }
+    if not isinstance(payload, dict):
+        return {"ok": False, "infrastructure_failure": True, "error_class": "runner_invalid_shape"}
+    return payload
+
+
+def _member_index(condition: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {member["family"]: member for member in condition["members"]}
+
+
+def validate_runner_response(response: dict[str, Any], condition: dict[str, Any]) -> list[str]:
+    """Validate result shape and exact family/model/transport integrity."""
+    errors: list[str] = []
+    calls = response.get("calls")
+    if not isinstance(calls, list):
+        return ["calls must be a list"]
+    expected = _member_index(condition)
+    observed: Counter[str] = Counter()
+    for index, call in enumerate(calls):
+        if not isinstance(call, dict):
+            errors.append(f"calls[{index}] must be an object")
+            continue
+        family = call.get("family")
+        observed[str(family)] += 1
+        member = expected.get(str(family))
+        if member is None:
+            errors.append(f"calls[{index}] unexpected family {family!r}")
+            continue
+        if call.get("requested_model") != member["requested_model"]:
+            errors.append(f"calls[{index}] requested model drift")
+        if call.get("resolved_model") not in member["allowed_resolved_models"]:
+            errors.append(f"calls[{index}] resolved model identity mismatch")
+        if call.get("transport") != member["transport"]:
+            errors.append(f"calls[{index}] transport drift")
+        if call.get("billing_class") != member["billing_class"]:
+            errors.append(f"calls[{index}] billing class drift")
+        latency = call.get("latency_ms")
+        cost = call.get("cost_usd")
+        if not isinstance(latency, (int, float)) or latency < 0:
+            errors.append(f"calls[{index}] invalid latency")
+        if not isinstance(cost, (int, float)) or not math.isfinite(float(cost)) or cost < 0:
+            errors.append(f"calls[{index}] invalid cost")
+    for family in expected:
+        if observed[family] == 0:
+            errors.append(f"incomplete roster: missing {family}")
+    output = response.get("output")
+    if not isinstance(output, dict):
+        errors.append("output must be an object")
+    else:
+        if not isinstance(output.get("selected_option_id"), str):
+            errors.append("output.selected_option_id is required")
+        probability = output.get("forecast_probability")
+        if not isinstance(probability, (int, float)) or not 0 <= float(probability) <= 1:
+            errors.append("output.forecast_probability must be in [0,1]")
+        for key in ("cruxes", "source_ids"):
+            if not isinstance(output.get(key), list) or not all(
+                isinstance(item, str) and item.strip() for item in output.get(key, [])
+            ):
+                errors.append(f"output.{key} must contain non-empty strings")
+    return errors
+
+
+def verify_receipt(
+    path: Path | None,
+    *,
+    expected_input_hash: str | None = None,
+    expected_output: dict[str, Any] | None = None,
+) -> tuple[str | None, str]:
+    """Hash and independently verify a team DecisionReceipt."""
+    if path is None:
+        return None, "missing"
+    payload, issue = load_json_document(path)
+    if issue is not None or not isinstance(payload, dict):
+        return None, "invalid"
+    digest = canonical_sha256(payload)
+    if expected_input_hash is not None and payload.get("input_hash") != expected_input_hash:
+        return digest, "input_mismatch"
+    if expected_output is not None and payload.get("decision_payload") != expected_output:
+        return digest, "decision_mismatch"
+    try:
+        from aragora.gauntlet.receipt_models import DecisionReceipt
+
+        receipt = DecisionReceipt.from_dict(payload)
+        verified = receipt.verify_integrity()
+    except (AttributeError, ImportError, KeyError, TypeError, ValueError):
+        return digest, "invalid"
+    return digest, "verified" if verified else "failed"
+
+
+def holdout_lock_payload(bundle: BenchmarkBundle, implementation_sha: str) -> dict[str, Any]:
+    return {
+        "schema_version": HOLDOUT_LOCK_SCHEMA_VERSION,
+        "benchmark_id": bundle.manifest["benchmark_id"],
+        "revision": bundle.manifest["revision"],
+        "manifest_sha256": bundle.manifest_sha256,
+        "corpus_sha256": canonical_sha256(bundle.corpus),
+        "outcomes_sha256": canonical_sha256(bundle.outcomes),
+        "prompt_sha256": bundle.manifest["prompt"]["sha256"],
+        "roster_sha256": bundle.manifest["roster"]["sha256"],
+        "scorer_contract_version": SCORER_CONTRACT_VERSION,
+        "implementation_sha": implementation_sha,
+    }
+
+
+def ensure_holdout_lock(path: Path, bundle: BenchmarkBundle, implementation_sha: str) -> None:
+    expected = holdout_lock_payload(bundle, implementation_sha)
+    if path.exists():
+        observed, issue = load_json_document(path)
+        if issue is not None or observed != expected:
+            raise RuntimeError("holdout lock mismatch: inputs changed between repetitions")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(expected, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False))
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def execute_batch(
+    bundle: BenchmarkBundle,
+    runner: Runner,
+    *,
+    split: str,
+    repetition: int,
+    implementation_sha: str,
+    run_id: str,
+    results_path: Path,
+    cost_ledger: CostLedger,
+    recorded_at: datetime | None = None,
+    max_cases: int | None = None,
+    holdout_lock_path: Path | None = None,
+) -> dict[str, Any]:
+    """Execute one bounded batch and append every success/failure result."""
+    if split not in {"development", "holdout"}:
+        raise ValueError("split must be development or holdout")
+    if _SHA_PATTERN.fullmatch(implementation_sha) is None:
+        raise ValueError("implementation_sha must be a full lowercase git SHA")
+    if split == "development" and repetition != 1:
+        raise ValueError("development cases run once")
+    if split == "holdout" and repetition not in (1, 2):
+        raise ValueError("holdout repetition must be 1 or 2")
+    if split == "holdout":
+        ensure_holdout_lock(
+            holdout_lock_path or results_path.parent / "holdout-lock.json",
+            bundle,
+            implementation_sha,
+        )
+    now = recorded_at or datetime.now(UTC)
+    utc_day = now.date().isoformat()
+    outcome_by_case = {item["case_id"]: item for item in bundle.outcomes["outcomes"]}
+    cases = [case for case in bundle.cases if case["split"] == split]
+    if max_cases is not None:
+        cases = cases[:max_cases]
+    completed = 0
+    failures = 0
+    retries = 0
+    for case in cases:
+        for condition_name in REQUIRED_CONDITIONS:
+            condition = bundle.roster["conditions"][condition_name]
+            max_paid = float(condition.get("max_paid_cost_usd", 0.0))
+            cost_ledger.require_capacity(utc_day, max_paid)
+            request = build_model_visible_request(
+                bundle,
+                case,
+                condition_name,
+                repetition=repetition,
+                implementation_sha=implementation_sha,
+            )
+            if request_contains_outcome_data(request, outcome_by_case[case["case_id"]]):
+                raise RuntimeError(f"outcome leakage detected in request for {case['case_id']}")
+            attempts = 0
+            response: dict[str, Any]
+            while True:
+                attempts += 1
+                response = runner(request)
+                if not response.get("infrastructure_failure") or attempts >= 2:
+                    break
+                retries += 1
+            errors = validate_runner_response(response, condition)
+            if response.get("ok") is not True:
+                errors.append(str(response.get("error_class") or "runner_failure"))
+            receipt_path_value = response.get("receipt_path")
+            receipt_path = Path(receipt_path_value) if isinstance(receipt_path_value, str) else None
+            response_output = response.get("output")
+            receipt_hash, receipt_verification = (
+                verify_receipt(
+                    receipt_path,
+                    expected_input_hash=hashlib.sha256(canonical_json_bytes(request)).hexdigest(),
+                    expected_output=response_output if isinstance(response_output, dict) else None,
+                )
+                if condition_name == "aragora_team"
+                else (None, "not_applicable")
+            )
+            if condition_name == "aragora_team" and receipt_verification != "verified":
+                errors.append(f"team receipt {receipt_verification}")
+            raw_calls = response.get("calls")
+            calls: list[Any] = raw_calls if isinstance(raw_calls, list) else []
+            cost_entries: list[CostEntry] = []
+            for call in calls:
+                if not isinstance(call, dict):
+                    continue
+                cost_entries.append(
+                    CostEntry(
+                        recorded_at=now.isoformat().replace("+00:00", "Z"),
+                        run_id=run_id,
+                        case_id=case["case_id"],
+                        condition=condition_name,
+                        family=str(call.get("family", "")),
+                        model=str(call.get("resolved_model", "")),
+                        transport=str(call.get("transport", "")),
+                        billing_class=str(call.get("billing_class", "")),
+                        cost_usd=float(call.get("cost_usd", 0.0)),
+                    )
+                )
+            actual_paid = sum(
+                entry.cost_usd for entry in cost_entries if entry.billing_class == "paid_api"
+            )
+            try:
+                cost_ledger.require_capacity(utc_day, actual_paid)
+            except RuntimeError as exc:
+                errors.append(str(exc))
+            cost_ledger.append(cost_entries)
+            primary_call = calls[-1] if calls else {}
+            result = {
+                "schema_version": RESULT_SCHEMA_VERSION,
+                "run_id": run_id,
+                "benchmark_id": bundle.manifest["benchmark_id"],
+                "revision": bundle.manifest["revision"],
+                "manifest_sha256": bundle.manifest_sha256,
+                "implementation_sha": implementation_sha,
+                "case_id": case["case_id"],
+                "domain": case["domain"],
+                "split": split,
+                "repetition": repetition,
+                "condition": condition_name,
+                "requested_model": primary_call.get("requested_model"),
+                "resolved_model": primary_call.get("resolved_model"),
+                "transport": primary_call.get("transport"),
+                "calls": calls,
+                "output": response.get("output"),
+                "latency_ms": sum(
+                    float(call.get("latency_ms", 0.0)) for call in calls if isinstance(call, dict)
+                ),
+                "cost_usd": sum(entry.cost_usd for entry in cost_entries),
+                "errors": sorted(set(errors)),
+                "attempt_count": attempts,
+                "receipt_hash": receipt_hash,
+                "receipt_verification": receipt_verification,
+                "recorded_at": now.isoformat().replace("+00:00", "Z"),
+            }
+            _append_jsonl(results_path, result)
+            if errors:
+                failures += 1
+            else:
+                completed += 1
+    return {
+        "ok": failures == 0,
+        "completed": completed,
+        "failures": failures,
+        "infrastructure_retries": retries,
+        "results_path": str(results_path),
+        "paid_api_spend_today": cost_ledger.paid_total(utc_day),
+    }
+
+
+def _normalize_tokens(text: str) -> set[str]:
+    return set(_TOKEN_PATTERN.findall(text.lower()))
+
+
+def crux_recall(predicted: list[str], expected: list[dict[str, Any]]) -> float:
+    """Deterministically score preregistered crux coverage."""
+    if not expected:
+        return 0.0
+    predicted_tokens = [_normalize_tokens(item) for item in predicted]
+    hits = 0
+    for crux in expected:
+        candidates = [str(crux.get("description", "")), *crux.get("aliases", [])]
+        matched = False
+        for candidate in candidates:
+            expected_tokens = _normalize_tokens(candidate)
+            if not expected_tokens:
+                continue
+            for observed in predicted_tokens:
+                overlap = len(expected_tokens & observed) / len(expected_tokens)
+                if overlap >= 0.6:
+                    matched = True
+                    break
+            if matched:
+                break
+        hits += int(matched)
+    return hits / len(expected)
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * percentile
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (index - lower)
+
+
+def load_results(paths: Iterable[Path]) -> tuple[list[dict[str, Any]], list[str]]:
+    results: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for path in paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            errors.append(f"{path}: {exc}")
+            continue
+        for line_number, line in enumerate(lines, start=1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path}:{line_number}: {exc}")
+                continue
+            if not isinstance(value, dict) or value.get("schema_version") != RESULT_SCHEMA_VERSION:
+                errors.append(f"{path}:{line_number}: invalid result schema")
+            else:
+                results.append(value)
+    return results, errors
+
+
+def score_results(bundle: BenchmarkBundle, results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Produce deterministic per-condition metrics and best-single deltas."""
+    case_by_id = {case["case_id"]: case for case in bundle.cases}
+    outcome_by_id = {outcome["case_id"]: outcome for outcome in bundle.outcomes["outcomes"]}
+    per_condition: dict[str, list[dict[str, float]]] = defaultdict(list)
+    per_split: dict[str, dict[str, list[dict[str, float]]]] = {
+        "development": defaultdict(list),
+        "holdout": defaultdict(list),
+    }
+    incomplete: list[str] = []
+    observed_keys: Counter[str] = Counter()
+    for result in sorted(
+        results,
+        key=lambda item: (
+            item.get("split", ""),
+            item.get("repetition", 0),
+            item.get("case_id", ""),
+            item.get("condition", ""),
+        ),
+    ):
+        key = f"{result.get('case_id')}:{result.get('condition')}:r{result.get('repetition')}"
+        observed_keys[key] += 1
+        if result.get("errors"):
+            incomplete.append(key)
+            continue
+        case = case_by_id.get(result.get("case_id"))
+        outcome = outcome_by_id.get(result.get("case_id"))
+        output = result.get("output")
+        if case is None or outcome is None or not isinstance(output, dict):
+            incomplete.append(key)
+            continue
+        try:
+            probability = float(output["forecast_probability"])
+        except (KeyError, TypeError, ValueError):
+            incomplete.append(key)
+            continue
+        if not 0 <= probability <= 1:
+            incomplete.append(key)
+            continue
+        target = int(outcome["correct_option_id"] == case["forecast_option_id"])
+        source_ids = {source["source_id"] for source in case["sources"]}
+        cited = {str(item) for item in output.get("source_ids", [])}
+        provenance = len(source_ids & cited) / len(source_ids) if source_ids else 1.0
+        try:
+            row = {
+                "brier": brier_score(probability, target),
+                "accuracy": float(output["selected_option_id"] == outcome["correct_option_id"]),
+                "crux_recall": crux_recall(output.get("cruxes", []), outcome["cruxes"]),
+                "provenance": provenance,
+                "receipt_verified": float(result.get("receipt_verification") == "verified"),
+                "latency_ms": float(result.get("latency_ms", 0.0)),
+                "cost_usd": float(result.get("cost_usd", 0.0)),
+                "calls": float(len(result.get("calls", []))),
+            }
+        except (KeyError, TypeError, ValueError):
+            incomplete.append(key)
+            continue
+        condition_name = str(result.get("condition", ""))
+        split_name = str(result.get("split", ""))
+        if condition_name not in REQUIRED_CONDITIONS or split_name not in per_split:
+            incomplete.append(key)
+            continue
+        per_condition[condition_name].append(row)
+        per_split[split_name][condition_name].append(row)
+
+    expected_keys = {
+        f"{case['case_id']}:{condition}:r{repetition}"
+        for case in bundle.cases
+        for condition in REQUIRED_CONDITIONS
+        for repetition in ((1,) if case["split"] == "development" else (1, 2))
+    }
+    incomplete.extend(sorted(expected_keys - observed_keys.keys()))
+    incomplete.extend(sorted(key for key, count in observed_keys.items() if count != 1))
+    summaries: dict[str, dict[str, Any]] = {}
+    for condition in REQUIRED_CONDITIONS:
+        rows = per_condition.get(condition, [])
+        summaries[condition] = _summarize_rows(rows)
+    split_summaries = {
+        split_name: {
+            condition: _summarize_rows(per_split[split_name].get(condition, []))
+            for condition in REQUIRED_CONDITIONS
+        }
+        for split_name in ("development", "holdout")
+    }
+    primary = split_summaries["holdout"]
+    complete_singles = [name for name in REQUIRED_CONDITIONS[:3] if primary[name]["n"] > 0]
+    best_single = (
+        min(complete_singles, key=lambda name: primary[name]["mean_brier"])
+        if complete_singles
+        else None
+    )
+    team_brier = primary["aragora_team"]["mean_brier"]
+    delta = (
+        primary[best_single]["mean_brier"] - team_brier
+        if best_single is not None and team_brier is not None
+        else None
+    )
+    return {
+        "schema_version": SCORE_SCHEMA_VERSION,
+        "benchmark_id": bundle.manifest["benchmark_id"],
+        "revision": bundle.manifest["revision"],
+        "manifest_sha256": bundle.manifest_sha256,
+        "result_count": len(results),
+        "incomplete_results": sorted(set(incomplete)),
+        "conditions": summaries,
+        "splits": split_summaries,
+        "best_single_condition": best_single,
+        "team_brier_improvement": delta,
+        "target_team_brier_improvement": 0.05,
+        "decision": _score_decision(summaries, incomplete, delta),
+        "uncertainty_note": (
+            "Descriptive ranges are reported for this small frozen corpus; "
+            "no statistical-significance claim is made."
+        ),
+    }
+
+
+def _summarize_rows(rows: list[dict[str, float]]) -> dict[str, Any]:
+    if not rows:
+        return {
+            "n": 0,
+            "mean_brier": None,
+            "brier_range": None,
+            "directional_accuracy": None,
+            "crux_recall": None,
+            "provenance_completeness": None,
+            "receipt_verification_rate": None,
+            "p50_latency_ms": None,
+            "p95_latency_ms": None,
+            "model_calls": 0,
+            "cost_usd": 0.0,
+        }
+    briers = [row["brier"] for row in rows]
+    return {
+        "n": len(rows),
+        "mean_brier": statistics.fmean(briers),
+        "brier_range": [min(briers), max(briers)],
+        "directional_accuracy": statistics.fmean(row["accuracy"] for row in rows),
+        "crux_recall": statistics.fmean(row["crux_recall"] for row in rows),
+        "provenance_completeness": statistics.fmean(row["provenance"] for row in rows),
+        "receipt_verification_rate": statistics.fmean(row["receipt_verified"] for row in rows),
+        "p50_latency_ms": _percentile([row["latency_ms"] for row in rows], 0.5),
+        "p95_latency_ms": _percentile([row["latency_ms"] for row in rows], 0.95),
+        "model_calls": int(sum(row["calls"] for row in rows)),
+        "cost_usd": sum(row["cost_usd"] for row in rows),
+    }
+
+
+def _score_decision(
+    summaries: dict[str, dict[str, Any]], incomplete: list[str], delta: float | None
+) -> str:
+    if incomplete or any(summaries[name]["n"] == 0 for name in REQUIRED_CONDITIONS):
+        return "incomplete"
+    team = summaries["aragora_team"]
+    if team["receipt_verification_rate"] != 1.0:
+        return "no_go"
+    return "go" if delta is not None and delta >= 0.05 else "conditional_go"
+
+
+def render_markdown(score: dict[str, Any]) -> str:
+    """Render a deterministic concise decision-quality report."""
+    lines = [
+        "# Outcome-Backed Decision Quality Report",
+        "",
+        f"- Benchmark: `{score['benchmark_id']}`",
+        f"- Revision: `{score['revision']}`",
+        f"- Manifest: `{score['manifest_sha256']}`",
+        f"- Decision: `{score['decision']}`",
+        f"- Best single: `{score['best_single_condition']}`",
+        f"- Holdout team Brier improvement: `{_format_metric(score['team_brier_improvement'])}`",
+        "- Target improvement: `0.05`",
+        "",
+        "## Metrics",
+        "",
+        "| Condition | N | Brier | Accuracy | Crux recall | Provenance | Receipt verify | Calls | Cost USD |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for condition in REQUIRED_CONDITIONS:
+        metrics = score["conditions"][condition]
+        lines.append(
+            f"| `{condition}` | {metrics['n']} | {_format_metric(metrics['mean_brier'])} | "
+            f"{_format_metric(metrics['directional_accuracy'])} | "
+            f"{_format_metric(metrics['crux_recall'])} | "
+            f"{_format_metric(metrics['provenance_completeness'])} | "
+            f"{_format_metric(metrics['receipt_verification_rate'])} | "
+            f"{metrics['model_calls']} | {metrics['cost_usd']:.4f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Limitations",
+            "",
+            f"- {score['uncertainty_note']}",
+            f"- Incomplete result records: `{len(score['incomplete_results'])}`.",
+            "- Outcomes and post-cutoff sources were withheld from all model prompts.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _format_metric(value: Any) -> str:
+    return "n/a" if value is None else f"{float(value):.4f}"
+
+
+__all__ = [
+    "BenchmarkBundle",
+    "BenchmarkContractReport",
+    "CANONICAL_JSON_CONVENTION",
+    "CostEntry",
+    "CostLedger",
+    "HOLDOUT_LOCK_SCHEMA_VERSION",
+    "MANIFEST_SCHEMA_VERSION",
+    "REQUIRED_CONDITIONS",
+    "RESULT_SCHEMA_VERSION",
+    "ROSTER_SCHEMA_VERSION",
+    "SCORER_CONTRACT_VERSION",
+    "SCORE_SCHEMA_VERSION",
+    "build_model_visible_request",
+    "crux_recall",
+    "ensure_holdout_lock",
+    "execute_batch",
+    "holdout_lock_payload",
+    "load_benchmark_bundle",
+    "load_results",
+    "render_markdown",
+    "request_contains_outcome_data",
+    "run_subprocess_runner",
+    "score_results",
+    "validate_runner_response",
+    "verify_receipt",
+]

--- a/docs/benchmarks/decision_quality/README.md
+++ b/docs/benchmarks/decision_quality/README.md
@@ -1,0 +1,71 @@
+# Outcome-Backed Decision Quality Benchmark
+
+This benchmark tests the bounded claim that Aragora's fixed heterogeneous team
+improves outcome-backed decision quality over its strongest constituent single
+model. Truthful completion is valid whether the final result is `go`,
+`conditional_go`, or `no_go`.
+
+## Frozen Contract
+
+`benchmark-manifest.json` binds eight construction tranches, the aggregate
+24-case corpus and outcome-sidecar digests, the prompt, the exact model roster,
+the scorer contract, the retry policy, and the paid-API budget. The canonical
+JSON convention is Python `json.dumps` with sorted keys, compact separators,
+UTF-8 output, `ensure_ascii=False`, and non-finite numbers rejected. It is a
+documented benchmark convention, not a claim of RFC 8785 compatibility.
+
+The outcome sidecars are never model-visible. `run` builds one isolated packet
+per case and rejects a packet that contains outcome IDs, resolution text,
+authoritative outcome-source IDs, or preregistered crux IDs. Any correction to
+a tranche, prompt, roster, scorer contract, or answer key requires a new
+benchmark revision and invalidates affected runs.
+
+The fixed conditions are:
+
+- `single_claude`
+- `single_openai`
+- `single_gemini`
+- `aragora_team`, using the same three families, one adversarial round, and one
+  declared synthesis
+
+The frozen roster uses subscription-backed `vibeproxy-required` transport.
+The runner must fail closed on a requested/resolved model mismatch and must not
+substitute an incomplete family roster. Paid API fallback remains capped at
+USD 25 per UTC day and is not enabled by this manifest.
+
+## Commands
+
+```bash
+python3 scripts/outcome_decision_quality_benchmark.py validate-corpus
+
+python3 scripts/outcome_decision_quality_benchmark.py run \
+  --split development --repetition 1 \
+  --implementation-sha <40-char-sha> --run-id <id> \
+  --runner-command '<json-in-json-out-runner>' \
+  --results <run-dir>/results.jsonl
+
+python3 scripts/outcome_decision_quality_benchmark.py score \
+  --results <run-dir>/results.jsonl --output <run-dir>/score.json
+
+python3 scripts/outcome_decision_quality_benchmark.py render \
+  --score <run-dir>/score.json --output <run-dir>/report.md
+```
+
+The benchmark runner command reads one request JSON object on standard input
+and emits one response JSON object on standard output. Infrastructure failures
+receive at most one retry. All terminal successes and failures are append-only
+result records. Team responses require an independently verified
+DecisionReceipt.
+
+The first holdout repetition creates a holdout lock that binds the corpus,
+outcomes, prompt, roster, scorer contract, and implementation SHA. The second
+repetition refuses to run if any bound field changed.
+
+## Result Interpretation
+
+Primary metrics are binary Brier score, directional accuracy, preregistered
+crux recall, provenance completeness, team receipt verification, latency,
+model calls, and cost. The target is an absolute holdout Brier improvement of
+at least 0.05 over the best single condition. Reports include descriptive
+ranges only; this 24-case corpus does not support a statistical-significance
+claim.

--- a/docs/benchmarks/decision_quality/README.md
+++ b/docs/benchmarks/decision_quality/README.md
@@ -45,6 +45,7 @@ python3 scripts/outcome_decision_quality_benchmark.py run \
   --results <run-dir>/results.jsonl
 
 python3 scripts/outcome_decision_quality_benchmark.py score \
+  --implementation-sha <40-char-sha> \
   --results <run-dir>/results.jsonl --output <run-dir>/score.json
 
 python3 scripts/outcome_decision_quality_benchmark.py render \

--- a/docs/benchmarks/decision_quality/benchmark-manifest.json
+++ b/docs/benchmarks/decision_quality/benchmark-manifest.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "decision-quality-benchmark/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "v1",
+  "frozen_at": "2026-08-30T03:52:00Z",
+  "canonical_json": "python-json-sort-keys-compact-utf8-no-nan-v1",
+  "conditions": [
+    "single_claude",
+    "single_openai",
+    "single_gemini",
+    "aragora_team"
+  ],
+  "tranches": [
+    {
+      "corpus_path": "tranches/business-operations-1.corpus.json",
+      "outcomes_path": "tranches/business-operations-1.outcomes.json",
+      "corpus_sha256": "ac9676ff9715b724a436ac3f697e3599aba8416e061fe009088eea4360ad8bba",
+      "outcomes_sha256": "ce281b2caab29f79b07d7784c3d19a08243ad914e1e384226dd17ff63f1452d4"
+    },
+    {
+      "corpus_path": "tranches/business-operations-holdout-1.corpus.json",
+      "outcomes_path": "tranches/business-operations-holdout-1.outcomes.json",
+      "corpus_sha256": "2036afb2a909e1ffd16d5764fefd1fbccbeb298dd29924222d6034ec30d7e855",
+      "outcomes_sha256": "05a6640cbee4878d0726d8dbbe92f6e9ebcb97a7eae7b0a03939cea2829358ff"
+    },
+    {
+      "corpus_path": "tranches/policy-compliance-1.corpus.json",
+      "outcomes_path": "tranches/policy-compliance-1.outcomes.json",
+      "corpus_sha256": "17bce195c719c30c128b0ce86e906754c076e2c03da4a10f6421d9e80f57943b",
+      "outcomes_sha256": "171cb032ca3047305ecb2086ad0913417d5a95fcfaec8dc228ba1b4f1dcf197b"
+    },
+    {
+      "corpus_path": "tranches/policy-compliance-holdout-1.corpus.json",
+      "outcomes_path": "tranches/policy-compliance-holdout-1.outcomes.json",
+      "corpus_sha256": "318c209ccfc5d24b82f6083f284334fb89f752a9dfc6a8ab0ee68d6f5a5dbd4d",
+      "outcomes_sha256": "247848041189c398c20a57547901aafff6d30d51fd98206e5e5a5e0c4689e8a1"
+    },
+    {
+      "corpus_path": "tranches/science-forecasting-1.corpus.json",
+      "outcomes_path": "tranches/science-forecasting-1.outcomes.json",
+      "corpus_sha256": "2fc5525c8b7a23c5f57faed12967cb170be1e83c6afcba58ac45b43cefa18445",
+      "outcomes_sha256": "061f6dc846889b01a22e3562b998d6b2b43f3bcf24efbe048f33b2089286de38"
+    },
+    {
+      "corpus_path": "tranches/science-forecasting-holdout-1.corpus.json",
+      "outcomes_path": "tranches/science-forecasting-holdout-1.outcomes.json",
+      "corpus_sha256": "503a5cc94a26fcd38f8c0bb264413ac82b2ae7a3489da8d22e6d646254702ed6",
+      "outcomes_sha256": "9d93b2f085b1c8586f67ee73538219bc1a98888ef0d4b3d11f196b9976b4e7d4"
+    },
+    {
+      "corpus_path": "tranches/software-development-1.corpus.json",
+      "outcomes_path": "tranches/software-development-1.outcomes.json",
+      "corpus_sha256": "e9ec5a9a62b6d2d9a6cd9664989d3be6e45b7cc7cbfe0d57919a4238e0770b27",
+      "outcomes_sha256": "cb3f1c0b7762b144142044a510f8c0cb489a15699ce6a7c6e262e2f35b17938d"
+    },
+    {
+      "corpus_path": "tranches/software-engineering-holdout-1.corpus.json",
+      "outcomes_path": "tranches/software-engineering-holdout-1.outcomes.json",
+      "corpus_sha256": "97da356b5d70618c332e5fc52a0510996e28c6723aa00111206e663dc581295e",
+      "outcomes_sha256": "1db3bd542e913b09c820af98a9ce4237f7dbfe8bbfed53d77f35fcf7f0bce292"
+    }
+  ],
+  "aggregate": {
+    "case_count": 24,
+    "corpus_sha256": "3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b",
+    "outcomes_sha256": "98702fe5d220d171e77fd0276d5803ec851e46c6900445dd73ccb4cbfdbf194d"
+  },
+  "prompt": {
+    "path": "prompt.md",
+    "sha256": "767f6552a17ae179fed027ff1bc2f737d893a1f72859c090b1a5730979439647"
+  },
+  "roster": {
+    "path": "roster.json",
+    "sha256": "2d7027906c5da8fe137cca2f52773eb2a9b2f2864753884c715774d54df2df71"
+  },
+  "scorer": {
+    "contract_version": "outcome-decision-quality-scorer/1.0",
+    "module": "aragora.evaluation.outcome_decision_quality",
+    "primary_metrics": [
+      "binary_brier",
+      "directional_accuracy",
+      "crux_recall",
+      "provenance_completeness",
+      "receipt_verification_rate",
+      "latency",
+      "model_calls",
+      "cost"
+    ]
+  },
+  "budget": {
+    "paid_api_daily_usd": 25.0,
+    "infrastructure_retries_per_call": 1
+  },
+  "holdout": {
+    "repetitions": 2,
+    "cases_per_domain": 2,
+    "invalidate_on_change": [
+      "corpus",
+      "outcomes",
+      "prompt",
+      "roster",
+      "scorer_contract",
+      "implementation_sha"
+    ]
+  }
+}

--- a/docs/benchmarks/decision_quality/prompt.md
+++ b/docs/benchmarks/decision_quality/prompt.md
@@ -1,0 +1,30 @@
+# Outcome-Backed Decision Quality Prompt Contract v1
+
+You are making a bounded decision using only the case packet supplied with
+this prompt. The packet contains an information cutoff and pre-cutoff source
+metadata. Do not use later knowledge, web searches, hidden outcomes, or facts
+from another benchmark case.
+
+Choose exactly one of the two option IDs. Report a probability from 0 through
+1 for the case's `forecast_option_id`, even when you select the other option.
+Identify the three to five uncertainties that most affect the choice. Cite
+only `source_id` values present in this case packet. State limitations rather
+than inventing missing evidence.
+
+Return one JSON object with exactly these fields:
+
+```json
+{
+  "selected_option_id": "one supplied option_id",
+  "forecast_probability": 0.5,
+  "cruxes": ["bounded decision-relevant uncertainty"],
+  "source_ids": ["one supplied source_id"],
+  "rationale": "concise reasoning grounded in the supplied packet"
+}
+```
+
+For the `aragora_team` condition, the same three model families first produce
+independent answers, perform one bounded adversarial critique round, and then
+the declared synthesizer emits the same JSON shape. No member may receive an
+outcome sidecar or another benchmark case. The runner must emit a verifiable
+DecisionReceipt for the synthesized result.

--- a/docs/benchmarks/decision_quality/result.schema.json
+++ b/docs/benchmarks/decision_quality/result.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aragora.ai/schemas/decision-quality-result-v1.json",
+  "title": "Outcome-Backed Decision Quality Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "benchmark_id",
+    "revision",
+    "manifest_sha256",
+    "implementation_sha",
+    "case_id",
+    "domain",
+    "split",
+    "repetition",
+    "condition",
+    "requested_model",
+    "resolved_model",
+    "transport",
+    "calls",
+    "output",
+    "latency_ms",
+    "cost_usd",
+    "errors",
+    "attempt_count",
+    "receipt_hash",
+    "receipt_verification",
+    "recorded_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "decision-quality-result/1.0"
+    },
+    "run_id": {"type": "string", "minLength": 1},
+    "benchmark_id": {"type": "string", "minLength": 1},
+    "revision": {"type": "string", "minLength": 1},
+    "manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "implementation_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "case_id": {"type": "string", "minLength": 1},
+    "domain": {
+      "enum": [
+        "software_engineering",
+        "business_operations",
+        "policy_compliance",
+        "science_forecasting"
+      ]
+    },
+    "split": {"enum": ["development", "holdout"]},
+    "repetition": {"type": "integer", "minimum": 1, "maximum": 2},
+    "condition": {
+      "enum": ["single_claude", "single_openai", "single_gemini", "aragora_team"]
+    },
+    "requested_model": {"type": ["string", "null"]},
+    "resolved_model": {"type": ["string", "null"]},
+    "transport": {"type": ["string", "null"]},
+    "calls": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "family",
+          "requested_model",
+          "resolved_model",
+          "transport",
+          "billing_class",
+          "latency_ms",
+          "cost_usd"
+        ]
+      }
+    },
+    "output": {
+      "type": ["object", "null"],
+      "properties": {
+        "selected_option_id": {"type": "string"},
+        "forecast_probability": {"type": "number", "minimum": 0, "maximum": 1},
+        "cruxes": {"type": "array", "items": {"type": "string"}},
+        "source_ids": {"type": "array", "items": {"type": "string"}},
+        "rationale": {"type": "string"}
+      },
+      "required": ["selected_option_id", "forecast_probability", "cruxes", "source_ids"]
+    },
+    "latency_ms": {"type": "number", "minimum": 0},
+    "cost_usd": {"type": "number", "minimum": 0},
+    "errors": {"type": "array", "items": {"type": "string"}},
+    "attempt_count": {"type": "integer", "minimum": 1, "maximum": 2},
+    "receipt_hash": {
+      "oneOf": [
+        {"type": "null"},
+        {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      ]
+    },
+    "receipt_verification": {
+      "enum": [
+        "not_applicable",
+        "missing",
+        "invalid",
+        "input_mismatch",
+        "decision_mismatch",
+        "failed",
+        "verified"
+      ]
+    },
+    "recorded_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/docs/benchmarks/decision_quality/roster.json
+++ b/docs/benchmarks/decision_quality/roster.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "decision-quality-roster/1.0",
+  "conditions": {
+    "single_claude": {
+      "mode": "single",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "claude",
+          "requested_model": "claude-fable-5",
+          "allowed_resolved_models": [
+            "claude-fable-5"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    },
+    "single_openai": {
+      "mode": "single",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "openai",
+          "requested_model": "gpt-5.6-sol",
+          "allowed_resolved_models": [
+            "gpt-5.6-sol"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    },
+    "single_gemini": {
+      "mode": "single",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "gemini",
+          "requested_model": "gemini-3.1-pro-preview",
+          "allowed_resolved_models": [
+            "gemini-3.1-pro-preview"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    },
+    "aragora_team": {
+      "mode": "team",
+      "adversarial_rounds": 1,
+      "synthesizer_family": "claude",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "claude",
+          "requested_model": "claude-fable-5",
+          "allowed_resolved_models": [
+            "claude-fable-5"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        },
+        {
+          "family": "openai",
+          "requested_model": "gpt-5.6-sol",
+          "allowed_resolved_models": [
+            "gpt-5.6-sol"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        },
+        {
+          "family": "gemini",
+          "requested_model": "gemini-3.1-pro-preview",
+          "allowed_resolved_models": [
+            "gemini-3.1-pro-preview"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/outcome_decision_quality_benchmark.py
+++ b/scripts/outcome_decision_quality_benchmark.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Frozen outcome-backed decision-quality benchmark CLI.
+
+The CLI deliberately separates validation, execution, scoring, and rendering.
+It emits structured JSON for every terminal result and never exposes the
+outcome sidecar to a runner process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+from datetime import UTC, datetime
+from functools import partial
+from pathlib import Path
+from typing import Any, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from aragora.evaluation.outcome_decision_quality import (  # noqa: E402
+    BenchmarkBundle,
+    CostLedger,
+    execute_batch,
+    load_benchmark_bundle,
+    load_results,
+    render_markdown,
+    run_subprocess_runner,
+    score_results,
+)
+
+DEFAULT_MANIFEST = PROJECT_ROOT / "docs/benchmarks/decision_quality/benchmark-manifest.json"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+
+    validate = subparsers.add_parser("validate-corpus", help="validate frozen corpus contract")
+    validate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+
+    run = subparsers.add_parser("run", help="run one bounded split through a JSON runner")
+    run.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    run.add_argument("--split", choices=("development", "holdout"), required=True)
+    run.add_argument("--repetition", type=int, default=1)
+    run.add_argument("--implementation-sha", required=True)
+    run.add_argument("--run-id", required=True)
+    run.add_argument("--runner-command", required=True)
+    run.add_argument("--runner-timeout", type=float, default=600.0)
+    run.add_argument("--results", type=Path, required=True)
+    run.add_argument("--cost-ledger", type=Path)
+    run.add_argument("--holdout-lock", type=Path)
+    run.add_argument("--max-cases", type=int)
+
+    score = subparsers.add_parser("score", help="score one or more result ledgers")
+    score.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    score.add_argument("--results", type=Path, nargs="+", required=True)
+    score.add_argument("--output", type=Path)
+
+    render = subparsers.add_parser("render", help="render deterministic Markdown from a score")
+    render.add_argument("--score", type=Path, required=True)
+    render.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def _emit(payload: dict[str, Any], *, exit_code: int = 0) -> int:
+    print(json.dumps(payload, indent=2, sort_keys=True, allow_nan=False))
+    return exit_code
+
+
+def _load_bundle_or_error(manifest: Path) -> tuple[BenchmarkBundle | None, int | None]:
+    bundle, report = load_benchmark_bundle(manifest)
+    if bundle is None:
+        return None, _emit({"operation": "validate-corpus", **report.to_dict()}, exit_code=2)
+    return bundle, None
+
+
+def _validate(args: argparse.Namespace) -> int:
+    _, report = load_benchmark_bundle(args.manifest)
+    return _emit(
+        {"operation": "validate-corpus", **report.to_dict()}, exit_code=0 if report.ok else 2
+    )
+
+
+def _run(args: argparse.Namespace) -> int:
+    bundle, error_code = _load_bundle_or_error(args.manifest)
+    if error_code is not None:
+        return error_code
+    assert bundle is not None
+    command = shlex.split(args.runner_command)
+    if not command:
+        return _emit(
+            {"ok": False, "operation": "run", "error": "empty runner command"}, exit_code=2
+        )
+    budget = float(bundle.manifest["budget"]["paid_api_daily_usd"])
+    cost_path = args.cost_ledger or args.results.parent / "costs.jsonl"
+    ledger = CostLedger.load(cost_path, budget)
+    runner = partial(run_subprocess_runner, command, timeout=args.runner_timeout)
+    summary = execute_batch(
+        bundle,
+        runner,
+        split=args.split,
+        repetition=args.repetition,
+        implementation_sha=args.implementation_sha,
+        run_id=args.run_id,
+        results_path=args.results,
+        cost_ledger=ledger,
+        max_cases=args.max_cases,
+        holdout_lock_path=args.holdout_lock,
+    )
+    return _emit({"operation": "run", **summary}, exit_code=0 if summary["ok"] else 1)
+
+
+def _score(args: argparse.Namespace) -> int:
+    bundle, error_code = _load_bundle_or_error(args.manifest)
+    if error_code is not None:
+        return error_code
+    assert bundle is not None
+    results, errors = load_results(args.results)
+    if errors:
+        return _emit({"ok": False, "operation": "score", "errors": errors}, exit_code=2)
+    score = score_results(bundle, results)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(score, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return _emit({"ok": True, "operation": "score", "score": score})
+
+
+def _render(args: argparse.Namespace) -> int:
+    try:
+        score = json.loads(args.score.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return _emit({"ok": False, "operation": "render", "error": str(exc)}, exit_code=2)
+    except UnicodeError as exc:
+        return _emit({"ok": False, "operation": "render", "error": str(exc)}, exit_code=2)
+    except json.JSONDecodeError as exc:
+        return _emit({"ok": False, "operation": "render", "error": str(exc)}, exit_code=2)
+    if not isinstance(score, dict):
+        return _emit(
+            {"ok": False, "operation": "render", "error": "score must be a JSON object"},
+            exit_code=2,
+        )
+    markdown = render_markdown(score)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(markdown, encoding="utf-8")
+    return _emit(
+        {
+            "ok": True,
+            "operation": "render",
+            "output": str(args.output),
+            "sha256": __import__("hashlib").sha256(markdown.encode("utf-8")).hexdigest(),
+        }
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.operation == "validate-corpus":
+            return _validate(args)
+        if args.operation == "run":
+            return _run(args)
+        if args.operation == "score":
+            return _score(args)
+        if args.operation == "render":
+            return _render(args)
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        return _emit({"ok": False, "operation": args.operation, "error": str(exc)}, exit_code=2)
+    return _emit(
+        {"ok": False, "operation": args.operation, "error": "unknown operation"}, exit_code=2
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/outcome_decision_quality_benchmark.py
+++ b/scripts/outcome_decision_quality_benchmark.py
@@ -57,6 +57,7 @@ def _parser() -> argparse.ArgumentParser:
     score = subparsers.add_parser("score", help="score one or more result ledgers")
     score.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     score.add_argument("--results", type=Path, nargs="+", required=True)
+    score.add_argument("--implementation-sha", required=True)
     score.add_argument("--output", type=Path)
 
     render = subparsers.add_parser("render", help="render deterministic Markdown from a score")
@@ -121,7 +122,7 @@ def _score(args: argparse.Namespace) -> int:
     results, errors = load_results(args.results)
     if errors:
         return _emit({"ok": False, "operation": "score", "errors": errors}, exit_code=2)
-    score = score_results(bundle, results)
+    score = score_results(bundle, results, implementation_sha=args.implementation_sha)
     if args.output is not None:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(score, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/evaluation/test_decision_quality_corpus.py
+++ b/tests/evaluation/test_decision_quality_corpus.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.evaluation.decision_quality_corpus import (
+    canonical_sha256,
+    is_public_https_url,
+    validate_corpus_documents,
+    validate_corpus_files,
+)
+from aragora.evaluation.outcome_decision_quality import load_benchmark_bundle
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "docs/benchmarks/decision_quality/benchmark-manifest.json"
+
+
+def _case() -> dict[str, object]:
+    return {
+        "case_id": "case-1",
+        "domain": "software_engineering",
+        "split": "development",
+        "title": "A resolved decision",
+        "decision_prompt": "Choose one action.",
+        "forecast_question": "What is the probability of option a?",
+        "forecast_option_id": "a",
+        "options": [
+            {"option_id": "a", "label": "A", "description": "Action A"},
+            {"option_id": "b", "label": "B", "description": "Action B"},
+        ],
+        "information_cutoff": "2025-01-01T00:00:00Z",
+        "sources": [
+            {
+                "source_id": "evidence-1",
+                "title": "Evidence",
+                "url": "https://example.com/evidence",
+                "published_at": "2024-12-31T00:00:00Z",
+                "content_sha256": "1" * 64,
+            }
+        ],
+    }
+
+
+def _documents() -> tuple[dict[str, object], dict[str, object]]:
+    corpus: dict[str, object] = {
+        "schema_version": "decision-quality-corpus/1.0",
+        "benchmark_id": "benchmark-v1",
+        "revision": "v1",
+        "frozen_at": "2025-03-01T00:00:00Z",
+        "cases": [_case()],
+    }
+    outcomes: dict[str, object] = {
+        "schema_version": "decision-quality-outcomes/1.0",
+        "benchmark_id": "benchmark-v1",
+        "corpus_sha256": canonical_sha256(corpus),
+        "outcomes": [
+            {
+                "case_id": "case-1",
+                "resolved_at": "2025-02-01T00:00:00Z",
+                "correct_option_id": "a",
+                "resolution_summary": "A occurred.",
+                "authoritative_sources": [
+                    {
+                        "source_id": "outcome-1",
+                        "title": "Outcome",
+                        "url": "https://example.com/outcome",
+                        "published_at": "2025-02-01T00:00:00Z",
+                        "content_sha256": "2" * 64,
+                    }
+                ],
+                "cruxes": [
+                    {"crux_id": "c1", "description": "First crux", "aliases": []},
+                    {"crux_id": "c2", "description": "Second crux", "aliases": []},
+                    {"crux_id": "c3", "description": "Third crux", "aliases": []},
+                ],
+            }
+        ],
+    }
+    return corpus, outcomes
+
+
+def _codes(report: object) -> set[str]:
+    return {issue.code for issue in report.issues}  # type: ignore[attr-defined]
+
+
+def test_live_manifest_freezes_complete_balanced_corpus() -> None:
+    bundle, report = load_benchmark_bundle(MANIFEST)
+
+    assert report.ok
+    assert bundle is not None
+    assert report.case_count == 24
+    assert (
+        report.corpus_sha256 == "3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b"
+    )
+    assert (
+        report.outcomes_sha256 == "98702fe5d220d171e77fd0276d5803ec851e46c6900445dd73ccb4cbfdbf194d"
+    )
+
+
+def test_outcome_leakage_after_cutoff_is_rejected() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["sources"][0]["published_at"] = "2025-01-02T00:00:00Z"  # type: ignore[index]
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "outcome_leakage" in _codes(report)
+
+
+def test_options_must_have_stable_lexicographic_order() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["options"].reverse()  # type: ignore[index, union-attr]
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "unsorted_options" in _codes(report)
+
+
+def test_outcome_source_must_not_predate_resolution() -> None:
+    corpus, outcomes = _documents()
+    outcomes["outcomes"][0]["authoritative_sources"][0]["published_at"] = (  # type: ignore[index]
+        "2025-01-31T00:00:00Z"
+    )
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "premature_outcome_source" in _codes(report)
+
+
+def test_freeze_must_follow_every_resolution() -> None:
+    corpus, outcomes = _documents()
+    corpus["frozen_at"] = "2025-01-15T00:00:00Z"
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "premature_freeze" in _codes(report)
+
+
+def test_full_corpus_rejects_unbalanced_answer_targets() -> None:
+    bundle, manifest_report = load_benchmark_bundle(MANIFEST)
+    assert manifest_report.ok and bundle is not None
+    corpus = copy.deepcopy(bundle.corpus)
+    outcomes = copy.deepcopy(bundle.outcomes)
+    cases = {case["case_id"]: case for case in corpus["cases"]}
+    changed = False
+    for outcome in outcomes["outcomes"]:
+        case = cases[outcome["case_id"]]
+        if outcome["correct_option_id"] != case["forecast_option_id"]:
+            outcome["correct_option_id"] = case["forecast_option_id"]
+            changed = True
+            break
+    assert changed
+
+    report = validate_corpus_documents(corpus, outcomes)
+
+    assert "wrong_target_balance" in _codes(report)
+
+
+def test_answer_key_is_rejected_from_model_visible_case() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["correct_option_id"] = "a"  # type: ignore[index]
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "unknown_field" in _codes(report)
+
+
+def test_canonical_hash_ignores_object_key_order_and_rejects_nan() -> None:
+    corpus, _ = _documents()
+    reordered = {key: corpus[key] for key in reversed(corpus)}
+    assert canonical_sha256(corpus) == canonical_sha256(reordered)
+    with pytest.raises(ValueError):
+        canonical_sha256({"value": float("nan")})
+
+
+def test_mutating_answer_key_fails_frozen_outcomes_hash() -> None:
+    corpus, outcomes = _documents()
+    frozen = canonical_sha256(outcomes)
+    mutated = copy.deepcopy(outcomes)
+    mutated["outcomes"][0]["correct_option_id"] = "b"  # type: ignore[index]
+
+    report = validate_corpus_documents(
+        corpus,
+        mutated,
+        allow_partial=True,
+        expected_outcomes_sha256=frozen,
+    )
+
+    assert "outcomes_hash_mismatch" in _codes(report)
+
+
+def test_file_loader_returns_structured_invalid_utf8(tmp_path: Path) -> None:
+    corpus_path = tmp_path / "corpus.json"
+    outcomes_path = tmp_path / "outcomes.json"
+    corpus_path.write_bytes(b"\xff\xfe")
+    outcomes_path.write_text("{}", encoding="utf-8")
+
+    report = validate_corpus_files(corpus_path, outcomes_path, allow_partial=True)
+
+    assert not report.ok
+    assert "invalid_utf8" in _codes(report)
+
+
+def test_file_loader_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    corpus, outcomes = _documents()
+    corpus_path = tmp_path / "corpus.json"
+    outcomes_path = tmp_path / "outcomes.json"
+    corpus_path.write_text(
+        json.dumps(corpus).replace('"revision": "v1"', '"revision": "v1", "revision": "v2"')
+    )
+    outcomes_path.write_text(json.dumps(outcomes))
+
+    report = validate_corpus_files(corpus_path, outcomes_path, allow_partial=True)
+
+    assert "duplicate_json_key" in _codes(report)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/a",
+        "https://localhost/a",
+        "https://service.internal/a",
+        "https://127.0.0.1/a",
+        "https://[::1]/a",
+        "https://bad host/a",
+        "https://example.com:bad/a",
+    ],
+)
+def test_public_source_url_validation_fails_closed(url: str) -> None:
+    assert not is_public_https_url(url)
+
+
+def test_public_source_url_accepts_normal_https() -> None:
+    assert is_public_https_url("https://example.com/evidence")

--- a/tests/evaluation/test_outcome_decision_quality.py
+++ b/tests/evaluation/test_outcome_decision_quality.py
@@ -180,6 +180,10 @@ def test_outcome_leakage_detector_allows_incidental_generic_alias_overlap(bundle
             lambda response: response["calls"][0].update(family="openai"),
             "unexpected family",
         ),
+        (
+            lambda response: response["calls"].append(dict(response["calls"][0])),
+            "duplicate family claude",
+        ),
     ],
 )
 def test_family_integrity_rejects_absent_mismatched_and_ambiguous_roster(
@@ -345,6 +349,37 @@ def test_execute_batch_never_retries_model_failure(bundle, tmp_path: Path) -> No
     assert calls == 4
 
 
+def test_execute_batch_records_malformed_runner_numerics(bundle, tmp_path: Path) -> None:
+    results_path = tmp_path / "results.jsonl"
+
+    def runner(request: dict[str, Any]) -> dict[str, Any]:
+        response = _response(request)
+        response["calls"][0]["cost_usd"] = None
+        response["calls"][0]["latency_ms"] = "fast"
+        return response
+
+    summary = execute_batch(
+        bundle,
+        runner,
+        split="development",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+        run_id="malformed-numeric-run",
+        results_path=results_path,
+        cost_ledger=CostLedger(tmp_path / "costs.jsonl", 25.0),
+        recorded_at=datetime(2026, 8, 30, tzinfo=UTC),
+        max_cases=1,
+    )
+    results = [json.loads(line) for line in results_path.read_text().splitlines()]
+
+    assert summary["failures"] == 4
+    assert len(results) == 4
+    assert all(result["latency_ms"] >= 0 for result in results)
+    assert all(result["cost_usd"] >= 0 for result in results)
+    assert all("calls[0] invalid latency" in result["errors"] for result in results)
+    assert all("calls[0] invalid cost" in result["errors"] for result in results)
+
+
 def test_subprocess_runner_does_not_persist_secret_output() -> None:
     secret = "sk-do-not-persist-this"
     response = run_subprocess_runner(
@@ -367,6 +402,10 @@ def test_scoring_and_rendering_are_deterministic(bundle) -> None:
         results.append(
             {
                 "schema_version": "decision-quality-result/1.0",
+                "benchmark_id": bundle.manifest["benchmark_id"],
+                "revision": bundle.manifest["revision"],
+                "manifest_sha256": bundle.manifest_sha256,
+                "implementation_sha": IMPLEMENTATION_SHA,
                 "case_id": case["case_id"],
                 "condition": condition,
                 "split": case["split"],
@@ -388,7 +427,7 @@ def test_scoring_and_rendering_are_deterministic(bundle) -> None:
                 "calls": [{}],
             }
         )
-    score = score_results(bundle, results)
+    score = score_results(bundle, results, implementation_sha=IMPLEMENTATION_SHA)
     first = render_markdown(score)
     second = render_markdown(score)
 
@@ -398,3 +437,39 @@ def test_scoring_and_rendering_are_deterministic(bundle) -> None:
     assert score["decision"] == "incomplete"
     assert score["team_brier_improvement"] is None
     assert "Holdout team Brier improvement" in first
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("benchmark_id", "stale-benchmark"),
+        ("revision", "stale-revision"),
+        ("manifest_sha256", "b" * 64),
+        ("implementation_sha", "b" * 40),
+    ],
+)
+def test_scoring_rejects_stale_or_mixed_result_bindings(
+    bundle, field_name: str, value: str
+) -> None:
+    case = bundle.cases[0]
+    result = {
+        "schema_version": "decision-quality-result/1.0",
+        "benchmark_id": bundle.manifest["benchmark_id"],
+        "revision": bundle.manifest["revision"],
+        "manifest_sha256": bundle.manifest_sha256,
+        "implementation_sha": IMPLEMENTATION_SHA,
+        "case_id": case["case_id"],
+        "condition": "single_claude",
+        "split": case["split"],
+        "repetition": 1,
+        "errors": [],
+        "output": {},
+        "receipt_verification": "not_applicable",
+        "latency_ms": 0.0,
+        "cost_usd": 0.0,
+        "calls": [],
+    }
+    result[field_name] = value
+
+    with pytest.raises(ValueError, match=field_name):
+        score_results(bundle, [result], implementation_sha=IMPLEMENTATION_SHA)

--- a/tests/evaluation/test_outcome_decision_quality.py
+++ b/tests/evaluation/test_outcome_decision_quality.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import json
+import hashlib
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.evaluation.outcome_decision_quality import (
+    CostEntry,
+    CostLedger,
+    REQUIRED_CONDITIONS,
+    build_model_visible_request,
+    crux_recall,
+    ensure_holdout_lock,
+    execute_batch,
+    load_benchmark_bundle,
+    render_markdown,
+    request_contains_outcome_data,
+    run_subprocess_runner,
+    score_results,
+    validate_runner_response,
+    verify_receipt,
+)
+from aragora.evaluation.decision_quality_corpus import canonical_json_bytes
+from aragora.gauntlet.receipt_models import DecisionReceipt
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "docs/benchmarks/decision_quality/benchmark-manifest.json"
+IMPLEMENTATION_SHA = "a" * 40
+
+
+@pytest.fixture(scope="module")
+def bundle():
+    loaded, report = load_benchmark_bundle(MANIFEST)
+    assert report.ok and loaded is not None
+    return loaded
+
+
+def _response(request: dict[str, Any], *, receipt_path: str | None = None) -> dict[str, Any]:
+    condition = request["roster"]
+    calls = [
+        {
+            "family": member["family"],
+            "requested_model": member["requested_model"],
+            "resolved_model": member["allowed_resolved_models"][0],
+            "transport": member["transport"],
+            "billing_class": member["billing_class"],
+            "latency_ms": 10.0,
+            "cost_usd": 0.0,
+        }
+        for member in condition["members"]
+    ]
+    response: dict[str, Any] = {
+        "ok": True,
+        "calls": calls,
+        "output": {
+            "selected_option_id": request["case"]["options"][0]["option_id"],
+            "forecast_probability": 0.6,
+            "cruxes": ["schedule credibility and implementation readiness"],
+            "source_ids": [request["case"]["sources"][0]["source_id"]],
+            "rationale": "Bounded rationale.",
+        },
+    }
+    if receipt_path is not None:
+        response["receipt_path"] = receipt_path
+    return response
+
+
+def _receipt(
+    path: Path,
+    *,
+    input_hash: str = "1" * 64,
+    output: dict[str, Any] | None = None,
+) -> None:
+    receipt = DecisionReceipt(
+        receipt_id="receipt-1",
+        gauntlet_id="gauntlet-1",
+        timestamp="2026-08-30T00:00:00Z",
+        input_summary="Decision quality case",
+        input_hash=input_hash,
+        risk_summary={"critical": 0, "high": 0, "medium": 0, "low": 0},
+        attacks_attempted=0,
+        attacks_successful=0,
+        probes_run=0,
+        vulnerabilities_found=0,
+        verdict="PASS",
+        confidence=0.8,
+        robustness_score=0.8,
+        decision_payload=output,
+    )
+    path.write_text(json.dumps(receipt.to_dict(), indent=2), encoding="utf-8")
+
+
+def test_model_request_excludes_outcome_sidecar(bundle) -> None:
+    case = bundle.cases[0]
+    outcome = next(
+        item for item in bundle.outcomes["outcomes"] if item["case_id"] == case["case_id"]
+    )
+
+    request = build_model_visible_request(
+        bundle,
+        case,
+        "single_claude",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+    )
+
+    assert not request_contains_outcome_data(request, outcome)
+    assert "correct_option_id" not in json.dumps(request)
+    assert "resolution_summary" not in json.dumps(request)
+
+
+def test_outcome_leakage_detector_rejects_resolution_text(bundle) -> None:
+    case = bundle.cases[0]
+    outcome = next(
+        item for item in bundle.outcomes["outcomes"] if item["case_id"] == case["case_id"]
+    )
+    request = build_model_visible_request(
+        bundle,
+        case,
+        "single_claude",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+    )
+    request["leak"] = outcome["resolution_summary"]
+
+    assert request_contains_outcome_data(request, outcome)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda response: response.update(calls=[]), "missing claude"),
+        (
+            lambda response: response["calls"][0].update(resolved_model="other-owner/model"),
+            "resolved model identity mismatch",
+        ),
+        (
+            lambda response: response["calls"][0].update(family="openai"),
+            "unexpected family",
+        ),
+    ],
+)
+def test_family_integrity_rejects_absent_mismatched_and_ambiguous_roster(
+    bundle, mutation, message: str
+) -> None:
+    request = build_model_visible_request(
+        bundle,
+        bundle.cases[0],
+        "single_claude",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+    )
+    response = _response(request)
+    mutation(response)
+
+    errors = validate_runner_response(response, request["roster"])
+
+    assert any(message in error for error in errors)
+
+
+def test_family_integrity_accepts_exact_frozen_owner(bundle) -> None:
+    request = build_model_visible_request(
+        bundle,
+        bundle.cases[0],
+        "single_claude",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+    )
+    assert not validate_runner_response(_response(request), request["roster"])
+
+
+def test_crux_recall_is_deterministic() -> None:
+    expected = [
+        {
+            "description": "Whether the published schedule remains credible",
+            "aliases": ["schedule credibility"],
+        },
+        {
+            "description": "Whether a replacement implementation is ready",
+            "aliases": ["replacement readiness"],
+        },
+    ]
+    assert crux_recall(["schedule credibility is uncertain"], expected) == 0.5
+
+
+def test_cost_ledger_enforces_paid_api_utc_cap(tmp_path: Path) -> None:
+    ledger = CostLedger(tmp_path / "costs.jsonl", daily_cap_usd=25.0)
+    entry = CostEntry(
+        recorded_at="2026-08-30T12:00:00Z",
+        run_id="run-1",
+        case_id="case-1",
+        condition="single_openai",
+        family="openai",
+        model="model",
+        transport="api",
+        billing_class="paid_api",
+        cost_usd=24.5,
+    )
+    ledger.append([entry])
+    ledger.require_capacity("2026-08-30", 0.5)
+    with pytest.raises(RuntimeError, match="budget exhausted"):
+        ledger.require_capacity("2026-08-30", 0.51)
+
+
+def test_holdout_lock_rejects_implementation_drift(bundle, tmp_path: Path) -> None:
+    lock = tmp_path / "lock.json"
+    ensure_holdout_lock(lock, bundle, IMPLEMENTATION_SHA)
+    with pytest.raises(RuntimeError, match="holdout lock mismatch"):
+        ensure_holdout_lock(lock, bundle, "b" * 40)
+
+
+def test_receipt_verification_is_independent_and_detects_tampering(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "receipt.json"
+    _receipt(receipt_path)
+    digest, status = verify_receipt(receipt_path)
+    assert digest and status == "verified"
+    payload = json.loads(receipt_path.read_text())
+    payload["verdict"] = "FAIL"
+    receipt_path.write_text(json.dumps(payload))
+    _, status = verify_receipt(receipt_path)
+    assert status == "failed"
+
+
+def test_receipt_verification_binds_request_and_decision(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "receipt.json"
+    output = {"selected_option_id": "a"}
+    _receipt(receipt_path, input_hash="a" * 64, output=output)
+
+    _, status = verify_receipt(
+        receipt_path,
+        expected_input_hash="a" * 64,
+        expected_output=output,
+    )
+    assert status == "verified"
+    _, status = verify_receipt(receipt_path, expected_input_hash="b" * 64)
+    assert status == "input_mismatch"
+    _, status = verify_receipt(receipt_path, expected_output={"selected_option_id": "b"})
+    assert status == "decision_mismatch"
+
+
+def test_execute_batch_retries_infrastructure_once_and_records_failures(
+    bundle, tmp_path: Path
+) -> None:
+    attempts: dict[str, int] = {}
+    receipt_path = tmp_path / "team-receipt.json"
+    _receipt(receipt_path)
+
+    def runner(request: dict[str, Any]) -> dict[str, Any]:
+        key = f"{request['case']['case_id']}:{request['condition']}"
+        attempts[key] = attempts.get(key, 0) + 1
+        if attempts[key] == 1:
+            return {"ok": False, "infrastructure_failure": True, "error_class": "transient"}
+        response = _response(request)
+        if request["condition"] == "aragora_team":
+            _receipt(
+                receipt_path,
+                input_hash=hashlib.sha256(canonical_json_bytes(request)).hexdigest(),
+                output=response["output"],
+            )
+            response["receipt_path"] = str(receipt_path)
+        return response
+
+    summary = execute_batch(
+        bundle,
+        runner,
+        split="development",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+        run_id="retry-run",
+        results_path=tmp_path / "results.jsonl",
+        cost_ledger=CostLedger(tmp_path / "costs.jsonl", 25.0),
+        recorded_at=datetime(2026, 8, 30, tzinfo=UTC),
+        max_cases=1,
+    )
+
+    assert summary["completed"] == 4
+    assert summary["infrastructure_retries"] == 4
+    assert all(count == 2 for count in attempts.values())
+
+
+def test_execute_batch_never_retries_model_failure(bundle, tmp_path: Path) -> None:
+    calls = 0
+
+    def runner(_: dict[str, Any]) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"ok": False, "infrastructure_failure": False, "error_class": "model_refusal"}
+
+    summary = execute_batch(
+        bundle,
+        runner,
+        split="development",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+        run_id="failure-run",
+        results_path=tmp_path / "results.jsonl",
+        cost_ledger=CostLedger(tmp_path / "costs.jsonl", 25.0),
+        recorded_at=datetime(2026, 8, 30, tzinfo=UTC),
+        max_cases=1,
+    )
+
+    assert summary["failures"] == 4
+    assert calls == 4
+
+
+def test_subprocess_runner_does_not_persist_secret_output() -> None:
+    secret = "sk-do-not-persist-this"
+    response = run_subprocess_runner(
+        [sys.executable, "-c", f"import sys; sys.stderr.write('{secret}'); sys.exit(2)"],
+        {"request": "safe"},
+        timeout=5,
+    )
+
+    assert response["error_class"] == "runner_nonzero_exit"
+    assert secret not in json.dumps(response)
+
+
+def test_scoring_and_rendering_are_deterministic(bundle) -> None:
+    case = bundle.cases[0]
+    outcome = next(
+        item for item in bundle.outcomes["outcomes"] if item["case_id"] == case["case_id"]
+    )
+    results = []
+    for condition in REQUIRED_CONDITIONS:
+        results.append(
+            {
+                "schema_version": "decision-quality-result/1.0",
+                "case_id": case["case_id"],
+                "condition": condition,
+                "split": case["split"],
+                "repetition": 1,
+                "errors": [],
+                "output": {
+                    "selected_option_id": outcome["correct_option_id"],
+                    "forecast_probability": 0.9
+                    if outcome["correct_option_id"] == case["forecast_option_id"]
+                    else 0.1,
+                    "cruxes": [outcome["cruxes"][0]["description"]],
+                    "source_ids": [source["source_id"] for source in case["sources"]],
+                },
+                "receipt_verification": "verified"
+                if condition == "aragora_team"
+                else "not_applicable",
+                "latency_ms": 10.0,
+                "cost_usd": 0.0,
+                "calls": [{}],
+            }
+        )
+    score = score_results(bundle, results)
+    first = render_markdown(score)
+    second = render_markdown(score)
+
+    assert score["conditions"]["single_claude"]["mean_brier"] == pytest.approx(0.01)
+    assert first == second
+    assert "no statistical-significance claim" in first
+    assert score["decision"] == "incomplete"
+    assert score["team_brier_improvement"] is None
+    assert "Holdout team Brier improvement" in first

--- a/tests/evaluation/test_outcome_decision_quality.py
+++ b/tests/evaluation/test_outcome_decision_quality.py
@@ -131,6 +131,43 @@ def test_outcome_leakage_detector_rejects_resolution_text(bundle) -> None:
     assert request_contains_outcome_data(request, outcome)
 
 
+def test_outcome_leakage_detector_rejects_preregistered_crux_description(bundle) -> None:
+    case = bundle.cases[0]
+    outcome = next(
+        item for item in bundle.outcomes["outcomes"] if item["case_id"] == case["case_id"]
+    )
+    request = build_model_visible_request(
+        bundle,
+        case,
+        "single_claude",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+    )
+    request["leak"] = outcome["cruxes"][0]["description"]
+
+    assert request_contains_outcome_data(request, outcome)
+
+
+def test_outcome_leakage_detector_allows_incidental_generic_alias_overlap(bundle) -> None:
+    case = next(
+        item for item in bundle.cases if item["case_id"] == "policy-dev-sec-cyber-disclosure-2023"
+    )
+    outcome = next(
+        item for item in bundle.outcomes["outcomes"] if item["case_id"] == case["case_id"]
+    )
+    request = build_model_visible_request(
+        bundle,
+        case,
+        "single_claude",
+        repetition=1,
+        implementation_sha=IMPLEMENTATION_SHA,
+    )
+
+    assert "compliance readiness" in canonical_json_bytes(request).decode("utf-8")
+    assert "compliance readiness" in outcome["cruxes"][2]["aliases"]
+    assert not request_contains_outcome_data(request, outcome)
+
+
 @pytest.mark.parametrize(
     ("mutation", "message"),
     [

--- a/tests/scripts/test_outcome_decision_quality_benchmark.py
+++ b/tests/scripts/test_outcome_decision_quality_benchmark.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from scripts import outcome_decision_quality_benchmark as cli
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_validate_corpus_cli_reports_frozen_contract(capsys) -> None:
+    exit_code = cli.main(["validate-corpus"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["case_count"] == 24
+
+
+def test_validate_corpus_cli_returns_structured_error_for_invalid_utf8(
+    tmp_path: Path, capsys
+) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_bytes(b"\xff\xfe")
+
+    exit_code = cli.main(["validate-corpus", "--manifest", str(manifest)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["ok"] is False
+    assert payload["issues"][0]["code"] == "invalid_utf8"
+
+
+def test_render_cli_is_deterministic(tmp_path: Path, capsys) -> None:
+    score: dict[str, Any] = {
+        "benchmark_id": "benchmark",
+        "revision": "v1",
+        "manifest_sha256": "1" * 64,
+        "decision": "incomplete",
+        "best_single_condition": None,
+        "team_brier_improvement": None,
+        "incomplete_results": [],
+        "uncertainty_note": "Descriptive only.",
+        "conditions": {
+            condition: {
+                "n": 0,
+                "mean_brier": None,
+                "directional_accuracy": None,
+                "crux_recall": None,
+                "provenance_completeness": None,
+                "receipt_verification_rate": None,
+                "model_calls": 0,
+                "cost_usd": 0.0,
+            }
+            for condition in (
+                "single_claude",
+                "single_openai",
+                "single_gemini",
+                "aragora_team",
+            )
+        },
+    }
+    score_path = tmp_path / "score.json"
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    score_path.write_text(json.dumps(score), encoding="utf-8")
+
+    assert cli.main(["render", "--score", str(score_path), "--output", str(first)]) == 0
+    capsys.readouterr()
+    assert cli.main(["render", "--score", str(score_path), "--output", str(second)]) == 0
+    capsys.readouterr()
+    assert first.read_bytes() == second.read_bytes()
+
+
+def test_result_schema_covers_required_proof_fields() -> None:
+    schema = json.loads((ROOT / "docs/benchmarks/decision_quality/result.schema.json").read_text())
+    required = set(schema["required"])
+
+    assert {
+        "case_id",
+        "condition",
+        "requested_model",
+        "resolved_model",
+        "transport",
+        "output",
+        "latency_ms",
+        "cost_usd",
+        "errors",
+        "receipt_hash",
+        "receipt_verification",
+    } <= required
+    Draft202012Validator.check_schema(schema)


### PR DESCRIPTION
## Summary

- freeze the 24-case outcome-backed decision-quality corpus, prompt, roster, scorer, retry, budget, and holdout contracts
- add fail-closed corpus/leakage/model-family validation, append-only result and cost ledgers, independent DecisionReceipt verification, and holdout locks
- add deterministic Brier/crux/provenance/receipt scoring, report rendering, and a four-operation benchmark CLI

No model inference or reviewer evidence was run by this change. Corpus data landed separately in #9881; this PR binds and executes that corpus without exposing the outcome sidecar.

## Validation

- `python3 -m pytest tests/evaluation/test_decision_quality_corpus.py tests/evaluation/test_outcome_decision_quality.py tests/scripts/test_outcome_decision_quality_benchmark.py -q` (38 passed)
- `python3 -m ruff check ...` (passed)
- focused baseline-aware mypy (0 new errors)
- `uv run --locked --extra dev bash scripts/test_tiers.sh typecheck`
- `python3 scripts/report_code_quality.py --check`
- `python3 scripts/outcome_decision_quality_benchmark.py validate-corpus`
- result JSON Schema validation
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

## Frozen Contract

- Corpus SHA-256: `3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b`
- Outcomes SHA-256: `98702fe5d220d171e77fd0276d5803ec851e46c6900445dd73ccb4cbfdbf194d`
- 24 cases: 16 development / 8 holdout, 6 per domain
- 4 conditions: Claude, OpenAI, Gemini, and same-family Aragora team
- Holdout repetitions: 2, implementation/prompt/roster/scorer/corpus locked
- Paid API daily cap: USD 25; one infrastructure retry per call
