### PR TITLE
test(agents): isolate integration SQLite state

### DIFF
--- a/tests/agents/test_integration_e2e.py
+++ b/tests/agents/test_integration_e2e.py
@@ -12,7 +12,6 @@ Tests complete flows across multiple subsystems:
 
 import asyncio
 import json
-import tempfile
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -83,11 +82,26 @@ class MockAgent(Agent):
         )
 
 
+@pytest.fixture(autouse=True)
+def isolated_aragora_data_dir(monkeypatch, tmp_path):
+    """Keep auto-created subsystem databases local to each test."""
+    data_dir = tmp_path / "aragora-data"
+    data_dir.mkdir()
+    monkeypatch.setenv("ARAGORA_DATA_DIR", str(data_dir))
+    return data_dir
+
+
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database for testing."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield Path(tmpdir) / "test.db"
+    return tmp_path / "test.db"
+
+
+def test_default_database_paths_are_test_local(isolated_aragora_data_dir):
+    """Auto-created subsystem databases must not leak across test workers."""
+    from aragora.persistence.db_config import DatabaseType, get_db_path
+
+    assert get_db_path(DatabaseType.CALIBRATION).parent == isolated_aragora_data_dir
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- isolate auto-created Aragora subsystem databases under each integration test's `tmp_path`
- keep explicit fixture databases test-local without manual temporary-directory management
- add focused proof that the default calibration database resolves inside the per-test directory

## Why

PR #9706 exposed a real non-required agents-shard failure at exact head `d550ed86fb7edec3e3699cc23fcfdf3508f75817`:

`tests/agents/test_integration_e2e.py::TestGroundedPersonasIntegration::test_position_ledger_integration` failed while `Arena` auto-created `CalibrationTracker` against the shared default SQLite database. Under xdist, `PRAGMA journal_mode=WAL` raced with another worker and raised `sqlite3.OperationalError: database is locked`.

No open PR touched this test or the implicated ledger/calibration files when the repair was claimed. This is a net-negative quality repair under #9039 and should land before #9706 is refreshed; it does not change #9706 itself.

## Validation

- `python3 -m pytest -n 4 tests/agents/test_integration_e2e.py -q` -> 23 passed
- 8 simultaneous runs of the failing test node -> 8 passed
- `python3 -m ruff check tests/agents/test_integration_e2e.py` -> passed
- `python3 -m ruff format --check tests/agents/test_integration_e2e.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- `git diff --check origin/main...HEAD` -> passed
- pre-commit and pre-push hooks -> passed

Targeted mypy on this legacy test file still reports eight pre-existing `MockAgent` annotation/override errors outside this diff; no new mypy finding points to the isolation fixture.

## Scope

One test file only. No production source, workflow, required context, #9706 branch, evidence, settlement, merge, or branch-protection mutation.

Related: #9039, #9706
