### PR TITLE
fix(governance): pin the capsule builder git environment for byte-reproducible fixed-ref payloads [Tier 4]

### DIFF
--- a/scripts/build_contract_drift_historical_backfill.py
+++ b/scripts/build_contract_drift_historical_backfill.py
@@ -336,14 +336,21 @@ def _git_text(repo_root: Path, *args: str) -> str:
 
 
 def _git_env() -> dict[str, str]:
-    return {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": os.devnull,
-        "GIT_CONFIG_NOSYSTEM": "1",
-        "GIT_NO_REPLACE_OBJECTS": "1",
-        "GIT_OPTIONAL_LOCKS": "0",
-        "LC_ALL": "C",
-    }
+    # Ambient GIT_* variables (GIT_CONFIG_COUNT/GIT_CONFIG_PARAMETERS
+    # command-scope config, identity/date overrides, object-store redirection)
+    # bypass the two config pins below and make fixed-ref output
+    # session-dependent, so drop them all before pinning.
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    env.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "LC_ALL": "C",
+        }
+    )
+    return env
 
 
 def _git_bytes(repo_root: Path, *args: str) -> bytes:
@@ -821,6 +828,10 @@ def _load_authority_manifest(repo_root: Path, source_sha: str) -> dict[str, Any]
         ],
         cwd=repo_root,
         capture_output=True,
+        # The generator shells out to git without scrubbing, so its whole
+        # child tree must inherit the pinned git environment or the manifest
+        # digest embedded in the payload absorbs session git config.
+        env=_git_env(),
     )
     if proc.returncode != 0:
         _fail(

--- a/tests/scripts/test_build_contract_drift_historical_backfill.py
+++ b/tests/scripts/test_build_contract_drift_historical_backfill.py
@@ -67,6 +67,7 @@ def _authority_manifest() -> dict[str, Any]:
                 SOURCE_SHA,
             ],
             cwd=ROOT,
+            env=backfill._git_env(),
         )
     )
 
@@ -1125,6 +1126,45 @@ def test_builder_isolates_every_git_subprocess(
         assert env["GIT_CONFIG_NOSYSTEM"] == "1"
         assert env["GIT_NO_REPLACE_OBJECTS"] == "1"
         assert env["LC_ALL"] == "C"
+
+
+def test_builder_payload_bytes_are_environment_independent(
+    assets: dict[str, bytes],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # core.autocrlf reaches `git archive` inside the authority-manifest
+    # generator when the ambient git environment leaks into that subprocess,
+    # which is exactly the channel that made fixed-ref rebuilds session-
+    # dependent; the rebuild below must stay byte-identical anyway.
+    hostile_home = tmp_path / "hostile-home"
+    hostile_home.mkdir()
+    (hostile_home / ".gitconfig").write_text(
+        "[core]\n"
+        "\tautocrlf = true\n"
+        "\tquotepath = false\n"
+        "[diff]\n"
+        "\talgorithm = histogram\n"
+        "[log]\n"
+        "\tshowSignature = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(hostile_home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("GIT_CONFIG_GLOBAL", raising=False)
+    monkeypatch.delenv("GIT_CONFIG_NOSYSTEM", raising=False)
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.autocrlf")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "true")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Hostile Session")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "hostile@example.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Hostile Session")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "hostile@example.invalid")
+    rebuilt = backfill.build_payload(
+        repo_root=ROOT,
+        input_document=_input_document(),
+    )
+    assert backfill.build_capsule_bytes(rebuilt) == assets
 
 
 def test_builder_cli_is_supported_from_outside_the_repository(tmp_path: Path) -> None:


### PR DESCRIPTION
## Source

Mission feature `cdg-capsule-builder-payload-env-pin` (milestone `cdg-bootstrap-route-truth`, Structural Excellence). Deterministic-builder hardening follow-up to Stage 1 worker f9250674's 2026-08-21 finding: `build_payload` output was not byte-reproducible across sessions because an environment-derived channel reached the payload.

**HARD GATE verified:** PR #9750 MERGED 2026-08-26T01:53Z (head `05d0e1e1ff0d`); PR #9820 MERGED (merge `fe97dc28cd`). Builder paths unowned; fresh 74-PR overlap census clean on every touched path.

## Measured channel (differential builds first, per mandate)

- Ambient double-build at base `d52e5be14d` is byte-identical AND exactly reproduces the recorded post-#9820 capsule pins (see digest table below), so today's ambient env is benign.
- Perturbation probes isolated the live channel: `_load_authority_manifest()` launched `scripts/generate_contract_drift_inventory.py --authority-manifest` with **no `env` kwarg**, and `_git_env()` passed through all ambient `GIT_*` variables. The generator child tree (including its `git archive` authority extraction) therefore inherited ambient git configuration.
- Carrier field in the payload: `authority.authority_manifest_sha256`, the only non-test-pinned, length-preserving 64-hex field fed by that subprocess (all sibling digests are equality-pinned fail-closed).
- Pre-fix red proof: a hostile `HOME` gitconfig + `GIT_CONFIG_COUNT` (`core.autocrlf=true` etc.) made the build fail with `extracted authority member differs from exact-ref blob: .github/actions/pr-scope-classifier/action.yml`, demonstrating ambient config reaching `git archive` bytes inside the authority-manifest subprocess, i.e. cross-session non-reproducibility.

## Fix (+59/−8, two files)

- `scripts/build_contract_drift_historical_backfill.py` (+19/−8): `_git_env()` now drops every ambient `GIT_*` variable before applying the five pins (`GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `GIT_NO_REPLACE_OBJECTS=1`, `GIT_OPTIONAL_LOCKS=0`, `LC_ALL=C`); the authority-manifest generator subprocess now runs with `env=_git_env()`.
- `tests/scripts/test_build_contract_drift_historical_backfill.py` (+40/−0): red-first `test_builder_payload_bytes_are_environment_independent` rebuilds the capsule under a hostile git environment (poisoned `HOME` gitconfig, `GIT_CONFIG_COUNT` autocrlf, identity vars) and asserts payload/manifest/checksums bytes equal the module fixture assets; `_authority_manifest()` helper now uses `env=backfill._git_env()`.

Semantic digests unchanged; no analyzer-bundle member touched (`ANALYZER_BUNDLE_FILES` = checker, generator, program.json), so no `contract_drift_inventory.json` rebind is required.

## Digest table (capsule assets at base `d52e5be14d`)

| Asset | Bytes | SHA-256 |
|---|---|---|
| `payload.json` | 1122038 | `567b6c26…` |
| `manifest.json` | 457 | `5ad2630d…` |
| `checksums.txt` | 159 | `cd54b0f9…` |

Identical before and after the fix in benign environments, and identical to the recorded post-#9820 pins.

## Probe matrix (7 controlled environments)

scrub / gitparams / identity / missiondir / locale / authroot / fakehome (hostile `~/.gitconfig`): pre-fix, fakehome FAILED the build; post-fix all 7 produce byte-identical `payload.json` `567b6c26…`.

## Validation (all at head `456acdb38e`)

- Red-first: new test fails on base with the exact predicted generator error; passes post-fix.
- Focused builder + schema suites: **154 passed**.
- cdg-focused-tests-smoke matrix at exact head: **1601 passed, 1 skipped** (baseline 1596/1).
- Smoke tier: **138 passed**; `make test-smoke` green.
- `make lint`, `ruff format --check`, `ruff check` (touched script), `bash scripts/preflight_mypy.sh --diff-base origin/main`, `bash scripts/automation_pr_preflight.sh origin/main HEAD`: all clean.
- Pre-commit hooks: all passed at commit time.

## Risks

- Low: `_git_env()` scrub could drop a `GIT_*` variable some operator flow relied on; mitigated because every git subprocess in this builder already demanded hermetic behavior and the isolation test pins the five required values.
- Builder script is a Tier-4 governance surface: this draft is parked `operator-review-required`; prepare-only evidence attached to the settlement packet. No ready/posting/settlement/merge authorized from this lane.
