### PR TITLE
fix(essay,gti): harden numeric coercion against huge-int OverflowError

### DIFF
--- a/aragora/essay/rubric.py
+++ b/aragora/essay/rubric.py
@@ -86,7 +86,7 @@ def _normalize_score(value: Any) -> float:
     """Coerce a model-provided score field into a safe float."""
     try:
         score = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0.0
     return score if math.isfinite(score) else 0.0
 

--- a/aragora/gti/receipt.py
+++ b/aragora/gti/receipt.py
@@ -48,10 +48,12 @@ def validate_belief_provenance(beliefs: list[BeliefProvenance], now_iso: str) ->
             continue
 
         ttl = b.freshness_ttl_seconds
+        # isfinite only sees floats: ints are always finite, and math.isfinite
+        # raises OverflowError on ints too large to convert to float.
         if (
             isinstance(ttl, bool)
             or not isinstance(ttl, (int, float))
-            or not math.isfinite(ttl)
+            or (isinstance(ttl, float) and not math.isfinite(ttl))
             or ttl <= 0
         ):
             problems.append(f"{b.belief_id}: invalid freshness_ttl_seconds")

--- a/tests/essay/test_rubric.py
+++ b/tests/essay/test_rubric.py
@@ -13,6 +13,7 @@ import yaml
 from aragora.essay.rubric import (
     EssayScore,
     _DEFAULT_WEIGHTS,
+    _normalize_score,
     load_rubric,
     parse_score_response,
 )
@@ -221,3 +222,25 @@ def test_parse_score_response_returns_empty_on_garbage():
     score = parse_score_response("This is not JSON at all!")
     assert score.overall == 0.0
     assert score.thesis_clarity == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 10. Huge model-emitted integers must not raise OverflowError
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_score_huge_int_returns_zero():
+    """An arbitrary-precision int coerces to 0.0 instead of raising OverflowError."""
+    assert _normalize_score(10**400) == 0.0
+
+
+def test_normalize_score_huge_negative_int_returns_zero():
+    assert _normalize_score(-(10**400)) == 0.0
+
+
+def test_parse_score_response_handles_huge_int_score():
+    """A huge int in model JSON survives the full parse path as 0.0."""
+    text = json.dumps({"thesis_clarity": 10**400, "originality": 0.3})
+    score = parse_score_response(text)
+    assert score.thesis_clarity == 0.0
+    assert score.originality == 0.3

--- a/tests/gti/test_gti_receipt.py
+++ b/tests/gti/test_gti_receipt.py
@@ -89,3 +89,13 @@ def test_past_ttl_but_revalidated_is_valid():
         NOW,
     )
     assert problems == []
+
+
+def test_huge_int_ttl_is_valid_not_overflow_error():
+    problems = validate_belief_provenance([_belief(freshness_ttl_seconds=10**400)], NOW)
+    assert problems == []
+
+
+def test_huge_negative_int_ttl_is_invalid_problem_not_exception():
+    problems = validate_belief_provenance([_belief(freshness_ttl_seconds=-(10**400))], NOW)
+    assert problems == ["b1: invalid freshness_ttl_seconds"]


### PR DESCRIPTION
## Summary

Two tiny model-output/latent numeric hardening items from PR #9845's isfinite census (both census-documented in the #9845 settlement packet; provenance is model output / latent internal values, NOT request JSON, so they were out of #9845's scope):

1. **`aragora/essay/rubric.py::_normalize_score`** caught only `(TypeError, ValueError)` around `float(value)` of model-emitted values. A huge model-emitted int (e.g. `10**400`) raised an uncaught `OverflowError`. Fix: add `OverflowError` to the except tuple, coercing to `0.0` like every other unusable value (matches the function's existing shape).
2. **`aragora/gti/receipt.py::validate_belief_provenance`** applied `math.isfinite` to the TTL after an `isinstance(ttl, (int, float))` check, but `math.isfinite` itself raises `OverflowError` on ints too large to convert to float. Fix: scope the isfinite call to floats (ints are always finite), keeping bool rejection and non-positive rejection intact. Latent today (zero external callers), safe if it gains callers.

## Semantics

Identical for all finite/normal inputs; only the overflow path changes from crash to handled:

- rubric: huge int score → `0.0` (was: `OverflowError`)
- receipt: huge positive int TTL → valid (finite by construction; was: `OverflowError`), huge negative int TTL → `invalid freshness_ttl_seconds` problem string (was: `OverflowError`)

## Testing (red-first)

- 5 new tests written first and captured failing with `OverflowError: int too large to convert to float` (3 at `rubric.py:88`, 2 at `receipt.py:54`)
- After the fix: `tests/essay/` + `tests/gti/` → 71 passed; 5-seed randomization sweep on both touched files → 27 passed per seed
- `make lint`, `ruff format --check`, `preflight_mypy.sh --diff-base origin/main` (4 files, no issues), hook-variant mypy, AWS-neutralized `make test-smoke` all green

Diff: 4 files, +37/-2 (source delta +4/-2). Expected tier 0-1, standard settle-now flow.
