### PR TITLE
fix(cli): make doctor keyless-demo aware (#9189)

### DIFF
--- a/aragora/cli/doctor.py
+++ b/aragora/cli/doctor.py
@@ -264,10 +264,21 @@ def check_api_keys(validate_live: bool = False) -> list[HealthCheck]:
                 )
             )
         else:
-            detail = "NO API KEY SET"
             if report.discovery_errors:
-                detail += f" ({'; '.join(report.discovery_errors)})"
-            checks.append(("LLM Provider", detail, False))
+                detail = f"credential discovery failed ({'; '.join(report.discovery_errors)})"
+                checks.append(("LLM Provider", detail, False))
+            elif validate_live:
+                checks.append(
+                    ("LLM Provider", "NO API KEY SET; live validation unavailable", False)
+                )
+            else:
+                checks.append(
+                    (
+                        "LLM Provider",
+                        "not configured (offline/demo mode available; required for live debates)",
+                        None,
+                    )
+                )
 
     return checks
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -268,8 +268,8 @@ class TestCheckApiKeys:
         assert "NO API KEY SET" not in status
         assert "AWS Secrets Manager" in status
 
-    def test_no_env_keys_and_no_aws_posture_still_fails(self, monkeypatch):
-        """A genuinely keyless machine (no env keys, no AWS posture) must still FAIL."""
+    def test_no_env_keys_and_no_aws_posture_is_offline_ready(self, monkeypatch):
+        """A keyless machine remains ready for the advertised offline demo path."""
         _clear_provider_env(monkeypatch)
 
         def fake_posture():
@@ -285,9 +285,53 @@ class TestCheckApiKeys:
         result = check_api_keys()
         llm_provider = [item for item in result if item[0] == "LLM Provider"]
 
-        assert llm_provider
-        assert llm_provider[0][2] is False
-        assert "NO API KEY SET" in llm_provider[0][1]
+        assert llm_provider == [
+            (
+                "LLM Provider",
+                "not configured (offline/demo mode available; required for live debates)",
+                None,
+            )
+        ]
+
+    def test_no_env_keys_still_fail_live_validation(self, monkeypatch):
+        """Explicit live validation must fail when no provider can be tested."""
+        _clear_provider_env(monkeypatch)
+        monkeypatch.setattr(
+            "aragora.cli.doctor._aws_secrets_provider_posture",
+            lambda: SimpleNamespace(
+                available=False, providers=(), detail="", honored_by_runtime=False
+            ),
+        )
+
+        result = check_api_keys(validate_live=True)
+
+        assert [item for item in result if item[0] == "LLM Provider"] == [
+            ("LLM Provider", "NO API KEY SET; live validation unavailable", False)
+        ]
+
+    def test_provider_discovery_errors_remain_fail_closed(self, monkeypatch):
+        """Offline readiness must not hide malformed credential configuration."""
+        monkeypatch.setattr(
+            "aragora.cli.doctor.discover_provider_credentials",
+            lambda: SimpleNamespace(
+                providers=(),
+                any_configured=False,
+                configured_providers=(),
+                discovery_errors=("invalid .env entry",),
+            ),
+        )
+        monkeypatch.setattr(
+            "aragora.cli.doctor._aws_secrets_provider_posture",
+            lambda: SimpleNamespace(
+                available=False, providers=(), detail="", honored_by_runtime=False
+            ),
+        )
+
+        result = check_api_keys()
+
+        assert [item for item in result if item[0] == "LLM Provider"] == [
+            ("LLM Provider", "credential discovery failed (invalid .env entry)", False)
+        ]
 
     def test_aws_posture_present_but_runtime_disabled_warns_not_ok(self, monkeypatch):
         """Keys in AWS but use_aws disabled => WARN (None), not a green OK.
@@ -694,13 +738,21 @@ class TestMain:
 
         assert result == 0
 
-    def test_returns_1_when_checks_fail(self, monkeypatch):
-        """Test returns 1 when checks fail."""
-        # Remove all provider keys to cause failure
+    def test_returns_0_for_keyless_offline_readiness(self, monkeypatch):
+        """Default doctor succeeds when only live-provider capability is absent."""
         _clear_provider_env(monkeypatch)
 
         with patch("aragora.cli.doctor.check_server", new=AsyncMock(return_value=[])):
             result = main()
+
+        assert result == 0
+
+    def test_returns_1_when_live_validation_has_no_provider(self, monkeypatch):
+        """Explicit live-provider validation remains fail-closed without a key."""
+        _clear_provider_env(monkeypatch)
+
+        with patch("aragora.cli.doctor.check_server", new=AsyncMock(return_value=[])):
+            result = main(validate_keys=True)
 
         assert result == 1
 


### PR DESCRIPTION
## Summary

- treat an absent LLM provider as an optional capability in ordinary `aragora doctor`, matching the advertised zero-key demo path
- keep `aragora doctor --validate` and `aragora validate` fail-closed when no provider can be validated
- keep credential-discovery errors as hard failures rather than masking malformed configuration

Fixes the F8 unit in #9189. Contributes to #9242 and the #9039 stranger-experience campaign.

## Current-main reproduction

Clean detached checkout at `44a0214a61515d194915a89cdfb0c3c28547b0c5`, isolated `HOME`, empty provider environment, AWS/Secrets Manager disabled:

```text
aragora doctor
  before: exit 1; LLM Provider: NO API KEY SET
  after:  exit 0; LLM Provider: not configured (offline/demo mode available; required for live debates)

aragora doctor --validate
  after:  exit 1; LLM Provider: NO API KEY SET; live validation unavailable
```

The same isolated stranger run also proved:

```text
aragora quickstart --demo --no-browser       exit 0 (1.401s)
aragora receipt verify <quickstart-receipt>  exit 0 (0.450s)
aragora quickstart --demo --spec-first       exit 0 (0.463s)
aragora demo --offline --receipt ...         exit 0 (0.428s)
aragora receipt export ... --format odr      exit 0 (0.392s)
python -m aragora_verify <odr>                exit 0 (0.061s)
```

## Validation

- `pytest -q tests/cli/test_doctor.py tests/cli/test_cli_doctor.py tests/cli/test_main_argv_pollution.py` — 64 passed
- `ruff check aragora/cli/doctor.py tests/cli/test_doctor.py` — passed
- `ruff format --check aragora/cli/doctor.py tests/cli/test_doctor.py` — passed
- `mypy aragora/cli/doctor.py` — passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — passed
- `git diff --check origin/main...HEAD` — passed

## Scope

No workflow, required-check, generated-doc, evidence, settlement, merge, or branch-protection changes.
