### PR TITLE
fix(swarm): lease and diagnose preflight publication (#7209)

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -1328,7 +1328,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 if failure_terminal_text:
                     print(f"failure_terminal_class={failure_terminal_text}")
             else:
-                print("swarm preflight: ok")
+                preflight_passed = bool(payload.get("passed", False))
+                print(f"swarm preflight: {'ok' if preflight_passed else 'blocked'}")
                 print(f"repo_root={payload['repo_root']}")
                 print(f"agent={payload['agent']}")
                 print(f"base_ref={payload['base_ref']}")
@@ -1338,6 +1339,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 if checksum:
                     print(f"worker_contract_checksum={checksum}")
         if contract_arg and payload["admission_gate"]["verdict"] != "pass":
+            raise SystemExit(2)
+        if not contract_arg and not bool(payload.get("passed", False)):
             raise SystemExit(2)
         return
 

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 import time
@@ -642,7 +643,7 @@ def _claim_branch_write_lease(
                 "work_id": work_id,
             },
         )
-    except Exception as exc:
+    except (OSError, RuntimeError, sqlite3.Error, ValueError) as exc:
         detail = sanitize_error(str(exc), max_length=4000)
         raise PreflightOperationError(
             stage="branch_write_lease_claim",
@@ -659,7 +660,7 @@ def _claim_branch_write_lease(
 def _release_branch_write_lease(claim: _BranchWriteLease) -> None:
     try:
         claim.store.release_lease(claim.lease_id)
-    except Exception as exc:
+    except (OSError, RuntimeError, sqlite3.Error, ValueError, KeyError) as exc:
         detail = sanitize_error(str(exc), max_length=4000)
         raise PreflightOperationError(
             stage="branch_write_lease_release",

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -2083,10 +2083,17 @@ def main() -> int:
     if args.json:
         _write_stdout_line(json.dumps(result.to_dict(), indent=2))
     else:
-        _write_stdout_line("preflight=ok")
+        _write_stdout_line(f"preflight={'ok' if result.passed else 'blocked'}")
         _write_stdout_line(f"agent={result.agent}")
         _write_stdout_line(f"base_ref={result.base_ref}")
         _write_stdout_line(f"branch={result.branch}")
+        if not result.passed:
+            failed_check = next(
+                (item for item in result.checks if not bool(item.get("passed", False))),
+                None,
+            )
+            if failed_check is not None:
+                _write_stdout_line(f"failed_check={failed_check.get('name', 'preflight')}")
         checksum = str(result.worker.get("worker_contract_checksum", "")).strip()
         if checksum:
             _write_stdout_line(f"worker_contract_checksum={checksum}")
@@ -2095,7 +2102,7 @@ def main() -> int:
         ]
         if commit_shas:
             _write_stdout_line(f"commit_shas={','.join(commit_shas)}")
-    return 0
+    return 0 if result.passed else 2
 
 
 if __name__ == "__main__":

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -21,6 +21,7 @@ from aragora.swarm.terminal_truth import TerminalClass, classify_preflight_failu
 from aragora.swarm.worker_contract import WorkerContract, checksum_contract_payload
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher, WorkerProcess
 from aragora.utils.async_utils import run_async
+from aragora.utils.error_sanitizer import sanitize_error
 
 _PREFLIGHT_RECEIPT_SCHEMA_VERSION = 1
 _PREFLIGHT_TTL_SECONDS = {
@@ -48,6 +49,10 @@ class PreflightResult:
     checks: list[dict[str, Any]] = field(default_factory=list)
     duration_seconds: float = 0.0
     envelope: CredentialEnvelope | None = None
+    branch_lease_id: str = ""
+    branch_lease_owner_session_id: str = ""
+    branch_lease_work_id: str = ""
+    branch_lease_released: bool = False
 
     @property
     def failure_terminal_class(self) -> TerminalClass | None:
@@ -75,6 +80,51 @@ class PreflightResult:
             "cleanup_branch_removed": self.cleanup_branch_removed,
             "dispatch_gate": dict(self.dispatch_gate),
             "worker": dict(self.worker),
+            "branch_lease_id": self.branch_lease_id,
+            "branch_lease_owner_session_id": self.branch_lease_owner_session_id,
+            "branch_lease_work_id": self.branch_lease_work_id,
+            "branch_lease_released": self.branch_lease_released,
+        }
+
+
+@dataclass(slots=True)
+class _BranchWriteLease:
+    store: Any
+    lease_id: str
+    owner_session_id: str
+    work_id: str
+
+
+class PreflightOperationError(RuntimeError):
+    """Structured failure for an expected preflight infrastructure operation."""
+
+    def __init__(
+        self,
+        *,
+        stage: str,
+        detail: str,
+        command: list[str] | None = None,
+        returncode: int | None = None,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        super().__init__(detail)
+        self.stage = stage
+        self.detail = detail
+        self.command = list(command or [])
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def to_check(self) -> dict[str, Any]:
+        return {
+            "name": self.stage,
+            "passed": False,
+            "detail": self.detail,
+            "command": list(self.command),
+            "returncode": self.returncode,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
         }
 
 
@@ -487,19 +537,134 @@ def _find_open_pr_by_branch(
     return None, ""
 
 
+def _command_stage(cmd: list[str]) -> str:
+    if cmd[:3] == ["git", "worktree", "add"]:
+        return "git_worktree_add"
+    if cmd[:3] == ["git", "push", "origin"]:
+        return "git_push"
+    if cmd[:3] == ["gh", "pr", "create"]:
+        return "gh_pr_create"
+    if cmd[:3] == ["gh", "pr", "close"]:
+        return "gh_pr_close"
+    return "_".join(cmd[:2]) if cmd else "preflight_command"
+
+
+def _operation_failure_detail(
+    *,
+    cmd: list[str],
+    returncode: int | None,
+    stdout: str,
+    stderr: str,
+) -> tuple[str, str, str]:
+    sanitized_stdout = sanitize_error((stdout or "").strip(), max_length=2000)
+    sanitized_stderr = sanitize_error((stderr or "").strip(), max_length=2000)
+    parts = [f"command={' '.join(cmd)}"]
+    if returncode is not None:
+        parts.append(f"returncode={returncode}")
+    if sanitized_stdout:
+        parts.append(f"stdout:\n{sanitized_stdout}")
+    if sanitized_stderr:
+        parts.append(f"stderr:\n{sanitized_stderr}")
+    detail = "\n".join(parts)
+    return detail, sanitized_stdout, sanitized_stderr
+
+
 def _run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
-    result = subprocess.run(
-        cmd,
-        cwd=str(cwd),
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        detail, stdout, stderr = _operation_failure_detail(
+            cmd=cmd,
+            returncode=None,
+            stdout="",
+            stderr=str(exc),
+        )
+        raise PreflightOperationError(
+            stage=_command_stage(cmd),
+            detail=detail,
+            command=cmd,
+            stdout=stdout,
+            stderr=stderr,
+        ) from exc
     if result.returncode != 0:
-        detail = (result.stderr or result.stdout or "").strip()
-        raise RuntimeError(detail or f"Command failed: {' '.join(cmd)}")
+        detail, stdout, stderr = _operation_failure_detail(
+            cmd=cmd,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+        raise PreflightOperationError(
+            stage=_command_stage(cmd),
+            detail=detail,
+            command=cmd,
+            returncode=result.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+
+def _claim_branch_write_lease(
+    *,
+    repo_root: Path,
+    branch: str,
+    worktree_path: Path,
+    agent: str,
+) -> _BranchWriteLease:
+    from aragora.nomic.dev_coordination import DevCoordinationStore
+
+    owner_session_id = str(os.environ.get("ARAGORA_SESSION_ID") or "").strip()
+    if not owner_session_id:
+        owner_session_id = f"swarm-preflight:{os.getpid()}:{branch}"
+    work_id = f"branch:{branch}"
+    try:
+        store = DevCoordinationStore(repo_root=repo_root)
+        lease = store.claim_lease(
+            task_id=work_id,
+            title=f"Remote publication preflight for {branch}",
+            owner_agent=f"swarm-preflight:{agent}",
+            owner_session_id=owner_session_id,
+            branch=branch,
+            worktree_path=str(worktree_path),
+            allowed_globs=[f".aragora/branch-locks/{branch}"],
+            claimed_paths=[],
+            expected_tests=[],
+            ttl_hours=1.0,
+            metadata={
+                "claimed_via": "swarm_preflight",
+                "work_id": work_id,
+            },
+        )
+    except Exception as exc:
+        detail = sanitize_error(str(exc), max_length=4000)
+        raise PreflightOperationError(
+            stage="branch_write_lease_claim",
+            detail=detail or f"Failed to claim branch write lease for {branch}",
+        ) from exc
+    return _BranchWriteLease(
+        store=store,
+        lease_id=lease.lease_id,
+        owner_session_id=owner_session_id,
+        work_id=work_id,
+    )
+
+
+def _release_branch_write_lease(claim: _BranchWriteLease) -> None:
+    try:
+        claim.store.release_lease(claim.lease_id)
+    except Exception as exc:
+        detail = sanitize_error(str(exc), max_length=4000)
+        raise PreflightOperationError(
+            stage="branch_write_lease_release",
+            detail=detail or f"Failed to release branch write lease {claim.lease_id}",
+        ) from exc
 
 
 def _check_git_clean(repo_root: Path) -> dict[str, Any]:
@@ -1120,6 +1285,10 @@ def _save_contract_preflight_receipt(
             for item in list((result.worker or {}).get("commit_shas") or [])
             if str(item).strip()
         ],
+        "branch_lease_id": str(result.branch_lease_id or "").strip(),
+        "branch_lease_owner_session_id": str(result.branch_lease_owner_session_id or "").strip(),
+        "branch_lease_work_id": str(result.branch_lease_work_id or "").strip(),
+        "branch_lease_released": bool(result.branch_lease_released),
     }
     receipt = _finalize_preflight_receipt(
         repo_root=resolved_repo_root,
@@ -1213,6 +1382,12 @@ def run_contract_preflight_receipt(
                     for item in list((result.worker or {}).get("commit_shas") or [])
                     if str(item).strip()
                 ],
+                "branch_lease_id": str(result.branch_lease_id or "").strip(),
+                "branch_lease_owner_session_id": str(
+                    result.branch_lease_owner_session_id or ""
+                ).strip(),
+                "branch_lease_work_id": str(result.branch_lease_work_id or "").strip(),
+                "branch_lease_released": bool(result.branch_lease_released),
             }
         )
 
@@ -1725,6 +1900,9 @@ def run_preflight(
     cleanup_worktree_removed = False
     cleanup_branch_removed = False
     dispatch_gate: dict[str, Any] = {}
+    branch_lease: _BranchWriteLease | None = None
+    branch_lease_released = False
+    operation_failure: PreflightOperationError | None = None
 
     try:
         _run(
@@ -1754,13 +1932,29 @@ def run_preflight(
             raise RuntimeError("Preflight worker did not produce a commit.")
 
         if not skip_publication:
+            branch_lease = _claim_branch_write_lease(
+                repo_root=resolved_repo_root,
+                branch=branch,
+                worktree_path=worktree_path,
+                agent=normalized_agent,
+            )
             _run(["git", "push", "origin", "HEAD"], cwd=worktree_path, env=git_safe_env())
             published = True
             _create_pr(resolved_repo_root, branch, normalized_base_ref)
             pull_request_created = True
             _close_pr(resolved_repo_root, branch)
             pull_request_closed = True
+    except PreflightOperationError as exc:
+        operation_failure = exc
     finally:
+        if branch_lease is not None:
+            try:
+                _release_branch_write_lease(branch_lease)
+            except PreflightOperationError as exc:
+                if operation_failure is None:
+                    operation_failure = exc
+            else:
+                branch_lease_released = True
         if worktree_created:
             worktree_remove = subprocess.run(
                 ["git", "worktree", "remove", "--force", str(worktree_path)],
@@ -1779,13 +1973,25 @@ def run_preflight(
             )
             cleanup_branch_removed = branch_remove.returncode == 0
 
+    checks: list[dict[str, Any]] = []
+    if operation_failure is not None:
+        checks.append(operation_failure.to_check())
+        failure_class = classify_preflight_failure(passed=False, checks=checks)
+        dispatch_gate = GateEvaluation(
+            gate_type=GateType.DISPATCH_READY.value,
+            verdict=GateVerdict.BLOCKED.value,
+            failure_classes=[(failure_class or TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED).value],
+            required_evidence=["preflight_receipt"],
+            notes=f"Preflight operation failed at {operation_failure.stage}.",
+        ).to_dict()
+
     passed = False
-    if dispatch_gate:
+    if dispatch_gate and operation_failure is None:
         passed = str(dispatch_gate.get("verdict", "")).strip() == GateVerdict.PASS.value
     duration = time.monotonic() - start
     result = PreflightResult(
         passed=passed,
-        checks=[],
+        checks=checks,
         duration_seconds=duration,
         envelope=None,
         repo_root=str(resolved_repo_root),
@@ -1800,6 +2006,12 @@ def run_preflight(
         cleanup_branch_removed=cleanup_branch_removed,
         dispatch_gate=dispatch_gate,
         worker=worker.to_dict() if worker is not None else {},
+        branch_lease_id=branch_lease.lease_id if branch_lease is not None else "",
+        branch_lease_owner_session_id=(
+            branch_lease.owner_session_id if branch_lease is not None else ""
+        ),
+        branch_lease_work_id=branch_lease.work_id if branch_lease is not None else "",
+        branch_lease_released=branch_lease_released,
     )
     if normalized_contract_path is not None:
         envelope_for_receipt = CredentialEnvelope.from_environment(os.environ)

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -625,6 +625,7 @@ class TestSwarmParser:
                 "pull_request_closed": False,
                 "cleanup_worktree_removed": True,
                 "cleanup_branch_removed": True,
+                "passed": True,
                 "worker": {"worker_contract_checksum": "abc123", "commit_shas": ["deadbeef"]},
             }
         )
@@ -643,6 +644,37 @@ class TestSwarmParser:
         out = capsys.readouterr().out
         assert '"mode": "swarm-preflight"' in out
         assert '"worker_contract_checksum": "abc123"' in out
+
+    def test_cmd_swarm_preflight_without_contract_fails_closed(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="preflight",
+            worker_model="codex",
+            target_branch="origin/main",
+            contract=None,
+            skip_publication=True,
+            json=False,
+        )
+        fake_result = SimpleNamespace(
+            to_dict=lambda: {
+                "repo_root": "/tmp/aragora",
+                "base_ref": "origin/main",
+                "branch": "preflight/failed-push",
+                "agent": "codex",
+                "passed": False,
+                "checks": [{"name": "git_push", "passed": False}],
+                "worker": {},
+            }
+        )
+
+        with (
+            patch("aragora.swarm.preflight.run_preflight", return_value=fake_result),
+            pytest.raises(SystemExit, match="2"),
+        ):
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert "swarm preflight: blocked" in out
+        assert "swarm preflight: ok" not in out
 
     def test_cmd_swarm_preflight_contract_path_emits_receipt_and_gate(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -151,8 +151,38 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     assert result.branch_lease_id == "lease-preflight-1"
     assert result.branch_lease_work_id == f"branch:{branch}"
     assert result.branch_lease_released is True
-    assert cleanup_commands[0] == ["git", "worktree", "remove", "--force", str(expected_worktree)]
+    assert cleanup_commands[0] == [
+        "git",
+        "worktree",
+        "remove",
+        "--force",
+        str(expected_worktree),
+    ]
     assert cleanup_commands[1] == ["git", "branch", "-D", branch]
+
+
+def test_main_reports_structured_failure_and_exits_nonzero(monkeypatch, capsys) -> None:
+    fake_result = SimpleNamespace(
+        passed=False,
+        agent="codex",
+        base_ref="main",
+        branch="preflight/failed-push",
+        checks=[{"name": "git_push", "passed": False}],
+        worker={},
+        to_dict=lambda: {
+            "passed": False,
+            "checks": [{"name": "git_push", "passed": False}],
+        },
+    )
+    monkeypatch.setattr(mod, "run_preflight", lambda **_: fake_result)
+    monkeypatch.setattr(mod.sys, "argv", ["preflight", "--skip-publication"])
+
+    assert mod.main() == 2
+
+    out = capsys.readouterr().out
+    assert "preflight=blocked" in out
+    assert "failed_check=git_push" in out
+    assert "preflight=ok" not in out
 
 
 def test_contract_preflight_receipt_preserves_push_failure_and_releases_lease(

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -270,6 +270,50 @@ def test_branch_write_lease_uses_branch_identity_and_releases(monkeypatch, tmp_p
     assert captured["released"] == "lease-branch-contract"
 
 
+def test_branch_write_lease_wraps_expected_store_failure(monkeypatch, tmp_path: Path) -> None:
+    from aragora.nomic import dev_coordination
+
+    class FailingStore:
+        def __init__(self, *, repo_root: Path) -> None:
+            del repo_root
+
+        def claim_lease(self, **kwargs: object) -> SimpleNamespace:
+            del kwargs
+            raise RuntimeError("coordination store unavailable")
+
+    monkeypatch.setattr(dev_coordination, "DevCoordinationStore", FailingStore)
+
+    with pytest.raises(mod.PreflightOperationError) as exc_info:
+        mod._claim_branch_write_lease(
+            repo_root=tmp_path,
+            branch="preflight/store-failure",
+            worktree_path=tmp_path / "worktree",
+            agent="codex",
+        )
+
+    assert exc_info.value.stage == "branch_write_lease_claim"
+    assert "coordination store unavailable" in exc_info.value.detail
+
+
+def test_branch_write_lease_wraps_unknown_lease_release() -> None:
+    class MissingLeaseStore:
+        def release_lease(self, lease_id: str) -> None:
+            raise KeyError(f"Unknown lease_id: {lease_id}")
+
+    claim = mod._BranchWriteLease(
+        store=MissingLeaseStore(),
+        lease_id="missing-lease",
+        owner_session_id="session-missing-lease",
+        work_id="branch:preflight/missing-lease",
+    )
+
+    with pytest.raises(mod.PreflightOperationError) as exc_info:
+        mod._release_branch_write_lease(claim)
+
+    assert exc_info.value.stage == "branch_write_lease_release"
+    assert "Unknown lease_id" in exc_info.value.detail
+
+
 @pytest.mark.asyncio
 async def test_run_preflight_succeeds_inside_running_event_loop(
     monkeypatch, tmp_path: Path

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -80,12 +80,15 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     repo_root.mkdir()
     commands: list[list[str]] = []
     cleanup_commands: list[list[str]] = []
+    publication_events: list[str] = []
 
     async def fake_run_worker(**_: object) -> WorkerProcess:
         return _worker(branch=branch)
 
     def fake_run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
         commands.append(list(cmd))
+        if cmd[:3] == ["git", "push", "origin"]:
+            publication_events.append("push")
 
     def fake_subprocess_run(cmd: list[str], **_: object) -> SimpleNamespace:
         cleanup_commands.append(list(cmd))
@@ -95,6 +98,23 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
     monkeypatch.setattr(mod, "_run", fake_run)
     monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+    lease = mod._BranchWriteLease(
+        store=object(),
+        lease_id="lease-preflight-1",
+        owner_session_id="session-preflight-1",
+        work_id=f"branch:{branch}",
+    )
+
+    def fake_claim(**_: object) -> mod._BranchWriteLease:
+        publication_events.append("claim")
+        return lease
+
+    def fake_release(actual: mod._BranchWriteLease) -> None:
+        assert actual is lease
+        publication_events.append("release")
+
+    monkeypatch.setattr(mod, "_claim_branch_write_lease", fake_claim)
+    monkeypatch.setattr(mod, "_release_branch_write_lease", fake_release)
 
     result = mod.run_preflight(
         repo_root=repo_root,
@@ -127,8 +147,127 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     assert result.worker["worker_contract_checksum"] == checksum_contract_payload(
         result.worker["worker_contract"]
     )
+    assert publication_events == ["claim", "push", "release"]
+    assert result.branch_lease_id == "lease-preflight-1"
+    assert result.branch_lease_work_id == f"branch:{branch}"
+    assert result.branch_lease_released is True
     assert cleanup_commands[0] == ["git", "worktree", "remove", "--force", str(expected_worktree)]
     assert cleanup_commands[1] == ["git", "branch", "-D", branch]
+
+
+def test_contract_preflight_receipt_preserves_push_failure_and_releases_lease(
+    monkeypatch, tmp_path: Path
+) -> None:
+    branch = "preflight/20260830-push-failure"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    contract_payload = _worker(branch=branch).worker_contract
+    contract_path = tmp_path / "worker_contract.json"
+    contract_path.write_text(json.dumps(contract_payload), encoding="utf-8")
+    publication_events: list[str] = []
+
+    async def fake_run_worker(**_: object) -> WorkerProcess:
+        return _worker(branch=branch)
+
+    def fake_subprocess_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd[:3] == ["git", "push", "origin"]:
+            publication_events.append("push")
+            return SimpleNamespace(
+                returncode=1,
+                stdout=(
+                    "BLOCKED: branch write lease metadata is missing\ntoken=should-not-survive"
+                ),
+                stderr="error: failed to push some refs to origin",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    lease = mod._BranchWriteLease(
+        store=object(),
+        lease_id="lease-preflight-failure",
+        owner_session_id="session-preflight-failure",
+        work_id=f"branch:{branch}",
+    )
+
+    def fake_claim(**_: object) -> mod._BranchWriteLease:
+        publication_events.append("claim")
+        return lease
+
+    def fake_release(actual: mod._BranchWriteLease) -> None:
+        assert actual is lease
+        publication_events.append("release")
+
+    monkeypatch.setattr(mod, "_branch_name", lambda: branch)
+    monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+    monkeypatch.setattr(mod, "_claim_branch_write_lease", fake_claim)
+    monkeypatch.setattr(mod, "_release_branch_write_lease", fake_release)
+
+    receipt = mod.run_contract_preflight_receipt(
+        repo_root=repo_root,
+        agent="codex",
+        base_ref="main",
+        skip_publication=False,
+        contract_path=contract_path,
+        envelope=_envelope(),
+    )
+
+    assert publication_events == ["claim", "push", "release"]
+    assert receipt.passed is False
+    assert receipt.failure_terminal_class == TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
+    assert receipt.artifacts["branch"] == branch
+    assert receipt.artifacts["commit_shas"] == ["deadbeef"]
+    assert receipt.artifacts["branch_lease_id"] == "lease-preflight-failure"
+    assert receipt.artifacts["branch_lease_work_id"] == f"branch:{branch}"
+    assert receipt.artifacts["branch_lease_released"] is True
+    push_check = next(check for check in receipt.checks if check["name"] == "git_push")
+    assert push_check["returncode"] == 1
+    assert "branch write lease metadata is missing" in push_check["stdout"]
+    assert "token=<REDACTED>" in push_check["stdout"]
+    assert "failed to push some refs" in push_check["stderr"]
+    assert "stdout:" in push_check["detail"]
+    assert "stderr:" in push_check["detail"]
+
+
+def test_branch_write_lease_uses_branch_identity_and_releases(monkeypatch, tmp_path: Path) -> None:
+    from aragora.nomic import dev_coordination
+
+    branch = "preflight/20260830-lease-contract"
+    captured: dict[str, object] = {}
+
+    class FakeStore:
+        def __init__(self, *, repo_root: Path) -> None:
+            captured["repo_root"] = repo_root
+
+        def claim_lease(self, **kwargs: object) -> SimpleNamespace:
+            captured["claim"] = kwargs
+            return SimpleNamespace(lease_id="lease-branch-contract")
+
+        def release_lease(self, lease_id: str) -> None:
+            captured["released"] = lease_id
+
+    monkeypatch.setenv("ARAGORA_SESSION_ID", "session-branch-contract")
+    monkeypatch.setattr(dev_coordination, "DevCoordinationStore", FakeStore)
+
+    claim = mod._claim_branch_write_lease(
+        repo_root=tmp_path,
+        branch=branch,
+        worktree_path=tmp_path / "worktree",
+        agent="codex",
+    )
+    mod._release_branch_write_lease(claim)
+
+    assert captured["repo_root"] == tmp_path
+    claim_kwargs = captured["claim"]
+    assert isinstance(claim_kwargs, dict)
+    assert claim_kwargs["task_id"] == f"branch:{branch}"
+    assert claim_kwargs["branch"] == branch
+    assert claim_kwargs["owner_session_id"] == "session-branch-contract"
+    assert claim_kwargs["allowed_globs"] == [f".aragora/branch-locks/{branch}"]
+    assert claim_kwargs["metadata"] == {
+        "claimed_via": "swarm_preflight",
+        "work_id": f"branch:{branch}",
+    }
+    assert captured["released"] == "lease-branch-contract"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- claim a branch-scoped dev-coordination lease before the generic worker preflight pushes its temporary branch
- hold that lease through temporary PR publication/closure, then release it before local cleanup
- preserve redacted stdout and stderr, command stage, return code, worker commit, cleanup, and lease facts when publication fails
- narrow expected lease-store failures so the code-quality ratchet remains at its current baseline
- make both public preflight CLI entry points fail closed when the structured result is blocked

This productizes the repeated remote_publish admission failure observed by the rev-7 B0 #5754 run. It does not change task dispatch, workflows, evidence, settlement, or underlying lease/publication behavior.

Refs #7209
Refs #5754

## Validation

- python3 -m pytest -q tests/swarm/test_preflight.py tests/cli/test_swarm_command.py (137 passed)
- python3 -m pytest -q tests/swarm/test_boss_loop.py -k 'remote_publish_receipt' (1 passed, 228 deselected)
- python3 -m ruff check aragora/swarm/preflight.py aragora/cli/commands/swarm.py tests/swarm/test_preflight.py tests/cli/test_swarm_command.py
- python3 -m ruff format --check aragora/swarm/preflight.py aragora/cli/commands/swarm.py tests/swarm/test_preflight.py tests/cli/test_swarm_command.py
- python3 -m mypy aragora/swarm/preflight.py aragora/cli/commands/swarm.py
- python3 scripts/report_code_quality.py --check (PASS, except Exception 900/900)
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- git diff --check origin/main...HEAD
- pre-commit and pre-push hook suites passed

## Review findings addressed

- Claude P2, fail-open non-contract entry points: both the standalone `aragora.swarm.preflight` CLI and `aragora swarm preflight` now preserve the structured failure payload, report `blocked` rather than `ok`, and exit 2 when `PreflightResult.passed` is false. Focused regressions cover both entry points.

## Broader Baseline Note

A full exploratory tests/swarm/test_boss_loop.py run on current main is not green: it reports 19 failures and one collection error across unrelated retry, labeling, backbone, and auto-publish tests, including a malformed test collected with a missing self fixture. The focused preflight/dispatch-contract slice passes and this PR does not modify boss_loop.py.
