### PR TITLE
fix(cli): unify record-settlement registration and add non-admin merge eligibility field

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3077,9 +3077,16 @@ def _build_merge_authorization_packet(
             # Non-admin-lane eligibility is the model-level verdict itself
             # (model-quorum satisfied + all effective REQUIRED contexts green +
             # zero unresolved dissent + tier settlement recorded where
-            # required). The live gate below blocks only the admin-squash
-            # lane, so this stays True in blocked_by_live_gate shapes —
-            # settlement Decisions cite this field instead of entry status.
+            # required). It is deliberately independent of admin-squash-lane
+            # live-gate state: it stays True in blocked_by_live_gate shapes,
+            # under an operator-review-required label hold, and when
+            # mergeStateStatus is unavailable. Those holds remain visible and
+            # controlling via the sibling operator_review_required /
+            # admin_squash_allowed / admin_squash_gate_blockers keys; a
+            # label-ANDed variant would read False for every parked draft at
+            # packet time, which is exactly when settlement Decisions consume
+            # it. Decisions cite this field for the model-level verdict and
+            # must still honor the sibling hold keys.
             "non_admin_merge_eligible": model_quorum_admin_squash_allowed,
             "admin_squash_gate_blockers": admin_squash_gate_blockers,
             "merge_state_status": packet.merge_state_status,

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3074,6 +3074,13 @@ def _build_merge_authorization_packet(
                 model_quorum_admin_squash_allowed and not admin_squash_gate_blockers
             ),
             "model_quorum_admin_squash_allowed": model_quorum_admin_squash_allowed,
+            # Non-admin-lane eligibility is the model-level verdict itself
+            # (model-quorum satisfied + all effective REQUIRED contexts green +
+            # zero unresolved dissent + tier settlement recorded where
+            # required). The live gate below blocks only the admin-squash
+            # lane, so this stays True in blocked_by_live_gate shapes —
+            # settlement Decisions cite this field instead of entry status.
+            "non_admin_merge_eligible": model_quorum_admin_squash_allowed,
             "admin_squash_gate_blockers": admin_squash_gate_blockers,
             "merge_state_status": packet.merge_state_status,
             "unstable_non_required_contexts_ignored": (
@@ -3197,14 +3204,28 @@ def _explicit_merged_pr_merge_packet_entry(
         "status": "already_merged",
         "verdict": "already_merged_noop",
         "admin_squash_allowed": False,
+        "non_admin_merge_eligible": False,
         "requires_human_risk_settlement": False,
         "unresolved_dissent": False,
         "reviewer_signals": [],
         "dogfood_evidence": [],
         "counted_reviewer_ids": [],
         "counted_model_families": [],
+        # tier/tier_name/counted_* above are noop placeholders — this entry
+        # deliberately skips quorum hydration, so zero values here are not
+        # computed results. Authoritative post-merge tier/families live in the
+        # merged head's quorum collector JSON artifact.
+        "noop_placeholder_fields": [
+            "tier",
+            "tier_name",
+            "counted_reviewer_ids",
+            "counted_model_families",
+        ],
         "reasons": [
             "PR is already merged; merge-packet readiness is obsolete",
+            "tier=0 and empty counted_* values are noop placeholders, not "
+            "computed results; authoritative tier/families live in the "
+            "collector JSON artifact for the merged head",
         ],
     }
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2247,52 +2247,16 @@ def _add_review_queue_parser(subparsers) -> None:
     )
     act_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
 
-    record_parser = queue_subparsers.add_parser(
-        "record-settlement",
-        help="Record an already-authorized PR settlement without mutating GitHub",
+    # Route through the shared registration helper (argparse-only import) so
+    # this surface and the standalone review-queue CLI cannot drift apart:
+    # an inline copy here repeatedly lost flags the helper registers (e.g.
+    # --post-github-status), leaving documented commands unexecutable.
+    from aragora.cli.commands.review_queue_parsers import add_record_settlement_parser
+
+    add_record_settlement_parser(queue_subparsers)
+    queue_subparsers.choices["record-settlement"].set_defaults(
+        func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue")
     )
-    record_parser.add_argument("pr", help="PR number or URL")
-    record_parser.add_argument(
-        "--repo",
-        default=None,
-        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
-    )
-    record_parser.add_argument(
-        "--head-sha",
-        required=True,
-        help="Exact PR head SHA that was externally settled.",
-    )
-    record_parser.add_argument(
-        "--action",
-        required=True,
-        choices=("approve", "request_changes", "comment", "admin_squash_merge"),
-        help="Externally observed settlement action to record.",
-    )
-    record_parser.add_argument(
-        "--reason",
-        required=True,
-        help="One-line operator reason or authorization reference.",
-    )
-    record_parser.add_argument(
-        "--review-queue-root",
-        default=None,
-        help="Override the review-queue root used for settlement receipts.",
-    )
-    record_parser.add_argument(
-        "--apply-post-merge-lane-audit",
-        action="store_true",
-        help=(
-            "For admin_squash_merge records, apply merged-PR lane supersession "
-            "using the live merge commit guard. Default is dry-run/report only."
-        ),
-    )
-    record_parser.add_argument(
-        "--json",
-        dest="json_output",
-        action="store_true",
-        help="Output local receipt as JSON.",
-    )
-    record_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
 
     evidence_lint_parser = queue_subparsers.add_parser(
         "evidence-lint",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4339,7 +4339,9 @@ class TestGhTimeouts:
         def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
             captured["args"] = args
             captured["kwargs"] = kwargs
-            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+            # float() narrows the Any from kwargs for TimeoutExpired's typed
+            # parameter; _gh_json always passes a numeric timeout.
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=float(kwargs["timeout"]))
 
         monkeypatch.setattr("aragora.cli.commands.review_queue_transport.subprocess.run", fake_run)
 
@@ -6685,9 +6687,8 @@ class TestBuildQueueAndPacket:
         assert entry["machine_recommendation"] == "settled_noop"
         assert entry["admin_squash_allowed"] is False
         assert entry["requires_human_risk_settlement"] is False
-        assert entry["reasons"] == [
-            "PR is already merged; merge-packet readiness is obsolete",
-        ]
+        assert entry["reasons"][0] == "PR is already merged; merge-packet readiness is obsolete"
+        assert any("noop placeholders" in reason for reason in entry["reasons"])
         assert packet["admin_squash_order"] == []
         assert packet["human_risk_settlement_required"] == []
         assert packet["not_ready"] == []
@@ -7423,7 +7424,12 @@ class TestCommandDispatch:
         assert ns.action == "admin_squash_merge"
         assert ns.reason == "operator authorized exact-head merge"
         assert ns.apply_post_merge_lane_audit is True
-        assert ns.json_output is True
+        # The main CLI routes record-settlement through the shared helper
+        # registration, so --json maps to the helper's dest ("json"); the
+        # dispatch handler accepts either dest.
+        assert ns.json is True
+        assert ns.post_github_status is False
+        assert ns.github_status_context == "aragora/human-settlement"
 
     def test_top_level_parser_registers_evidence_lint(self) -> None:
         from aragora.cli.parser import build_parser

--- a/tests/cli/commands/test_review_queue_merge_packet_fields.py
+++ b/tests/cli/commands/test_review_queue_merge_packet_fields.py
@@ -1,0 +1,189 @@
+"""Entry-level merge-packet output fields.
+
+Covers the additive ``non_admin_merge_eligible`` field (the #9858 drafting-rule
+triple: model-quorum satisfied + all effective REQUIRED contexts green + zero
+unresolved dissent + tier settlement recorded where required, independent of
+admin-squash-lane live-gate state) and the noop-placeholder labeling on the
+``already_merged`` entry (tier 0 / empty counted families are placeholders, not
+computed values). Existing fields must keep their exact shapes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aragora.cli.commands.review_queue import (
+    ReviewPacket,
+    _build_merge_authorization_packet,
+    _explicit_merged_pr_merge_packet_entry,
+)
+
+
+def _quorum(**overrides: Any) -> dict[str, Any]:
+    quorum: dict[str, Any] = {
+        "tier": 2,
+        "tier_name": "Tier 2",
+        "status": "satisfied",
+        "verdict": "admin_squash_allowed",
+        "admin_squash_allowed": True,
+        "requires_human_risk_settlement": False,
+        "unresolved_dissent": False,
+        "reviewer_signals": [],
+        "dogfood_evidence": [],
+        "counted_reviewer_ids": ["claude", "codex"],
+        "reasons": ["model quorum satisfied"],
+    }
+    quorum.update(overrides)
+    return quorum
+
+
+def _packet_factory(
+    *,
+    quorum: dict[str, Any],
+    labels: list[str] | None = None,
+    merge_state_status: str = "CLEAN",
+):
+    def _build(ref: str, **_kwargs: Any) -> ReviewPacket:
+        return ReviewPacket(
+            pr_number=int(ref),
+            title=f"PR {ref}",
+            url=f"https://github.com/synaptent/aragora/pull/{ref}",
+            head_sha="abc123",
+            base_sha="def456",
+            author="codex",
+            is_draft=False,
+            additions=1,
+            deletions=1,
+            changed_files=1,
+            queue_bucket="ready_now",
+            touched_subsystems=["scripts"],
+            high_risk_paths_touched=[],
+            validation=[],
+            checks_summary="4/4 green",
+            risk_flags=[],
+            machine_recommendation="approve_candidate",
+            machine_recommendation_reason="bounded test packet",
+            packet_sha="sha256:test",
+            generated_at="2026-08-30T00:00:00+00:00",
+            labels=labels or [],
+            merge_state_status=merge_state_status,
+            model_review_quorum=quorum,
+        )
+
+    return _build
+
+
+def _entry(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    quorum: dict[str, Any],
+    labels: list[str] | None = None,
+    merge_state_status: str = "CLEAN",
+) -> dict[str, Any]:
+    monkeypatch.setattr(
+        "aragora.cli.commands.review_queue._build_packet",
+        _packet_factory(quorum=quorum, labels=labels, merge_state_status=merge_state_status),
+    )
+    monkeypatch.setattr(
+        "aragora.cli.commands.review_queue._explicit_merged_pr_merge_packet_entry",
+        lambda ref, repo_override: None,
+    )
+    packet = _build_merge_authorization_packet(pr_refs=["9858"], limit=30, repo_override=None)
+    return packet["entries"][0]
+
+
+class TestNonAdminMergeEligible:
+    def test_true_when_only_admin_lane_live_gate_blocks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        entry = _entry(monkeypatch, quorum=_quorum(), merge_state_status="UNSTABLE")
+
+        # Existing #8965 relabel shape stays byte-identical.
+        assert entry["status"] == "blocked_by_live_gate"
+        assert entry["verdict"] == "admin_squash_blocked_by_live_gate"
+        assert entry["admin_squash_allowed"] is False
+        assert entry["model_quorum_admin_squash_allowed"] is True
+        assert entry["admin_squash_gate_blockers"]
+
+        # The non-admin lane is unaffected by the admin-squash live gate.
+        assert entry["non_admin_merge_eligible"] is True
+
+    def test_true_when_fully_clean(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        entry = _entry(monkeypatch, quorum=_quorum(), merge_state_status="CLEAN")
+
+        assert entry["status"] == "satisfied"
+        assert entry["admin_squash_allowed"] is True
+        assert entry["non_admin_merge_eligible"] is True
+
+    def test_false_when_model_quorum_not_satisfied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        entry = _entry(
+            monkeypatch,
+            quorum=_quorum(
+                status="needs_model_review_quorum",
+                verdict="collect_model_quorum_before_merge",
+                admin_squash_allowed=False,
+                counted_reviewer_ids=[],
+                reasons=["model quorum incomplete: 0/2 signal(s)"],
+            ),
+            merge_state_status="CLEAN",
+        )
+
+        assert entry["status"] == "needs_model_review_quorum"
+        assert entry["non_admin_merge_eligible"] is False
+
+    def test_false_when_unresolved_dissent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        entry = _entry(
+            monkeypatch,
+            quorum=_quorum(
+                status="unresolved_dissent",
+                verdict="human_risk_settlement_required",
+                admin_squash_allowed=False,
+                requires_human_risk_settlement=True,
+                unresolved_dissent=True,
+                reasons=["unresolved model dissent is present"],
+            ),
+            merge_state_status="CLEAN",
+        )
+
+        assert entry["unresolved_dissent"] is True
+        assert entry["non_admin_merge_eligible"] is False
+
+
+class TestAlreadyMergedNoopEntry:
+    def test_labels_noop_placeholder_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda _args: {
+                "number": 9750,
+                "title": "merged upstream",
+                "url": "https://github.com/synaptent/aragora/pull/9750",
+                "headRefOid": "057407297d7c057407297d7c057407297d7c0574",
+                "state": "MERGED",
+                "mergedAt": "2026-08-27T00:00:00Z",
+                "mergeCommit": {"oid": "057407297d7c"},
+            },
+        )
+
+        entry = _explicit_merged_pr_merge_packet_entry("9750", None)
+
+        assert entry is not None
+        assert entry["status"] == "already_merged"
+        assert entry["tier"] == 0
+        assert entry["counted_model_families"] == []
+
+        # The zero values must be explicitly labeled as noop placeholders so
+        # after-the-fact auditors do not read tier 0 / no families as computed
+        # results (authoritative values live in the collector JSON artifact).
+        assert set(entry["noop_placeholder_fields"]) == {
+            "tier",
+            "tier_name",
+            "counted_reviewer_ids",
+            "counted_model_families",
+        }
+        assert any("noop placeholders" in reason for reason in entry["reasons"])
+        assert any("collector JSON artifact" in reason for reason in entry["reasons"])
+
+        # An already-merged PR is not eligible for any merge lane.
+        assert entry["non_admin_merge_eligible"] is False

--- a/tests/cli/commands/test_review_queue_merge_packet_fields.py
+++ b/tests/cli/commands/test_review_queue_merge_packet_fields.py
@@ -117,6 +117,39 @@ class TestNonAdminMergeEligible:
         assert entry["admin_squash_allowed"] is True
         assert entry["non_admin_merge_eligible"] is True
 
+    def test_true_under_operator_review_required_label_hold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        entry = _entry(
+            monkeypatch,
+            quorum=_quorum(),
+            labels=["operator-review-required"],
+            merge_state_status="CLEAN",
+        )
+
+        # The operator hold blocks the admin-squash lane and stays visible in
+        # the sibling keys; the model-level verdict is label-independent (it
+        # must stay True while a compliant parked draft still carries the
+        # label, or the field would be constant-false at packet time).
+        assert entry["operator_review_required"] is True
+        assert entry["admin_squash_allowed"] is False
+        assert any(
+            "operator-review-required" in blocker for blocker in entry["admin_squash_gate_blockers"]
+        )
+        assert entry["non_admin_merge_eligible"] is True
+
+    def test_true_when_merge_state_status_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        entry = _entry(monkeypatch, quorum=_quorum(), merge_state_status="")
+
+        # Unavailable mergeStateStatus zeroes only the admin-squash lane; the
+        # model-level verdict does not claim live mergeability.
+        assert entry["admin_squash_allowed"] is False
+        assert any("mergeStateStatus" in blocker for blocker in entry["admin_squash_gate_blockers"])
+        assert entry["non_admin_merge_eligible"] is True
+        assert entry["operator_review_required"] is False
+
     def test_false_when_model_quorum_not_satisfied(self, monkeypatch: pytest.MonkeyPatch) -> None:
         entry = _entry(
             monkeypatch,

--- a/tests/cli/commands/test_review_queue_parser_parity.py
+++ b/tests/cli/commands/test_review_queue_parser_parity.py
@@ -1,0 +1,145 @@
+"""Parity tests for the two record-settlement parser registration surfaces.
+
+The main CLI (``aragora.cli.parser``) and the standalone review-queue CLI
+(``aragora.cli.commands.review_queue.add_review_queue_parser``, which routes
+through ``review_queue_parsers.add_record_settlement_parser``) must expose an
+identical record-settlement option surface. Three consecutive live settlements
+(#9817, #9822, #9858 lineage) hit drift between the two registrations, so the
+comparison is structural: ``(option_strings, dest, required, choices)`` for
+every action, not just flag presence.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from aragora.cli.commands.review_queue import add_review_queue_parser
+from aragora.cli.parser import build_parser
+
+
+def _subparsers_action(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    raise AssertionError(f"no subparsers registered on {parser.prog!r}")
+
+
+def _record_settlement_parser(root: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    review_queue = _subparsers_action(root).choices["review-queue"]
+    return _subparsers_action(review_queue).choices["record-settlement"]
+
+
+def _main_cli_root() -> argparse.ArgumentParser:
+    return build_parser()
+
+
+def _standalone_root() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(prog="review-queue-standalone")
+    add_review_queue_parser(root.add_subparsers(dest="command"))
+    return root
+
+
+def _option_surface(
+    parser: argparse.ArgumentParser,
+) -> set[tuple[tuple[str, ...], str, bool, tuple[str, ...] | None]]:
+    surface: set[tuple[tuple[str, ...], str, bool, tuple[str, ...] | None]] = set()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            continue
+        choices = tuple(str(c) for c in action.choices) if action.choices is not None else None
+        surface.add(
+            (
+                tuple(action.option_strings),
+                str(action.dest),
+                bool(action.required),
+                choices,
+            )
+        )
+    return surface
+
+
+class TestRecordSettlementParserParity:
+    def test_surfaces_expose_identical_option_tuples(self) -> None:
+        main_surface = _option_surface(_record_settlement_parser(_main_cli_root()))
+        standalone_surface = _option_surface(_record_settlement_parser(_standalone_root()))
+
+        assert main_surface == standalone_surface, (
+            "record-settlement registrations diverged:\n"
+            f"main CLI only: {sorted(main_surface - standalone_surface)}\n"
+            f"standalone only: {sorted(standalone_surface - main_surface)}"
+        )
+
+    def test_main_cli_registers_post_github_status(self) -> None:
+        args = _main_cli_root().parse_args(
+            [
+                "review-queue",
+                "record-settlement",
+                "9817",
+                "--head-sha",
+                "017d33990628ed8a3369dfb600cafcc0a6548bc7",
+                "--action",
+                "approve",
+                "--reason",
+                "exact-head operator settlement",
+                "--post-github-status",
+            ]
+        )
+
+        assert args.post_github_status is True
+        assert args.github_status_context == "aragora/human-settlement"
+
+    def test_main_cli_post_github_status_defaults_off(self) -> None:
+        args = _main_cli_root().parse_args(
+            [
+                "review-queue",
+                "record-settlement",
+                "9817",
+                "--head-sha",
+                "017d33990628ed8a3369dfb600cafcc0a6548bc7",
+                "--action",
+                "approve",
+                "--reason",
+                "exact-head operator settlement",
+            ]
+        )
+
+        assert args.post_github_status is False
+
+    def test_main_cli_github_status_context_override(self) -> None:
+        args = _main_cli_root().parse_args(
+            [
+                "review-queue",
+                "record-settlement",
+                "9817",
+                "--head-sha",
+                "017d33990628ed8a3369dfb600cafcc0a6548bc7",
+                "--action",
+                "approve",
+                "--reason",
+                "exact-head operator settlement",
+                "--post-github-status",
+                "--github-status-context",
+                "aragora/custom-settlement",
+            ]
+        )
+
+        assert args.github_status_context == "aragora/custom-settlement"
+
+    @pytest.mark.parametrize("root_factory", [_main_cli_root, _standalone_root])
+    def test_reason_stays_mandatory_on_both_surfaces(self, root_factory) -> None:
+        # Original registration semantics, not drift: recording an external
+        # settlement without an operator reason must be rejected at parse time.
+        with pytest.raises(SystemExit):
+            root_factory().parse_args(
+                [
+                    "review-queue",
+                    "record-settlement",
+                    "9817",
+                    "--head-sha",
+                    "017d33990628ed8a3369dfb600cafcc0a6548bc7",
+                    "--action",
+                    "approve",
+                ]
+            )


### PR DESCRIPTION
## Source

Mission feature `misc-review-queue-settlement-cli-flag-restore` (milestone `cdg-bootstrap-route-truth`), executed under the operator Decision "overlap ratification for misc-review-queue-settlement-cli-flag-restore GRANTED (2026-08-30)" recorded in both authority files. **Prepare-only terminal: this PR parks as a labeled draft with UNPOSTED evidence; no ready, posting, settlement, or merge is authorized under the ratification.**

## Behavior summary

Three consecutive live settlements (#9811, #9817, #9822) hit CLI parser/implementation drift: the main CLI's inline `record-settlement` registration in `aragora/cli/parser.py` had lost `--post-github-status` / `--github-status-context` (while `_cmd_record_settlement` retains the atomic receipt-then-status branch) and mapped `--json` to a divergent dest (`json_output` vs the helper's `json`).

1. **Registration unification (parser.py:~2252):** the main CLI review-queue `record-settlement` subtree now routes through the shared `aragora/cli/commands/review_queue_parsers.py::add_record_settlement_parser` (argparse-only import), the same helper the standalone review-queue CLI uses. Both flags are restored and the option surface is a single source of truth. `--reason` stays MANDATORY (original #7079 registration semantics, not drift). The dispatch handler already accepts both `--json` dests via `getattr`, so runtime behavior is unchanged.
2. **Parser-parity test (NEW file `tests/cli/commands/test_review_queue_parser_parity.py`):** structural comparison of `(option_strings, dest, required, choices)` tuples across both registration surfaces, plus flag-restoration and `--reason`-mandatory pins. Captured failing before the fix (SystemExit on `--post-github-status`; tuple divergence on the two flags + `--json` dest).
3. **`non_admin_merge_eligible` entry field (review_queue.py:~3054):** additive merge-packet entry field emitting the model-level verdict per the merge-gate 2026-08-29 drafting rule (model-quorum satisfied + all effective REQUIRED contexts green + zero unresolved dissent + tier settlement recorded where required). Stays `true` in `blocked_by_live_gate` shapes, which are admin-squash-lane-only relabels. Zero change to existing fields/consumers; settlement Decisions can cite this field instead of "packet reads satisfied".
4. **already_merged noop placeholder labeling (review_queue.py:~3195):** the noop entry now carries `noop_placeholder_fields` + an explicit reasons line so after-the-fact auditors do not read the hardcoded `tier: 0` / empty `counted_model_families` as computed results (authoritative values live in the collector JSON artifact); also emits `non_admin_merge_eligible: false`. New tests in NEW file `tests/cli/commands/test_review_queue_merge_packet_fields.py` (captured failing first: `KeyError` on both new fields).
5. **`--prepared-json` scope decision (guidance, no code):** formally RETIRED from `aragora review-queue collect-evidence` packet-template guidance. The CLI subtree never had the flag and threading it would require edits outside the ratification's pinned regions; artifact byte-exact reuse is already fully supported via `python3 scripts/collect_quorum_evidence.py --repo <slug> --pr <N> --prepared-json <artifact>` (`run_collect_cli` threads it), which packet templates should pin, with fresh collection on the unchanged exact head as the fallback. Recorded in the mission library.
6. **Drift archaeology (banked, cited):** born divergent — #7762 (85ea19624e) added the two flags only to review_queue.py's in-file registration, #8185 (58251e67c4) split that into `review_queue_parsers.py`, and parser.py's #7079 registration never had them. Full findings banked in the mission library environment census (2026-08-30, worker ba5c389a).

## Validation

- Red-first: `python3 -m pytest tests/cli/commands/test_review_queue_parser_parity.py tests/cli/commands/test_review_queue_merge_packet_fields.py -q` → 9 failed / 2 passed before the fix; all green after.
- `python3 -m pytest tests/cli/commands/test_review_queue.py tests/cli/test_cli_main.py tests/ci/test_merge_quorum_status_vocabulary.py tests/approvals/test_inbox.py tests/cli/commands/test_review_queue_parser_parity.py tests/cli/commands/test_review_queue_merge_packet_fields.py tests/cli/commands/test_review_queue_settlement_status.py tests/cli/commands/test_review_queue_import_boundaries.py -q` → **468 passed**.
- Frozen atomic-property test `tests/cli/commands/test_review_queue_settlement_status.py` untouched, 6 passed.
- `make lint` + `ruff format --check` → clean. `bash scripts/preflight_mypy.sh --diff-base origin/main` → "Success: no issues found in 5 source files".
- `make test-smoke` → passed; `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` → 138 passed.
- Measured LOC (`git diff --numstat origin/main...HEAD`): +375 / −50 = 425 changed lines (≤800).

## Risks and disclosures

- **Census (at push):** all 8 Decision-pinned tolerated owner heads verified exact (`#9147 eded2273`, `#9011 4523dff2`, `#8406 ac8d65f1` on review_queue.py; `#9720 e1820263`, `#9697 746bde93`, `#9660 e6651fd6`, `#9513 8990d3ab`, `#8906 a007a932` on parser.py); `review_queue_parsers.py` and both new test files census-CLEAN; no new production-file owner. Additional disclosure: open PR **#9512** (head `1547d4d5ad`) also owns `tests/cli/commands/test_review_queue.py`, which this PR edits (2 drift-pinning assertions updated + 1 bounded type-narrowing); test-file overlap only, outside the Decision's production-file STOP rule — disclosed per disclose-not-void.
- **Existing-test updates (non-frozen file):** `test_top_level_parser_registers_record_settlement` now asserts the unified helper dest (`ns.json`) and the restored flags; the already_merged short-circuit test accepts the additive placeholder reasons line. Both preserve original intent.
- **Bounded pre-existing typing fix:** `test_review_queue.py:4342` carried a latent `arg-type` error (reproduced byte-identical at origin/main) that reds the authoritative `preflight_mypy.sh` gate for any PR touching the file; fixed with a runtime-identical `float(...)` narrowing, disclosed per the 2026-08-27 latent-debt rule.
- **Decision path nit:** the ratification names `aragora/swarm/review_queue_parsers.py`; the module actually lives at `aragora/cli/commands/review_queue_parsers.py` (no aragora/swarm variant exists). It was imported/routed-through only and NOT edited, per the Decision's parity-wiring clause.
- `--json` dest on the main-CLI record-settlement surface changes `json_output` → `json` (helper dest). All dispatch handlers read both via `getattr`; no runtime consumer of the old dest exists outside the updated assertion.

## Evidence rounds (prepare-only, apply=False, UNPOSTED)

Collector self-computed **tier 4** (parser.py + review_queue.py are TIER_4_PREFIXES surfaces) and self-forced `action: prepare` both rounds; `posted_families: []` in both artifacts. Bodies are banked head-pinned in the mission library with sha256 pins; post them byte-exact at settlement via `python3 scripts/collect_quorum_evidence.py --repo synaptent/aragora --pr 9908 --prepared-json <banked r2 artifact> --apply` (VOID on head movement; fresh collection on the unchanged head is the fallback).

- **r1** @ `97dc4ddd85b3`: openai PASS (counted); claude grounded CHANGES-REQUESTED, [P2]+[P3] on the `non_admin_merge_eligible` × `operator-review-required` label interaction. Adjudicated per-premise: the semantic-bypass premise is rebutted by the field's charter (merge-gate.md 2026-08-29 drafting rule; a label-ANDed variant would read constant-false for every compliant parked draft at packet time, and the hold stays visible and controlling via the sibling `operator_review_required` / `admin_squash_allowed` / `admin_squash_gate_blockers` keys); the test-gap and comment-scope premises were conceded and fixed in `8d35e8938866` (split-verdict pin tests for the label hold and unavailable mergeStateStatus, sharpened emission comment).
- **r2** @ `8d35e8938866` (current head): **both families counted supportive, zero dissent** (`has_supportive_quorum: true`). Claude PASS explicitly re-verified the adjudicated design: the field is "computed independently of `_admin_squash_live_gate_blockers` (labels/mergeStateStatus), matching the inline comment's claims". Residual claude [P3] (dissent-shape test is a pass-through pin, not a quorum-builder branch test): acknowledged-no-change; the file's unit under test is entry-level packet output, and the builder's dissent branch is covered by the pre-existing quorum-ladder suites.
