### PR TITLE
feat(evaluation): add outcome-backed report verdict contract

### DIFF
--- a/aragora/evaluation/outcome_backed_analysis.py
+++ b/aragora/evaluation/outcome_backed_analysis.py
@@ -8,13 +8,14 @@ has the highest mean composite score; exact ties use the lexicographically
 smallest condition ID.
 
 The exact paired sign-flip test is two-sided and fully enumerates every sign
-assignment for at most 16 development cases.  A result is ``team_outperforms``
-or ``baseline_outperforms`` only when all 16 development pairs are present,
-the exact p-value is below 0.05, the mean composite delta has the matching
-sign, and the absolute mean Brier improvement is at least 0.05 in that
-direction.  Otherwise the verdict is ``no_difference``; fewer than 16 pairs
-is ``insufficient_data``.  Holdout case IDs are rejected by this development
-analysis contract.
+assignment for at most 16 cases.  A result is ``team_outperforms`` or
+``baseline_outperforms`` only when every pair for the selected phase is
+present (16 development or eight holdout), the exact p-value is below 0.05,
+the mean composite delta has the matching sign, and the absolute mean Brier
+improvement is at least 0.05 in that direction.  Otherwise the verdict is
+``no_difference``; an incomplete phase is ``insufficient_data``.  Development
+analysis rejects holdout IDs, while holdout analysis accepts only registered
+holdout IDs.
 """
 
 from __future__ import annotations
@@ -23,13 +24,16 @@ from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
 from itertools import product
 import math
-from typing import Any
+from typing import Any, Literal
 
+from aragora.evaluation.outcome_backed_corpus import SPLIT_COUNTS
 from aragora.evaluation.outcome_backed_scoring import SCORER_CONTRACT_VERSION
 
 
-ANALYSIS_CONTRACT_VERSION = "outcome-backed-decision-quality-analysis/1.0"
-DEVELOPMENT_CASE_COUNT = 16
+ANALYSIS_CONTRACT_VERSION = "outcome-backed-decision-quality-analysis/1.1"
+AnalysisPhase = Literal["development", "holdout"]
+DEVELOPMENT_CASE_COUNT = SPLIT_COUNTS["development"]
+HOLDOUT_CASE_COUNT = SPLIT_COUNTS["holdout"]
 MAX_EXACT_CASE_COUNT = 16
 TIE_EPSILON = 1e-9
 P_VALUE_THRESHOLD = 0.05
@@ -99,6 +103,7 @@ class BaselineSummary:
 class AnalysisReport:
     """Serializable benchmark analysis bound to scorer and analysis contracts."""
 
+    phase: AnalysisPhase
     team_condition_id: str
     n: int
     strongest_baseline_id: str
@@ -109,12 +114,15 @@ class AnalysisReport:
         return {
             "analysis_contract_version": ANALYSIS_CONTRACT_VERSION,
             "scorer_contract_version": SCORER_CONTRACT_VERSION,
+            "phase": self.phase,
             "team_condition_id": self.team_condition_id,
             "n": self.n,
             "strongest_baseline_id": self.strongest_baseline_id,
             "strongest_baseline_rule": STRONGEST_BASELINE_RULE,
             "thresholds": {
+                "expected_case_count": _expected_case_count(self.phase),
                 "development_case_count": DEVELOPMENT_CASE_COUNT,
+                "holdout_case_count": HOLDOUT_CASE_COUNT,
                 "tie_epsilon": TIE_EPSILON,
                 "p_value": P_VALUE_THRESHOLD,
                 "minimum_absolute_brier_improvement": MIN_ABSOLUTE_BRIER_IMPROVEMENT,
@@ -249,22 +257,64 @@ def _summarize_baseline(
     )
 
 
-def _verdict(strongest: BaselineSummary, n: int) -> str:
-    if n < DEVELOPMENT_CASE_COUNT:
+def _expected_case_count(phase: AnalysisPhase) -> int:
+    return DEVELOPMENT_CASE_COUNT if phase == "development" else HOLDOUT_CASE_COUNT
+
+
+def classify_analysis_verdict(
+    *,
+    phase: AnalysisPhase,
+    n: int,
+    mean_composite_delta: float,
+    mean_brier_improvement: float,
+    exact_sign_flip_p_value: float,
+) -> str:
+    """Classify metrics under the frozen phase-specific analysis thresholds."""
+
+    if phase not in ("development", "holdout"):
+        raise ValueError("phase must be 'development' or 'holdout'")
+    if isinstance(n, bool) or not isinstance(n, int) or n < 1:
+        raise ValueError("n must be a positive integer")
+    expected_count = _expected_case_count(phase)
+    if n > expected_count:
+        raise ValueError(f"{phase} analysis supports at most {expected_count} cases")
+    metrics = {
+        "mean_composite_delta": mean_composite_delta,
+        "mean_brier_improvement": mean_brier_improvement,
+        "exact_sign_flip_p_value": exact_sign_flip_p_value,
+    }
+    for field, value in metrics.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{field} must be finite")
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{field} must be finite")
+    if not 0.0 <= exact_sign_flip_p_value <= 1.0:
+        raise ValueError("exact_sign_flip_p_value must be between 0 and 1")
+    if n < expected_count:
         return "insufficient_data"
     if (
-        strongest.exact_sign_flip_p_value < P_VALUE_THRESHOLD
-        and strongest.mean_composite_delta > TIE_EPSILON
-        and strongest.mean_brier_improvement >= MIN_ABSOLUTE_BRIER_IMPROVEMENT - TIE_EPSILON
+        exact_sign_flip_p_value < P_VALUE_THRESHOLD
+        and mean_composite_delta > TIE_EPSILON
+        and mean_brier_improvement >= MIN_ABSOLUTE_BRIER_IMPROVEMENT - TIE_EPSILON
     ):
         return "team_outperforms"
     if (
-        strongest.exact_sign_flip_p_value < P_VALUE_THRESHOLD
-        and strongest.mean_composite_delta < -TIE_EPSILON
-        and strongest.mean_brier_improvement <= -MIN_ABSOLUTE_BRIER_IMPROVEMENT + TIE_EPSILON
+        exact_sign_flip_p_value < P_VALUE_THRESHOLD
+        and mean_composite_delta < -TIE_EPSILON
+        and mean_brier_improvement <= -MIN_ABSOLUTE_BRIER_IMPROVEMENT + TIE_EPSILON
     ):
         return "baseline_outperforms"
     return "no_difference"
+
+
+def _verdict(strongest: BaselineSummary, *, phase: AnalysisPhase, n: int) -> str:
+    return classify_analysis_verdict(
+        phase=phase,
+        n=n,
+        mean_composite_delta=strongest.mean_composite_delta,
+        mean_brier_improvement=strongest.mean_brier_improvement,
+        exact_sign_flip_p_value=strongest.exact_sign_flip_p_value,
+    )
 
 
 def analyze_scored_conditions(
@@ -273,8 +323,9 @@ def analyze_scored_conditions(
     team_condition_id: str,
     scorer_contract_version: str,
     holdout_case_ids: Collection[str],
+    phase: AnalysisPhase = "development",
 ) -> AnalysisReport:
-    """Analyze scored development results for team and fixed baseline conditions."""
+    """Analyze one scored benchmark phase for team and fixed baselines."""
 
     if scorer_contract_version != SCORER_CONTRACT_VERSION:
         raise ValueError(
@@ -288,13 +339,17 @@ def analyze_scored_conditions(
     if len(condition_results) < 2:
         raise ValueError("analysis requires one team and at least one baseline condition")
 
+    if phase not in ("development", "holdout"):
+        raise ValueError("phase must be 'development' or 'holdout'")
+
     indexed = {
         condition_id: _condition_rows(condition_id, rows)
         for condition_id, rows in condition_results.items()
     }
     team_case_ids = set(indexed[team_condition_id])
-    if len(team_case_ids) > MAX_EXACT_CASE_COUNT:
-        raise ValueError(f"analysis supports at most {MAX_EXACT_CASE_COUNT} development cases")
+    expected_count = _expected_case_count(phase)
+    if len(team_case_ids) > expected_count:
+        raise ValueError(f"{phase} analysis supports at most {expected_count} cases")
     for condition_id, rows in indexed.items():
         if set(rows) != team_case_ids:
             raise ValueError(
@@ -306,9 +361,14 @@ def analyze_scored_conditions(
     ):
         raise ValueError("holdout_case_ids must contain non-empty strings")
     holdouts = set(holdout_case_ids)
-    leaked_holdouts = sorted(team_case_ids & holdouts)
-    if leaked_holdouts:
-        raise ValueError("holdout case IDs are not allowed: " + ", ".join(leaked_holdouts))
+    if phase == "development":
+        leaked_holdouts = sorted(team_case_ids & holdouts)
+        if leaked_holdouts:
+            raise ValueError("holdout case IDs are not allowed: " + ", ".join(leaked_holdouts))
+    else:
+        unregistered = sorted(team_case_ids - holdouts)
+        if unregistered:
+            raise ValueError("non-holdout case IDs are not allowed: " + ", ".join(unregistered))
 
     case_ids = tuple(sorted(team_case_ids))
     summaries = tuple(
@@ -326,25 +386,29 @@ def analyze_scored_conditions(
         key=lambda summary: (-summary.baseline_mean_composite_score, summary.condition_id),
     )
     return AnalysisReport(
+        phase=phase,
         team_condition_id=team_condition_id,
         n=len(case_ids),
         strongest_baseline_id=strongest.condition_id,
-        verdict=_verdict(strongest, len(case_ids)),
+        verdict=_verdict(strongest, phase=phase, n=len(case_ids)),
         per_baseline=summaries,
     )
 
 
 __all__ = [
     "ANALYSIS_CONTRACT_VERSION",
+    "AnalysisPhase",
     "AnalysisReport",
     "BaselineSummary",
     "CaseDelta",
     "DEVELOPMENT_CASE_COUNT",
+    "HOLDOUT_CASE_COUNT",
     "MIN_ABSOLUTE_BRIER_IMPROVEMENT",
     "P_VALUE_THRESHOLD",
     "STRONGEST_BASELINE_RULE",
     "TIE_EPSILON",
     "analyze_scored_conditions",
+    "classify_analysis_verdict",
     "composite_score",
     "exact_paired_sign_flip_p_value",
 ]

--- a/aragora/evaluation/outcome_backed_report.py
+++ b/aragora/evaluation/outcome_backed_report.py
@@ -20,7 +20,11 @@ from decimal import Decimal, InvalidOperation
 import math
 import re
 
-from aragora.evaluation.outcome_backed_analysis import ANALYSIS_CONTRACT_VERSION
+from aragora.evaluation.outcome_backed_analysis import (
+    ANALYSIS_CONTRACT_VERSION,
+    AnalysisPhase,
+    classify_analysis_verdict,
+)
 from aragora.evaluation.outcome_backed_budget import (
     BUDGET_LEDGER_SCHEMA,
     DAILY_BUDGET_CAP_USD,
@@ -83,10 +87,14 @@ def _money_text(value: Decimal) -> str:
     return text or "0"
 
 
+def _normalized_summary_number(summary: Mapping[str, object], field: str) -> float:
+    return _finite_number(summary.get(field), f"normalized_summary.{field}")
+
+
 def _analysis_report(
     report: Mapping[str, object],
     *,
-    phase: str,
+    phase: AnalysisPhase,
     expected_count: int,
 ) -> dict[str, object]:
     if not isinstance(report, Mapping):
@@ -95,6 +103,8 @@ def _analysis_report(
         raise ValueError(f"{phase}_report analysis contract version mismatch")
     if report.get("scorer_contract_version") != SCORER_CONTRACT_VERSION:
         raise ValueError(f"{phase}_report scorer contract version mismatch")
+    if report.get("phase") != phase:
+        raise ValueError(f"{phase}_report phase mismatch")
 
     n = _integer(report.get("n"), f"{phase}_report.n", minimum=1)
     if n != expected_count:
@@ -130,19 +140,24 @@ def _analysis_report(
             raw_summary.get("exact_sign_flip_p_value"),
             f"{prefix}.exact_sign_flip_p_value",
         )
+        team_mean = _finite_number(
+            raw_summary.get("team_mean_composite_score"),
+            f"{prefix}.team_mean_composite_score",
+        )
+        baseline_mean = _finite_number(
+            raw_summary.get("baseline_mean_composite_score"),
+            f"{prefix}.baseline_mean_composite_score",
+        )
+        mean_delta = _finite_number(
+            raw_summary.get("mean_composite_delta"), f"{prefix}.mean_composite_delta"
+        )
+        if not math.isclose(team_mean - baseline_mean, mean_delta, rel_tol=0.0, abs_tol=1e-9):
+            raise ValueError(f"{prefix}.mean_composite_delta does not match the reported means")
         summary = {
             "condition_id": condition_id,
-            "team_mean_composite_score": _finite_number(
-                raw_summary.get("team_mean_composite_score"),
-                f"{prefix}.team_mean_composite_score",
-            ),
-            "baseline_mean_composite_score": _finite_number(
-                raw_summary.get("baseline_mean_composite_score"),
-                f"{prefix}.baseline_mean_composite_score",
-            ),
-            "mean_composite_delta": _finite_number(
-                raw_summary.get("mean_composite_delta"), f"{prefix}.mean_composite_delta"
-            ),
+            "team_mean_composite_score": team_mean,
+            "baseline_mean_composite_score": baseline_mean,
+            "mean_composite_delta": mean_delta,
             "mean_brier_improvement": _finite_number(
                 raw_summary.get("mean_brier_improvement"),
                 f"{prefix}.mean_brier_improvement",
@@ -154,6 +169,29 @@ def _analysis_report(
         summaries.append(summary)
     if strongest_baseline_id not in condition_ids:
         raise ValueError(f"{phase}_report strongest baseline is missing from per_baseline")
+
+    computed_strongest = min(
+        summaries,
+        key=lambda summary: (
+            -_normalized_summary_number(summary, "baseline_mean_composite_score"),
+            str(summary["condition_id"]),
+        ),
+    )
+    if strongest_baseline_id != computed_strongest["condition_id"]:
+        raise ValueError(f"{phase}_report strongest baseline does not match its metrics")
+    computed_verdict = classify_analysis_verdict(
+        phase=phase,
+        n=n,
+        mean_composite_delta=_normalized_summary_number(computed_strongest, "mean_composite_delta"),
+        mean_brier_improvement=_normalized_summary_number(
+            computed_strongest, "mean_brier_improvement"
+        ),
+        exact_sign_flip_p_value=_normalized_summary_number(
+            computed_strongest, "exact_sign_flip_p_value"
+        ),
+    )
+    if verdict != computed_verdict:
+        raise ValueError(f"{phase}_report verdict does not match its strongest-baseline metrics")
 
     return {
         "phase": phase,
@@ -352,8 +390,8 @@ def final_verdict(
     and holdout analyses with settled, under-cap budget custody and two or
     three recorded holdout exposures.  ``conditional_go`` requires a
     development win and a complete but statistically unconfirmed holdout
-    result (``no_difference`` or ``insufficient_data``) under the same custody
-    gates.  Every baseline win, inconclusive development result, budget
+    result (``no_difference``) under the same custody gates.  Every baseline
+    win, inconclusive development result, budget
     violation, or holdout custody violation returns ``no_go``.
 
     Missing, malformed, or version-mismatched inputs raise ``ValueError``.
@@ -371,7 +409,7 @@ def final_verdict(
         return "no_go"
     if holdout["verdict"] == "team_outperforms":
         return "go"
-    if holdout["verdict"] in {"no_difference", "insufficient_data"}:
+    if holdout["verdict"] == "no_difference":
         return "conditional_go"
     return "no_go"
 

--- a/aragora/evaluation/outcome_backed_report.py
+++ b/aragora/evaluation/outcome_backed_report.py
@@ -1,0 +1,541 @@
+"""Deterministic final reporting for outcome-backed decision quality.
+
+This contract is intentionally frozen before benchmark inference begins.  It
+maps the pre-registered development and holdout analysis results, paid-call
+budget custody, and holdout exposure custody to exactly one public verdict:
+``go``, ``conditional_go``, or ``no_go``.
+
+Malformed or version-mismatched inputs raise ``ValueError``.  Valid negative
+evidence does not: a baseline win, budget breach, unsettled reservation, or
+holdout custody violation deterministically worsens the result to ``no_go``.
+That distinction keeps data-integrity failures fail-closed while preserving an
+honest benchmark outcome.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date
+from decimal import Decimal, InvalidOperation
+import math
+import re
+
+from aragora.evaluation.outcome_backed_analysis import ANALYSIS_CONTRACT_VERSION
+from aragora.evaluation.outcome_backed_budget import (
+    BUDGET_LEDGER_SCHEMA,
+    DAILY_BUDGET_CAP_USD,
+)
+from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID, SPLIT_COUNTS
+from aragora.evaluation.outcome_backed_holdout import (
+    HOLDOUT_CONTRACT_VERSION,
+    MAX_HOLDOUT_EXPOSURES,
+)
+from aragora.evaluation.outcome_backed_scoring import SCORER_CONTRACT_VERSION
+
+
+REPORT_CONTRACT_VERSION = "outcome-backed-decision-quality-report/1.0"
+MIN_REQUIRED_HOLDOUT_EXPOSURES = 2
+
+_ANALYSIS_VERDICTS = frozenset(
+    {"team_outperforms", "baseline_outperforms", "no_difference", "insufficient_data"}
+)
+_FINAL_VERDICTS = frozenset({"go", "conditional_go", "no_go"})
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _required_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _integer(value: object, field: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{field} must be an integer >= {minimum}")
+    return value
+
+
+def _finite_number(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a finite number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{field} must be a finite number")
+    return number
+
+
+def _money(value: object, field: str) -> Decimal:
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be a finite non-negative USD amount")
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        raise ValueError(f"{field} must be a finite non-negative USD amount") from None
+    if not amount.is_finite() or amount < 0:
+        raise ValueError(f"{field} must be a finite non-negative USD amount")
+    return amount
+
+
+def _money_text(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _analysis_report(
+    report: Mapping[str, object],
+    *,
+    phase: str,
+    expected_count: int,
+) -> dict[str, object]:
+    if not isinstance(report, Mapping):
+        raise ValueError(f"{phase}_report must be an object")
+    if report.get("analysis_contract_version") != ANALYSIS_CONTRACT_VERSION:
+        raise ValueError(f"{phase}_report analysis contract version mismatch")
+    if report.get("scorer_contract_version") != SCORER_CONTRACT_VERSION:
+        raise ValueError(f"{phase}_report scorer contract version mismatch")
+
+    n = _integer(report.get("n"), f"{phase}_report.n", minimum=1)
+    if n != expected_count:
+        raise ValueError(f"{phase}_report.n must equal {expected_count}")
+    team_condition_id = _required_text(
+        report.get("team_condition_id"), f"{phase}_report.team_condition_id"
+    )
+    strongest_baseline_id = _required_text(
+        report.get("strongest_baseline_id"), f"{phase}_report.strongest_baseline_id"
+    )
+    verdict = report.get("verdict")
+    if verdict not in _ANALYSIS_VERDICTS:
+        raise ValueError(f"{phase}_report.verdict is not recognized")
+
+    raw_summaries = report.get("per_baseline")
+    if (
+        isinstance(raw_summaries, (str, bytes))
+        or not isinstance(raw_summaries, Sequence)
+        or not raw_summaries
+    ):
+        raise ValueError(f"{phase}_report.per_baseline must be a non-empty array")
+    summaries: list[dict[str, object]] = []
+    condition_ids: set[str] = set()
+    for index, raw_summary in enumerate(raw_summaries):
+        if not isinstance(raw_summary, Mapping):
+            raise ValueError(f"{phase}_report.per_baseline[{index}] must be an object")
+        prefix = f"{phase}_report.per_baseline[{index}]"
+        condition_id = _required_text(raw_summary.get("condition_id"), f"{prefix}.condition_id")
+        if condition_id in condition_ids:
+            raise ValueError(f"{phase}_report has duplicate baseline {condition_id!r}")
+        condition_ids.add(condition_id)
+        p_value = _finite_number(
+            raw_summary.get("exact_sign_flip_p_value"),
+            f"{prefix}.exact_sign_flip_p_value",
+        )
+        summary = {
+            "condition_id": condition_id,
+            "team_mean_composite_score": _finite_number(
+                raw_summary.get("team_mean_composite_score"),
+                f"{prefix}.team_mean_composite_score",
+            ),
+            "baseline_mean_composite_score": _finite_number(
+                raw_summary.get("baseline_mean_composite_score"),
+                f"{prefix}.baseline_mean_composite_score",
+            ),
+            "mean_composite_delta": _finite_number(
+                raw_summary.get("mean_composite_delta"), f"{prefix}.mean_composite_delta"
+            ),
+            "mean_brier_improvement": _finite_number(
+                raw_summary.get("mean_brier_improvement"),
+                f"{prefix}.mean_brier_improvement",
+            ),
+            "exact_sign_flip_p_value": p_value,
+        }
+        if not 0.0 <= p_value <= 1.0:
+            raise ValueError(f"{prefix}.exact_sign_flip_p_value must be between 0 and 1")
+        summaries.append(summary)
+    if strongest_baseline_id not in condition_ids:
+        raise ValueError(f"{phase}_report strongest baseline is missing from per_baseline")
+
+    return {
+        "phase": phase,
+        "n": n,
+        "team_condition_id": team_condition_id,
+        "strongest_baseline_id": strongest_baseline_id,
+        "verdict": verdict,
+        "per_baseline": sorted(summaries, key=lambda item: str(item["condition_id"])),
+    }
+
+
+def _budget_documents(
+    snapshots: Sequence[Mapping[str, object]],
+) -> tuple[dict[str, object], ...]:
+    if isinstance(snapshots, (str, bytes)) or not isinstance(snapshots, Sequence):
+        raise ValueError("budget_snapshots must be an array")
+    if not snapshots:
+        raise ValueError("budget_snapshots must contain at least one UTC day")
+
+    documents: list[dict[str, object]] = []
+    seen_dates: set[str] = set()
+    for index, snapshot in enumerate(snapshots):
+        if not isinstance(snapshot, Mapping):
+            raise ValueError(f"budget_snapshots[{index}] must be an object")
+        prefix = f"budget_snapshots[{index}]"
+        utc_date = _required_text(snapshot.get("utc_date"), f"{prefix}.utc_date")
+        try:
+            date.fromisoformat(utc_date)
+        except ValueError:
+            raise ValueError(f"{prefix}.utc_date must be YYYY-MM-DD") from None
+        if utc_date in seen_dates:
+            raise ValueError(f"budget_snapshots has duplicate UTC date {utc_date}")
+        seen_dates.add(utc_date)
+
+        cap = _money(snapshot.get("cap_usd"), f"{prefix}.cap_usd")
+        if cap != DAILY_BUDGET_CAP_USD:
+            raise ValueError(
+                f"{prefix}.cap_usd must equal the frozen ${_money_text(DAILY_BUDGET_CAP_USD)} cap"
+            )
+        settled = _money(snapshot.get("settled_usd"), f"{prefix}.settled_usd")
+        reserved = _money(snapshot.get("reserved_usd"), f"{prefix}.reserved_usd")
+        committed = _money(snapshot.get("committed_usd"), f"{prefix}.committed_usd")
+        remaining = _money(snapshot.get("remaining_usd"), f"{prefix}.remaining_usd")
+        if committed != settled + reserved:
+            raise ValueError(f"{prefix}.committed_usd does not equal settled plus reserved")
+        if remaining != max(Decimal("0"), cap - committed):
+            raise ValueError(f"{prefix}.remaining_usd is inconsistent with committed spend")
+        open_reservations = _integer(
+            snapshot.get("open_reservations"), f"{prefix}.open_reservations"
+        )
+        event_count = _integer(snapshot.get("event_count"), f"{prefix}.event_count")
+        exceeded = snapshot.get("exceeded")
+        if not isinstance(exceeded, bool):
+            raise ValueError(f"{prefix}.exceeded must be a boolean")
+        if exceeded != (committed > cap):
+            raise ValueError(f"{prefix}.exceeded is inconsistent with committed spend")
+        documents.append(
+            {
+                "utc_date": utc_date,
+                "cap_usd": _money_text(cap),
+                "settled_usd": _money_text(settled),
+                "reserved_usd": _money_text(reserved),
+                "committed_usd": _money_text(committed),
+                "remaining_usd": _money_text(remaining),
+                "open_reservations": open_reservations,
+                "event_count": event_count,
+                "exceeded": exceeded,
+            }
+        )
+    return tuple(sorted(documents, key=lambda item: str(item["utc_date"])))
+
+
+def _holdout_document(snapshot: Mapping[str, object]) -> dict[str, object]:
+    if not isinstance(snapshot, Mapping):
+        raise ValueError("holdout_snapshot must be an object")
+    if snapshot.get("holdout_contract_version") != HOLDOUT_CONTRACT_VERSION:
+        raise ValueError("holdout_snapshot contract version mismatch")
+    max_exposures = _integer(
+        snapshot.get("max_exposures_per_registry"),
+        "holdout_snapshot.max_exposures_per_registry",
+        minimum=1,
+    )
+    if max_exposures != MAX_HOLDOUT_EXPOSURES:
+        raise ValueError("holdout_snapshot exposure limit mismatch")
+    event_count = _integer(snapshot.get("event_count"), "holdout_snapshot.event_count")
+    raw_registries = snapshot.get("registries")
+    if (
+        isinstance(raw_registries, (str, bytes))
+        or not isinstance(raw_registries, Sequence)
+        or len(raw_registries) != 1
+    ):
+        raise ValueError("holdout_snapshot must contain exactly one frozen registry")
+
+    raw_registry = raw_registries[0]
+    if not isinstance(raw_registry, Mapping):
+        raise ValueError("holdout_snapshot.registries[0] must be an object")
+    registry_hash = raw_registry.get("registry_hash")
+    if not isinstance(registry_hash, str) or not _SHA256_RE.fullmatch(registry_hash):
+        raise ValueError("holdout_snapshot registry hash must be lowercase SHA-256")
+    exposure_count = _integer(raw_registry.get("exposure_count"), "holdout_snapshot.exposure_count")
+    remaining_exposures = _integer(
+        raw_registry.get("remaining_exposures"), "holdout_snapshot.remaining_exposures"
+    )
+    expected_remaining = max(0, max_exposures - exposure_count)
+    if remaining_exposures != expected_remaining:
+        raise ValueError("holdout_snapshot remaining exposures are inconsistent")
+    raw_labels = raw_registry.get("run_labels")
+    if isinstance(raw_labels, (str, bytes)) or not isinstance(raw_labels, Sequence):
+        raise ValueError("holdout_snapshot run_labels must be an array")
+    run_labels = tuple(
+        _required_text(label, f"holdout_snapshot.run_labels[{index}]")
+        for index, label in enumerate(raw_labels)
+    )
+    if len(run_labels) != exposure_count or len(set(run_labels)) != len(run_labels):
+        raise ValueError("holdout_snapshot run_labels must uniquely match exposure_count")
+    if event_count != exposure_count:
+        raise ValueError(
+            "holdout_snapshot event_count must match the frozen registry exposure count"
+        )
+    return {
+        "holdout_contract_version": HOLDOUT_CONTRACT_VERSION,
+        "max_exposures_per_registry": max_exposures,
+        "event_count": event_count,
+        "registries": [
+            {
+                "registry_hash": registry_hash,
+                "exposure_count": exposure_count,
+                "remaining_exposures": remaining_exposures,
+                "run_labels": sorted(run_labels),
+            }
+        ],
+    }
+
+
+def _budget_is_clean(snapshots: Sequence[Mapping[str, object]]) -> bool:
+    for index, snapshot in enumerate(snapshots):
+        open_reservations = _integer(
+            snapshot.get("open_reservations"), f"budget_snapshots[{index}].open_reservations"
+        )
+        committed = _money(
+            snapshot.get("committed_usd"), f"budget_snapshots[{index}].committed_usd"
+        )
+        if bool(snapshot.get("exceeded")) or committed > DAILY_BUDGET_CAP_USD:
+            return False
+        if open_reservations:
+            return False
+    return True
+
+
+def _single_registry(snapshot: Mapping[str, object]) -> Mapping[str, object]:
+    registries = snapshot.get("registries")
+    if not isinstance(registries, list) or len(registries) != 1:
+        raise ValueError("normalized holdout snapshot must contain one registry")
+    registry = registries[0]
+    if not isinstance(registry, Mapping):
+        raise ValueError("normalized holdout registry must be an object")
+    return registry
+
+
+def _holdout_custody_is_clean(snapshot: Mapping[str, object]) -> bool:
+    registry = _single_registry(snapshot)
+    exposure_count = _integer(registry.get("exposure_count"), "holdout_snapshot.exposure_count")
+    return MIN_REQUIRED_HOLDOUT_EXPOSURES <= exposure_count <= MAX_HOLDOUT_EXPOSURES
+
+
+def _validated_inputs(
+    development_report: Mapping[str, object],
+    holdout_report: Mapping[str, object],
+    budget_snapshots: Sequence[Mapping[str, object]],
+    holdout_snapshot: Mapping[str, object],
+) -> tuple[dict[str, object], dict[str, object], tuple[dict[str, object], ...], dict[str, object]]:
+    development = _analysis_report(
+        development_report,
+        phase="development",
+        expected_count=SPLIT_COUNTS["development"],
+    )
+    holdout = _analysis_report(
+        holdout_report,
+        phase="holdout",
+        expected_count=SPLIT_COUNTS["holdout"],
+    )
+    budgets = _budget_documents(budget_snapshots)
+    custody = _holdout_document(holdout_snapshot)
+    return development, holdout, budgets, custody
+
+
+def final_verdict(
+    development_report: Mapping[str, object],
+    holdout_report: Mapping[str, object],
+    budget_snapshots: Sequence[Mapping[str, object]],
+    holdout_snapshot: Mapping[str, object],
+) -> str:
+    """Return the frozen final benchmark verdict.
+
+    ``go`` requires the team to outperform in both the complete development
+    and holdout analyses with settled, under-cap budget custody and two or
+    three recorded holdout exposures.  ``conditional_go`` requires a
+    development win and a complete but statistically unconfirmed holdout
+    result (``no_difference`` or ``insufficient_data``) under the same custody
+    gates.  Every baseline win, inconclusive development result, budget
+    violation, or holdout custody violation returns ``no_go``.
+
+    Missing, malformed, or version-mismatched inputs raise ``ValueError``.
+    """
+
+    development, holdout, budgets, custody = _validated_inputs(
+        development_report,
+        holdout_report,
+        budget_snapshots,
+        holdout_snapshot,
+    )
+    if not _budget_is_clean(budgets) or not _holdout_custody_is_clean(custody):
+        return "no_go"
+    if development["verdict"] != "team_outperforms":
+        return "no_go"
+    if holdout["verdict"] == "team_outperforms":
+        return "go"
+    if holdout["verdict"] in {"no_difference", "insufficient_data"}:
+        return "conditional_go"
+    return "no_go"
+
+
+def _strongest_summary(report: Mapping[str, object]) -> Mapping[str, object]:
+    strongest = report["strongest_baseline_id"]
+    summaries = report.get("per_baseline")
+    if not isinstance(summaries, list):
+        raise ValueError("normalized analysis report must contain baseline summaries")
+    for summary in summaries:
+        if isinstance(summary, Mapping) and summary.get("condition_id") == strongest:
+            return summary
+    raise ValueError("normalized analysis report is missing its strongest baseline")
+
+
+def _format_metric(value: object) -> str:
+    return format(_finite_number(value, "report metric"), ".6f")
+
+
+def _verdict_reasons(
+    development: Mapping[str, object],
+    holdout: Mapping[str, object],
+    budgets: Sequence[Mapping[str, object]],
+    custody: Mapping[str, object],
+) -> tuple[str, ...]:
+    reasons = [
+        f"Development analysis: `{development['verdict']}`.",
+        f"Holdout analysis: `{holdout['verdict']}`.",
+        "Budget custody: `clean`." if _budget_is_clean(budgets) else "Budget custody: `violated`.",
+        (
+            "Holdout custody: `clean`."
+            if _holdout_custody_is_clean(custody)
+            else "Holdout custody: `violated or incomplete`."
+        ),
+    ]
+    return tuple(reasons)
+
+
+def render_report(
+    development_report: Mapping[str, object],
+    holdout_report: Mapping[str, object],
+    budget_snapshots: Sequence[Mapping[str, object]],
+    holdout_snapshot: Mapping[str, object],
+) -> str:
+    """Render byte-deterministic Markdown for the final benchmark report."""
+
+    development, holdout, budgets, custody = _validated_inputs(
+        development_report,
+        holdout_report,
+        budget_snapshots,
+        holdout_snapshot,
+    )
+    verdict = final_verdict(development_report, holdout_report, budget_snapshots, holdout_snapshot)
+    if verdict not in _FINAL_VERDICTS:  # pragma: no cover - defensive contract assertion
+        raise ValueError("final verdict is not recognized")
+    development_summary = _strongest_summary(development)
+    holdout_summary = _strongest_summary(holdout)
+    registry = _single_registry(custody)
+    run_labels = registry.get("run_labels")
+    if not isinstance(run_labels, list):
+        raise ValueError("normalized holdout registry must contain run labels")
+
+    lines = [
+        "# Decision Quality Delta Benchmark Report",
+        "",
+        "## 1. Benchmark Contract",
+        "",
+        f"- Benchmark ID: `{BENCHMARK_ID}`",
+        f"- Report contract: `{REPORT_CONTRACT_VERSION}`",
+        f"- Analysis contract: `{ANALYSIS_CONTRACT_VERSION}`",
+        f"- Scorer contract: `{SCORER_CONTRACT_VERSION}`",
+        f"- Budget ledger schema: `{BUDGET_LEDGER_SCHEMA}`",
+        f"- Holdout contract: `{HOLDOUT_CONTRACT_VERSION}`",
+        "",
+        "## 2. Benchmark Statement",
+        "",
+        "Same frozen cases and evidence compare fixed single-model baselines with the "
+        "Aragora team; outcomes are scored without result-dependent threshold changes.",
+        "",
+        "## 3. Condition Summary",
+        "",
+        "| Phase | Cases | Team condition | Strongest single baseline | Analysis verdict |",
+        "|---|---:|---|---|---|",
+        (
+            f"| Development | {development['n']} | `{development['team_condition_id']}` | "
+            f"`{development['strongest_baseline_id']}` | `{development['verdict']}` |"
+        ),
+        (
+            f"| Holdout | {holdout['n']} | `{holdout['team_condition_id']}` | "
+            f"`{holdout['strongest_baseline_id']}` | `{holdout['verdict']}` |"
+        ),
+        "",
+        "## 4. Primary Metrics",
+        "",
+        "| Phase | Team composite | Best-single composite | Composite delta | "
+        "Brier improvement | Exact p-value |",
+        "|---|---:|---:|---:|---:|---:|",
+        (
+            f"| Development | {_format_metric(development_summary['team_mean_composite_score'])} | "
+            f"{_format_metric(development_summary['baseline_mean_composite_score'])} | "
+            f"{_format_metric(development_summary['mean_composite_delta'])} | "
+            f"{_format_metric(development_summary['mean_brier_improvement'])} | "
+            f"{_format_metric(development_summary['exact_sign_flip_p_value'])} |"
+        ),
+        (
+            f"| Holdout | {_format_metric(holdout_summary['team_mean_composite_score'])} | "
+            f"{_format_metric(holdout_summary['baseline_mean_composite_score'])} | "
+            f"{_format_metric(holdout_summary['mean_composite_delta'])} | "
+            f"{_format_metric(holdout_summary['mean_brier_improvement'])} | "
+            f"{_format_metric(holdout_summary['exact_sign_flip_p_value'])} |"
+        ),
+        "",
+        "The frozen absolute Brier-improvement target is `>= 0.05`; uncertainty is "
+        "descriptive and this corpus does not justify a broad significance claim.",
+        "",
+        "## 5. Cost and Custody",
+        "",
+        "| UTC date | Settled USD | Reserved USD | Committed USD | Cap USD | Open reservations | Status |",
+        "|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for snapshot in budgets:
+        status = "violation" if snapshot["exceeded"] or snapshot["open_reservations"] else "clean"
+        lines.append(
+            f"| {snapshot['utc_date']} | {snapshot['settled_usd']} | {snapshot['reserved_usd']} | "
+            f"{snapshot['committed_usd']} | {snapshot['cap_usd']} | "
+            f"{snapshot['open_reservations']} | {status} |"
+        )
+    lines.extend(
+        [
+            "",
+            "| Holdout registry | Exposures | Remaining | Run labels | Custody |",
+            "|---|---:|---:|---|---|",
+            (
+                f"| `{registry['registry_hash']}` | {registry['exposure_count']} | "
+                f"{registry['remaining_exposures']} | "
+                f"{', '.join(f'`{label}`' for label in run_labels)} | "
+                f"{'clean' if _holdout_custody_is_clean(custody) else 'violation or incomplete'} |"
+            ),
+            "",
+            "## 6. Interpretation",
+            "",
+        ]
+    )
+    lines.extend(
+        f"- {reason}" for reason in _verdict_reasons(development, holdout, budgets, custody)
+    )
+    lines.extend(
+        [
+            "",
+            "## 7. Gate Decision",
+            "",
+            f"`{verdict}`",
+            "",
+            "This verdict is produced mechanically from the frozen contracts above. "
+            "It is not a claim of statistical significance and does not erase recorded failures.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "MIN_REQUIRED_HOLDOUT_EXPOSURES",
+    "REPORT_CONTRACT_VERSION",
+    "final_verdict",
+    "render_report",
+]

--- a/tests/evaluation/test_outcome_backed_analysis.py
+++ b/tests/evaluation/test_outcome_backed_analysis.py
@@ -60,6 +60,12 @@ def _rows(count: int, *, team_brier: float, baseline_brier: float):
     return team, baseline
 
 
+def _holdout_rows(count: int, *, team_brier: float, baseline_brier: float):
+    team = [_score(f"holdout-{index:02d}", brier=team_brier) for index in range(count)]
+    baseline = [_score(f"holdout-{index:02d}", brier=baseline_brier) for index in range(count)]
+    return team, baseline
+
+
 def test_report_is_byte_identical_across_repeated_calls() -> None:
     team, baseline = _rows(16, team_brier=0.2, baseline_brier=0.3)
 
@@ -69,6 +75,7 @@ def test_report_is_byte_identical_across_repeated_calls() -> None:
     assert json.dumps(first, sort_keys=True, separators=(",", ":")) == json.dumps(
         second, sort_keys=True, separators=(",", ":")
     )
+    assert first["phase"] == "development"
 
 
 def test_hand_computed_three_case_summary_and_exact_p_value() -> None:
@@ -159,6 +166,49 @@ def test_fewer_than_sixteen_pairs_is_insufficient_data() -> None:
     team, baseline = _rows(15, team_brier=0.2, baseline_brier=0.3)
 
     assert _analyze(team, baseline).verdict == "insufficient_data"
+
+
+def test_complete_holdout_phase_can_outperform() -> None:
+    team, baseline = _holdout_rows(8, team_brier=0.2, baseline_brier=0.3)
+    holdout_case_ids = {str(row["case_id"]) for row in team}
+
+    report = _analyze(
+        team,
+        baseline,
+        phase="holdout",
+        holdout_case_ids=holdout_case_ids,
+    )
+
+    assert report.phase == "holdout"
+    assert report.n == 8
+    assert report.verdict == "team_outperforms"
+    assert report.to_dict()["thresholds"]["expected_case_count"] == 8
+
+
+def test_partial_holdout_phase_is_insufficient_data() -> None:
+    team, baseline = _holdout_rows(7, team_brier=0.2, baseline_brier=0.3)
+    holdout_case_ids = {f"holdout-{index:02d}" for index in range(8)}
+
+    report = _analyze(
+        team,
+        baseline,
+        phase="holdout",
+        holdout_case_ids=holdout_case_ids,
+    )
+
+    assert report.verdict == "insufficient_data"
+
+
+def test_holdout_phase_rejects_unregistered_case_id() -> None:
+    team, baseline = _holdout_rows(2, team_brier=0.2, baseline_brier=0.3)
+
+    with pytest.raises(ValueError, match="non-holdout case IDs"):
+        _analyze(
+            team,
+            baseline,
+            phase="holdout",
+            holdout_case_ids={"holdout-00"},
+        )
 
 
 def test_exact_sign_flip_matches_independent_brute_force_for_eight_pairs() -> None:

--- a/tests/evaluation/test_outcome_backed_report.py
+++ b/tests/evaluation/test_outcome_backed_report.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from aragora.evaluation.outcome_backed_analysis import ANALYSIS_CONTRACT_VERSION
+from aragora.evaluation.outcome_backed_holdout import (
+    HOLDOUT_CONTRACT_VERSION,
+    MAX_HOLDOUT_EXPOSURES,
+)
+from aragora.evaluation.outcome_backed_report import (
+    REPORT_CONTRACT_VERSION,
+    final_verdict,
+    render_report,
+)
+from aragora.evaluation.outcome_backed_scoring import SCORER_CONTRACT_VERSION
+
+
+REGISTRY_HASH = "a" * 64
+
+
+def _summary(condition_id: str, *, brier_improvement: float = 0.08) -> dict[str, object]:
+    return {
+        "condition_id": condition_id,
+        "team_mean_composite_score": 0.78,
+        "baseline_mean_composite_score": 0.68,
+        "mean_composite_delta": 0.1,
+        "mean_brier_improvement": brier_improvement,
+        "wins": 14,
+        "ties": 1,
+        "losses": 1,
+        "exact_sign_flip_p_value": 0.01,
+        "case_deltas": [],
+    }
+
+
+def _analysis_report(
+    phase: str,
+    verdict: str,
+    *,
+    reverse_baselines: bool = False,
+) -> dict[str, object]:
+    summaries = [_summary("openai"), _summary("claude", brier_improvement=0.06)]
+    if reverse_baselines:
+        summaries.reverse()
+    return {
+        "analysis_contract_version": ANALYSIS_CONTRACT_VERSION,
+        "scorer_contract_version": SCORER_CONTRACT_VERSION,
+        "team_condition_id": "aragora_team",
+        "n": 16 if phase == "development" else 8,
+        "strongest_baseline_id": "claude",
+        "strongest_baseline_rule": "frozen rule",
+        "thresholds": {},
+        "per_baseline": summaries,
+        "verdict": verdict,
+    }
+
+
+def _budget_snapshot(
+    utc_date: str = "2026-08-30",
+    *,
+    settled: str = "4",
+    reserved: str = "0",
+    open_reservations: int = 0,
+    exceeded: bool = False,
+) -> dict[str, object]:
+    committed = str(float(settled) + float(reserved)).rstrip("0").rstrip(".") or "0"
+    remaining = str(max(0.0, 25.0 - float(committed))).rstrip("0").rstrip(".") or "0"
+    return {
+        "utc_date": utc_date,
+        "cap_usd": "25",
+        "settled_usd": settled,
+        "reserved_usd": reserved,
+        "committed_usd": committed,
+        "remaining_usd": remaining,
+        "open_reservations": open_reservations,
+        "event_count": 2,
+        "exceeded": exceeded,
+    }
+
+
+def _holdout_snapshot(exposure_count: int = 2) -> dict[str, object]:
+    return {
+        "holdout_contract_version": HOLDOUT_CONTRACT_VERSION,
+        "max_exposures_per_registry": MAX_HOLDOUT_EXPOSURES,
+        "event_count": exposure_count,
+        "registries": [
+            {
+                "registry_hash": REGISTRY_HASH,
+                "exposure_count": exposure_count,
+                "remaining_exposures": max(0, MAX_HOLDOUT_EXPOSURES - exposure_count),
+                "run_labels": [f"holdout-r{index}" for index in range(1, exposure_count + 1)],
+            }
+        ],
+    }
+
+
+def _verdict(
+    development: str,
+    holdout: str,
+    *,
+    budgets: list[dict[str, object]] | None = None,
+    custody: dict[str, object] | None = None,
+) -> str:
+    return final_verdict(
+        _analysis_report("development", development),
+        _analysis_report("holdout", holdout),
+        budgets or [_budget_snapshot()],
+        custody or _holdout_snapshot(),
+    )
+
+
+def test_report_contract_version_is_frozen() -> None:
+    assert REPORT_CONTRACT_VERSION == "outcome-backed-decision-quality-report/1.0"
+
+
+@pytest.mark.parametrize(
+    ("development", "holdout", "expected"),
+    [
+        ("team_outperforms", "team_outperforms", "go"),
+        ("team_outperforms", "no_difference", "conditional_go"),
+        ("team_outperforms", "insufficient_data", "conditional_go"),
+        ("team_outperforms", "baseline_outperforms", "no_go"),
+        ("baseline_outperforms", "team_outperforms", "no_go"),
+        ("no_difference", "team_outperforms", "no_go"),
+        ("insufficient_data", "team_outperforms", "no_go"),
+    ],
+)
+def test_frozen_verdict_branches(development: str, holdout: str, expected: str) -> None:
+    assert _verdict(development, holdout) == expected
+
+
+@pytest.mark.parametrize(
+    "budget",
+    [
+        _budget_snapshot(settled="26", exceeded=True),
+        _budget_snapshot(reserved="1", open_reservations=1),
+    ],
+)
+def test_budget_violation_forces_no_go_despite_team_wins(budget: dict[str, object]) -> None:
+    assert _verdict("team_outperforms", "team_outperforms", budgets=[budget]) == "no_go"
+
+
+@pytest.mark.parametrize("exposures", [1, MAX_HOLDOUT_EXPOSURES + 1])
+def test_holdout_custody_violation_forces_no_go_despite_team_wins(exposures: int) -> None:
+    assert (
+        _verdict(
+            "team_outperforms",
+            "team_outperforms",
+            custody=_holdout_snapshot(exposures),
+        )
+        == "no_go"
+    )
+
+
+@pytest.mark.parametrize(
+    ("target", "field", "value", "message"),
+    [
+        ("development", "analysis_contract_version", "future-analysis", "analysis contract"),
+        ("holdout", "scorer_contract_version", "future-scorer", "scorer contract"),
+        ("development", "n", 15, r"n must equal 16"),
+        ("holdout", "n", 7, r"n must equal 8"),
+        ("development", "per_baseline", [], "non-empty array"),
+    ],
+)
+def test_analysis_input_defects_fail_closed(
+    target: str,
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    development = _analysis_report("development", "team_outperforms")
+    holdout = _analysis_report("holdout", "team_outperforms")
+    report = development if target == "development" else holdout
+    report[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        final_verdict(development, holdout, [_budget_snapshot()], _holdout_snapshot())
+
+
+def test_budget_shape_defect_fails_closed() -> None:
+    budget = _budget_snapshot()
+    budget["committed_usd"] = "5"
+
+    with pytest.raises(ValueError, match="settled plus reserved"):
+        _verdict("team_outperforms", "team_outperforms", budgets=[budget])
+
+
+def test_holdout_shape_and_version_defects_fail_closed() -> None:
+    wrong_version = _holdout_snapshot()
+    wrong_version["holdout_contract_version"] = "future-holdout"
+    with pytest.raises(ValueError, match="contract version mismatch"):
+        _verdict("team_outperforms", "team_outperforms", custody=wrong_version)
+
+    missing_registry = _holdout_snapshot()
+    missing_registry["registries"] = []
+    with pytest.raises(ValueError, match="exactly one frozen registry"):
+        _verdict("team_outperforms", "team_outperforms", custody=missing_registry)
+
+
+def test_render_report_is_byte_identical_and_stably_ordered() -> None:
+    development = _analysis_report("development", "team_outperforms")
+    holdout = _analysis_report("holdout", "no_difference")
+    budgets = [_budget_snapshot("2026-08-31"), _budget_snapshot("2026-08-30")]
+
+    first = render_report(development, holdout, budgets, _holdout_snapshot())
+    second = render_report(
+        _analysis_report("development", "team_outperforms", reverse_baselines=True),
+        _analysis_report("holdout", "no_difference", reverse_baselines=True),
+        list(reversed(deepcopy(budgets))),
+        _holdout_snapshot(),
+    )
+
+    assert first == second
+    assert first.index("2026-08-30") < first.index("2026-08-31")
+    assert "## 3. Condition Summary" in first
+    assert "## 4. Primary Metrics" in first
+    assert "## 7. Gate Decision" in first
+    assert "`conditional_go`" in first
+    assert "not a claim of statistical significance" in first

--- a/tests/evaluation/test_outcome_backed_report.py
+++ b/tests/evaluation/test_outcome_backed_report.py
@@ -4,7 +4,10 @@ from copy import deepcopy
 
 import pytest
 
-from aragora.evaluation.outcome_backed_analysis import ANALYSIS_CONTRACT_VERSION
+from aragora.evaluation.outcome_backed_analysis import (
+    ANALYSIS_CONTRACT_VERSION,
+    analyze_scored_conditions,
+)
 from aragora.evaluation.outcome_backed_holdout import (
     HOLDOUT_CONTRACT_VERSION,
     MAX_HOLDOUT_EXPOSURES,
@@ -20,17 +23,23 @@ from aragora.evaluation.outcome_backed_scoring import SCORER_CONTRACT_VERSION
 REGISTRY_HASH = "a" * 64
 
 
-def _summary(condition_id: str, *, brier_improvement: float = 0.08) -> dict[str, object]:
+def _summary(condition_id: str, verdict: str) -> dict[str, object]:
+    if verdict == "team_outperforms":
+        team_score, baseline_score, delta, brier, p_value = 0.78, 0.68, 0.1, 0.08, 0.01
+    elif verdict == "baseline_outperforms":
+        team_score, baseline_score, delta, brier, p_value = 0.68, 0.78, -0.1, -0.08, 0.01
+    else:
+        team_score, baseline_score, delta, brier, p_value = 0.7, 0.7, 0.0, 0.0, 1.0
     return {
         "condition_id": condition_id,
-        "team_mean_composite_score": 0.78,
-        "baseline_mean_composite_score": 0.68,
-        "mean_composite_delta": 0.1,
-        "mean_brier_improvement": brier_improvement,
+        "team_mean_composite_score": team_score,
+        "baseline_mean_composite_score": baseline_score,
+        "mean_composite_delta": delta,
+        "mean_brier_improvement": brier,
         "wins": 14,
         "ties": 1,
         "losses": 1,
-        "exact_sign_flip_p_value": 0.01,
+        "exact_sign_flip_p_value": p_value,
         "case_deltas": [],
     }
 
@@ -41,12 +50,13 @@ def _analysis_report(
     *,
     reverse_baselines: bool = False,
 ) -> dict[str, object]:
-    summaries = [_summary("openai"), _summary("claude", brier_improvement=0.06)]
+    summaries = [_summary("openai", verdict), _summary("claude", verdict)]
     if reverse_baselines:
         summaries.reverse()
     return {
         "analysis_contract_version": ANALYSIS_CONTRACT_VERSION,
         "scorer_contract_version": SCORER_CONTRACT_VERSION,
+        "phase": phase,
         "team_condition_id": "aragora_team",
         "n": 16 if phase == "development" else 8,
         "strongest_baseline_id": "claude",
@@ -120,11 +130,9 @@ def test_report_contract_version_is_frozen() -> None:
     [
         ("team_outperforms", "team_outperforms", "go"),
         ("team_outperforms", "no_difference", "conditional_go"),
-        ("team_outperforms", "insufficient_data", "conditional_go"),
         ("team_outperforms", "baseline_outperforms", "no_go"),
         ("baseline_outperforms", "team_outperforms", "no_go"),
         ("no_difference", "team_outperforms", "no_go"),
-        ("insufficient_data", "team_outperforms", "no_go"),
     ],
 )
 def test_frozen_verdict_branches(development: str, holdout: str, expected: str) -> None:
@@ -177,6 +185,95 @@ def test_analysis_input_defects_fail_closed(
 
     with pytest.raises(ValueError, match=message):
         final_verdict(development, holdout, [_budget_snapshot()], _holdout_snapshot())
+
+
+def test_analysis_phase_and_claimed_verdict_must_match_metrics() -> None:
+    development = _analysis_report("development", "team_outperforms")
+    holdout = _analysis_report("holdout", "team_outperforms")
+    holdout["phase"] = "development"
+    with pytest.raises(ValueError, match="phase mismatch"):
+        final_verdict(development, holdout, [_budget_snapshot()], _holdout_snapshot())
+
+    holdout = _analysis_report("holdout", "team_outperforms")
+    holdout["verdict"] = "no_difference"
+    with pytest.raises(ValueError, match="verdict does not match"):
+        final_verdict(development, holdout, [_budget_snapshot()], _holdout_snapshot())
+
+
+def test_strongest_baseline_must_match_metrics() -> None:
+    development = _analysis_report("development", "team_outperforms")
+    holdout = _analysis_report("holdout", "team_outperforms")
+    development["strongest_baseline_id"] = "openai"
+
+    with pytest.raises(ValueError, match="strongest baseline does not match"):
+        final_verdict(development, holdout, [_budget_snapshot()], _holdout_snapshot())
+
+
+def test_summary_delta_must_match_reported_means() -> None:
+    development = _analysis_report("development", "team_outperforms")
+    holdout = _analysis_report("holdout", "team_outperforms")
+    summaries = development["per_baseline"]
+    assert isinstance(summaries, list)
+    summaries[0]["mean_composite_delta"] = 0.2
+
+    with pytest.raises(ValueError, match="mean_composite_delta does not match"):
+        final_verdict(development, holdout, [_budget_snapshot()], _holdout_snapshot())
+
+
+def test_complete_report_rejects_insufficient_data_claim() -> None:
+    development = _analysis_report("development", "team_outperforms")
+    holdout = _analysis_report("holdout", "no_difference")
+    holdout["verdict"] = "insufficient_data"
+
+    with pytest.raises(ValueError, match="verdict does not match"):
+        final_verdict(development, holdout, [_budget_snapshot()], _holdout_snapshot())
+
+
+def _scored_rows(prefix: str, count: int, *, brier: float) -> list[dict[str, object]]:
+    return [
+        {
+            "case_id": f"{prefix}-{index:02d}",
+            "binary_brier": brier,
+            "directional_accuracy": 1.0,
+            "crux_recall": 0.8,
+            "provenance_completeness": 1.0,
+            "receipt_verification_rate": 1.0,
+        }
+        for index in range(count)
+    ]
+
+
+def test_real_development_and_holdout_analysis_can_produce_go() -> None:
+    development = analyze_scored_conditions(
+        {
+            "aragora_team": _scored_rows("dev", 16, brier=0.2),
+            "openai": _scored_rows("dev", 16, brier=0.3),
+        },
+        team_condition_id="aragora_team",
+        scorer_contract_version=SCORER_CONTRACT_VERSION,
+        holdout_case_ids=set(),
+    ).to_dict()
+    holdout_ids = {f"holdout-{index:02d}" for index in range(8)}
+    holdout = analyze_scored_conditions(
+        {
+            "aragora_team": _scored_rows("holdout", 8, brier=0.2),
+            "openai": _scored_rows("holdout", 8, brier=0.3),
+        },
+        team_condition_id="aragora_team",
+        scorer_contract_version=SCORER_CONTRACT_VERSION,
+        holdout_case_ids=holdout_ids,
+        phase="holdout",
+    ).to_dict()
+
+    assert (
+        final_verdict(
+            development,
+            holdout,
+            [_budget_snapshot()],
+            _holdout_snapshot(),
+        )
+        == "go"
+    )
 
 
 def test_budget_shape_defect_fails_closed() -> None:


### PR DESCRIPTION
## Summary
- freeze deterministic `go` / `conditional_go` / `no_go` semantics before outcome-backed benchmark inference begins
- fail closed on malformed or version-mismatched analysis, budget, and holdout-custody inputs
- render a byte-deterministic Markdown report with condition, metric, cost, custody, and verdict sections

## Why
Without a pre-registered mapping from statistical analysis to the public gate decision, the final benchmark verdict could be reinterpreted after results are observed. This contract makes that step mechanical while preserving honest `no_go` outcomes.

## Validation
- `python3 -m pytest tests/evaluation/test_outcome_backed_*.py -q` (101 passed)
- `python3 -m ruff check aragora/evaluation/outcome_backed_report.py tests/evaluation/test_outcome_backed_report.py`
- `python3 -m ruff format --check aragora/evaluation/outcome_backed_report.py tests/evaluation/test_outcome_backed_report.py`
- `uv run --locked --extra dev mypy aragora/evaluation/outcome_backed_report.py tests/evaluation/test_outcome_backed_report.py`
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --cached --check` before commit

## Scope guards
- does not create or modify `aragora/evaluation/outcome_backed_contract.py` owned by parked PR #9901
- no model calls, workflow changes, settlement changes, or other live-lane edits
- report semantics are frozen pre-run; later benchmark results cannot alter them without an explicit contract-version change