### PR TITLE
feat(evaluation): freeze decision quality corpus contract

### DIFF
--- a/aragora/evaluation/decision_quality_contract.py
+++ b/aragora/evaluation/decision_quality_contract.py
@@ -1,0 +1,322 @@
+"""Frozen contract loading for the outcome-backed decision-quality benchmark.
+
+This module validates the benchmark manifest, prompt, roster, tranche hashes,
+and aggregate corpus without running models or scoring results. Execution and
+scoring are deliberately separate so the frozen contract can land first.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from aragora.evaluation.decision_quality_corpus import (
+    CorpusValidationReport,
+    TrancheInput,
+    assemble_tranches,
+    canonical_sha256,
+    load_json_document,
+)
+
+MANIFEST_SCHEMA_VERSION = "decision-quality-benchmark/1.0"
+ROSTER_SCHEMA_VERSION = "decision-quality-roster/1.0"
+SCORER_CONTRACT_VERSION = "outcome-decision-quality-scorer/1.0"
+CANONICAL_JSON_CONVENTION = "python-json-sort-keys-compact-utf8-no-nan-v1"
+REQUIRED_CONDITIONS = (
+    "single_claude",
+    "single_openai",
+    "single_gemini",
+    "aragora_team",
+)
+
+
+@dataclass(frozen=True)
+class ContractIssue:
+    path: str
+    code: str
+    message: str
+
+
+@dataclass
+class BenchmarkContractReport:
+    manifest_sha256: str | None = None
+    corpus_sha256: str | None = None
+    outcomes_sha256: str | None = None
+    case_count: int = 0
+    issues: list[ContractIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "manifest_sha256": self.manifest_sha256,
+            "corpus_sha256": self.corpus_sha256,
+            "outcomes_sha256": self.outcomes_sha256,
+            "case_count": self.case_count,
+            "issues": [asdict(issue) for issue in self.issues],
+        }
+
+
+@dataclass(frozen=True)
+class BenchmarkBundle:
+    manifest_path: Path
+    manifest: dict[str, Any]
+    manifest_sha256: str
+    corpus: dict[str, Any]
+    outcomes: dict[str, Any]
+    prompt_contract: str
+    roster: dict[str, Any]
+
+    @property
+    def cases(self) -> list[dict[str, Any]]:
+        return list(self.corpus["cases"])
+
+
+def _contract_issue(report: BenchmarkContractReport, path: str, code: str, message: str) -> None:
+    report.issues.append(ContractIssue(path, code, message))
+
+
+def _safe_artifact_path(manifest_dir: Path, relative: Any) -> Path | None:
+    if not isinstance(relative, str) or not relative or Path(relative).is_absolute():
+        return None
+    resolved = (manifest_dir / relative).resolve()
+    try:
+        resolved.relative_to(manifest_dir.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _read_text(path: Path) -> tuple[str | None, ContractIssue | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except OSError as exc:
+        return None, ContractIssue(str(path), "read_error", str(exc))
+    except UnicodeError as exc:
+        return None, ContractIssue(str(path), "invalid_utf8", str(exc))
+
+
+def load_benchmark_bundle(
+    manifest_path: Path,
+) -> tuple[BenchmarkBundle | None, BenchmarkContractReport]:
+    """Load and verify every file pinned by the frozen benchmark manifest."""
+    report = BenchmarkContractReport()
+    manifest_doc, manifest_issue = load_json_document(manifest_path)
+    if manifest_issue is not None:
+        report.issues.append(ContractIssue(**asdict(manifest_issue)))
+        return None, report
+    if not isinstance(manifest_doc, dict):
+        _contract_issue(report, "$", "invalid_manifest", "manifest must be a JSON object")
+        return None, report
+    try:
+        report.manifest_sha256 = canonical_sha256(manifest_doc)
+    except (TypeError, ValueError) as exc:
+        _contract_issue(report, "$", "non_canonical_json", str(exc))
+        return None, report
+    if manifest_doc.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        _contract_issue(report, "$.schema_version", "unsupported_schema", MANIFEST_SCHEMA_VERSION)
+    if manifest_doc.get("canonical_json") != CANONICAL_JSON_CONVENTION:
+        _contract_issue(report, "$.canonical_json", "canonicalization_mismatch", "unsupported")
+    if tuple(manifest_doc.get("conditions", ())) != REQUIRED_CONDITIONS:
+        _contract_issue(
+            report,
+            "$.conditions",
+            "condition_roster_mismatch",
+            f"must equal {REQUIRED_CONDITIONS}",
+        )
+
+    manifest_dir = manifest_path.resolve().parent
+    prompt_spec = manifest_doc.get("prompt")
+    roster_spec = manifest_doc.get("roster")
+    if not isinstance(prompt_spec, dict) or not isinstance(roster_spec, dict):
+        _contract_issue(report, "$", "missing_contract_artifact", "prompt and roster are required")
+        return None, report
+    prompt_path = _safe_artifact_path(manifest_dir, prompt_spec.get("path"))
+    roster_path = _safe_artifact_path(manifest_dir, roster_spec.get("path"))
+    if prompt_path is None or roster_path is None:
+        _contract_issue(report, "$", "unsafe_artifact_path", "artifact paths must stay local")
+        return None, report
+    prompt_text, prompt_issue = _read_text(prompt_path)
+    roster_doc, roster_issue = load_json_document(roster_path)
+    if prompt_issue is not None:
+        report.issues.append(prompt_issue)
+    if roster_issue is not None:
+        report.issues.append(ContractIssue(**asdict(roster_issue)))
+    if roster_doc is not None and not isinstance(roster_doc, dict):
+        _contract_issue(report, "$.roster", "invalid_roster", "must be a JSON object")
+    if prompt_text is None or not isinstance(roster_doc, dict):
+        return None, report
+    prompt_digest = hashlib.sha256(prompt_text.encode("utf-8")).hexdigest()
+    if prompt_digest != prompt_spec.get("sha256"):
+        _contract_issue(report, "$.prompt.sha256", "artifact_hash_mismatch", prompt_digest)
+    roster_digest = canonical_sha256(roster_doc)
+    if roster_digest != roster_spec.get("sha256"):
+        _contract_issue(report, "$.roster.sha256", "artifact_hash_mismatch", roster_digest)
+    _validate_roster(roster_doc, report)
+
+    tranches = manifest_doc.get("tranches")
+    tranche_inputs: list[TrancheInput] = []
+    if not isinstance(tranches, list) or len(tranches) != 8:
+        _contract_issue(report, "$.tranches", "invalid_tranche_count", "must contain eight")
+    else:
+        for index, raw in enumerate(tranches):
+            if not isinstance(raw, dict):
+                _contract_issue(report, f"$.tranches[{index}]", "invalid_tranche", "must be object")
+                continue
+            corpus_path = _safe_artifact_path(manifest_dir, raw.get("corpus_path"))
+            outcomes_path = _safe_artifact_path(manifest_dir, raw.get("outcomes_path"))
+            corpus_digest = raw.get("corpus_sha256")
+            outcomes_digest = raw.get("outcomes_sha256")
+            if corpus_path is None or outcomes_path is None:
+                _contract_issue(
+                    report, f"$.tranches[{index}]", "unsafe_artifact_path", "invalid path"
+                )
+            elif not all(
+                isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value)
+                for value in (corpus_digest, outcomes_digest)
+            ):
+                _contract_issue(
+                    report, f"$.tranches[{index}]", "invalid_sha256", "digests required"
+                )
+            else:
+                tranche_inputs.append(
+                    TrancheInput(
+                        corpus_path, outcomes_path, str(corpus_digest), str(outcomes_digest)
+                    )
+                )
+
+    corpus: dict[str, Any] | None = None
+    outcomes: dict[str, Any] | None = None
+    if len(tranche_inputs) == 8:
+        corpus, outcomes, corpus_report = assemble_tranches(
+            tranche_inputs,
+            benchmark_id=str(manifest_doc.get("benchmark_id", "")),
+            revision=str(manifest_doc.get("revision", "")),
+            frozen_at=str(manifest_doc.get("frozen_at", "")),
+        )
+        _copy_corpus_issues(corpus_report, report)
+        report.corpus_sha256 = corpus_report.corpus_sha256
+        report.outcomes_sha256 = corpus_report.outcomes_sha256
+        report.case_count = corpus_report.case_count
+    aggregate = manifest_doc.get("aggregate")
+    if not isinstance(aggregate, dict):
+        _contract_issue(report, "$.aggregate", "missing_aggregate", "required")
+    else:
+        for key, actual in (
+            ("corpus_sha256", report.corpus_sha256),
+            ("outcomes_sha256", report.outcomes_sha256),
+            ("case_count", report.case_count),
+        ):
+            if aggregate.get(key) != actual:
+                _contract_issue(report, f"$.aggregate.{key}", "aggregate_mismatch", str(actual))
+    scorer = manifest_doc.get("scorer")
+    if not isinstance(scorer, dict) or scorer.get("contract_version") != SCORER_CONTRACT_VERSION:
+        _contract_issue(report, "$.scorer", "scorer_contract_mismatch", SCORER_CONTRACT_VERSION)
+    budget = manifest_doc.get("budget")
+    if (
+        not isinstance(budget, dict)
+        or budget.get("paid_api_daily_usd") != 25.0
+        or budget.get("infrastructure_retries_per_call") != 1
+    ):
+        _contract_issue(report, "$.budget", "budget_contract_mismatch", "must be $25 and one retry")
+    holdout = manifest_doc.get("holdout")
+    if not isinstance(holdout, dict) or holdout.get("repetitions") != 2:
+        _contract_issue(
+            report, "$.holdout", "holdout_contract_mismatch", "two repetitions required"
+        )
+    if report.issues or corpus is None or outcomes is None:
+        return None, report
+    return (
+        BenchmarkBundle(
+            manifest_path=manifest_path.resolve(),
+            manifest=manifest_doc,
+            manifest_sha256=report.manifest_sha256 or "",
+            corpus=corpus,
+            outcomes=outcomes,
+            prompt_contract=prompt_text,
+            roster=roster_doc,
+        ),
+        report,
+    )
+
+
+def _copy_corpus_issues(source: CorpusValidationReport, target: BenchmarkContractReport) -> None:
+    for issue in source.issues:
+        target.issues.append(ContractIssue(issue.path, issue.code, issue.message))
+
+
+def _validate_roster(roster: dict[str, Any], report: BenchmarkContractReport) -> None:
+    if roster.get("schema_version") != ROSTER_SCHEMA_VERSION:
+        _contract_issue(
+            report, "$.roster.schema_version", "unsupported_schema", ROSTER_SCHEMA_VERSION
+        )
+    conditions = roster.get("conditions")
+    if not isinstance(conditions, dict) or set(conditions) != set(REQUIRED_CONDITIONS):
+        _contract_issue(
+            report, "$.roster.conditions", "incomplete_roster", "four conditions required"
+        )
+        return
+    for condition_name, condition in conditions.items():
+        if not isinstance(condition, dict):
+            _contract_issue(report, f"$.roster.{condition_name}", "invalid_condition", "object")
+            continue
+        members = condition.get("members")
+        if not isinstance(members, list) or not members:
+            _contract_issue(
+                report, f"$.roster.{condition_name}.members", "incomplete_roster", "required"
+            )
+            continue
+        families: set[str] = set()
+        for index, member in enumerate(members):
+            path = f"$.roster.{condition_name}.members[{index}]"
+            if not isinstance(member, dict):
+                _contract_issue(report, path, "invalid_member", "must be object")
+                continue
+            family = member.get("family")
+            if family in families:
+                _contract_issue(report, f"{path}.family", "duplicate_family", str(family))
+            elif isinstance(family, str):
+                families.add(family)
+            for key in ("requested_model", "transport", "billing_class"):
+                if not isinstance(member.get(key), str) or not member[key]:
+                    _contract_issue(report, f"{path}.{key}", "missing_field", "required")
+            resolved = member.get("allowed_resolved_models")
+            if (
+                not isinstance(resolved, list)
+                or not resolved
+                or not all(isinstance(model, str) and model for model in resolved)
+            ):
+                _contract_issue(
+                    report, f"{path}.allowed_resolved_models", "missing_field", "required"
+                )
+        expected = {condition_name.removeprefix("single_")}
+        if condition_name == "aragora_team":
+            expected = {"claude", "openai", "gemini"}
+            if condition.get("adversarial_rounds") != 1:
+                _contract_issue(report, f"$.roster.{condition_name}", "round_contract", "one round")
+        if families != expected:
+            _contract_issue(
+                report,
+                f"$.roster.{condition_name}.members",
+                "family_roster_mismatch",
+                f"expected {sorted(expected)}",
+            )
+
+
+__all__ = [
+    "BenchmarkBundle",
+    "BenchmarkContractReport",
+    "CANONICAL_JSON_CONVENTION",
+    "ContractIssue",
+    "MANIFEST_SCHEMA_VERSION",
+    "REQUIRED_CONDITIONS",
+    "ROSTER_SCHEMA_VERSION",
+    "SCORER_CONTRACT_VERSION",
+    "load_benchmark_bundle",
+]

--- a/aragora/evaluation/decision_quality_contract.py
+++ b/aragora/evaluation/decision_quality_contract.py
@@ -31,6 +31,27 @@ REQUIRED_CONDITIONS = (
     "single_gemini",
     "aragora_team",
 )
+EXPECTED_FAMILY_MODELS = {
+    "claude": "claude-fable-5",
+    "openai": "gpt-5.6-sol",
+    "gemini": "gemini-3.1-pro-preview",
+}
+EXPECTED_TRANSPORT = "vibeproxy-required"
+EXPECTED_BILLING_CLASS = "subscription"
+
+_ROSTER_KEYS = {"schema_version", "conditions"}
+_SINGLE_CONDITION_KEYS = {"mode", "max_paid_cost_usd", "members"}
+_TEAM_CONDITION_KEYS = _SINGLE_CONDITION_KEYS | {
+    "adversarial_rounds",
+    "synthesizer_family",
+}
+_MEMBER_KEYS = {
+    "family",
+    "requested_model",
+    "allowed_resolved_models",
+    "transport",
+    "billing_class",
+}
 
 
 @dataclass(frozen=True)
@@ -80,6 +101,15 @@ class BenchmarkBundle:
 
 def _contract_issue(report: BenchmarkContractReport, path: str, code: str, message: str) -> None:
     report.issues.append(ContractIssue(path, code, message))
+
+
+def _exact_keys(
+    value: dict[str, Any], expected: set[str], path: str, report: BenchmarkContractReport
+) -> None:
+    for key in sorted(expected - value.keys()):
+        _contract_issue(report, f"{path}.{key}", "missing_field", "field is required")
+    for key in sorted(value.keys() - expected):
+        _contract_issue(report, f"{path}.{key}", "unknown_field", "field is not permitted")
 
 
 def _safe_artifact_path(manifest_dir: Path, relative: Any) -> Path | None:
@@ -252,6 +282,7 @@ def _copy_corpus_issues(source: CorpusValidationReport, target: BenchmarkContrac
 
 
 def _validate_roster(roster: dict[str, Any], report: BenchmarkContractReport) -> None:
+    _exact_keys(roster, _ROSTER_KEYS, "$.roster", report)
     if roster.get("schema_version") != ROSTER_SCHEMA_VERSION:
         _contract_issue(
             report, "$.roster.schema_version", "unsupported_schema", ROSTER_SCHEMA_VERSION
@@ -266,6 +297,31 @@ def _validate_roster(roster: dict[str, Any], report: BenchmarkContractReport) ->
         if not isinstance(condition, dict):
             _contract_issue(report, f"$.roster.{condition_name}", "invalid_condition", "object")
             continue
+        condition_path = f"$.roster.{condition_name}"
+        expected_mode = "team" if condition_name == "aragora_team" else "single"
+        expected_keys = (
+            _TEAM_CONDITION_KEYS if condition_name == "aragora_team" else _SINGLE_CONDITION_KEYS
+        )
+        _exact_keys(condition, expected_keys, condition_path, report)
+        if condition.get("mode") != expected_mode:
+            _contract_issue(
+                report,
+                f"{condition_path}.mode",
+                "mode_contract_mismatch",
+                f"must equal {expected_mode!r}",
+            )
+        max_paid_cost = condition.get("max_paid_cost_usd")
+        if (
+            isinstance(max_paid_cost, bool)
+            or not isinstance(max_paid_cost, (int, float))
+            or float(max_paid_cost) != 0.0
+        ):
+            _contract_issue(
+                report,
+                f"{condition_path}.max_paid_cost_usd",
+                "paid_cost_contract_mismatch",
+                "must be numeric zero for the subscription-only frozen roster",
+            )
         members = condition.get("members")
         if not isinstance(members, list) or not members:
             _contract_issue(
@@ -278,28 +334,56 @@ def _validate_roster(roster: dict[str, Any], report: BenchmarkContractReport) ->
             if not isinstance(member, dict):
                 _contract_issue(report, path, "invalid_member", "must be object")
                 continue
+            _exact_keys(member, _MEMBER_KEYS, path, report)
             family = member.get("family")
             if family in families:
                 _contract_issue(report, f"{path}.family", "duplicate_family", str(family))
             elif isinstance(family, str):
                 families.add(family)
-            for key in ("requested_model", "transport", "billing_class"):
-                if not isinstance(member.get(key), str) or not member[key]:
-                    _contract_issue(report, f"{path}.{key}", "missing_field", "required")
-            resolved = member.get("allowed_resolved_models")
-            if (
-                not isinstance(resolved, list)
-                or not resolved
-                or not all(isinstance(model, str) and model for model in resolved)
-            ):
+            expected_model = EXPECTED_FAMILY_MODELS.get(family) if isinstance(family, str) else None
+            requested_model = member.get("requested_model")
+            if requested_model != expected_model:
                 _contract_issue(
-                    report, f"{path}.allowed_resolved_models", "missing_field", "required"
+                    report,
+                    f"{path}.requested_model",
+                    "model_contract_mismatch",
+                    f"must equal {expected_model!r} for family {family!r}",
+                )
+            resolved = member.get("allowed_resolved_models")
+            if resolved != [expected_model]:
+                _contract_issue(
+                    report,
+                    f"{path}.allowed_resolved_models",
+                    "model_contract_mismatch",
+                    f"must equal [{expected_model!r}] for family {family!r}",
+                )
+            if member.get("transport") != EXPECTED_TRANSPORT:
+                _contract_issue(
+                    report,
+                    f"{path}.transport",
+                    "transport_contract_mismatch",
+                    f"must equal {EXPECTED_TRANSPORT!r}",
+                )
+            if member.get("billing_class") != EXPECTED_BILLING_CLASS:
+                _contract_issue(
+                    report,
+                    f"{path}.billing_class",
+                    "billing_contract_mismatch",
+                    f"must equal {EXPECTED_BILLING_CLASS!r}",
                 )
         expected = {condition_name.removeprefix("single_")}
         if condition_name == "aragora_team":
             expected = {"claude", "openai", "gemini"}
-            if condition.get("adversarial_rounds") != 1:
+            adversarial_rounds = condition.get("adversarial_rounds")
+            if isinstance(adversarial_rounds, bool) or adversarial_rounds != 1:
                 _contract_issue(report, f"$.roster.{condition_name}", "round_contract", "one round")
+            if condition.get("synthesizer_family") != "claude":
+                _contract_issue(
+                    report,
+                    f"$.roster.{condition_name}.synthesizer_family",
+                    "synthesizer_contract_mismatch",
+                    "must equal 'claude'",
+                )
         if families != expected:
             _contract_issue(
                 report,
@@ -314,6 +398,9 @@ __all__ = [
     "BenchmarkContractReport",
     "CANONICAL_JSON_CONVENTION",
     "ContractIssue",
+    "EXPECTED_BILLING_CLASS",
+    "EXPECTED_FAMILY_MODELS",
+    "EXPECTED_TRANSPORT",
     "MANIFEST_SCHEMA_VERSION",
     "REQUIRED_CONDITIONS",
     "ROSTER_SCHEMA_VERSION",

--- a/aragora/evaluation/decision_quality_corpus.py
+++ b/aragora/evaluation/decision_quality_corpus.py
@@ -1,0 +1,685 @@
+"""Frozen corpus validation for the outcome-backed decision-quality benchmark.
+
+The model-visible corpus and resolved outcomes remain separate.  Tranche files
+are immutable construction inputs; the benchmark manifest binds their canonical
+digests and the aggregate corpus/outcome digests before any inference occurs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+CORPUS_SCHEMA_VERSION = "decision-quality-corpus/1.0"
+OUTCOMES_SCHEMA_VERSION = "decision-quality-outcomes/1.0"
+DOMAINS = (
+    "software_engineering",
+    "business_operations",
+    "policy_compliance",
+    "science_forecasting",
+)
+SPLITS = ("development", "holdout")
+
+_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_HOST_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_NON_PUBLIC_SUFFIXES = (".home", ".internal", ".lan", ".local", ".localhost")
+
+_CORPUS_KEYS = {"schema_version", "benchmark_id", "revision", "frozen_at", "cases"}
+_CASE_KEYS = {
+    "case_id",
+    "domain",
+    "split",
+    "title",
+    "decision_prompt",
+    "forecast_question",
+    "forecast_option_id",
+    "options",
+    "information_cutoff",
+    "sources",
+}
+_OPTION_KEYS = {"option_id", "label", "description"}
+_SOURCE_KEYS = {"source_id", "title", "url", "published_at", "content_sha256"}
+_OUTCOMES_KEYS = {"schema_version", "benchmark_id", "corpus_sha256", "outcomes"}
+_OUTCOME_KEYS = {
+    "case_id",
+    "resolved_at",
+    "correct_option_id",
+    "resolution_summary",
+    "authoritative_sources",
+    "cruxes",
+}
+_CRUX_KEYS = {"crux_id", "description", "aliases"}
+
+
+class DuplicateObjectKeyError(ValueError):
+    """Raised when a JSON object repeats a key."""
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        super().__init__(f"duplicate JSON object key: {key!r}")
+
+
+def _reject_duplicate_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateObjectKeyError(key)
+        result[key] = value
+    return result
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """One fail-closed corpus validation issue."""
+
+    path: str
+    code: str
+    message: str
+
+
+@dataclass
+class CorpusValidationReport:
+    """Structured corpus validation result."""
+
+    corpus_sha256: str | None = None
+    outcomes_sha256: str | None = None
+    case_count: int = 0
+    domain_counts: dict[str, int] = field(default_factory=dict)
+    split_counts: dict[str, int] = field(default_factory=dict)
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "corpus_sha256": self.corpus_sha256,
+            "outcomes_sha256": self.outcomes_sha256,
+            "case_count": self.case_count,
+            "domain_counts": self.domain_counts,
+            "split_counts": self.split_counts,
+            "issues": [asdict(issue) for issue in self.issues],
+        }
+
+
+@dataclass(frozen=True)
+class TrancheInput:
+    """One manifest-pinned corpus/outcome tranche pair."""
+
+    corpus_path: Path
+    outcomes_path: Path
+    corpus_sha256: str
+    outcomes_sha256: str
+
+
+def canonical_json_bytes(document: Any) -> bytes:
+    """Return the benchmark's documented Python canonical JSON encoding."""
+    return json.dumps(
+        document,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_sha256(document: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(document)).hexdigest()
+
+
+def _issue(report: CorpusValidationReport, path: str, code: str, message: str) -> None:
+    report.issues.append(ValidationIssue(path, code, message))
+
+
+def load_json_document(path: Path) -> tuple[Any | None, ValidationIssue | None]:
+    """Load JSON with duplicate-key and encoding failures returned as data."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        return json.loads(raw, object_pairs_hook=_reject_duplicate_object_keys), None
+    except OSError as exc:
+        return None, ValidationIssue(str(path), "read_error", str(exc))
+    except UnicodeError as exc:
+        return None, ValidationIssue(str(path), "invalid_utf8", str(exc))
+    except DuplicateObjectKeyError as exc:
+        return None, ValidationIssue(str(path), "duplicate_json_key", str(exc))
+    except json.JSONDecodeError as exc:
+        return None, ValidationIssue(
+            str(path),
+            "invalid_json",
+            f"line {exc.lineno}, column {exc.colno}: {exc.msg}",
+        )
+
+
+def _object(value: Any, path: str, report: CorpusValidationReport) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        _issue(report, path, "invalid_type", "must be a JSON object")
+        return None
+    return value
+
+
+def _keys(
+    value: dict[str, Any], allowed: set[str], path: str, report: CorpusValidationReport
+) -> None:
+    for key in sorted(allowed - value.keys()):
+        _issue(report, f"{path}.{key}", "missing_field", "field is required")
+    for key in sorted(value.keys() - allowed):
+        _issue(report, f"{path}.{key}", "unknown_field", "field is not permitted")
+
+
+def _text(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        _issue(report, path, "invalid_string", "must be a non-empty string")
+        return None
+    return value
+
+
+def _identifier(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    text = _text(value, path, report)
+    if text is not None and _ID_PATTERN.fullmatch(text) is None:
+        _issue(report, path, "invalid_identifier", "must be a lowercase benchmark identifier")
+        return None
+    return text
+
+
+def _timestamp(value: Any, path: str, report: CorpusValidationReport) -> datetime | None:
+    text = _text(value, path, report)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        _issue(report, path, "invalid_timestamp", "must be an ISO-8601 timestamp")
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _issue(report, path, "naive_timestamp", "must include a UTC offset")
+        return None
+    return parsed
+
+
+def _sha256(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    text = _text(value, path, report)
+    if text is not None and _SHA256_PATTERN.fullmatch(text) is None:
+        _issue(report, path, "invalid_sha256", "must be a lowercase 64-character SHA-256")
+        return None
+    return text
+
+
+def _public_https(value: Any, path: str, report: CorpusValidationReport) -> str | None:
+    text = _text(value, path, report)
+    if text is not None and not is_public_https_url(text):
+        _issue(report, path, "non_public_url", "must use a syntactically public HTTPS URL")
+        return None
+    return text
+
+
+def is_public_https_url(text: str) -> bool:
+    """Fail closed for local, credential-bearing, or malformed source URLs."""
+    try:
+        parsed = urlsplit(text)
+        host = parsed.hostname
+        parsed.port
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or host is None
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return False
+    normalized = host.rstrip(".").lower()
+    if not normalized:
+        return False
+    try:
+        return ipaddress.ip_address(normalized).is_global
+    except ValueError:
+        try:
+            ascii_host = normalized.encode("idna").decode("ascii")
+        except UnicodeError:
+            return False
+        if "." not in ascii_host or ascii_host.endswith(_NON_PUBLIC_SUFFIXES):
+            return False
+        return all(_HOST_LABEL_PATTERN.fullmatch(label) for label in ascii_host.split("."))
+
+
+def _source(
+    value: Any,
+    path: str,
+    report: CorpusValidationReport,
+    *,
+    cutoff: datetime | None = None,
+    not_before: datetime | None = None,
+) -> str | None:
+    source = _object(value, path, report)
+    if source is None:
+        return None
+    _keys(source, _SOURCE_KEYS, path, report)
+    source_id = _identifier(source.get("source_id"), f"{path}.source_id", report)
+    _text(source.get("title"), f"{path}.title", report)
+    _public_https(source.get("url"), f"{path}.url", report)
+    published_at = _timestamp(source.get("published_at"), f"{path}.published_at", report)
+    _sha256(source.get("content_sha256"), f"{path}.content_sha256", report)
+    if cutoff is not None and published_at is not None and published_at > cutoff:
+        _issue(
+            report,
+            f"{path}.published_at",
+            "outcome_leakage",
+            "model-visible evidence must not postdate the information cutoff",
+        )
+    if not_before is not None and published_at is not None and published_at < not_before:
+        _issue(
+            report,
+            f"{path}.published_at",
+            "premature_outcome_source",
+            "authoritative outcome evidence must not predate resolution",
+        )
+    return source_id
+
+
+def _case(
+    value: Any, index: int, report: CorpusValidationReport
+) -> tuple[str | None, set[str], datetime | None, str | None, str | None, str | None]:
+    path = f"$.cases[{index}]"
+    case = _object(value, path, report)
+    if case is None:
+        return None, set(), None, None, None, None
+    _keys(case, _CASE_KEYS, path, report)
+    case_id = _identifier(case.get("case_id"), f"{path}.case_id", report)
+    domain = _text(case.get("domain"), f"{path}.domain", report)
+    split = _text(case.get("split"), f"{path}.split", report)
+    if domain is not None and domain not in DOMAINS:
+        _issue(report, f"{path}.domain", "invalid_domain", f"must be one of {DOMAINS}")
+    if split is not None and split not in SPLITS:
+        _issue(report, f"{path}.split", "invalid_split", f"must be one of {SPLITS}")
+    for key in ("title", "decision_prompt", "forecast_question"):
+        _text(case.get(key), f"{path}.{key}", report)
+    cutoff = _timestamp(case.get("information_cutoff"), f"{path}.information_cutoff", report)
+
+    option_ids: set[str] = set()
+    option_id_order: list[str] = []
+    options = case.get("options")
+    if not isinstance(options, list) or len(options) != 2:
+        _issue(report, f"{path}.options", "invalid_options", "must contain exactly two options")
+    else:
+        for option_index, raw in enumerate(options):
+            option_path = f"{path}.options[{option_index}]"
+            option = _object(raw, option_path, report)
+            if option is None:
+                continue
+            _keys(option, _OPTION_KEYS, option_path, report)
+            option_id = _identifier(option.get("option_id"), f"{option_path}.option_id", report)
+            _text(option.get("label"), f"{option_path}.label", report)
+            _text(option.get("description"), f"{option_path}.description", report)
+            if option_id in option_ids:
+                _issue(report, f"{option_path}.option_id", "duplicate_option_id", "must be unique")
+            elif option_id is not None:
+                option_ids.add(option_id)
+                option_id_order.append(option_id)
+        if len(option_id_order) == 2 and option_id_order != sorted(option_id_order):
+            _issue(
+                report,
+                f"{path}.options",
+                "unsorted_options",
+                "option IDs must be in lexicographic order to prevent position leakage",
+            )
+    forecast_option = _identifier(
+        case.get("forecast_option_id"), f"{path}.forecast_option_id", report
+    )
+    if forecast_option is not None and forecast_option not in option_ids:
+        _issue(report, f"{path}.forecast_option_id", "unknown_forecast_option", "unknown option")
+
+    sources = case.get("sources")
+    if not isinstance(sources, list) or not sources:
+        _issue(report, f"{path}.sources", "missing_sources", "must contain public evidence")
+    else:
+        source_ids: set[str] = set()
+        for source_index, raw in enumerate(sources):
+            source_path = f"{path}.sources[{source_index}]"
+            source_id = _source(raw, source_path, report, cutoff=cutoff)
+            if source_id in source_ids:
+                _issue(report, f"{source_path}.source_id", "duplicate_source_id", "must be unique")
+            elif source_id is not None:
+                source_ids.add(source_id)
+    return case_id, option_ids, cutoff, domain, split, forecast_option
+
+
+def _outcome(
+    value: Any,
+    index: int,
+    case_options: dict[str, set[str]],
+    case_cutoffs: dict[str, datetime],
+    report: CorpusValidationReport,
+) -> tuple[str | None, datetime | None, str | None]:
+    path = f"$.outcomes[{index}]"
+    outcome = _object(value, path, report)
+    if outcome is None:
+        return None, None, None
+    _keys(outcome, _OUTCOME_KEYS, path, report)
+    case_id = _identifier(outcome.get("case_id"), f"{path}.case_id", report)
+    resolved_at = _timestamp(outcome.get("resolved_at"), f"{path}.resolved_at", report)
+    correct_option = _identifier(
+        outcome.get("correct_option_id"), f"{path}.correct_option_id", report
+    )
+    _text(outcome.get("resolution_summary"), f"{path}.resolution_summary", report)
+    if case_id is not None:
+        if case_id not in case_options:
+            _issue(report, f"{path}.case_id", "unknown_case", "has no matching corpus case")
+        elif correct_option not in case_options[case_id]:
+            _issue(report, f"{path}.correct_option_id", "unknown_correct_option", "unknown option")
+        cutoff = case_cutoffs.get(case_id)
+        if cutoff is not None and resolved_at is not None and resolved_at <= cutoff:
+            _issue(
+                report,
+                f"{path}.resolved_at",
+                "invalid_resolution_time",
+                "must be later than the information cutoff",
+            )
+
+    sources = outcome.get("authoritative_sources")
+    if not isinstance(sources, list) or not sources:
+        _issue(report, f"{path}.authoritative_sources", "missing_outcome_sources", "required")
+    else:
+        source_ids: set[str] = set()
+        for source_index, raw in enumerate(sources):
+            source_path = f"{path}.authoritative_sources[{source_index}]"
+            source_id = _source(raw, source_path, report, not_before=resolved_at)
+            if source_id in source_ids:
+                _issue(report, f"{source_path}.source_id", "duplicate_source_id", "must be unique")
+            elif source_id is not None:
+                source_ids.add(source_id)
+
+    cruxes = outcome.get("cruxes")
+    if not isinstance(cruxes, list) or not 3 <= len(cruxes) <= 5:
+        _issue(report, f"{path}.cruxes", "invalid_crux_count", "must contain 3 to 5 cruxes")
+    else:
+        crux_ids: set[str] = set()
+        for crux_index, raw in enumerate(cruxes):
+            crux_path = f"{path}.cruxes[{crux_index}]"
+            crux = _object(raw, crux_path, report)
+            if crux is None:
+                continue
+            _keys(crux, _CRUX_KEYS, crux_path, report)
+            crux_id = _identifier(crux.get("crux_id"), f"{crux_path}.crux_id", report)
+            _text(crux.get("description"), f"{crux_path}.description", report)
+            aliases = crux.get("aliases")
+            if not isinstance(aliases, list) or not all(
+                isinstance(alias, str) and alias.strip() for alias in aliases
+            ):
+                _issue(report, f"{crux_path}.aliases", "invalid_aliases", "must be strings")
+            if crux_id in crux_ids:
+                _issue(report, f"{crux_path}.crux_id", "duplicate_crux_id", "must be unique")
+            elif crux_id is not None:
+                crux_ids.add(crux_id)
+    return case_id, resolved_at, correct_option
+
+
+def validate_corpus_documents(
+    corpus: Any,
+    outcomes: Any,
+    *,
+    allow_partial: bool = False,
+    expected_outcomes_sha256: str | None = None,
+) -> CorpusValidationReport:
+    """Validate model-visible cases and their hash-bound outcome sidecar."""
+    report = CorpusValidationReport()
+    corpus_object = _object(corpus, "$corpus", report)
+    outcomes_object = _object(outcomes, "$outcomes", report)
+    if corpus_object is None or outcomes_object is None:
+        return report
+    try:
+        report.corpus_sha256 = canonical_sha256(corpus_object)
+        report.outcomes_sha256 = canonical_sha256(outcomes_object)
+    except (TypeError, ValueError) as exc:
+        _issue(report, "$", "non_canonical_json", str(exc))
+        return report
+    _keys(corpus_object, _CORPUS_KEYS, "$corpus", report)
+    _keys(outcomes_object, _OUTCOMES_KEYS, "$outcomes", report)
+    if corpus_object.get("schema_version") != CORPUS_SCHEMA_VERSION:
+        _issue(report, "$corpus.schema_version", "unsupported_schema", CORPUS_SCHEMA_VERSION)
+    if outcomes_object.get("schema_version") != OUTCOMES_SCHEMA_VERSION:
+        _issue(
+            report,
+            "$outcomes.schema_version",
+            "unsupported_schema",
+            OUTCOMES_SCHEMA_VERSION,
+        )
+    benchmark_id = _identifier(corpus_object.get("benchmark_id"), "$corpus.benchmark_id", report)
+    outcome_benchmark = _identifier(
+        outcomes_object.get("benchmark_id"), "$outcomes.benchmark_id", report
+    )
+    if benchmark_id is not None and outcome_benchmark != benchmark_id:
+        _issue(report, "$outcomes.benchmark_id", "benchmark_id_mismatch", "must match corpus")
+    _identifier(corpus_object.get("revision"), "$corpus.revision", report)
+    frozen_at = _timestamp(corpus_object.get("frozen_at"), "$corpus.frozen_at", report)
+    declared_corpus_hash = _sha256(
+        outcomes_object.get("corpus_sha256"), "$outcomes.corpus_sha256", report
+    )
+    if declared_corpus_hash is not None and declared_corpus_hash != report.corpus_sha256:
+        _issue(report, "$outcomes.corpus_sha256", "corpus_hash_mismatch", "must bind corpus")
+    if expected_outcomes_sha256 is not None:
+        if _SHA256_PATTERN.fullmatch(expected_outcomes_sha256) is None:
+            _issue(report, "$expected_outcomes_sha256", "invalid_sha256", "invalid digest")
+        elif expected_outcomes_sha256 != report.outcomes_sha256:
+            _issue(report, "$expected_outcomes_sha256", "outcomes_hash_mismatch", "digest drift")
+
+    cases = corpus_object.get("cases")
+    if not isinstance(cases, list):
+        _issue(report, "$corpus.cases", "invalid_type", "must be an array")
+        cases = []
+    report.case_count = len(cases)
+    if not cases:
+        _issue(report, "$corpus.cases", "empty_corpus", "must contain cases")
+    case_options: dict[str, set[str]] = {}
+    case_cutoffs: dict[str, datetime] = {}
+    case_domains: dict[str, str] = {}
+    case_splits: dict[str, str] = {}
+    case_forecast_options: dict[str, str] = {}
+    domains: list[str] = []
+    splits: list[str] = []
+    domain_splits: Counter[tuple[str, str]] = Counter()
+    for index, raw in enumerate(cases):
+        case_id, options, cutoff, domain, split, forecast_option = _case(raw, index, report)
+        if case_id in case_options:
+            _issue(report, f"$corpus.cases[{index}].case_id", "duplicate_case_id", "must be unique")
+        elif case_id is not None:
+            case_options[case_id] = options
+            if cutoff is not None:
+                case_cutoffs[case_id] = cutoff
+            if domain in DOMAINS:
+                case_domains[case_id] = domain
+            if split in SPLITS:
+                case_splits[case_id] = split
+            if forecast_option is not None:
+                case_forecast_options[case_id] = forecast_option
+        if domain in DOMAINS:
+            domains.append(domain)
+        if split in SPLITS:
+            splits.append(split)
+        if domain in DOMAINS and split in SPLITS:
+            domain_splits[(domain, split)] += 1
+    report.domain_counts = dict(sorted(Counter(domains).items()))
+    report.split_counts = dict(sorted(Counter(splits).items()))
+    if not allow_partial:
+        if len(cases) != 24:
+            _issue(report, "$corpus.cases", "wrong_case_count", "must contain exactly 24 cases")
+        for domain in DOMAINS:
+            if report.domain_counts.get(domain, 0) != 6:
+                _issue(report, "$corpus.cases", "wrong_domain_count", f"{domain} must have 6")
+            if domain_splits[(domain, "development")] != 4:
+                _issue(report, "$corpus.cases", "wrong_development_count", f"{domain} must have 4")
+            if domain_splits[(domain, "holdout")] != 2:
+                _issue(report, "$corpus.cases", "wrong_holdout_count", f"{domain} must have 2")
+
+    raw_outcomes = outcomes_object.get("outcomes")
+    if not isinstance(raw_outcomes, list):
+        _issue(report, "$outcomes.outcomes", "invalid_type", "must be an array")
+        raw_outcomes = []
+    if not raw_outcomes:
+        _issue(report, "$outcomes.outcomes", "empty_outcomes", "must contain outcomes")
+    outcome_ids: set[str] = set()
+    positive_targets: list[str] = []
+    for index, raw in enumerate(raw_outcomes):
+        case_id, resolved_at, correct_option = _outcome(
+            raw, index, case_options, case_cutoffs, report
+        )
+        if case_id in outcome_ids:
+            _issue(
+                report,
+                f"$outcomes.outcomes[{index}].case_id",
+                "duplicate_outcome",
+                "must be unique",
+            )
+        elif case_id is not None:
+            outcome_ids.add(case_id)
+            if correct_option == case_forecast_options.get(case_id):
+                positive_targets.append(case_id)
+        if frozen_at is not None and resolved_at is not None and frozen_at < resolved_at:
+            _issue(
+                report,
+                f"$outcomes.outcomes[{index}].resolved_at",
+                "premature_freeze",
+                "corpus freeze must not predate any resolved outcome",
+            )
+    missing = sorted(case_options.keys() - outcome_ids)
+    extra = sorted(outcome_ids - case_options.keys())
+    if missing:
+        _issue(report, "$outcomes.outcomes", "missing_outcomes", ", ".join(missing))
+    if extra:
+        _issue(report, "$outcomes.outcomes", "extra_outcomes", ", ".join(extra))
+    if not allow_partial:
+        if len(positive_targets) != 12:
+            _issue(
+                report,
+                "$outcomes.outcomes",
+                "wrong_target_balance",
+                "exactly 12 of 24 outcomes must match the forecast option",
+            )
+        target_domain_splits = Counter(
+            (case_domains.get(case_id), case_splits.get(case_id)) for case_id in positive_targets
+        )
+        for domain in DOMAINS:
+            if sum(target_domain_splits[(domain, split)] for split in SPLITS) != 3:
+                _issue(
+                    report,
+                    "$outcomes.outcomes",
+                    "wrong_domain_target_balance",
+                    f"{domain} must contain exactly 3 positive targets",
+                )
+            if target_domain_splits[(domain, "development")] != 2:
+                _issue(
+                    report,
+                    "$outcomes.outcomes",
+                    "wrong_development_target_balance",
+                    f"{domain} development must contain exactly 2 positive targets",
+                )
+            if target_domain_splits[(domain, "holdout")] != 1:
+                _issue(
+                    report,
+                    "$outcomes.outcomes",
+                    "wrong_holdout_target_balance",
+                    f"{domain} holdout must contain exactly 1 positive target",
+                )
+    return report
+
+
+def validate_corpus_files(
+    corpus_path: Path,
+    outcomes_path: Path,
+    *,
+    allow_partial: bool = False,
+    expected_outcomes_sha256: str | None = None,
+) -> CorpusValidationReport:
+    """Load and validate two files without raising on malformed input."""
+    corpus, corpus_issue = load_json_document(corpus_path)
+    outcomes, outcomes_issue = load_json_document(outcomes_path)
+    if corpus_issue is not None or outcomes_issue is not None:
+        return CorpusValidationReport(
+            issues=[issue for issue in (corpus_issue, outcomes_issue) if issue is not None]
+        )
+    return validate_corpus_documents(
+        corpus,
+        outcomes,
+        allow_partial=allow_partial,
+        expected_outcomes_sha256=expected_outcomes_sha256,
+    )
+
+
+def assemble_tranches(
+    inputs: list[TrancheInput],
+    *,
+    benchmark_id: str,
+    revision: str,
+    frozen_at: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, CorpusValidationReport]:
+    """Assemble manifest-pinned tranche inputs into one canonical benchmark."""
+    report = CorpusValidationReport()
+    cases: list[dict[str, Any]] = []
+    outcomes: list[dict[str, Any]] = []
+    for index, item in enumerate(inputs):
+        corpus_doc, corpus_issue = load_json_document(item.corpus_path)
+        outcomes_doc, outcomes_issue = load_json_document(item.outcomes_path)
+        for issue in (corpus_issue, outcomes_issue):
+            if issue is not None:
+                report.issues.append(issue)
+        if corpus_doc is None or outcomes_doc is None:
+            continue
+        try:
+            actual_corpus = canonical_sha256(corpus_doc)
+            actual_outcomes = canonical_sha256(outcomes_doc)
+        except (TypeError, ValueError) as exc:
+            _issue(report, f"$tranches[{index}]", "non_canonical_json", str(exc))
+            continue
+        if actual_corpus != item.corpus_sha256:
+            _issue(report, f"$tranches[{index}].corpus", "tranche_hash_mismatch", actual_corpus)
+        if actual_outcomes != item.outcomes_sha256:
+            _issue(report, f"$tranches[{index}].outcomes", "tranche_hash_mismatch", actual_outcomes)
+        partial = validate_corpus_documents(corpus_doc, outcomes_doc, allow_partial=True)
+        report.issues.extend(partial.issues)
+        if partial.ok:
+            cases.extend(corpus_doc["cases"])
+            outcomes.extend(outcomes_doc["outcomes"])
+    if report.issues:
+        return None, None, report
+    corpus = {
+        "schema_version": CORPUS_SCHEMA_VERSION,
+        "benchmark_id": benchmark_id,
+        "revision": revision,
+        "frozen_at": frozen_at,
+        "cases": sorted(cases, key=lambda item: item["case_id"]),
+    }
+    outcome_sidecar = {
+        "schema_version": OUTCOMES_SCHEMA_VERSION,
+        "benchmark_id": benchmark_id,
+        "corpus_sha256": canonical_sha256(corpus),
+        "outcomes": sorted(outcomes, key=lambda item: item["case_id"]),
+    }
+    return corpus, outcome_sidecar, validate_corpus_documents(corpus, outcome_sidecar)
+
+
+__all__ = [
+    "CORPUS_SCHEMA_VERSION",
+    "OUTCOMES_SCHEMA_VERSION",
+    "DOMAINS",
+    "SPLITS",
+    "CorpusValidationReport",
+    "TrancheInput",
+    "ValidationIssue",
+    "assemble_tranches",
+    "canonical_json_bytes",
+    "canonical_sha256",
+    "is_public_https_url",
+    "load_json_document",
+    "validate_corpus_documents",
+    "validate_corpus_files",
+]

--- a/docs/benchmarks/decision_quality/README.md
+++ b/docs/benchmarks/decision_quality/README.md
@@ -1,0 +1,60 @@
+# Outcome-Backed Decision Quality Benchmark
+
+This benchmark tests the bounded claim that Aragora's fixed heterogeneous team
+improves outcome-backed decision quality over its strongest constituent single
+model. Truthful completion is valid whether the final result is `go`,
+`conditional_go`, or `no_go`.
+
+## Frozen Contract
+
+`benchmark-manifest.json` binds eight construction tranches, the aggregate
+24-case corpus and outcome-sidecar digests, the prompt, the exact model roster,
+the scorer contract, the retry policy, and the paid-API budget. The canonical
+JSON convention is Python `json.dumps` with sorted keys, compact separators,
+UTF-8 output, `ensure_ascii=False`, and non-finite numbers rejected. It is a
+documented benchmark convention, not a claim of RFC 8785 compatibility.
+
+The outcome sidecars are never model-visible. `run` builds one isolated packet
+per case and rejects a packet that contains outcome IDs, resolution text,
+authoritative outcome-source IDs, or preregistered crux IDs. Any correction to
+a tranche, prompt, roster, scorer contract, or answer key requires a new
+benchmark revision and invalidates affected runs.
+
+The fixed conditions are:
+
+- `single_claude`
+- `single_openai`
+- `single_gemini`
+- `aragora_team`, using the same three families, one adversarial round, and one
+  declared synthesis
+
+The frozen roster uses subscription-backed `vibeproxy-required` transport.
+The runner must fail closed on a requested/resolved model mismatch and must not
+substitute an incomplete family roster. Paid API fallback remains capped at
+USD 25 per UTC day and is not enabled by this manifest.
+
+## Available Command
+
+```bash
+python3 scripts/outcome_decision_quality_benchmark.py validate-corpus
+```
+
+This contract-first slice intentionally does not execute models or score
+results. The later `run`, `score`, and `render` implementation must extend this
+same CLI without changing the frozen corpus, prompt, roster, scorer contract,
+retry policy, or budget. Before inference, that implementation must prove its
+result records are bound to the manifest, case packet, split, repetition, and
+implementation SHA.
+
+The first holdout repetition creates a holdout lock that binds the corpus,
+outcomes, prompt, roster, scorer contract, and implementation SHA. The second
+repetition refuses to run if any bound field changed.
+
+## Result Interpretation
+
+Primary metrics are binary Brier score, directional accuracy, preregistered
+crux recall, provenance completeness, team receipt verification, latency,
+model calls, and cost. The target is an absolute holdout Brier improvement of
+at least 0.05 over the best single condition. Reports include descriptive
+ranges only; this 24-case corpus does not support a statistical-significance
+claim.

--- a/docs/benchmarks/decision_quality/benchmark-manifest.json
+++ b/docs/benchmarks/decision_quality/benchmark-manifest.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "decision-quality-benchmark/1.0",
+  "benchmark_id": "outcome-backed-decision-quality-v1",
+  "revision": "v1",
+  "frozen_at": "2026-08-30T03:52:00Z",
+  "canonical_json": "python-json-sort-keys-compact-utf8-no-nan-v1",
+  "conditions": [
+    "single_claude",
+    "single_openai",
+    "single_gemini",
+    "aragora_team"
+  ],
+  "tranches": [
+    {
+      "corpus_path": "tranches/business-operations-1.corpus.json",
+      "outcomes_path": "tranches/business-operations-1.outcomes.json",
+      "corpus_sha256": "ac9676ff9715b724a436ac3f697e3599aba8416e061fe009088eea4360ad8bba",
+      "outcomes_sha256": "ce281b2caab29f79b07d7784c3d19a08243ad914e1e384226dd17ff63f1452d4"
+    },
+    {
+      "corpus_path": "tranches/business-operations-holdout-1.corpus.json",
+      "outcomes_path": "tranches/business-operations-holdout-1.outcomes.json",
+      "corpus_sha256": "2036afb2a909e1ffd16d5764fefd1fbccbeb298dd29924222d6034ec30d7e855",
+      "outcomes_sha256": "05a6640cbee4878d0726d8dbbe92f6e9ebcb97a7eae7b0a03939cea2829358ff"
+    },
+    {
+      "corpus_path": "tranches/policy-compliance-1.corpus.json",
+      "outcomes_path": "tranches/policy-compliance-1.outcomes.json",
+      "corpus_sha256": "17bce195c719c30c128b0ce86e906754c076e2c03da4a10f6421d9e80f57943b",
+      "outcomes_sha256": "171cb032ca3047305ecb2086ad0913417d5a95fcfaec8dc228ba1b4f1dcf197b"
+    },
+    {
+      "corpus_path": "tranches/policy-compliance-holdout-1.corpus.json",
+      "outcomes_path": "tranches/policy-compliance-holdout-1.outcomes.json",
+      "corpus_sha256": "318c209ccfc5d24b82f6083f284334fb89f752a9dfc6a8ab0ee68d6f5a5dbd4d",
+      "outcomes_sha256": "247848041189c398c20a57547901aafff6d30d51fd98206e5e5a5e0c4689e8a1"
+    },
+    {
+      "corpus_path": "tranches/science-forecasting-1.corpus.json",
+      "outcomes_path": "tranches/science-forecasting-1.outcomes.json",
+      "corpus_sha256": "2fc5525c8b7a23c5f57faed12967cb170be1e83c6afcba58ac45b43cefa18445",
+      "outcomes_sha256": "061f6dc846889b01a22e3562b998d6b2b43f3bcf24efbe048f33b2089286de38"
+    },
+    {
+      "corpus_path": "tranches/science-forecasting-holdout-1.corpus.json",
+      "outcomes_path": "tranches/science-forecasting-holdout-1.outcomes.json",
+      "corpus_sha256": "503a5cc94a26fcd38f8c0bb264413ac82b2ae7a3489da8d22e6d646254702ed6",
+      "outcomes_sha256": "9d93b2f085b1c8586f67ee73538219bc1a98888ef0d4b3d11f196b9976b4e7d4"
+    },
+    {
+      "corpus_path": "tranches/software-development-1.corpus.json",
+      "outcomes_path": "tranches/software-development-1.outcomes.json",
+      "corpus_sha256": "e9ec5a9a62b6d2d9a6cd9664989d3be6e45b7cc7cbfe0d57919a4238e0770b27",
+      "outcomes_sha256": "cb3f1c0b7762b144142044a510f8c0cb489a15699ce6a7c6e262e2f35b17938d"
+    },
+    {
+      "corpus_path": "tranches/software-engineering-holdout-1.corpus.json",
+      "outcomes_path": "tranches/software-engineering-holdout-1.outcomes.json",
+      "corpus_sha256": "97da356b5d70618c332e5fc52a0510996e28c6723aa00111206e663dc581295e",
+      "outcomes_sha256": "1db3bd542e913b09c820af98a9ce4237f7dbfe8bbfed53d77f35fcf7f0bce292"
+    }
+  ],
+  "aggregate": {
+    "case_count": 24,
+    "corpus_sha256": "3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b",
+    "outcomes_sha256": "98702fe5d220d171e77fd0276d5803ec851e46c6900445dd73ccb4cbfdbf194d"
+  },
+  "prompt": {
+    "path": "prompt.md",
+    "sha256": "767f6552a17ae179fed027ff1bc2f737d893a1f72859c090b1a5730979439647"
+  },
+  "roster": {
+    "path": "roster.json",
+    "sha256": "2d7027906c5da8fe137cca2f52773eb2a9b2f2864753884c715774d54df2df71"
+  },
+  "scorer": {
+    "contract_version": "outcome-decision-quality-scorer/1.0",
+    "module": "aragora.evaluation.outcome_decision_quality",
+    "primary_metrics": [
+      "binary_brier",
+      "directional_accuracy",
+      "crux_recall",
+      "provenance_completeness",
+      "receipt_verification_rate",
+      "latency",
+      "model_calls",
+      "cost"
+    ]
+  },
+  "budget": {
+    "paid_api_daily_usd": 25.0,
+    "infrastructure_retries_per_call": 1
+  },
+  "holdout": {
+    "repetitions": 2,
+    "cases_per_domain": 2,
+    "invalidate_on_change": [
+      "corpus",
+      "outcomes",
+      "prompt",
+      "roster",
+      "scorer_contract",
+      "implementation_sha"
+    ]
+  }
+}

--- a/docs/benchmarks/decision_quality/prompt.md
+++ b/docs/benchmarks/decision_quality/prompt.md
@@ -1,0 +1,30 @@
+# Outcome-Backed Decision Quality Prompt Contract v1
+
+You are making a bounded decision using only the case packet supplied with
+this prompt. The packet contains an information cutoff and pre-cutoff source
+metadata. Do not use later knowledge, web searches, hidden outcomes, or facts
+from another benchmark case.
+
+Choose exactly one of the two option IDs. Report a probability from 0 through
+1 for the case's `forecast_option_id`, even when you select the other option.
+Identify the three to five uncertainties that most affect the choice. Cite
+only `source_id` values present in this case packet. State limitations rather
+than inventing missing evidence.
+
+Return one JSON object with exactly these fields:
+
+```json
+{
+  "selected_option_id": "one supplied option_id",
+  "forecast_probability": 0.5,
+  "cruxes": ["bounded decision-relevant uncertainty"],
+  "source_ids": ["one supplied source_id"],
+  "rationale": "concise reasoning grounded in the supplied packet"
+}
+```
+
+For the `aragora_team` condition, the same three model families first produce
+independent answers, perform one bounded adversarial critique round, and then
+the declared synthesizer emits the same JSON shape. No member may receive an
+outcome sidecar or another benchmark case. The runner must emit a verifiable
+DecisionReceipt for the synthesized result.

--- a/docs/benchmarks/decision_quality/roster.json
+++ b/docs/benchmarks/decision_quality/roster.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "decision-quality-roster/1.0",
+  "conditions": {
+    "single_claude": {
+      "mode": "single",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "claude",
+          "requested_model": "claude-fable-5",
+          "allowed_resolved_models": [
+            "claude-fable-5"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    },
+    "single_openai": {
+      "mode": "single",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "openai",
+          "requested_model": "gpt-5.6-sol",
+          "allowed_resolved_models": [
+            "gpt-5.6-sol"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    },
+    "single_gemini": {
+      "mode": "single",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "gemini",
+          "requested_model": "gemini-3.1-pro-preview",
+          "allowed_resolved_models": [
+            "gemini-3.1-pro-preview"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    },
+    "aragora_team": {
+      "mode": "team",
+      "adversarial_rounds": 1,
+      "synthesizer_family": "claude",
+      "max_paid_cost_usd": 0.0,
+      "members": [
+        {
+          "family": "claude",
+          "requested_model": "claude-fable-5",
+          "allowed_resolved_models": [
+            "claude-fable-5"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        },
+        {
+          "family": "openai",
+          "requested_model": "gpt-5.6-sol",
+          "allowed_resolved_models": [
+            "gpt-5.6-sol"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        },
+        {
+          "family": "gemini",
+          "requested_model": "gemini-3.1-pro-preview",
+          "allowed_resolved_models": [
+            "gemini-3.1-pro-preview"
+          ],
+          "transport": "vibeproxy-required",
+          "billing_class": "subscription"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/outcome_decision_quality_benchmark.py
+++ b/scripts/outcome_decision_quality_benchmark.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Frozen outcome-backed decision-quality benchmark contract CLI.
+
+This first slice exposes corpus/contract validation only. Model execution,
+scoring, and report rendering land separately after the contract is frozen.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from aragora.evaluation.decision_quality_contract import (  # noqa: E402
+    load_benchmark_bundle,
+)
+
+DEFAULT_MANIFEST = PROJECT_ROOT / "docs/benchmarks/decision_quality/benchmark-manifest.json"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+
+    validate = subparsers.add_parser("validate-corpus", help="validate frozen corpus contract")
+    validate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+
+    return parser
+
+
+def _emit(payload: dict[str, Any], *, exit_code: int = 0) -> int:
+    print(json.dumps(payload, indent=2, sort_keys=True, allow_nan=False))
+    return exit_code
+
+
+def _validate(args: argparse.Namespace) -> int:
+    _, report = load_benchmark_bundle(args.manifest)
+    return _emit(
+        {"operation": "validate-corpus", **report.to_dict()}, exit_code=0 if report.ok else 2
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.operation == "validate-corpus":
+            return _validate(args)
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        return _emit({"ok": False, "operation": args.operation, "error": str(exc)}, exit_code=2)
+    return _emit(
+        {"ok": False, "operation": args.operation, "error": "unknown operation"}, exit_code=2
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/evaluation/test_decision_quality_contract.py
+++ b/tests/evaluation/test_decision_quality_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+from pathlib import Path
+
+from aragora.evaluation.decision_quality_contract import load_benchmark_bundle
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIR = ROOT / "docs/benchmarks/decision_quality"
+MANIFEST = BENCHMARK_DIR / "benchmark-manifest.json"
+
+
+def _copy_contract(tmp_path: Path) -> Path:
+    destination = tmp_path / "decision_quality"
+    shutil.copytree(BENCHMARK_DIR, destination)
+    return destination / "benchmark-manifest.json"
+
+
+def _issue_codes(report: object) -> set[str]:
+    return {issue.code for issue in report.issues}  # type: ignore[attr-defined]
+
+
+def test_live_contract_binds_complete_frozen_corpus() -> None:
+    bundle, report = load_benchmark_bundle(MANIFEST)
+
+    assert report.ok
+    assert bundle is not None
+    assert report.case_count == 24
+    assert (
+        report.corpus_sha256 == "3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b"
+    )
+    assert (
+        report.outcomes_sha256 == "98702fe5d220d171e77fd0276d5803ec851e46c6900445dd73ccb4cbfdbf194d"
+    )
+    assert set(bundle.roster["conditions"]) == {
+        "single_claude",
+        "single_openai",
+        "single_gemini",
+        "aragora_team",
+    }
+
+
+def test_contract_rejects_prompt_digest_drift(tmp_path: Path) -> None:
+    manifest_path = _copy_contract(tmp_path)
+    prompt_path = manifest_path.parent / "prompt.md"
+    prompt_path.write_text(
+        prompt_path.read_text(encoding="utf-8") + "\nchanged\n", encoding="utf-8"
+    )
+
+    bundle, report = load_benchmark_bundle(manifest_path)
+
+    assert bundle is None
+    assert "artifact_hash_mismatch" in _issue_codes(report)
+
+
+def test_contract_rejects_artifact_path_escape(tmp_path: Path) -> None:
+    manifest_path = _copy_contract(tmp_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["prompt"]["path"] = "../prompt.md"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    bundle, report = load_benchmark_bundle(manifest_path)
+
+    assert bundle is None
+    assert "unsafe_artifact_path" in _issue_codes(report)
+
+
+def test_contract_rejects_duplicate_roster_family(tmp_path: Path) -> None:
+    manifest_path = _copy_contract(tmp_path)
+    roster_path = manifest_path.parent / "roster.json"
+    roster = json.loads(roster_path.read_text(encoding="utf-8"))
+    members = roster["conditions"]["aragora_team"]["members"]
+    members.append(copy.deepcopy(members[0]))
+    roster_path.write_text(json.dumps(roster), encoding="utf-8")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    from aragora.evaluation.decision_quality_corpus import canonical_sha256
+
+    manifest["roster"]["sha256"] = canonical_sha256(roster)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    bundle, report = load_benchmark_bundle(manifest_path)
+
+    assert bundle is None
+    assert "duplicate_family" in _issue_codes(report)

--- a/tests/evaluation/test_decision_quality_contract.py
+++ b/tests/evaluation/test_decision_quality_contract.py
@@ -5,6 +5,9 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
+
+from aragora.evaluation.decision_quality_corpus import canonical_sha256
 from aragora.evaluation.decision_quality_contract import load_benchmark_bundle
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -20,6 +23,14 @@ def _copy_contract(tmp_path: Path) -> Path:
 
 def _issue_codes(report: object) -> set[str]:
     return {issue.code for issue in report.issues}  # type: ignore[attr-defined]
+
+
+def _write_roster(manifest_path: Path, roster: dict[str, object]) -> None:
+    roster_path = manifest_path.parent / "roster.json"
+    roster_path.write_text(json.dumps(roster), encoding="utf-8")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["roster"]["sha256"] = canonical_sha256(roster)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
 
 def test_live_contract_binds_complete_frozen_corpus() -> None:
@@ -73,14 +84,66 @@ def test_contract_rejects_duplicate_roster_family(tmp_path: Path) -> None:
     roster = json.loads(roster_path.read_text(encoding="utf-8"))
     members = roster["conditions"]["aragora_team"]["members"]
     members.append(copy.deepcopy(members[0]))
-    roster_path.write_text(json.dumps(roster), encoding="utf-8")
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    from aragora.evaluation.decision_quality_corpus import canonical_sha256
-
-    manifest["roster"]["sha256"] = canonical_sha256(roster)
-    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    _write_roster(manifest_path, roster)
 
     bundle, report = load_benchmark_bundle(manifest_path)
 
     assert bundle is None
     assert "duplicate_family" in _issue_codes(report)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "issue_code"),
+    [
+        ("requested_model", "other/model", "model_contract_mismatch"),
+        ("allowed_resolved_models", ["other/model"], "model_contract_mismatch"),
+        ("transport", "paid-api-fallback", "transport_contract_mismatch"),
+        ("billing_class", "paid_api", "billing_contract_mismatch"),
+    ],
+)
+def test_contract_rejects_member_identity_drift(
+    tmp_path: Path, field: str, value: object, issue_code: str
+) -> None:
+    manifest_path = _copy_contract(tmp_path)
+    roster_path = manifest_path.parent / "roster.json"
+    roster = json.loads(roster_path.read_text(encoding="utf-8"))
+    roster["conditions"]["single_openai"]["members"][0][field] = value
+    _write_roster(manifest_path, roster)
+
+    bundle, report = load_benchmark_bundle(manifest_path)
+
+    assert bundle is None
+    assert issue_code in _issue_codes(report)
+
+
+@pytest.mark.parametrize(
+    ("condition", "field", "value", "issue_code"),
+    [
+        ("single_claude", "mode", "team", "mode_contract_mismatch"),
+        ("single_openai", "max_paid_cost_usd", True, "paid_cost_contract_mismatch"),
+        ("aragora_team", "adversarial_rounds", True, "round_contract"),
+        (
+            "aragora_team",
+            "synthesizer_family",
+            "openai",
+            "synthesizer_contract_mismatch",
+        ),
+    ],
+)
+def test_contract_rejects_condition_semantic_drift(
+    tmp_path: Path,
+    condition: str,
+    field: str,
+    value: object,
+    issue_code: str,
+) -> None:
+    manifest_path = _copy_contract(tmp_path)
+    roster_path = manifest_path.parent / "roster.json"
+    roster = json.loads(roster_path.read_text(encoding="utf-8"))
+    roster["conditions"][condition][field] = value
+    _write_roster(manifest_path, roster)
+
+    bundle, report = load_benchmark_bundle(manifest_path)
+
+    assert bundle is None
+    assert issue_code in _issue_codes(report)

--- a/tests/evaluation/test_decision_quality_corpus.py
+++ b/tests/evaluation/test_decision_quality_corpus.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.evaluation.decision_quality_corpus import (
+    canonical_sha256,
+    is_public_https_url,
+    validate_corpus_documents,
+    validate_corpus_files,
+)
+from aragora.evaluation.decision_quality_contract import load_benchmark_bundle
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "docs/benchmarks/decision_quality/benchmark-manifest.json"
+
+
+def _case() -> dict[str, object]:
+    return {
+        "case_id": "case-1",
+        "domain": "software_engineering",
+        "split": "development",
+        "title": "A resolved decision",
+        "decision_prompt": "Choose one action.",
+        "forecast_question": "What is the probability of option a?",
+        "forecast_option_id": "a",
+        "options": [
+            {"option_id": "a", "label": "A", "description": "Action A"},
+            {"option_id": "b", "label": "B", "description": "Action B"},
+        ],
+        "information_cutoff": "2025-01-01T00:00:00Z",
+        "sources": [
+            {
+                "source_id": "evidence-1",
+                "title": "Evidence",
+                "url": "https://example.com/evidence",
+                "published_at": "2024-12-31T00:00:00Z",
+                "content_sha256": "1" * 64,
+            }
+        ],
+    }
+
+
+def _documents() -> tuple[dict[str, object], dict[str, object]]:
+    corpus: dict[str, object] = {
+        "schema_version": "decision-quality-corpus/1.0",
+        "benchmark_id": "benchmark-v1",
+        "revision": "v1",
+        "frozen_at": "2025-03-01T00:00:00Z",
+        "cases": [_case()],
+    }
+    outcomes: dict[str, object] = {
+        "schema_version": "decision-quality-outcomes/1.0",
+        "benchmark_id": "benchmark-v1",
+        "corpus_sha256": canonical_sha256(corpus),
+        "outcomes": [
+            {
+                "case_id": "case-1",
+                "resolved_at": "2025-02-01T00:00:00Z",
+                "correct_option_id": "a",
+                "resolution_summary": "A occurred.",
+                "authoritative_sources": [
+                    {
+                        "source_id": "outcome-1",
+                        "title": "Outcome",
+                        "url": "https://example.com/outcome",
+                        "published_at": "2025-02-01T00:00:00Z",
+                        "content_sha256": "2" * 64,
+                    }
+                ],
+                "cruxes": [
+                    {"crux_id": "c1", "description": "First crux", "aliases": []},
+                    {"crux_id": "c2", "description": "Second crux", "aliases": []},
+                    {"crux_id": "c3", "description": "Third crux", "aliases": []},
+                ],
+            }
+        ],
+    }
+    return corpus, outcomes
+
+
+def _codes(report: object) -> set[str]:
+    return {issue.code for issue in report.issues}  # type: ignore[attr-defined]
+
+
+def test_live_manifest_freezes_complete_balanced_corpus() -> None:
+    bundle, report = load_benchmark_bundle(MANIFEST)
+
+    assert report.ok
+    assert bundle is not None
+    assert report.case_count == 24
+    assert (
+        report.corpus_sha256 == "3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b"
+    )
+    assert (
+        report.outcomes_sha256 == "98702fe5d220d171e77fd0276d5803ec851e46c6900445dd73ccb4cbfdbf194d"
+    )
+
+
+def test_outcome_leakage_after_cutoff_is_rejected() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["sources"][0]["published_at"] = "2025-01-02T00:00:00Z"  # type: ignore[index]
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "outcome_leakage" in _codes(report)
+
+
+def test_options_must_have_stable_lexicographic_order() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["options"].reverse()  # type: ignore[index, union-attr]
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "unsorted_options" in _codes(report)
+
+
+def test_outcome_source_must_not_predate_resolution() -> None:
+    corpus, outcomes = _documents()
+    outcomes["outcomes"][0]["authoritative_sources"][0]["published_at"] = (  # type: ignore[index]
+        "2025-01-31T00:00:00Z"
+    )
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "premature_outcome_source" in _codes(report)
+
+
+def test_freeze_must_follow_every_resolution() -> None:
+    corpus, outcomes = _documents()
+    corpus["frozen_at"] = "2025-01-15T00:00:00Z"
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "premature_freeze" in _codes(report)
+
+
+def test_full_corpus_rejects_unbalanced_answer_targets() -> None:
+    bundle, manifest_report = load_benchmark_bundle(MANIFEST)
+    assert manifest_report.ok and bundle is not None
+    corpus = copy.deepcopy(bundle.corpus)
+    outcomes = copy.deepcopy(bundle.outcomes)
+    cases = {case["case_id"]: case for case in corpus["cases"]}
+    changed = False
+    for outcome in outcomes["outcomes"]:
+        case = cases[outcome["case_id"]]
+        if outcome["correct_option_id"] != case["forecast_option_id"]:
+            outcome["correct_option_id"] = case["forecast_option_id"]
+            changed = True
+            break
+    assert changed
+
+    report = validate_corpus_documents(corpus, outcomes)
+
+    assert "wrong_target_balance" in _codes(report)
+
+
+def test_answer_key_is_rejected_from_model_visible_case() -> None:
+    corpus, outcomes = _documents()
+    corpus["cases"][0]["correct_option_id"] = "a"  # type: ignore[index]
+    outcomes["corpus_sha256"] = canonical_sha256(corpus)
+
+    report = validate_corpus_documents(corpus, outcomes, allow_partial=True)
+
+    assert "unknown_field" in _codes(report)
+
+
+def test_canonical_hash_ignores_object_key_order_and_rejects_nan() -> None:
+    corpus, _ = _documents()
+    reordered = {key: corpus[key] for key in reversed(corpus)}
+    assert canonical_sha256(corpus) == canonical_sha256(reordered)
+    with pytest.raises(ValueError):
+        canonical_sha256({"value": float("nan")})
+
+
+def test_mutating_answer_key_fails_frozen_outcomes_hash() -> None:
+    corpus, outcomes = _documents()
+    frozen = canonical_sha256(outcomes)
+    mutated = copy.deepcopy(outcomes)
+    mutated["outcomes"][0]["correct_option_id"] = "b"  # type: ignore[index]
+
+    report = validate_corpus_documents(
+        corpus,
+        mutated,
+        allow_partial=True,
+        expected_outcomes_sha256=frozen,
+    )
+
+    assert "outcomes_hash_mismatch" in _codes(report)
+
+
+def test_file_loader_returns_structured_invalid_utf8(tmp_path: Path) -> None:
+    corpus_path = tmp_path / "corpus.json"
+    outcomes_path = tmp_path / "outcomes.json"
+    corpus_path.write_bytes(b"\xff\xfe")
+    outcomes_path.write_text("{}", encoding="utf-8")
+
+    report = validate_corpus_files(corpus_path, outcomes_path, allow_partial=True)
+
+    assert not report.ok
+    assert "invalid_utf8" in _codes(report)
+
+
+def test_file_loader_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    corpus, outcomes = _documents()
+    corpus_path = tmp_path / "corpus.json"
+    outcomes_path = tmp_path / "outcomes.json"
+    corpus_path.write_text(
+        json.dumps(corpus).replace('"revision": "v1"', '"revision": "v1", "revision": "v2"')
+    )
+    outcomes_path.write_text(json.dumps(outcomes))
+
+    report = validate_corpus_files(corpus_path, outcomes_path, allow_partial=True)
+
+    assert "duplicate_json_key" in _codes(report)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/a",
+        "https://localhost/a",
+        "https://service.internal/a",
+        "https://127.0.0.1/a",
+        "https://[::1]/a",
+        "https://bad host/a",
+        "https://example.com:bad/a",
+    ],
+)
+def test_public_source_url_validation_fails_closed(url: str) -> None:
+    assert not is_public_https_url(url)
+
+
+def test_public_source_url_accepts_normal_https() -> None:
+    assert is_public_https_url("https://example.com/evidence")

--- a/tests/scripts/test_outcome_decision_quality_benchmark.py
+++ b/tests/scripts/test_outcome_decision_quality_benchmark.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/outcome_decision_quality_benchmark.py"
+
+
+def test_validate_corpus_cli_reports_frozen_contract() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "validate-corpus"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(completed.stdout)
+
+    assert completed.returncode == 0
+    assert payload["ok"] is True
+    assert payload["operation"] == "validate-corpus"
+    assert payload["case_count"] == 24
+    assert (
+        payload["corpus_sha256"]
+        == "3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b"
+    )
+
+
+def test_cli_exposes_only_contract_validation() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "run"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    assert "invalid choice" in completed.stderr


### PR DESCRIPTION
## Summary
- add fail-closed validation and assembly for the frozen 24-case outcome-backed decision-quality corpus
- bind tranche, aggregate, prompt, and roster hashes in a contract-only manifest
- expose only `validate-corpus`; intentionally exclude execution, scoring, result ledgers, and holdout logic

This is the convergence-sized contract/validation extraction from parked PR #9886. It does not copy either second-round scoring defect locus.

## Validation
- `python3 -m pytest tests/evaluation/test_decision_quality_corpus.py tests/evaluation/test_decision_quality_contract.py tests/scripts/test_outcome_decision_quality_benchmark.py -q`
- `python3 scripts/outcome_decision_quality_benchmark.py validate-corpus`
- `python3 -m ruff check ...` on touched Python files
- `uv run --locked --extra dev bash scripts/test_tiers.sh typecheck`
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

## Frozen proof
- corpus: `3a46198fe33e4cc984cf777c6db7f046e4adb7db10840e775f83e9a46e87172b`
- outcomes: `98702fe5d220d171e77fd0276d5803ec851e46c6900445dd73ccb4cbfdbf194d`
- manifest: `d593152d89d948afec22ac53574076dbe9d6e2441958dec0dd666beaf4c80ead`

## Follow-up boundary
A separate current-main PR must implement `run`, `score`, and `render` with fail-closed binding of every result to the frozen case packet, split, repetition, manifest, and implementation SHA. No model inference is performed by this PR.