### PR TITLE
fix(server): reject Cf/Cs chars and hoist length cap in quotas resource sanitizer

### DIFF
--- a/aragora/server/handlers/usage_metering.py
+++ b/aragora/server/handlers/usage_metering.py
@@ -740,15 +740,23 @@ class UsageMeteringHandler(SecureHandler):
         if not isinstance(resource, str) or not resource.strip():
             return error_response("Field 'resource' is required", 400)
         resource = resource.strip()
+        # O(1) length cap before the per-character category scan below, so an
+        # oversized value never pays for a full scan.
+        if len(resource) > 256:
+            return error_response("Field 'resource' exceeds maximum length of 256", 400)
         # The value feeds the audit log line below; control characters and
         # unicode line separators would allow forged log entries. Category Cc
         # covers C0, DEL, and C1 (e.g. U+009B bare CSI, a terminal-escape
-        # vector when logs are viewed in terminals); LS/PS are separators
-        # outside Cc.
-        if any(unicodedata.category(ch) == "Cc" or ch in "\u2028\u2029" for ch in resource):
+        # vector when logs are viewed in terminals); Cf covers format chars
+        # (e.g. U+202E RLO, zero-width joiners) that visually spoof the line;
+        # Cs covers lone surrogates (reachable via JSON \ud800 escapes) that
+        # a utf-8 log handler cannot encode, silently dropping the audit
+        # line; LS/PS are separators outside those categories.
+        if any(
+            unicodedata.category(ch) in ("Cc", "Cf", "Cs") or ch in "\u2028\u2029"
+            for ch in resource
+        ):
             return error_response("Field 'resource' contains invalid characters", 400)
-        if len(resource) > 256:
-            return error_response("Field 'resource' exceeds maximum length of 256", 400)
 
         requested_limit = body.get("requested_limit")
         # isfinite only applies to floats: converting an arbitrary-precision

--- a/tests/server/handlers/test_usage_metering.py
+++ b/tests/server/handlers/test_usage_metering.py
@@ -10,6 +10,7 @@ Tests coverage for:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -412,6 +413,17 @@ class TestQuotaIncreaseRequest:
             "a\x80b",
             "a\x9bb",
             "a\x9fb",
+            # Cf format chars: bidi overrides and zero-width joiners are not
+            # control chars but reorder or hide text, visually spoofing the
+            # audit line.
+            "a\u202eb",
+            "a\u200db",
+            "a\ufeffb",
+            # Cs lone surrogates arrive over the wire as pure-ASCII JSON
+            # \ud800 escapes (json.dumps ensure_ascii re-emits them here); a
+            # utf-8 log handler cannot encode the decoded value.
+            "a\ud800b",
+            "a\udfffb",
         ],
     )
     @pytest.mark.asyncio
@@ -461,6 +473,68 @@ class TestQuotaIncreaseRequest:
         assert result.status_code == 400
         body = parse_handler_response(result)
         assert "resource" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_overlong_resource_rejects_on_length_before_scan(
+        self, metering_handler, mock_http_handler
+    ):
+        """An oversized resource of scan-rejected chars fails on the LENGTH
+        message: the O(1) cap runs before the per-char category scan."""
+        mock_http = mock_http_handler(method="POST", body={"resource": "\x9b" * 300})
+        with patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter:
+            mock_limiter.is_allowed.return_value = True
+            result = await metering_handler.handle(
+                self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+            )
+        assert result.status_code == 400
+        body = parse_handler_response(result)
+        assert "maximum length" in body.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_post_request_increase_surrogate_escape_never_reaches_log_handler(
+        self, metering_handler, tmp_path
+    ):
+        """A wire-level JSON \\ud800 escape (pure-ASCII bytes) is rejected
+        before the audit log call: a utf-8 log handler cannot encode the
+        decoded lone surrogate and would silently drop the audit line."""
+        raw = b'{"resource": "a\\ud800b", "requested_limit": 5}'
+        mock_http = MagicMock()
+        mock_http.command = "POST"
+        mock_http.client_address = ("127.0.0.1", 12345)
+        mock_http.body = None
+        mock_http.request = None
+        mock_http.headers = {"Content-Length": str(len(raw))}
+        mock_http.rfile.read.return_value = raw
+
+        log_file = tmp_path / "audit.log"
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(logging.INFO)
+        module_logger = logging.getLogger("aragora.server.handlers.usage_metering")
+        previous_level = module_logger.level
+        module_logger.addHandler(file_handler)
+        module_logger.setLevel(logging.INFO)
+        try:
+            # emit() swallows UnicodeEncodeError into handleError; spying on
+            # it makes the silent-drop failure mode observable.
+            with (
+                patch.object(file_handler, "handleError") as mock_handle_error,
+                patch("aragora.server.handlers.usage_metering._usage_limiter") as mock_limiter,
+            ):
+                mock_limiter.is_allowed.return_value = True
+                result = await metering_handler.handle(
+                    self.REQUEST_INCREASE_PATH, {}, mock_http, "POST"
+                )
+        finally:
+            module_logger.removeHandler(file_handler)
+            module_logger.setLevel(previous_level)
+            file_handler.close()
+
+        assert result.status_code == 400
+        body = parse_handler_response(result)
+        assert "resource" in body.get("error", "").lower()
+        mock_handle_error.assert_not_called()
+        logged = log_file.read_text(encoding="utf-8")
+        assert "Quota increase request" not in logged
 
     @pytest.mark.asyncio
     async def test_post_request_increase_rejects_overlong_reason(


### PR DESCRIPTION
## Summary

Follow-up to #9845's quotas request-increase `resource` sanitizer, implementing its claude P3 advisories (per-P3 dispositions recorded in the #9845 settlement packet, 2026-08-28). Two bounded changes in `_request_quota_increase` (`aragora/server/handlers/usage_metering.py`):

1. **Extend character rejection from Cc+LS/PS to Cf and Cs.** Cf format chars (e.g. U+202E RLO, U+200D ZWJ, U+FEFF) reorder or hide text and can visually spoof the audit log line. Cs lone surrogates are reachable over the wire as pure-ASCII JSON `\ud800` escapes; a utf-8 `logging.FileHandler` cannot encode the decoded value, so the audit line would be silently dropped via `Handler.handleError`.
2. **Hoist the O(1) 256-char length cap above the per-char category scan** so oversized values reject cheaply before any scan work (observable via the length error message).

Zero change for currently-accepted values (mechanically proven, see below).

## Red-first proof

All 7 new cases captured failing on the unmodified sanitizer before the fix:

- 5 new `bad_resource` param cases (`a\u202eb`, `a\u200db`, `a\ufeffb`, `a\ud800b`, `a\udfffb`): each `assert 200 == 400` (previously accepted).
- Length-before-scan ordering case (300 x U+009B): got `"Field 'resource' contains invalid characters"` instead of the length message (scan ran first).
- End-to-end wire-level `\ud800`-escape request (raw ASCII bytes through the body-read path, utf-8 FileHandler attached with `handleError` spied): returned 200 (re-proven red after a spy refactor via stash of the production change: `assert 200 == 400`).

## Validation

| Gate | Command | Result |
|---|---|---|
| Targeted tests | `python3 -m pytest tests/server/handlers/test_usage_metering.py -q` | 46/46 passed |
| Seed sweep | same, `-p randomly --randomly-seed={1,42,100,2024,12345}` | 46/46 on all 5 seeds |
| Lint | `make lint` | pass |
| Format | `ruff format --check` (both files) | pass |
| Quality ratchet | `python3 scripts/report_code_quality.py --check` | PASS (no new markers) |
| Mypy (preflight) | `bash scripts/preflight_mypy.sh --diff-base origin/main` | no issues in 2 source files |
| Mypy (hook flags) | `mypy --ignore-missing-imports --follow-imports=skip` on changed files | no issues |
| Smoke | `make test-smoke` (AWS-neutralized) | pass |
| Smoke tier | `bash scripts/test_tiers.sh smoke` | 138 passed |
| Merge contract | `bash scripts/automation_pr_preflight.sh origin/main HEAD` | ok |

## Zero-regression differential proof

Exhaustive diff of the old vs. new rejection predicate over all 0x110000 codepoints (unidata 14.0.0):

- Newly-rejected set == **exactly** Cf ∪ Cs: 2211 codepoints (163 Cf + 2048 Cs).
- Previously-rejected values now accepted: **0**.

## Scope

- +87/−5 lines across 2 files (production: +13/−5).
- Path-freeze census at placement and at push: 74 open PRs, zero overlap on both touched files, no open PR ≥100 files.

NOTE: `usage_metering.py` computed tier 3 on #9839 and #9845; this PR expects the tier-3 park terminal (prepare-only, unposted evidence, settlement packet + operator-review-required label).
