### PR TITLE
fix(metrics): align require_permission reproduction command with generator file set

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,11 +12,11 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4312` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1995659` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4310` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1994907` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5553` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `226069` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5551` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `226025` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `1032` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2912` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1114` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1108` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `97` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,23 +12,23 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4310` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1994907` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4312` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1995659` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5551` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `226025` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5553` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `226069` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `1032` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2912` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3205` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
-| @require_permission decorator calls | `1364` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
+| @require_permission decorator calls | `1364` | `aragora/` | `git grep -E '@require_permission\(' -- 'aragora/*.py' \| wc -l` |
 | Unique permission strings | `423` | `aragora/` | `git grep -h -o -E "@require_permission\(['\"][^'\"]+['\"]\)" -- aragora \| sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/" \| sort -u \| wc -l` |
 | Python SDK modules | `198` | `sdk/python/` | `git ls-files sdk/python/aragora_sdk \| grep -E '\.py$' \| grep -v '/__' \| awk -F/ 'NF<=5' \| wc -l` |
 | TypeScript SDK modules | `216` | `sdk/typescript/` | `git ls-files sdk/typescript/src \| grep -E '\.ts$' \| awk -F/ 'NF<=5' \| wc -l` |
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1108` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1114` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `97` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/security/PENTEST_RFP.md
+++ b/docs/security/PENTEST_RFP.md
@@ -17,7 +17,7 @@ Aragora is a multi-agent debate framework that orchestrates 46 agent types to de
 
 **Platform Scale:**
 - 3,205 API operations across 2,912 paths
-- 225,919 automated tests
+- 226,025 automated tests
 - Multi-tenant SaaS architecture
 - WebSocket real-time communication
 - Integration with major AI providers

--- a/scripts/regenerate_metrics.py
+++ b/scripts/regenerate_metrics.py
@@ -287,7 +287,10 @@ def gather_metrics() -> MetricsSnapshot:
             key="rbac_permission_calls",
             label="@require_permission decorator calls",
             value=permission_calls,
-            command="git grep -E '@require_permission\\(' -- aragora | wc -l",
+            # The pathspec must stay restricted to .py files: the generator
+            # counts decorator calls, and non-.py hits (README/YAML prose
+            # mentions) would inflate a reproduction over all tracked files.
+            command="git grep -E '@require_permission\\(' -- 'aragora/*.py' | wc -l",
             source="aragora/",
         )
     )

--- a/tests/scripts/test_regenerate_metrics.py
+++ b/tests/scripts/test_regenerate_metrics.py
@@ -102,6 +102,31 @@ def test_metric_above_lower_bound(snapshot, metric_key, min_value):
     )
 
 
+def test_rbac_permission_calls_command_reproduces_value(snapshot):
+    """The printed reproduction command must count the generator's file set.
+
+    Every METRICS.md row promises a cold auditor can reproduce the value by
+    running the row's command. For rbac_permission_calls the generator counts
+    tracked ``.py`` files only (decorator calls cannot exist elsewhere; README
+    and YAML mentions are not calls), so the printed command must apply the
+    same restriction or the auditor gets a different number.
+    """
+    metric = snapshot["rbac_permission_calls"]
+    result = subprocess.run(
+        ["bash", "-c", metric.command],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    reproduced = int(result.stdout.strip())
+    assert reproduced == metric.value, (
+        f"printed command reproduces {reproduced} but the generator computed "
+        f"{metric.value}; the command's file set must match "
+        f"_count_line_matches' file set"
+    )
+
+
 def test_markdown_has_no_timestamp_or_sha(snapshot):
     """Canonical doc must not embed generation timestamp or git SHA.
 


### PR DESCRIPTION
## What

Two bounded docs-tooling alignments (mission feature `misc-metrics-doc-tooling-alignment`, milestone `cdg-bootstrap-route-truth`):

1. **require_permission row vs its printed command** (`scripts/regenerate_metrics.py`): the generator counts `@require_permission(` over tracked `.py` files only, but the row's printed reproduction command grepped ALL tracked files under `aragora/`. A cold auditor running the printed command got **1368** while the doc says **1364** (the 4 extra hits are prose mentions in `aragora/capabilities.yaml`, `aragora/rbac/README.md`, `aragora/server/handlers/README.md`, `aragora/tenancy/README.md` — not decorator calls). Fix: restrict the printed command to `'aragora/*.py'` (the .py-only count is the honest metric; the command follows the generator). The committed `docs/METRICS.md` change is exactly the one command cell, byte-identical to what the fixed generator emits (verified via a scratch bare regen); value cells are untouched. Regression test added that executes the printed command and compares it to the computed value.
2. **Check-3 claim-site refresh** (`docs/security/PENTEST_RFP.md:20`): `225,919` → `226,025` automated tests, matching the Check-3 canonical in `docs/CANONICAL_GOALS.md`. `python3 scripts/check_docs_consistency.py` → all PASS (Checks 1-4).

## Red → Green

- RED: printed command reproduced `1368` vs generator value `1364`; new test `test_rbac_permission_calls_command_reproduces_value` FAILED on the old command.
- GREEN: printed command reproduces `1364`; `tests/scripts/test_regenerate_metrics.py` 32/32 (stable across 5 random seeds); `check_docs_consistency.py` Checks 1-4 PASS; `doc_stats.py --write` reports `Updated 0 documentation files` and the `sync-docs.js` replay leaves the tree git-quiet (docs-build sync gate green by construction).

## History note (2 commits, squash collapses them)

The first commit refreshed all drifted METRICS.md value rows via the bare generator; the docs-build sync gate (`doc_stats.py --write`) then correctly showed those values rippling into ten stat-block files (CANONICAL_GOALS/EXTENDED_README/STATUS/ARCHITECTURE/FEATURE_DISCOVERY + docs-site mirrors) that are census-frozen by foreign open PRs and OUTSIDE the standing generated-file overlap tolerance (which names only `module_tiers.yaml`, `METRICS.md`, and METRICS docs-site mirrors). The second commit reverts the value cells to the base's committed numbers (all rows within the 0.5% tolerance) keeping only the corrected command cell.

## Known ambient state (pre-existing, NOT cured here)

Strict `python3 scripts/regenerate_metrics.py --check` is rc=1 on current main: `DRIFT: Markdown files under docs/ 1108 -> 1114 (0.54%)` — ambient docs growth that post-dates this feature's authoring. Curing it requires a value refresh whose doc_stats ripple is census-blocked (above), so it is left to the sanctioned regen lane / weekly refresh with census coordination. The PR-lane Metrics Drift check uses base attribution and is unaffected.

## Gates run

`make lint` + `ruff check scripts/regenerate_metrics.py` + `ruff format --check` clean; `preflight_mypy --diff-base origin/main` clean; `tests/scripts/test_doc_stats.py` + `test_check_docs_consistency.py` 20/20; AWS-neutralized `make test-smoke` pass; `automation_pr_preflight.sh` ok.

## Disclosures

- **Dropped optional rider**: the feature's optional `make regen-count-docs` target is dropped — `Makefile` is path-frozen by open PR #8939 (`4028b9e3`); the feature text explicitly permits dropping the rider.
- **Tolerated generated-file overlap** (standing 2026-08-19 policy on named generated LWW files): `docs/METRICS.md` also appears with stale regen hunks in open PRs #9882@781c8c36, #9880@fb7faed0, #9874@e512a61d, #9846@786aa181, #9682@32585913, #9677@13fc8850, #9074@4cab2792, #9057@bc314c79, #9028@f4835c2f, #8939@4028b9e3, #8823@99203f0b. All left untouched; last-writer-wins.
- Latent same-class quirk NOT fixed (out of scope): the `rbac_unique_permissions` row's printed command also greps all tracked files; it currently agrees with the generator (423 == 423) because the prose mentions carry no unique strings.

Tier 2 (scripts/); standard settle-now flow.
