### PR TITLE
fix(debate): count failed majority voters truthfully

### DIFF
--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -654,7 +654,6 @@ class ConsensusPhase:
             use_position_shuffling=True,
             unanimous_mode=False,
         )
-        voting_errors = max(voting_errors, len(ctx.agents) - len(votes))
         if not self._ensure_quorum(ctx, len(votes), failed_count=voting_errors):
             return
 
@@ -1680,17 +1679,19 @@ class ConsensusPhase:
         vote_count: int,
         failed_count: int,
     ) -> None:
-        """Record agent-ballot participation without conflating user votes."""
+        """Record agent ballots, failures, and intentional early-stop skips."""
         result = require_phase_result(ctx)
         eligible = len(ctx.agents)
         received = max(0, min(vote_count, eligible))
         failed = max(0, min(failed_count, eligible - received))
+        skipped = max(0, eligible - received - failed)
         current_metadata = getattr(result, "metadata", None)
         metadata = current_metadata if isinstance(current_metadata, dict) else {}
         metadata["vote_participation"] = {
             "eligible": eligible,
             "received": received,
             "failed": failed,
+            "skipped": skipped,
         }
         result.metadata = metadata
 

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -649,10 +649,20 @@ class ConsensusPhase:
         # Cast votes from all agents. Majority confidence is roster-relative:
         # a voter that fails to return a ballot cannot silently disappear from
         # the agreement denominator.
+        effective_threshold = (
+            threshold_override
+            if threshold_override is not None
+            else getattr(self.protocol, "consensus_threshold", 0.5)
+        )
+        fixed_rlm_weights = (
+            self._compute_vote_weights(ctx) if self._rlm_tally_inputs_are_fixed() else None
+        )
         votes, voting_errors = await self._collect_votes_with_errors(
             ctx,
             use_position_shuffling=True,
             unanimous_mode=False,
+            vote_weights=fixed_rlm_weights,
+            consensus_threshold=effective_threshold,
         )
         if not self._ensure_quorum(ctx, len(votes), failed_count=voting_errors):
             return
@@ -665,8 +675,14 @@ class ConsensusPhase:
         # Group similar votes
         vote_groups, choice_mapping = self._compute_vote_groups(votes)
 
-        # Pre-compute vote weights (pass votes for bias mitigation)
-        vote_weight_cache = self._compute_vote_weights(ctx, votes=votes)
+        # Reuse the exact roster-weight snapshot that authorized early
+        # termination. Context-dependent weighting computes only after every
+        # ballot has completed, which disables RLM fail-closed.
+        vote_weight_cache = (
+            fixed_rlm_weights
+            if fixed_rlm_weights is not None
+            else self._compute_vote_weights(ctx, votes=votes)
+        )
 
         # Count weighted votes
         vote_counts, total_weighted = self._count_weighted_votes(
@@ -1600,13 +1616,33 @@ class ConsensusPhase:
         *,
         use_position_shuffling: bool = False,
         unanimous_mode: bool = True,
+        vote_weights: dict[str, float] | None = None,
+        consensus_threshold: float | None = None,
     ) -> tuple[list["Vote"], int]:
         """Collect votes with error tracking and outer timeout protection."""
         return await self._vote_collector.collect_votes_with_errors(
             ctx,
             use_position_shuffling=use_position_shuffling,
             unanimous_mode=unanimous_mode,
+            vote_weights=vote_weights,
+            consensus_threshold=consensus_threshold,
         )
+
+    def _rlm_tally_inputs_are_fixed(self) -> bool:
+        """Return whether an early-stop tally can match the final tally exactly."""
+        if self.user_votes:
+            return False
+
+        vote_dependent_features = (
+            "enable_self_vote_mitigation",
+            "enable_verbosity_normalization",
+            "verify_claims_during_consensus",
+            "enable_evidence_weighting",
+            "enable_process_evaluation",
+            "enable_epistemic_hygiene",
+            "enable_truth_ratio_weighting",
+        )
+        return not any(getattr(self.protocol, name, False) for name in vote_dependent_features)
 
     def _compute_vote_groups(
         self, votes: list["Vote"]

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -30,7 +30,7 @@ import time
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 from aragora.agents.errors import _build_error_action
 from aragora.config import AGENT_TIMEOUT_SECONDS
@@ -93,6 +93,35 @@ class ConsensusCallbacks:
     get_belief_analyzer: Callable | None = None
     user_vote_multiplier: Callable | None = None
     verify_claims: Callable | None = None  # Optional verification callback
+
+
+@dataclass(frozen=True, slots=True)
+class _MajoritySnapshot:
+    """Immutable inputs shared by majority collection and finalization."""
+
+    effective_threshold: float
+    eligible_agents: tuple[Any, ...]
+    eligible_agent_names: tuple[str, ...]
+
+    @classmethod
+    def capture(cls, effective_threshold: float, agents: Iterable[Any]) -> "_MajoritySnapshot":
+        eligible_agents = tuple(agents)
+        return cls(
+            effective_threshold=effective_threshold,
+            eligible_agents=eligible_agents,
+            eligible_agent_names=tuple(
+                agent.name if isinstance(getattr(agent, "name", None), str) and agent.name else ""
+                for agent in eligible_agents
+            ),
+        )
+
+    @property
+    def eligible_count(self) -> int:
+        return len(self.eligible_agent_names)
+
+    @property
+    def unique_eligible_agent_names(self) -> frozenset[str]:
+        return frozenset(name for name in self.eligible_agent_names if name)
 
 
 class ConsensusPhase:
@@ -649,15 +678,13 @@ class ConsensusPhase:
         # Cast votes from all agents. Majority confidence is roster-relative:
         # a voter that fails to return a ballot cannot silently disappear from
         # the agreement denominator.
-        effective_threshold = (
-            threshold_override
-            if threshold_override is not None
-            else getattr(self.protocol, "consensus_threshold", 0.5)
-        )
-        eligible_agent_names = frozenset(
-            agent.name
-            for agent in ctx.agents
-            if isinstance(getattr(agent, "name", None), str) and agent.name
+        majority_snapshot = _MajoritySnapshot.capture(
+            (
+                threshold_override
+                if threshold_override is not None
+                else getattr(self.protocol, "consensus_threshold", 0.5)
+            ),
+            ctx.agents,
         )
         fixed_rlm_weights = (
             self._compute_vote_weights(ctx) if self._rlm_tally_inputs_are_fixed() else None
@@ -667,10 +694,15 @@ class ConsensusPhase:
             use_position_shuffling=True,
             unanimous_mode=False,
             vote_weights=fixed_rlm_weights,
-            consensus_threshold=effective_threshold,
-            eligible_agent_names=eligible_agent_names,
+            consensus_threshold=majority_snapshot.effective_threshold,
+            eligible_agent_names=majority_snapshot.unique_eligible_agent_names,
         )
-        if not self._ensure_quorum(ctx, len(votes), failed_count=voting_errors):
+        if not self._ensure_quorum(
+            ctx,
+            len(votes),
+            failed_count=voting_errors,
+            eligible_count=majority_snapshot.eligible_count,
+        ):
             return
 
         # Apply calibration adjustments to vote confidences
@@ -697,9 +729,9 @@ class ConsensusPhase:
 
         voting_agents = {vote.agent for vote in votes if getattr(vote, "agent", None)}
         total_weighted += sum(
-            vote_weight_cache.get(agent.name, 1.0)
-            for agent in ctx.agents
-            if agent.name not in voting_agents
+            vote_weight_cache.get(agent_name, 1.0)
+            for agent_name in majority_snapshot.eligible_agent_names
+            if agent_name not in voting_agents
         )
 
         # Include user votes
@@ -747,8 +779,12 @@ class ConsensusPhase:
             vote_counts,
             total_weighted,
             choice_mapping,
-            normalize_choice=self._normalize_choice_to_agent,
-            threshold_override=threshold_override,
+            normalize_choice=lambda choice, _agents, proposals: self._normalize_choice_to_agent(
+                choice,
+                list(majority_snapshot.eligible_agents),
+                proposals,
+            ),
+            threshold_override=majority_snapshot.effective_threshold,
         )
 
         # Apply process verification gate if enabled
@@ -1722,10 +1758,12 @@ class ConsensusPhase:
         ctx: "DebateContext",
         vote_count: int,
         failed_count: int,
+        *,
+        eligible_count: int | None = None,
     ) -> None:
         """Record agent ballots, failures, and intentional early-stop skips."""
         result = require_phase_result(ctx)
-        eligible = len(ctx.agents)
+        eligible = len(ctx.agents) if eligible_count is None else max(0, eligible_count)
         received = max(0, min(vote_count, eligible))
         failed = max(0, min(failed_count, eligible - received))
         skipped = max(0, eligible - received - failed)
@@ -1745,10 +1783,16 @@ class ConsensusPhase:
         vote_count: int,
         *,
         failed_count: int = 0,
+        eligible_count: int | None = None,
     ) -> bool:
         """Ensure enough agents participated to make consensus meaningful."""
-        self._record_vote_participation(ctx, vote_count, failed_count)
-        total_agents = len(ctx.agents)
+        self._record_vote_participation(
+            ctx,
+            vote_count,
+            failed_count,
+            eligible_count=eligible_count,
+        )
+        total_agents = len(ctx.agents) if eligible_count is None else max(0, eligible_count)
         required = self._required_participation(total_agents)
         if vote_count >= required:
             return True

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -646,9 +646,16 @@ class ConsensusPhase:
                 logger.debug("Adaptive consensus computation failed: %s", e)
                 threshold_override = None
 
-        # Cast votes from all agents
-        votes = await self._collect_votes(ctx)
-        if not self._ensure_quorum(ctx, len(votes)):
+        # Cast votes from all agents. Majority confidence is roster-relative:
+        # a voter that fails to return a ballot cannot silently disappear from
+        # the agreement denominator.
+        votes, voting_errors = await self._collect_votes_with_errors(
+            ctx,
+            use_position_shuffling=True,
+            unanimous_mode=False,
+        )
+        voting_errors = max(voting_errors, len(ctx.agents) - len(votes))
+        if not self._ensure_quorum(ctx, len(votes), failed_count=voting_errors):
             return
 
         # Apply calibration adjustments to vote confidences
@@ -665,6 +672,13 @@ class ConsensusPhase:
         # Count weighted votes
         vote_counts, total_weighted = self._count_weighted_votes(
             votes, choice_mapping, vote_weight_cache
+        )
+
+        voting_agents = {vote.agent for vote in votes if getattr(vote, "agent", None)}
+        total_weighted += sum(
+            vote_weight_cache.get(agent.name, 1.0)
+            for agent in ctx.agents
+            if agent.name not in voting_agents
         )
 
         # Include user votes
@@ -728,7 +742,8 @@ class ConsensusPhase:
         proposals = ctx.proposals
 
         votes, voting_errors = await self._collect_votes_with_errors(ctx)
-        if not self._ensure_quorum(ctx, len(votes)):
+        voting_errors = max(voting_errors, len(ctx.agents) - len(votes))
+        if not self._ensure_quorum(ctx, len(votes), failed_count=voting_errors):
             return
         votes = self._apply_calibration_to_votes(votes, ctx)
         result.votes.extend(votes)
@@ -1580,9 +1595,19 @@ class ConsensusPhase:
         """Collect votes from all agents with outer timeout protection."""
         return await self._vote_collector.collect_votes(ctx)
 
-    async def _collect_votes_with_errors(self, ctx: "DebateContext") -> tuple[list["Vote"], int]:
+    async def _collect_votes_with_errors(
+        self,
+        ctx: "DebateContext",
+        *,
+        use_position_shuffling: bool = False,
+        unanimous_mode: bool = True,
+    ) -> tuple[list["Vote"], int]:
         """Collect votes with error tracking and outer timeout protection."""
-        return await self._vote_collector.collect_votes_with_errors(ctx)
+        return await self._vote_collector.collect_votes_with_errors(
+            ctx,
+            use_position_shuffling=use_position_shuffling,
+            unanimous_mode=unanimous_mode,
+        )
 
     def _compute_vote_groups(
         self, votes: list["Vote"]
@@ -1649,8 +1674,35 @@ class ConsensusPhase:
         # Never require more votes than agents available
         return min(required, max(total_agents, 1))
 
-    def _ensure_quorum(self, ctx: "DebateContext", vote_count: int) -> bool:
+    def _record_vote_participation(
+        self,
+        ctx: "DebateContext",
+        vote_count: int,
+        failed_count: int,
+    ) -> None:
+        """Record agent-ballot participation without conflating user votes."""
+        result = require_phase_result(ctx)
+        eligible = len(ctx.agents)
+        received = max(0, min(vote_count, eligible))
+        failed = max(0, min(failed_count, eligible - received))
+        current_metadata = getattr(result, "metadata", None)
+        metadata = current_metadata if isinstance(current_metadata, dict) else {}
+        metadata["vote_participation"] = {
+            "eligible": eligible,
+            "received": received,
+            "failed": failed,
+        }
+        result.metadata = metadata
+
+    def _ensure_quorum(
+        self,
+        ctx: "DebateContext",
+        vote_count: int,
+        *,
+        failed_count: int = 0,
+    ) -> bool:
         """Ensure enough agents participated to make consensus meaningful."""
+        self._record_vote_participation(ctx, vote_count, failed_count)
         total_agents = len(ctx.agents)
         required = self._required_participation(total_agents)
         if vote_count >= required:

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -654,6 +654,11 @@ class ConsensusPhase:
             if threshold_override is not None
             else getattr(self.protocol, "consensus_threshold", 0.5)
         )
+        eligible_agent_names = frozenset(
+            agent.name
+            for agent in ctx.agents
+            if isinstance(getattr(agent, "name", None), str) and agent.name
+        )
         fixed_rlm_weights = (
             self._compute_vote_weights(ctx) if self._rlm_tally_inputs_are_fixed() else None
         )
@@ -663,6 +668,7 @@ class ConsensusPhase:
             unanimous_mode=False,
             vote_weights=fixed_rlm_weights,
             consensus_threshold=effective_threshold,
+            eligible_agent_names=eligible_agent_names,
         )
         if not self._ensure_quorum(ctx, len(votes), failed_count=voting_errors):
             return
@@ -1618,6 +1624,7 @@ class ConsensusPhase:
         unanimous_mode: bool = True,
         vote_weights: dict[str, float] | None = None,
         consensus_threshold: float | None = None,
+        eligible_agent_names: frozenset[str] | None = None,
     ) -> tuple[list["Vote"], int]:
         """Collect votes with error tracking and outer timeout protection."""
         return await self._vote_collector.collect_votes_with_errors(
@@ -1626,11 +1633,12 @@ class ConsensusPhase:
             unanimous_mode=unanimous_mode,
             vote_weights=vote_weights,
             consensus_threshold=consensus_threshold,
+            eligible_agent_names=eligible_agent_names,
         )
 
     def _rlm_tally_inputs_are_fixed(self) -> bool:
         """Return whether an early-stop tally can match the final tally exactly."""
-        if self.user_votes:
+        if self.user_votes or self._drain_user_events is not None:
             return False
 
         vote_dependent_features = (

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -557,7 +557,9 @@ class VoteCollector:
                 else:
                     vote_result = await vote_with_agent(agent, ctx.proposals, task)
                 return (agent, vote_result)
-            except (ValueError, KeyError, TypeError) as e:  # noqa: BLE001
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 - preserve the failing voter identity
                 logger.warning(
                     "vote_exception_%s agent=%s error=%s: %s",
                     vote_mode,
@@ -572,7 +574,29 @@ class VoteCollector:
             nonlocal voting_errors
             total_agents = len(ctx.agents)
             vote_tasks = [asyncio.create_task(cast_vote(agent)) for agent in ctx.agents]
+            processed_agent_ids: set[int] = set()
             early_terminated = False
+
+            def record_vote_failure(agent: Agent, vote_result: Any) -> None:
+                nonlocal voting_errors
+                if isinstance(vote_result, Exception):
+                    logger.error(
+                        "vote_error_%s agent=%s error=%s",
+                        vote_mode,
+                        agent.name,
+                        vote_result,
+                    )
+                else:
+                    logger.error(
+                        "vote_error_%s agent=%s error=vote returned None",
+                        vote_mode,
+                        agent.name,
+                        extra={
+                            "triage_diag_code": "vote_none",
+                            "triage_diag_severity": "degraded",
+                        },
+                    )
+                voting_errors += 1
 
             for completed_task in asyncio.as_completed(vote_tasks):
                 try:
@@ -584,25 +608,9 @@ class VoteCollector:
                     voting_errors += 1
                     continue
 
+                processed_agent_ids.add(id(agent))
                 if vote_result is None or isinstance(vote_result, Exception):
-                    if isinstance(vote_result, Exception):
-                        logger.error(
-                            "vote_error_%s agent=%s error=%s",
-                            vote_mode,
-                            agent.name,
-                            vote_result,
-                        )
-                    else:
-                        logger.error(
-                            "vote_error_%s agent=%s error=vote returned None",
-                            vote_mode,
-                            agent.name,
-                            extra={
-                                "triage_diag_code": "vote_none",
-                                "triage_diag_severity": "degraded",
-                            },
-                        )
-                    voting_errors += 1
+                    record_vote_failure(agent, vote_result)
                 else:
                     votes.append(vote_result)
                     self._handle_vote_success(
@@ -621,6 +629,33 @@ class VoteCollector:
                             for vote_task in vote_tasks:
                                 if not vote_task.done():
                                     vote_task.cancel()
+
+                            # Consume tasks so completed failures cannot become RLM skips;
+                            # unconsumed successful ballots remain intentionally skipped.
+                            remaining_results = await asyncio.gather(
+                                *vote_tasks,
+                                return_exceptions=True,
+                            )
+                            for remaining_result in remaining_results:
+                                if isinstance(remaining_result, asyncio.CancelledError):
+                                    continue
+                                if isinstance(remaining_result, BaseException):
+                                    logger.error(
+                                        "task_exception phase=%s_vote error=%s",
+                                        vote_mode,
+                                        remaining_result,
+                                    )
+                                    voting_errors += 1
+                                    continue
+                                remaining_agent, unconsumed_result = remaining_result
+                                if id(remaining_agent) in processed_agent_ids:
+                                    continue
+                                processed_agent_ids.add(id(remaining_agent))
+                                if unconsumed_result is None or isinstance(
+                                    unconsumed_result,
+                                    Exception,
+                                ):
+                                    record_vote_failure(remaining_agent, unconsumed_result)
                             early_terminated = True
 
                             if self._notify_spectator:

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
@@ -153,6 +154,9 @@ class VoteCollector:
         self,
         votes: list[Vote],
         total_agents: int,
+        *,
+        vote_weights: dict[str, float] | None = None,
+        consensus_threshold: float | None = None,
     ) -> tuple[bool, str | None]:
         """
         Check if a clear majority has been reached for RLM early termination.
@@ -165,9 +169,17 @@ class VoteCollector:
         2. Leading choice has > 50% of total agents
         3. Lead over second choice >= rlm_majority_lead_threshold (default 25%)
 
+        Roster-aware majority mode additionally supplies the exact full-roster
+        weights and effective consensus threshold used by the final tally. In
+        that mode the leader must already meet the threshold against the full
+        denominator and hold more weight than every other roster member
+        combined. Missing or malformed snapshot inputs fail closed.
+
         Args:
             votes: List of votes collected so far
             total_agents: Total number of agents in the debate
+            vote_weights: Fixed full-roster weights for the final tally
+            consensus_threshold: Effective threshold for the final tally
 
         Returns:
             Tuple of (has_clear_majority, winning_choice or None)
@@ -207,6 +219,59 @@ class VoteCollector:
         min_lead = int(total_agents * self.config.rlm_majority_lead_threshold)
 
         if lead >= min_lead:
+            weighted_guard_requested = vote_weights is not None or consensus_threshold is not None
+            if weighted_guard_requested:
+                if vote_weights is None or consensus_threshold is None:
+                    return False, None
+                if (
+                    isinstance(consensus_threshold, bool)
+                    or not isinstance(consensus_threshold, (int, float))
+                    or not math.isfinite(consensus_threshold)
+                    or not 0.0 <= consensus_threshold <= 1.0
+                    or len(vote_weights) != total_agents
+                ):
+                    return False, None
+
+                roster_weight = 0.0
+                for agent_name, weight in vote_weights.items():
+                    if (
+                        not isinstance(agent_name, str)
+                        or not agent_name
+                        or isinstance(weight, bool)
+                        or not isinstance(weight, (int, float))
+                        or not math.isfinite(weight)
+                        or weight < 0.0
+                    ):
+                        return False, None
+                    roster_weight += float(weight)
+                if roster_weight <= 0.0:
+                    return False, None
+
+                weighted_counts: dict[str, float] = {}
+                voting_agents: set[str] = set()
+                for vote in votes:
+                    vote_agent = getattr(vote, "agent", None)
+                    choice = getattr(vote, "choice", None)
+                    if (
+                        not isinstance(vote_agent, str)
+                        or not vote_agent
+                        or vote_agent in voting_agents
+                        or vote_agent not in vote_weights
+                    ):
+                        return False, None
+                    voting_agents.add(vote_agent)
+                    if isinstance(choice, str) and choice:
+                        weighted_counts[choice] = weighted_counts.get(choice, 0.0) + float(
+                            vote_weights[vote_agent]
+                        )
+
+                leader_weight = weighted_counts.get(leader, 0.0)
+                if (
+                    leader_weight / roster_weight < float(consensus_threshold)
+                    or leader_weight <= roster_weight - leader_weight
+                ):
+                    return False, None
+
             logger.info(
                 "rlm_early_termination_majority leader=%s votes=%s/%s lead=%s total_agents=%s",
                 leader,
@@ -512,6 +577,8 @@ class VoteCollector:
         *,
         use_position_shuffling: bool = False,
         unanimous_mode: bool = True,
+        vote_weights: dict[str, float] | None = None,
+        consensus_threshold: float | None = None,
     ) -> tuple[list[Vote], int]:
         """Collect votes with error tracking for roster-aware consensus.
 
@@ -677,7 +744,12 @@ class VoteCollector:
                     # Tasks deliberately skipped after a decisive ballot are
                     # not failures; only completed None/exception results are.
                     if not unanimous_mode:
-                        has_majority, leader = self._check_clear_majority(votes, total_agents)
+                        has_majority, leader = self._check_clear_majority(
+                            votes,
+                            total_agents,
+                            vote_weights=vote_weights,
+                            consensus_threshold=consensus_threshold,
+                        )
                         if has_majority:
                             _settle_decisive_vote_tasks(
                                 vote_tasks, consume_completed_task, observe_skipped_task

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -61,6 +61,22 @@ def get_complexity_governor() -> Any:
     return _get_governor()
 
 
+def _settle_decisive_vote_tasks(
+    tasks: list[asyncio.Task],
+    consume: Callable[[asyncio.Task], None],
+    observe: Callable[[asyncio.Task], None],
+) -> None:
+    for task in tasks:
+        if task.done():
+            consume(task)
+        elif task.cancel():
+            observe(task)
+        elif task.done():
+            consume(task)
+        else:
+            observe(task)
+
+
 @dataclass
 class VoteCollectorConfig:
     """Configuration for VoteCollector."""
@@ -600,6 +616,41 @@ class VoteCollector:
                     )
                 voting_errors += 1
 
+            def consume_completed_task(vote_task: asyncio.Task) -> None:
+                nonlocal voting_errors
+                if vote_task.cancelled():
+                    return
+                task_error = vote_task.exception()
+                if task_error is not None:
+                    raise task_error
+                remaining_agent, remaining_result = vote_task.result()
+                if id(remaining_agent) in processed_agent_ids:
+                    return
+                processed_agent_ids.add(id(remaining_agent))
+                if remaining_result is None or isinstance(remaining_result, Exception):
+                    record_vote_failure(remaining_agent, remaining_result)
+                    return
+                votes.append(remaining_result)
+                self._handle_vote_success(ctx, remaining_agent, remaining_result, unanimous_mode)
+
+            def observe_skipped_task(vote_task: asyncio.Task) -> None:
+                loop = asyncio.get_running_loop()
+
+                def retrieve_result(completed_task: asyncio.Task) -> None:
+                    if completed_task.cancelled():
+                        return
+                    task_error = completed_task.exception()
+                    if task_error is not None and not isinstance(task_error, Exception):
+                        loop.call_exception_handler(
+                            {
+                                "message": "control-flow failure in skipped vote cleanup",
+                                "exception": task_error,
+                                "task": completed_task,
+                            }
+                        )
+
+                vote_task.add_done_callback(retrieve_result)
+
             for completed_task in asyncio.as_completed(vote_tasks):
                 try:
                     agent, vote_result = await completed_task
@@ -628,35 +679,9 @@ class VoteCollector:
                     if not unanimous_mode:
                         has_majority, leader = self._check_clear_majority(votes, total_agents)
                         if has_majority:
-                            for vote_task in vote_tasks:
-                                if not vote_task.done():
-                                    vote_task.cancel()
-
-                            # Completed failures cannot become RLM skips; successes still can.
-                            remaining_results = await asyncio.gather(
-                                *vote_tasks,
-                                return_exceptions=True,
+                            _settle_decisive_vote_tasks(
+                                vote_tasks, consume_completed_task, observe_skipped_task
                             )
-                            for remaining_result in remaining_results:
-                                if isinstance(remaining_result, asyncio.CancelledError):
-                                    continue
-                                if isinstance(remaining_result, BaseException):
-                                    logger.error(
-                                        "task_exception phase=%s_vote error=%s",
-                                        vote_mode,
-                                        remaining_result,
-                                    )
-                                    voting_errors += 1
-                                    continue
-                                remaining_agent, unconsumed_result = remaining_result
-                                if id(remaining_agent) in processed_agent_ids:
-                                    continue
-                                processed_agent_ids.add(id(remaining_agent))
-                                if unconsumed_result is None or isinstance(
-                                    unconsumed_result,
-                                    Exception,
-                                ):
-                                    record_vote_failure(remaining_agent, unconsumed_result)
                             early_terminated = True
 
                             if self._notify_spectator:

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -559,7 +559,9 @@ class VoteCollector:
                 return (agent, vote_result)
             except asyncio.CancelledError:
                 raise
-            except Exception as e:  # noqa: BLE001 - preserve the failing voter identity
+            except BaseException as e:  # noqa: BLE001 - preserve the failing voter identity
+                if not isinstance(e, Exception):
+                    raise
                 logger.warning(
                     "vote_exception_%s agent=%s error=%s: %s",
                     vote_mode,
@@ -630,8 +632,7 @@ class VoteCollector:
                                 if not vote_task.done():
                                     vote_task.cancel()
 
-                            # Consume tasks so completed failures cannot become RLM skips;
-                            # unconsumed successful ballots remain intentionally skipped.
+                            # Completed failures cannot become RLM skips; successes still can.
                             remaining_results = await asyncio.gather(
                                 *vote_tasks,
                                 return_exceptions=True,

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -157,6 +157,7 @@ class VoteCollector:
         *,
         vote_weights: dict[str, float] | None = None,
         consensus_threshold: float | None = None,
+        eligible_agent_names: frozenset[str] | None = None,
     ) -> tuple[bool, str | None]:
         """
         Check if a clear majority has been reached for RLM early termination.
@@ -180,6 +181,7 @@ class VoteCollector:
             total_agents: Total number of agents in the debate
             vote_weights: Fixed full-roster weights for the final tally
             consensus_threshold: Effective threshold for the final tally
+            eligible_agent_names: Immutable exact roster represented by the weights
 
         Returns:
             Tuple of (has_clear_majority, winning_choice or None)
@@ -228,7 +230,14 @@ class VoteCollector:
                     or not isinstance(consensus_threshold, (int, float))
                     or not math.isfinite(consensus_threshold)
                     or not 0.0 <= consensus_threshold <= 1.0
+                    or not isinstance(eligible_agent_names, frozenset)
+                    or len(eligible_agent_names) != total_agents
+                    or any(
+                        not isinstance(agent_name, str) or not agent_name
+                        for agent_name in eligible_agent_names
+                    )
                     or len(vote_weights) != total_agents
+                    or set(vote_weights) != eligible_agent_names
                 ):
                     return False, None
 
@@ -244,6 +253,8 @@ class VoteCollector:
                     ):
                         return False, None
                     roster_weight += float(weight)
+                    if not math.isfinite(roster_weight):
+                        return False, None
                 if roster_weight <= 0.0:
                     return False, None
 
@@ -261,9 +272,12 @@ class VoteCollector:
                         return False, None
                     voting_agents.add(vote_agent)
                     if isinstance(choice, str) and choice:
-                        weighted_counts[choice] = weighted_counts.get(choice, 0.0) + float(
+                        choice_weight = weighted_counts.get(choice, 0.0) + float(
                             vote_weights[vote_agent]
                         )
+                        if not math.isfinite(choice_weight):
+                            return False, None
+                        weighted_counts[choice] = choice_weight
 
                 leader_weight = weighted_counts.get(leader, 0.0)
                 if (
@@ -579,6 +593,7 @@ class VoteCollector:
         unanimous_mode: bool = True,
         vote_weights: dict[str, float] | None = None,
         consensus_threshold: float | None = None,
+        eligible_agent_names: frozenset[str] | None = None,
     ) -> tuple[list[Vote], int]:
         """Collect votes with error tracking for roster-aware consensus.
 
@@ -590,6 +605,11 @@ class VoteCollector:
 
         Args:
             ctx: The debate context with agents and proposals
+            use_position_shuffling: Preserve the configured multi-permutation path
+            unanimous_mode: Disable early termination when unanimity is required
+            vote_weights: Fixed full-roster weights for majority early termination
+            consensus_threshold: Effective final-tally threshold
+            eligible_agent_names: Immutable exact roster represented by the weights
 
         Returns:
             Tuple of (votes list, error count)
@@ -749,6 +769,7 @@ class VoteCollector:
                             total_agents,
                             vote_weights=vote_weights,
                             consensus_threshold=consensus_threshold,
+                            eligible_agent_names=eligible_agent_names,
                         )
                         if has_majority:
                             _settle_decisive_vote_tasks(

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -568,9 +568,11 @@ class VoteCollector:
                 return (agent, e)
 
         async def collect_all_votes() -> None:
-            """Collect votes from all agents with error counting for unanimity checks."""
+            """Collect votes with truthful errors and majority-only early termination."""
             nonlocal voting_errors
+            total_agents = len(ctx.agents)
             vote_tasks = [asyncio.create_task(cast_vote(agent)) for agent in ctx.agents]
+            early_terminated = False
 
             for completed_task in asyncio.as_completed(vote_tasks):
                 try:
@@ -609,6 +611,44 @@ class VoteCollector:
                         vote_result,
                         unanimous=unanimous_mode,
                     )
+
+                    # Preserve the historical majority-mode RLM optimization.
+                    # Tasks deliberately skipped after a decisive ballot are
+                    # not failures; only completed None/exception results are.
+                    if not unanimous_mode:
+                        has_majority, leader = self._check_clear_majority(votes, total_agents)
+                        if has_majority:
+                            for vote_task in vote_tasks:
+                                if not vote_task.done():
+                                    vote_task.cancel()
+                            early_terminated = True
+
+                            if self._notify_spectator:
+                                self._notify_spectator(
+                                    "rlm_early_termination",
+                                    details=(
+                                        f"Clear majority for '{leader}' "
+                                        f"({len(votes)}/{total_agents} votes)"
+                                    ),
+                                    metric=len(votes) / total_agents,
+                                    agent="system",
+                                )
+
+                            if "on_rlm_early_termination" in self.hooks:
+                                self.hooks["on_rlm_early_termination"](
+                                    leader=leader,
+                                    votes_collected=len(votes),
+                                    total_agents=total_agents,
+                                )
+                            break
+
+            if early_terminated:
+                logger.info(
+                    "vote_collection_early_terminated_%s collected=%s total_agents=%s",
+                    vote_mode,
+                    len(votes),
+                    total_agents,
+                )
 
         # Apply outer timeout to prevent N*agent_timeout runaway
         try:

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -7,7 +7,7 @@ Handles the mechanics of collecting votes from agents with timeout protection.
 Key responsibilities:
 - Parallel vote collection from all agents
 - Timeout protection (per-agent and overall)
-- Error tracking for unanimity mode
+- Error tracking for roster-aware consensus modes
 - Vote grouping for similar choices
 - Success callbacks (hooks, recording, position tracking)
 - RLM-inspired early termination when clear majority is reached
@@ -111,7 +111,7 @@ class VoteCollector:
 
     Handles:
     - Parallel vote collection with timeout protection
-    - Error tracking for unanimity mode
+    - Error tracking for roster-aware consensus modes
     - Vote success callbacks (hooks, recording, position tracking)
     - Vote grouping for similar choices
     - RLM-inspired early termination when clear majority is reached
@@ -490,10 +490,19 @@ class VoteCollector:
 
         return votes
 
-    async def collect_votes_with_errors(self, ctx: DebateContext) -> tuple[list[Vote], int]:
-        """Collect votes with error tracking for unanimity mode.
+    async def collect_votes_with_errors(
+        self,
+        ctx: DebateContext,
+        *,
+        use_position_shuffling: bool = False,
+        unanimous_mode: bool = True,
+    ) -> tuple[list[Vote], int]:
+        """Collect votes with error tracking for roster-aware consensus.
 
-        Used for unanimity mode where we need to track errors.
+        Used by consensus modes where missing voters must remain visible in
+        the agreement denominator. Majority mode may opt into the existing
+        position-shuffling path; unanimity keeps its historical single-ballot
+        behavior.
         Uses VOTE_COLLECTION_TIMEOUT to prevent runaway collection time.
 
         Args:
@@ -503,10 +512,29 @@ class VoteCollector:
             Tuple of (votes list, error count)
         """
         if not self._vote_with_agent:
-            return [], 0
+            logger.warning("No vote_with_agent callback, skipping votes")
+            return [], len(ctx.agents)
+
+        if use_position_shuffling and self.config.enable_position_shuffling:
+            logger.info("position_shuffling_enabled - using multi-permutation voting")
+            try:
+                shuffled_votes = await asyncio.wait_for(
+                    self._collect_votes_with_shuffling(ctx),
+                    timeout=self.VOTE_COLLECTION_TIMEOUT
+                    * self.config.position_shuffling_permutations,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "position_shuffling_timeout timeout=%ss",
+                    self.VOTE_COLLECTION_TIMEOUT * self.config.position_shuffling_permutations,
+                )
+                shuffled_votes = []
+            voting_agents = {vote.agent for vote in shuffled_votes if getattr(vote, "agent", None)}
+            return shuffled_votes, max(0, len(ctx.agents) - len(voting_agents))
 
         votes: list[Vote] = []
         voting_errors = 0
+        vote_mode = "unanimous" if unanimous_mode else "majority_roster"
         task = ctx.env.task if ctx.env else ""
         vote_with_agent = self._vote_with_agent
         if vote_with_agent is None:
@@ -514,8 +542,8 @@ class VoteCollector:
         with_timeout = self._with_timeout
 
         async def cast_vote(agent: Agent) -> tuple[Any, Any]:
-            """Cast a vote for unanimous consensus with timeout protection."""
-            logger.debug("agent_voting_unanimous agent=%s", agent.name)
+            """Cast a vote for roster-aware consensus with timeout protection."""
+            logger.debug("agent_voting_%s agent=%s", vote_mode, agent.name)
             try:
                 timeout = get_complexity_governor().get_scaled_timeout(
                     float(self.config.agent_timeout)
@@ -531,7 +559,8 @@ class VoteCollector:
                 return (agent, vote_result)
             except (ValueError, KeyError, TypeError) as e:  # noqa: BLE001
                 logger.warning(
-                    "vote_exception_unanimous agent=%s error=%s: %s",
+                    "vote_exception_%s agent=%s error=%s: %s",
+                    vote_mode,
                     agent.name,
                     type(e).__name__,
                     e,
@@ -549,18 +578,22 @@ class VoteCollector:
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:  # noqa: BLE001 - phase isolation
-                    logger.error("task_exception phase=unanimous_vote error=%s", e)
+                    logger.error("task_exception phase=%s_vote error=%s", vote_mode, e)
                     voting_errors += 1
                     continue
 
                 if vote_result is None or isinstance(vote_result, Exception):
                     if isinstance(vote_result, Exception):
                         logger.error(
-                            "vote_error_unanimous agent=%s error=%s", agent.name, vote_result
+                            "vote_error_%s agent=%s error=%s",
+                            vote_mode,
+                            agent.name,
+                            vote_result,
                         )
                     else:
                         logger.error(
-                            "vote_error_unanimous agent=%s error=vote returned None",
+                            "vote_error_%s agent=%s error=vote returned None",
+                            vote_mode,
                             agent.name,
                             extra={
                                 "triage_diag_code": "vote_none",
@@ -570,7 +603,12 @@ class VoteCollector:
                     voting_errors += 1
                 else:
                     votes.append(vote_result)
-                    self._handle_vote_success(ctx, agent, vote_result, unanimous=True)
+                    self._handle_vote_success(
+                        ctx,
+                        agent,
+                        vote_result,
+                        unanimous=unanimous_mode,
+                    )
 
         # Apply outer timeout to prevent N*agent_timeout runaway
         try:
@@ -580,7 +618,8 @@ class VoteCollector:
             missing = len(ctx.agents) - len(votes) - voting_errors
             voting_errors += missing
             logger.warning(
-                "vote_collection_timeout_unanimous collected=%s errors=%s expected=%s timeout=%ss",
+                "vote_collection_timeout_%s collected=%s errors=%s expected=%s timeout=%ss",
+                vote_mode,
                 len(votes),
                 voting_errors,
                 len(ctx.agents),

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -398,6 +398,7 @@ class TestHandleMajorityConsensus:
             unanimous_mode=False,
             vote_weights=roster_weights,
             consensus_threshold=0.75,
+            eligible_agent_names=frozenset(agent.name for agent in agents),
         )
         phase._compute_vote_weights.assert_called_once_with(ctx)
 
@@ -424,8 +425,37 @@ class TestHandleMajorityConsensus:
             unanimous_mode=False,
             vote_weights=None,
             consensus_threshold=protocol.consensus_threshold,
+            eligible_agent_names=frozenset(agent.name for agent in agents),
         )
         phase._compute_vote_weights.assert_called_once_with(ctx, votes=votes)
+
+    @pytest.mark.asyncio
+    async def test_user_event_drain_disables_fixed_rlm_snapshot(self):
+        """A post-collection user-event drain can mutate the final tally."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(4)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        votes = [make_vote(agent=agent.name, choice="agent0") for agent in agents]
+        roster_weights = {agent.name: 1.0 for agent in agents}
+        drain_user_events = MagicMock()
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(drain_user_events=drain_user_events),
+        )
+        phase._compute_vote_weights = MagicMock(return_value=roster_weights)
+        phase._collect_votes_with_errors = AsyncMock(return_value=(votes, 0))
+
+        await phase._handle_majority_consensus(ctx)
+
+        phase._collect_votes_with_errors.assert_awaited_once_with(
+            ctx,
+            use_position_shuffling=True,
+            unanimous_mode=False,
+            vote_weights=None,
+            consensus_threshold=protocol.consensus_threshold,
+            eligible_agent_names=frozenset(agent.name for agent in agents),
+        )
+        phase._compute_vote_weights.assert_called_once_with(ctx, votes=votes)
+        drain_user_events.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_failed_voters_reduce_confidence_and_are_recorded(self):

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -395,7 +395,6 @@ class TestHandleMajorityConsensus:
             deps=ConsensusDependencies(protocol=protocol),
             callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
         )
-
         await phase._handle_majority_consensus(ctx)
 
         assert ctx.result.consensus_reached is False
@@ -440,12 +439,15 @@ class TestHandleMajorityConsensus:
         ctx, protocol = make_context(agents=agents, consensus_mode="majority")
 
         async def vote_with_agent(agent, proposals, task):
+            if int(agent.name.removeprefix("agent")) >= 6:
+                await asyncio.sleep(10)
             return make_vote(agent=agent.name, choice="agent0")
 
         phase = ConsensusPhase(
             deps=ConsensusDependencies(protocol=protocol),
             callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
         )
+        phase._vote_collector.config.rlm_early_termination_threshold = 0.5
 
         await phase._handle_majority_consensus(ctx)
 

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -462,7 +462,6 @@ class TestHandleMajorityConsensus:
 
     @pytest.mark.asyncio
     async def test_rlm_completed_failure_is_not_reported_as_skipped(self):
-        """A completed failure after decisive votes remains failed end to end."""
         agents = [MockAgent(name=f"agent{i}") for i in range(10)]
         ctx, protocol = make_context(agents=agents, consensus_mode="majority")
 

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -545,6 +545,78 @@ class TestHandleMajorityConsensus:
         }
 
     @pytest.mark.asyncio
+    async def test_rlm_finalization_uses_threshold_snapshot(self):
+        """A protocol mutation after collection starts cannot reverse the fixed decision."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(10)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.consensus_threshold = 0.6
+
+        async def vote_with_agent(agent, proposals, task):
+            agent_index = int(agent.name.removeprefix("agent"))
+            if agent_index >= 6:
+                await asyncio.sleep(10)
+            if agent_index == 5:
+                protocol.consensus_threshold = 0.9
+            return make_vote(agent=agent.name, choice="agent0")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+        phase._vote_collector.config.rlm_early_termination_threshold = 0.5
+
+        await phase._handle_majority_consensus(ctx)
+
+        participation = ctx.result.metadata["vote_participation"]
+        assert participation == {
+            "eligible": 10,
+            "received": 6,
+            "failed": 0,
+            "skipped": 4,
+        }
+        assert protocol.consensus_threshold == 0.9
+        assert ctx.result.consensus_reached is True
+        assert ctx.result.confidence == pytest.approx(0.6)
+
+    @pytest.mark.asyncio
+    async def test_rlm_finalization_uses_exact_roster_snapshot(self):
+        """Late context mutation cannot change quorum, participation, or denominator."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(10)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.consensus_threshold = 0.6
+        protocol.min_participation_ratio = 0.1
+        protocol.min_participation_count = 1
+
+        async def vote_with_agent(agent, proposals, task):
+            agent_index = int(agent.name.removeprefix("agent"))
+            if agent_index >= 6:
+                await asyncio.sleep(10)
+            if agent_index == 5:
+                ctx.agents[:0] = [MockAgent(name="agent")] + [
+                    MockAgent(name=f"ghost{i}") for i in range(1, 10)
+                ]
+            return make_vote(agent=agent.name, choice="agent0")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+        phase._vote_collector.config.rlm_early_termination_threshold = 0.5
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert len(ctx.agents) == 20
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 10,
+            "received": 6,
+            "failed": 0,
+            "skipped": 4,
+        }
+        assert ctx.result.consensus_reached is True
+        assert ctx.result.confidence == pytest.approx(0.6)
+        assert ctx.result.winner == "agent0"
+
+    @pytest.mark.asyncio
     async def test_rlm_completed_failure_is_not_reported_as_skipped(self):
         agents = [MockAgent(name=f"agent{i}") for i in range(10)]
         ctx, protocol = make_context(agents=agents, consensus_mode="majority")

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -461,6 +461,30 @@ class TestHandleMajorityConsensus:
         }
 
     @pytest.mark.asyncio
+    async def test_rlm_completed_failure_is_not_reported_as_skipped(self):
+        """A completed failure after decisive votes remains failed end to end."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(10)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+
+        async def vote_with_agent(agent, proposals, task):
+            if agent.name == "agent9":
+                return None
+            return make_vote(agent=agent.name, choice="agent0")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        participation = ctx.result.metadata["vote_participation"]
+        assert ctx.result.consensus_reached is True
+        assert participation["received"] < participation["eligible"]
+        assert participation["failed"] == 1
+        assert participation["skipped"] == 10 - participation["received"] - 1
+
+    @pytest.mark.asyncio
     async def test_insufficient_majority_records_missing_roster(self):
         """Quorum rejection still exposes how much of the roster was lost."""
         agents = [MockAgent(name=f"agent{i}") for i in range(1, 5)]

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -376,6 +376,58 @@ class TestHandleMajorityConsensus:
     """Tests for truthful majority-vote participation accounting."""
 
     @pytest.mark.asyncio
+    async def test_reuses_full_roster_weights_for_rlm_and_final_tally(self):
+        """The early-stop and winner decisions share one threshold/weight snapshot."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(4)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.consensus_threshold = 0.75
+        votes = [make_vote(agent=agent.name, choice="agent0") for agent in agents]
+        roster_weights = {agent.name: float(index + 1) for index, agent in enumerate(agents)}
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(),
+        )
+        phase._compute_vote_weights = MagicMock(return_value=roster_weights)
+        phase._collect_votes_with_errors = AsyncMock(return_value=(votes, 0))
+
+        await phase._handle_majority_consensus(ctx)
+
+        phase._collect_votes_with_errors.assert_awaited_once_with(
+            ctx,
+            use_position_shuffling=True,
+            unanimous_mode=False,
+            vote_weights=roster_weights,
+            consensus_threshold=0.75,
+        )
+        phase._compute_vote_weights.assert_called_once_with(ctx)
+
+    @pytest.mark.asyncio
+    async def test_vote_dependent_weights_disable_rlm_and_compute_after_collection(self):
+        """Contextual weighting fails closed to full collection."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(4)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.enable_self_vote_mitigation = True
+        votes = [make_vote(agent=agent.name, choice="agent0") for agent in agents]
+        roster_weights = {agent.name: 1.0 for agent in agents}
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(),
+        )
+        phase._compute_vote_weights = MagicMock(return_value=roster_weights)
+        phase._collect_votes_with_errors = AsyncMock(return_value=(votes, 0))
+
+        await phase._handle_majority_consensus(ctx)
+
+        phase._collect_votes_with_errors.assert_awaited_once_with(
+            ctx,
+            use_position_shuffling=True,
+            unanimous_mode=False,
+            vote_weights=None,
+            consensus_threshold=protocol.consensus_threshold,
+        )
+        phase._compute_vote_weights.assert_called_once_with(ctx, votes=votes)
+
+    @pytest.mark.asyncio
     async def test_failed_voters_reduce_confidence_and_are_recorded(self):
         """Two surviving votes cannot masquerade as a unanimous four-agent panel."""
         agents = [MockAgent(name=f"agent{i}") for i in range(1, 5)]

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -368,6 +368,129 @@ class TestHandleFallbackConsensusExtended:
 
 
 # =============================================================================
+# _handle_majority_consensus Tests
+# =============================================================================
+
+
+class TestHandleMajorityConsensus:
+    """Tests for truthful majority-vote participation accounting."""
+
+    @pytest.mark.asyncio
+    async def test_failed_voters_reduce_confidence_and_are_recorded(self):
+        """Two surviving votes cannot masquerade as a unanimous four-agent panel."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(1, 5)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.consensus_threshold = 0.6
+        protocol.min_participation_ratio = 0.5
+        protocol.min_participation_count = 2
+
+        async def vote_with_agent(agent, proposals, task):
+            if agent.name == "agent3":
+                raise RuntimeError("provider unavailable")
+            if agent.name == "agent4":
+                return None
+            return make_vote(agent=agent.name, choice="agent1")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert ctx.result.consensus_reached is False
+        assert ctx.result.confidence == pytest.approx(0.5)
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 4,
+            "received": 2,
+            "failed": 2,
+        }
+
+    @pytest.mark.asyncio
+    async def test_full_roster_keeps_existing_confidence_with_additive_metadata(self):
+        """Healthy majority behavior is unchanged apart from participation metadata."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(1, 5)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+
+        async def vote_with_agent(agent, proposals, task):
+            return make_vote(agent=agent.name, choice="agent1")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert ctx.result.consensus_reached is True
+        assert ctx.result.confidence == pytest.approx(1.0)
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 4,
+            "received": 4,
+            "failed": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_insufficient_majority_records_missing_roster(self):
+        """Quorum rejection still exposes how much of the roster was lost."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(1, 5)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.min_participation_ratio = 0.75
+        protocol.min_participation_count = 3
+
+        async def vote_with_agent(agent, proposals, task):
+            if agent.name != "agent1":
+                return None
+            return make_vote(agent=agent.name, choice="agent1")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert ctx.result.status == "insufficient_participation"
+        assert ctx.result.consensus_reached is False
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 4,
+            "received": 1,
+            "failed": 3,
+        }
+
+
+class TestHandleUnanimousConsensus:
+    """Tests for unanimous-vote participation metadata."""
+
+    @pytest.mark.asyncio
+    async def test_failed_voter_is_recorded_as_dissent(self):
+        agents = [MockAgent(name="agent1"), MockAgent(name="agent2")]
+        ctx, protocol = make_context(agents=agents, consensus_mode="unanimous")
+        protocol.min_participation_ratio = 0.5
+        protocol.min_participation_count = 1
+
+        async def vote_with_agent(agent, proposals, task):
+            if agent.name == "agent2":
+                return None
+            return make_vote(agent=agent.name, choice="agent1")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_unanimous_consensus(ctx)
+
+        assert ctx.result.consensus_reached is False
+        assert ctx.result.confidence == pytest.approx(0.5)
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 2,
+            "received": 1,
+            "failed": 1,
+        }
+
+
+# =============================================================================
 # _ensure_quorum Tests
 # =============================================================================
 

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -404,6 +404,7 @@ class TestHandleMajorityConsensus:
             "eligible": 4,
             "received": 2,
             "failed": 2,
+            "skipped": 0,
         }
 
     @pytest.mark.asyncio
@@ -411,6 +412,7 @@ class TestHandleMajorityConsensus:
         """Healthy majority behavior is unchanged apart from participation metadata."""
         agents = [MockAgent(name=f"agent{i}") for i in range(1, 5)]
         ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.enable_rlm_early_termination = False
 
         async def vote_with_agent(agent, proposals, task):
             return make_vote(agent=agent.name, choice="agent1")
@@ -428,6 +430,34 @@ class TestHandleMajorityConsensus:
             "eligible": 4,
             "received": 4,
             "failed": 0,
+            "skipped": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_rlm_skipped_voters_are_not_reported_as_failures(self):
+        """Default early termination keeps the full roster denominator without false failures."""
+        agents = [MockAgent(name=f"agent{i}") for i in range(10)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+
+        async def vote_with_agent(agent, proposals, task):
+            return make_vote(agent=agent.name, choice="agent0")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert ctx.result.consensus_reached is True
+        participation = ctx.result.metadata["vote_participation"]
+        assert 0 < participation["received"] < participation["eligible"]
+        assert ctx.result.confidence == pytest.approx(participation["received"] / 10)
+        assert participation == {
+            "eligible": 10,
+            "received": participation["received"],
+            "failed": 0,
+            "skipped": 10 - participation["received"],
         }
 
     @pytest.mark.asyncio
@@ -456,6 +486,7 @@ class TestHandleMajorityConsensus:
             "eligible": 4,
             "received": 1,
             "failed": 3,
+            "skipped": 0,
         }
 
 
@@ -487,6 +518,7 @@ class TestHandleUnanimousConsensus:
             "eligible": 2,
             "received": 1,
             "failed": 1,
+            "skipped": 0,
         }
 
 

--- a/tests/debate/phases/test_vote_collector.py
+++ b/tests/debate/phases/test_vote_collector.py
@@ -31,6 +31,7 @@ from aragora.debate.phases.vote_collector import (
     VOTE_COLLECTION_TIMEOUT,
     VoteCollector,
     VoteCollectorConfig,
+    _settle_decisive_vote_tasks,
     create_vote_collector,
 )
 
@@ -1056,46 +1057,69 @@ class TestCollectVotesWithErrors:
 
     @pytest.mark.asyncio
     async def test_majority_error_tracking_preserves_rlm_early_termination(self, mock_governor):
-        """Early-stopped voters are skipped, while a completed failure stays failed."""
-        hook_calls = []
-        notifications = []
+        """Canceled cleanup is observed off-path without changing skip accounting."""
+
+        class VoteAbort(BaseException): ...
+
+        hook = MagicMock()
+        notify = MagicMock()
+        loop_contexts = []
+        release_cleanup = asyncio.Event()
 
         async def mock_vote(agent, proposals, task):
-            if agent.name == "agent0":
-                return None
-            await asyncio.sleep(0.01)
-            return make_vote(agent=agent.name, choice="winner")
+            if int(agent.name.removeprefix("agent")) < 6:
+                return make_vote(agent=agent.name, choice="winner")
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await release_cleanup.wait()
+                agent_number = int(agent.name.removeprefix("agent"))
+                if agent_number == 6:
+                    return make_vote(agent=agent.name, choice="late")
+                if agent_number == 7:
+                    raise RuntimeError("late cleanup")
+                raise VoteAbort()
 
-        agents = [MockAgent(name=f"agent{i}") for i in range(10)]
-        config = VoteCollectorConfig(
-            vote_with_agent=mock_vote,
-            hooks={"on_rlm_early_termination": lambda **kwargs: hook_calls.append(kwargs)},
-            notify_spectator=lambda event, **kwargs: notifications.append((event, kwargs)),
-            enable_rlm_early_termination=True,
-            rlm_early_termination_threshold=0.5,
-            rlm_majority_lead_threshold=0.1,
-        )
-        collector = VoteCollector(config)
-        ctx = make_context(agents=agents)
-
-        with patch(
-            "aragora.debate.phases.vote_collector.get_complexity_governor",
-            return_value=mock_governor,
-        ):
-            votes, errors = await collector.collect_votes_with_errors(
-                ctx,
-                unanimous_mode=False,
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=mock_vote,
+                hooks={"on_rlm_early_termination": hook},
+                notify_spectator=notify,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+                vote_collection_timeout=0.05,
             )
+        )
+        loop = asyncio.get_running_loop()
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
 
-        assert len(votes) == 6
-        assert errors == 1
-        assert len(agents) - len(votes) - errors == 3
-        assert hook_calls == [{"leader": "winner", "votes_collected": 6, "total_agents": 10}]
-        assert [event for event, _ in notifications].count("rlm_early_termination") == 1
+        try:
+            with patch(
+                "aragora.debate.phases.vote_collector.get_complexity_governor",
+                return_value=mock_governor,
+            ):
+                votes, errors = await collector.collect_votes_with_errors(
+                    make_context(agents=[MockAgent(name=f"agent{i}") for i in range(10)]),
+                    unanimous_mode=False,
+                )
+
+            assert (len(votes), errors, 10 - len(votes) - errors) == (6, 0, 4)
+            hook.assert_called_once_with(leader="winner", votes_collected=6, total_agents=10)
+            assert (
+                sum(call.args[0] == "rlm_early_termination" for call in notify.call_args_list) == 1
+            )
+            release_cleanup.set()
+            await asyncio.sleep(0.01)
+            assert len(loop_contexts) == 2
+        finally:
+            release_cleanup.set()
+            await asyncio.sleep(0)
+            loop.set_exception_handler(old_handler)
 
     @pytest.mark.parametrize(
         "failure_mode",
-        ["none", "exception-result", "raised-exception"],
+        ["none", "exception-result", "raised-exception", "base-exception"],
     )
     @pytest.mark.asyncio
     async def test_rlm_counts_completed_failure_after_decisive_votes(
@@ -1105,12 +1129,16 @@ class TestCollectVotesWithErrors:
     ):
         """A completed but unconsumed failure is failed, not an RLM skip."""
 
+        class VoteAbort(BaseException): ...
+
         async def mock_vote(agent, proposals, task):
             if agent.name == "agent9":
                 if failure_mode == "none":
                     return None
                 if failure_mode == "exception-result":
                     return ValueError("completed failure")
+                if failure_mode == "base-exception":
+                    raise VoteAbort("completed control flow")
                 raise RuntimeError("completed failure")
             return make_vote(agent=agent.name, choice="winner")
 
@@ -1128,14 +1156,30 @@ class TestCollectVotesWithErrors:
             "aragora.debate.phases.vote_collector.get_complexity_governor",
             return_value=mock_governor,
         ):
+            if failure_mode == "base-exception":
+                with pytest.raises(VoteAbort, match="completed control flow"):
+                    await collector.collect_votes_with_errors(
+                        make_context(agents=agents), unanimous_mode=False
+                    )
+                return
             votes, errors = await collector.collect_votes_with_errors(
-                make_context(agents=agents),
-                unanimous_mode=False,
+                make_context(agents=agents), unanimous_mode=False
             )
 
-        assert len(votes) == 6
+        assert len(votes) == 9
         assert errors == 1
-        assert len(agents) - len(votes) - errors == 3
+        assert len(agents) - len(votes) - errors == 0
+
+    def test_completion_winning_cancel_race_is_consumed_once(self):
+        task = MagicMock()
+        task.done.side_effect = [False, True]
+        task.cancel.return_value = False
+        consume, observe = MagicMock(), MagicMock()
+
+        _settle_decisive_vote_tasks([task], consume, observe)
+
+        consume.assert_called_once_with(task)
+        observe.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_collect_votes_with_errors_counts_exceptions(self, mock_governor):

--- a/tests/debate/phases/test_vote_collector.py
+++ b/tests/debate/phases/test_vote_collector.py
@@ -1055,6 +1055,45 @@ class TestCollectVotesWithErrors:
         assert errors == 0
 
     @pytest.mark.asyncio
+    async def test_majority_error_tracking_preserves_rlm_early_termination(self, mock_governor):
+        """Early-stopped voters are skipped, while a completed failure stays failed."""
+        hook_calls = []
+        notifications = []
+
+        async def mock_vote(agent, proposals, task):
+            if agent.name == "agent0":
+                return None
+            await asyncio.sleep(0.01)
+            return make_vote(agent=agent.name, choice="winner")
+
+        agents = [MockAgent(name=f"agent{i}") for i in range(10)]
+        config = VoteCollectorConfig(
+            vote_with_agent=mock_vote,
+            hooks={"on_rlm_early_termination": lambda **kwargs: hook_calls.append(kwargs)},
+            notify_spectator=lambda event, **kwargs: notifications.append((event, kwargs)),
+            enable_rlm_early_termination=True,
+            rlm_early_termination_threshold=0.5,
+            rlm_majority_lead_threshold=0.1,
+        )
+        collector = VoteCollector(config)
+        ctx = make_context(agents=agents)
+
+        with patch(
+            "aragora.debate.phases.vote_collector.get_complexity_governor",
+            return_value=mock_governor,
+        ):
+            votes, errors = await collector.collect_votes_with_errors(
+                ctx,
+                unanimous_mode=False,
+            )
+
+        assert len(votes) == 6
+        assert errors == 1
+        assert len(agents) - len(votes) - errors == 3
+        assert hook_calls == [{"leader": "winner", "votes_collected": 6, "total_agents": 10}]
+        assert [event for event, _ in notifications].count("rlm_early_termination") == 1
+
+    @pytest.mark.asyncio
     async def test_collect_votes_with_errors_counts_exceptions(self, mock_governor):
         """Tracks errors from agent exceptions."""
 

--- a/tests/debate/phases/test_vote_collector.py
+++ b/tests/debate/phases/test_vote_collector.py
@@ -564,6 +564,7 @@ class TestRLMEarlyTermination:
             )
         )
         weights = {f"agent{i}": 1.0 for i in range(10)}
+        eligible_agents = frozenset(weights)
         seven_votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(7)]
         eight_votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(8)]
 
@@ -572,12 +573,14 @@ class TestRLMEarlyTermination:
             total_agents=10,
             vote_weights=weights,
             consensus_threshold=0.75,
+            eligible_agent_names=eligible_agents,
         ) == (False, None)
         assert collector._check_clear_majority(
             eight_votes,
             total_agents=10,
             vote_weights=weights,
             consensus_threshold=0.75,
+            eligible_agent_names=eligible_agents,
         ) == (True, "A")
 
     def test_weighted_head_count_majority_can_still_be_overtaken(self):
@@ -591,12 +594,14 @@ class TestRLMEarlyTermination:
         )
         votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(6)]
         weights = {f"agent{i}": 0.5 for i in range(6)} | {f"agent{i}": 2.0 for i in range(6, 10)}
+        eligible_agents = frozenset(weights)
 
         assert collector._check_clear_majority(
             votes,
             total_agents=10,
             vote_weights=weights,
             consensus_threshold=0.25,
+            eligible_agent_names=eligible_agents,
         ) == (False, None)
 
     @pytest.mark.parametrize(
@@ -622,6 +627,47 @@ class TestRLMEarlyTermination:
             total_agents=10,
             vote_weights=vote_weights,
             consensus_threshold=0.75,
+            eligible_agent_names=frozenset(f"agent{i}" for i in range(10)),
+        ) == (False, None)
+
+    def test_weighted_majority_rejects_same_size_wrong_roster(self):
+        """Ghost keys cannot stand in for pending eligible voters."""
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                enable_rlm_early_termination=True,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+            )
+        )
+        votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(8)]
+        weights = {f"agent{i}": 1.0 for i in range(8)} | {"ghost8": 0.0, "ghost9": 0.0}
+
+        assert collector._check_clear_majority(
+            votes,
+            total_agents=10,
+            vote_weights=weights,
+            consensus_threshold=0.75,
+            eligible_agent_names=frozenset(f"agent{i}" for i in range(10)),
+        ) == (False, None)
+
+    def test_weighted_majority_rejects_nonfinite_aggregate(self):
+        """Finite individual weights whose sum overflows must fail closed."""
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                enable_rlm_early_termination=True,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+            )
+        )
+        weights = {f"agent{i}": 1e308 for i in range(10)}
+        votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(8)]
+
+        assert collector._check_clear_majority(
+            votes,
+            total_agents=10,
+            vote_weights=weights,
+            consensus_threshold=0.75,
+            eligible_agent_names=frozenset(weights),
         ) == (False, None)
 
     def test_check_clear_majority_votes_without_choice(self):
@@ -1186,6 +1232,44 @@ class TestCollectVotesWithErrors:
             release_cleanup.set()
             await asyncio.sleep(0)
             loop.set_exception_handler(old_handler)
+
+    @pytest.mark.asyncio
+    async def test_majority_collection_threads_exact_roster_guard(self, mock_governor):
+        """A same-sized ghost roster cannot emit an early-stop event."""
+
+        async def mock_vote(agent, proposals, task):
+            await asyncio.sleep(0)
+            return make_vote(agent=agent.name, choice="winner")
+
+        hook = MagicMock()
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=mock_vote,
+                hooks={"on_rlm_early_termination": hook},
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+            )
+        )
+        ctx = make_context(agents=[MockAgent(name=f"agent{i}") for i in range(10)])
+        wrong_weights = {f"agent{i}": 1.0 for i in range(8)} | {
+            "ghost8": 0.0,
+            "ghost9": 0.0,
+        }
+
+        with patch(
+            "aragora.debate.phases.vote_collector.get_complexity_governor",
+            return_value=mock_governor,
+        ):
+            votes, errors = await collector.collect_votes_with_errors(
+                ctx,
+                unanimous_mode=False,
+                vote_weights=wrong_weights,
+                consensus_threshold=0.75,
+                eligible_agent_names=frozenset(agent.name for agent in ctx.agents),
+            )
+
+        assert (len(votes), errors) == (10, 0)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize(
         "failure_mode",

--- a/tests/debate/phases/test_vote_collector.py
+++ b/tests/debate/phases/test_vote_collector.py
@@ -1093,6 +1093,50 @@ class TestCollectVotesWithErrors:
         assert hook_calls == [{"leader": "winner", "votes_collected": 6, "total_agents": 10}]
         assert [event for event, _ in notifications].count("rlm_early_termination") == 1
 
+    @pytest.mark.parametrize(
+        "failure_mode",
+        ["none", "exception-result", "raised-exception"],
+    )
+    @pytest.mark.asyncio
+    async def test_rlm_counts_completed_failure_after_decisive_votes(
+        self,
+        mock_governor,
+        failure_mode,
+    ):
+        """A completed but unconsumed failure is failed, not an RLM skip."""
+
+        async def mock_vote(agent, proposals, task):
+            if agent.name == "agent9":
+                if failure_mode == "none":
+                    return None
+                if failure_mode == "exception-result":
+                    return ValueError("completed failure")
+                raise RuntimeError("completed failure")
+            return make_vote(agent=agent.name, choice="winner")
+
+        agents = [MockAgent(name=f"agent{i}") for i in range(10)]
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=mock_vote,
+                enable_rlm_early_termination=True,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+            )
+        )
+
+        with patch(
+            "aragora.debate.phases.vote_collector.get_complexity_governor",
+            return_value=mock_governor,
+        ):
+            votes, errors = await collector.collect_votes_with_errors(
+                make_context(agents=agents),
+                unanimous_mode=False,
+            )
+
+        assert len(votes) == 6
+        assert errors == 1
+        assert len(agents) - len(votes) - errors == 3
+
     @pytest.mark.asyncio
     async def test_collect_votes_with_errors_counts_exceptions(self, mock_governor):
         """Tracks errors from agent exceptions."""

--- a/tests/debate/phases/test_vote_collector.py
+++ b/tests/debate/phases/test_vote_collector.py
@@ -554,6 +554,76 @@ class TestRLMEarlyTermination:
         assert has_majority is True
         assert leader == "A"
 
+    def test_weighted_majority_must_meet_full_roster_threshold(self):
+        """Seven of ten cannot satisfy a 75% threshold; eight can."""
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                enable_rlm_early_termination=True,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+            )
+        )
+        weights = {f"agent{i}": 1.0 for i in range(10)}
+        seven_votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(7)]
+        eight_votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(8)]
+
+        assert collector._check_clear_majority(
+            seven_votes,
+            total_agents=10,
+            vote_weights=weights,
+            consensus_threshold=0.75,
+        ) == (False, None)
+        assert collector._check_clear_majority(
+            eight_votes,
+            total_agents=10,
+            vote_weights=weights,
+            consensus_threshold=0.75,
+        ) == (True, "A")
+
+    def test_weighted_head_count_majority_can_still_be_overtaken(self):
+        """A raw ballot majority is not decisive when pending agents hold most weight."""
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                enable_rlm_early_termination=True,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+            )
+        )
+        votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(6)]
+        weights = {f"agent{i}": 0.5 for i in range(6)} | {f"agent{i}": 2.0 for i in range(6, 10)}
+
+        assert collector._check_clear_majority(
+            votes,
+            total_agents=10,
+            vote_weights=weights,
+            consensus_threshold=0.25,
+        ) == (False, None)
+
+    @pytest.mark.parametrize(
+        "vote_weights",
+        [
+            None,
+            {"agent0": 1.0},
+            {f"agent{i}": 1.0 for i in range(9)} | {"agent9": float("nan")},
+        ],
+    )
+    def test_weighted_majority_fails_closed_without_exact_finite_roster(self, vote_weights):
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                enable_rlm_early_termination=True,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+            )
+        )
+        votes = [make_vote(agent=f"agent{i}", choice="A") for i in range(8)]
+
+        assert collector._check_clear_majority(
+            votes,
+            total_agents=10,
+            vote_weights=vote_weights,
+            consensus_threshold=0.75,
+        ) == (False, None)
+
     def test_check_clear_majority_votes_without_choice(self):
         """Handles votes without choice attribute."""
         config = VoteCollectorConfig(enable_rlm_early_termination=True)

--- a/tests/debate/phases/test_vote_collector.py
+++ b/tests/debate/phases/test_vote_collector.py
@@ -993,7 +993,7 @@ class TestCollectVotesWithErrors:
 
     @pytest.mark.asyncio
     async def test_collect_votes_with_errors_no_callback(self):
-        """Returns empty when no vote_with_agent callback."""
+        """A missing callback records every eligible voter as failed."""
         config = VoteCollectorConfig()
         collector = VoteCollector(config)
         ctx = make_context()
@@ -1001,7 +1001,38 @@ class TestCollectVotesWithErrors:
         votes, errors = await collector.collect_votes_with_errors(ctx)
 
         assert votes == []
-        assert errors == 0
+        assert errors == len(ctx.agents)
+
+    @pytest.mark.asyncio
+    async def test_error_tracking_preserves_position_shuffling(self):
+        """Majority error tracking still uses the configured shuffle path."""
+
+        async def mock_vote(agent, proposals, task):
+            return make_vote(agent=agent.name)
+
+        config = VoteCollectorConfig(
+            vote_with_agent=mock_vote,
+            enable_position_shuffling=True,
+            position_shuffling_permutations=2,
+        )
+        collector = VoteCollector(config)
+        ctx = make_context()
+        shuffled_votes = [make_vote(agent=agent.name) for agent in ctx.agents[:-1]]
+
+        with patch.object(
+            collector,
+            "_collect_votes_with_shuffling",
+            new_callable=AsyncMock,
+            return_value=shuffled_votes,
+        ) as collect_shuffled:
+            votes, errors = await collector.collect_votes_with_errors(
+                ctx,
+                use_position_shuffling=True,
+            )
+
+        collect_shuffled.assert_awaited_once_with(ctx)
+        assert votes == shuffled_votes
+        assert errors == 1
 
     @pytest.mark.asyncio
     async def test_collect_votes_with_errors_basic(self, mock_governor):

--- a/tests/debate/test_consensus_phase.py
+++ b/tests/debate/test_consensus_phase.py
@@ -884,6 +884,7 @@ class TestPhase11CEdgeCases:
     async def test_single_proposal_with_multiple_voters(self):
         """Single proposal should reach consensus if threshold met."""
         protocol = MockProtocol(consensus="majority", consensus_threshold=0.5)
+        protocol.enable_rlm_early_termination = False
 
         async def vote_with_agent(agent, proposals, task):
             return MockVote(agent=agent.name, choice="only_proposal", confidence=0.9)

--- a/tests/debate/test_consensus_phase_comprehensive.py
+++ b/tests/debate/test_consensus_phase_comprehensive.py
@@ -1422,6 +1422,7 @@ class TestConsensusIntegration:
         )
 
         protocol = MockProtocol(consensus="majority", consensus_threshold=0.5)
+        protocol.enable_rlm_early_termination = False
 
         votes_cast = []
 


### PR DESCRIPTION
## Summary

Closes the first Truthful Debate Completion unit's partial-roster accounting gaps: failed majority voters remain in the confidence denominator, decisive early termination distinguishes completed failures from intentional skips, and late canceled-task outcomes are observed without blocking the decision path.

The cumulative PR also hardens weighted RLM early termination so it uses the effective consensus threshold, an exact eligible-agent/weight snapshot, finite aggregate weights, and only immutable final-tally inputs.

The latest repair captures one frozen majority snapshot before collection and reuses it through quorum, participation accounting, the missing-voter denominator, winner normalization, and final threshold evaluation.

## Contract repairs

- preserve the full eligible roster in majority confidence and expose `vote_participation` as `{eligible, received, failed, skipped}`
- drain already-completed vote tasks at the decisive boundary, including `cancel() == false` completion races
- count completed `None`, returned exceptions, and raised ordinary exceptions exactly once; preserve non-`Exception` control-flow failures
- classify cancellation-accepted tasks as skips without awaiting cleanup, while observing later results and forwarding late control-flow failures
- bind weighted early-stop checks to the effective threshold and fixed full-roster weights
- reject missing, malformed, ghost/missing-key, duplicate-voter, non-finite, and aggregate-overflow snapshots
- disable RLM cancellation when user votes or a user-event drain can mutate the final tally after collection
- prevent later `protocol.consensus_threshold` or `ctx.agents` mutation from changing the decision authorized by the frozen majority snapshot

This unit does not claim receipt, API, or terminal-stream parity; those remain later campaign cells.

## Validation

- focused collector/consensus suites: 270 passed
- debate orchestrator/integration suites: 221 passed
- Ruff lint/format, CI-aligned changed-source mypy, `git diff --check`, and code-quality ratchet: passed
- commit and pre-push hooks: passed
- latest mutation breaks killed removal of snapshot threshold binding, snapshot quorum/participation, snapshot missing-voter weighting, and snapshot winner normalization
- all six current-head required GitHub checks: passed

## Terminal review status

A fresh independent non-countable terminal review of exact head `befe74dc07debdaf161960ea6c26e3811d864199` found five P2s and no P0/P1 findings:

- collection and context-dependent weighting still consume live `ctx.agents` rather than the captured roster
- final quorum re-reads mutable participation policy after early cancellation
- duplicate eligible names can remove a failed voter from the weighted denominator
- the shallow snapshot retains mutable agent objects, so renames can alter winner normalization
- timeout or caller cancellation can abandon vote tasks without observing later results or control-flow failures

The reviewer independently reproduced each defect, while the 270 changed-test suite, Ruff, changed-source mypy, and diff hygiene passed. Local, remote, and PR heads matched before and after review; no mutations were made.

Per the terminal rule, these P2s block the head and no further #9912 repair loop is authorized. The PR remains draft; no evidence, readiness transition, settlement, or merge was attempted.

## Scope

- Base: `6d35c57c2d38ce4840d797580fb93620020dd44c`
- Exact implementation head: `befe74dc07debdaf161960ea6c26e3811d864199`
- 6 files, +1066/-44; the cumulative expanded scope is recorded explicitly rather than treated as ordinary bounded-PR size
- no workflow, protected-governance, dependency, endpoint, receipt-model, deployment, or merge/evidence changes
- deterministic fake-agent tests only; no live product inference
