### PR TITLE
feat(evaluation): materialize outcome-blind source packets

### DIFF
--- a/aragora/evaluation/outcome_backed_corpus.py
+++ b/aragora/evaluation/outcome_backed_corpus.py
@@ -67,6 +67,17 @@ class _DuplicateKeyError(ValueError):
     pass
 
 
+class VisibleCorpusError(ValueError):
+    """Raised when the model-visible corpus cannot be loaded safely."""
+
+    def __init__(self, issues: tuple[ValidationIssue, ...]) -> None:
+        self.issues = issues
+        detail = "; ".join(f"{issue.code}: {issue.path}: {issue.message}" for issue in issues[:5])
+        if len(issues) > 5:
+            detail += f"; ... and {len(issues) - 5} more"
+        super().__init__(detail)
+
+
 @dataclass(frozen=True)
 class ValidationIssue:
     code: str
@@ -330,6 +341,81 @@ def _outcome(
 def _count(issues: list[ValidationIssue], code: str, path: str, actual: int, expected: int) -> None:
     if actual != expected:
         _add(issues, code, path, f"expected {expected}, found {actual}")
+
+
+def load_visible_cases(directory: Path | str) -> tuple[Mapping[str, Any], ...]:
+    """Load and validate only model-visible corpus files.
+
+    This intentionally never opens ``*.outcomes.json``.  Callers that build
+    inference packets can therefore prove that outcome sidecars were not part
+    of the packet-construction path.
+    """
+
+    root = Path(directory)
+    issues: list[ValidationIssue] = []
+    corpus_paths = sorted(root.glob("*.corpus.json"))
+    _count(issues, "corpus_file_count", str(root), len(corpus_paths), EXPECTED_PAIRS)
+
+    benchmark_ids: set[str] = set()
+    frozen_times: set[str] = set()
+    cases: dict[str, Mapping[str, Any]] = {}
+    split_counts: Counter[str] = Counter()
+    domain_counts: Counter[str] = Counter()
+    domain_splits: Counter[tuple[str, str]] = Counter()
+
+    for corpus_path in corpus_paths:
+        corpus = _load(corpus_path, issues)
+        if corpus is None:
+            continue
+        corpus_name = str(corpus_path)
+        _keys(corpus, _CORPUS_KEYS, corpus_name, issues)
+        _leakage(corpus, corpus_name, issues)
+        if corpus.get("schema_version") != CORPUS_SCHEMA:
+            _add(issues, "schema_version", f"{corpus_name}.schema_version", CORPUS_SCHEMA)
+        benchmark = _text(corpus.get("benchmark_id"), f"{corpus_name}.benchmark_id", issues)
+        if benchmark is not None:
+            benchmark_ids.add(benchmark)
+        _text(corpus.get("revision"), f"{corpus_name}.revision", issues)
+        frozen = corpus.get("frozen_at")
+        if _time(frozen, f"{corpus_name}.frozen_at", issues) is not None:
+            frozen_times.add(str(frozen))
+        corpus_cases = _list(corpus.get("cases"), f"{corpus_name}.cases", "invalid_cases", issues)
+        for index, value in enumerate(corpus_cases):
+            case_path = f"{corpus_name}.cases[{index}]"
+            case_id, domain, split, _, _ = _case(value, case_path, issues)
+            if case_id is not None:
+                if case_id in cases:
+                    _add(issues, "duplicate_case_id", f"{case_path}.case_id", case_id)
+                elif isinstance(value, dict):
+                    cases[case_id] = value
+            if domain is not None:
+                domain_counts[domain] += 1
+            if split is not None:
+                split_counts[split] += 1
+            if domain is not None and split is not None:
+                domain_splits[(domain, split)] += 1
+
+    if benchmark_ids != {BENCHMARK_ID}:
+        _add(issues, "benchmark_id_set", str(root), f"found {sorted(benchmark_ids)}")
+    if len(frozen_times) != 1:
+        _add(issues, "freeze_timestamp_set", str(root), f"found {sorted(frozen_times)}")
+    _count(issues, "case_count", str(root), len(cases), EXPECTED_CASES)
+    for split, expected in SPLIT_COUNTS.items():
+        _count(issues, "split_count", f"{root}:{split}", split_counts[split], expected)
+    for domain in DOMAINS:
+        _count(issues, "domain_count", f"{root}:{domain}", domain_counts[domain], 6)
+        for split, expected in DOMAIN_SPLIT_COUNTS.items():
+            _count(
+                issues,
+                "domain_split_count",
+                f"{root}:{domain}:{split}",
+                domain_splits[(domain, split)],
+                expected,
+            )
+
+    if issues:
+        raise VisibleCorpusError(tuple(issues))
+    return tuple(cases[case_id] for case_id in sorted(cases))
 
 
 def validate_corpus_directory(directory: Path | str) -> CorpusIntegrityReport:

--- a/aragora/evaluation/outcome_backed_packets.py
+++ b/aragora/evaluation/outcome_backed_packets.py
@@ -6,13 +6,16 @@ import base64
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 import hashlib
+from http.client import HTTPMessage
+import ipaddress
 import json
 from pathlib import Path
 import re
-from typing import Protocol
+import socket
+from typing import IO
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from aragora.evaluation.outcome_backed_corpus import (
     BENCHMARK_ID,
@@ -26,6 +29,21 @@ PACKET_SET_SCHEMA = "outcome-backed-source-packet-set/1.0"
 DEFAULT_MAX_SOURCE_BYTES = 10_000_000
 DEFAULT_TIMEOUT_SECONDS = 30.0
 SOURCE_USER_AGENT = "Mozilla/5.0 (compatible; AragoraBot/1.0; +https://aragora.ai)"
+SOURCE_HOST_ALLOWLIST = frozenset(
+    {
+        "assets.publishing.service.gov.uk",
+        "ntrs.nasa.gov",
+        "raw.githubusercontent.com",
+        "science.nasa.gov",
+        "www.ftc.gov",
+        "www.govinfo.gov",
+        "www.justice.gov",
+        "www.nasa.gov",
+        "www.nist.gov",
+        "www.noaa.gov",
+        "www.sec.gov",
+    }
+)
 
 _SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 _OUTCOME_KEYS = frozenset(
@@ -45,17 +63,82 @@ class SourcePacketError(ValueError):
     """Raised when source material cannot be packetized fail-closed."""
 
 
-class _ReadableResponse(Protocol):
-    def __enter__(self) -> _ReadableResponse: ...
+def _source_hostname(url: str, *, source_id: str, expected_hostname: str | None = None) -> str:
+    """Return an allowlisted HTTPS hostname without performing network I/O."""
 
-    def __exit__(self, *args: object) -> object: ...
+    try:
+        parsed = urlparse(url)
+        port = parsed.port
+    except ValueError as exc:
+        raise SourcePacketError(f"source {source_id} URL is malformed") from exc
+    hostname = (parsed.hostname or "").lower()
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or port not in {None, 443}
+    ):
+        raise SourcePacketError(f"source {source_id} URL must be credential-free HTTPS on port 443")
+    if hostname not in SOURCE_HOST_ALLOWLIST:
+        raise SourcePacketError(f"source {source_id} hostname is not in the frozen allowlist")
+    if expected_hostname is not None and hostname != expected_hostname:
+        raise SourcePacketError(f"source {source_id} redirect changed hostname")
+    return hostname
 
-    def read(self, amount: int = -1) -> bytes: ...
 
-    def geturl(self) -> str: ...
+def _validate_public_source_url(
+    url: str,
+    *,
+    source_id: str,
+    expected_hostname: str | None = None,
+) -> str:
+    """Fail closed unless every resolved address is globally routable."""
+
+    hostname = _source_hostname(
+        url,
+        source_id=source_id,
+        expected_hostname=expected_hostname,
+    )
+    try:
+        addresses = socket.getaddrinfo(hostname, 443, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except (TimeoutError, socket.gaierror, OSError) as exc:
+        raise SourcePacketError(f"source {source_id} DNS resolution failed") from exc
+    if not addresses:
+        raise SourcePacketError(f"source {source_id} DNS resolution returned no addresses")
+    for address in addresses:
+        try:
+            resolved = ipaddress.ip_address(str(address[4][0]))
+        except (IndexError, TypeError, ValueError) as exc:
+            raise SourcePacketError(f"source {source_id} DNS returned an invalid address") from exc
+        if not resolved.is_global:
+            raise SourcePacketError(f"source {source_id} resolved to a non-public address")
+    return hostname
 
 
-OpenUrl = Callable[..., _ReadableResponse]
+class _SourceRedirectHandler(HTTPRedirectHandler):
+    """Validate every redirect target before urllib opens it."""
+
+    def __init__(self, *, source_id: str, expected_hostname: str) -> None:
+        super().__init__()
+        self._source_id = source_id
+        self._expected_hostname = expected_hostname
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> Request | None:
+        _validate_public_source_url(
+            newurl,
+            source_id=self._source_id,
+            expected_hostname=self._expected_hostname,
+        )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
 @dataclass(frozen=True)
@@ -93,9 +176,7 @@ def _source_metadata(source: Mapping[str, object]) -> dict[str, str]:
         field: _required_text(source.get(field), f"source.{field}")
         for field in ("source_id", "title", "url", "published_at", "content_sha256")
     }
-    parsed = urlparse(metadata["url"])
-    if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
-        raise SourcePacketError("source.url must be credential-free HTTPS")
+    _source_hostname(metadata["url"], source_id=metadata["source_id"])
     if not re.fullmatch(r"[0-9a-f]{64}", metadata["content_sha256"]):
         raise SourcePacketError("source.content_sha256 must be lowercase SHA-256")
     return metadata
@@ -106,7 +187,6 @@ def fetch_source(
     *,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     max_source_bytes: int = DEFAULT_MAX_SOURCE_BYTES,
-    open_url: OpenUrl = urlopen,
 ) -> MaterializedSource:
     """Fetch one pinned source and verify its exact bytes before decoding."""
 
@@ -116,24 +196,29 @@ def fetch_source(
     if max_source_bytes <= 0:
         raise SourcePacketError("max_source_bytes must be positive")
 
+    source_hostname = _validate_public_source_url(
+        metadata["url"],
+        source_id=metadata["source_id"],
+    )
     request = Request(
         metadata["url"],
         headers={"User-Agent": SOURCE_USER_AGENT},
         method="GET",
     )
+    opener = build_opener(
+        _SourceRedirectHandler(
+            source_id=metadata["source_id"],
+            expected_hostname=source_hostname,
+        )
+    )
     try:
-        with open_url(request, timeout=timeout_seconds) as response:
+        with opener.open(request, timeout=timeout_seconds) as response:
             final_url = response.geturl()
-            parsed_final = urlparse(final_url)
-            if (
-                parsed_final.scheme != "https"
-                or not parsed_final.netloc
-                or parsed_final.username
-                or parsed_final.password
-            ):
-                raise SourcePacketError(
-                    f"source {metadata['source_id']} redirected outside credential-free HTTPS"
-                )
+            _source_hostname(
+                final_url,
+                source_id=metadata["source_id"],
+                expected_hostname=source_hostname,
+            )
             raw = response.read(max_source_bytes + 1)
     except SourcePacketError:
         raise
@@ -321,7 +406,6 @@ def materialize_source_packets(
     split: str,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     max_source_bytes: int = DEFAULT_MAX_SOURCE_BYTES,
-    open_url: OpenUrl = urlopen,
 ) -> dict[str, object]:
     """Load visible cases, fetch pinned evidence, and persist deterministic packets."""
 
@@ -332,7 +416,6 @@ def materialize_source_packets(
             metadata,
             timeout_seconds=timeout_seconds,
             max_source_bytes=max_source_bytes,
-            open_url=open_url,
         )
 
     manifest, packets = build_packet_set(cases, split=split, fetch=fetch)

--- a/aragora/evaluation/outcome_backed_packets.py
+++ b/aragora/evaluation/outcome_backed_packets.py
@@ -1,0 +1,340 @@
+"""Deterministic, outcome-blind source packets for decision-quality inference."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from aragora.evaluation.outcome_backed_corpus import (
+    BENCHMARK_ID,
+    canonical_json_sha256,
+    load_visible_cases,
+)
+
+
+SOURCE_PACKET_SCHEMA = "outcome-backed-source-packet/1.0"
+PACKET_SET_SCHEMA = "outcome-backed-source-packet-set/1.0"
+DEFAULT_MAX_SOURCE_BYTES = 10_000_000
+DEFAULT_TIMEOUT_SECONDS = 30.0
+SOURCE_USER_AGENT = "Mozilla/5.0 (compatible; AragoraBot/1.0; +https://aragora.ai)"
+
+_SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_OUTCOME_KEYS = frozenset(
+    {
+        "authoritative_sources",
+        "correct_option_id",
+        "cruxes",
+        "outcome",
+        "outcomes",
+        "resolution_summary",
+        "resolved_at",
+    }
+)
+
+
+class SourcePacketError(ValueError):
+    """Raised when source material cannot be packetized fail-closed."""
+
+
+class _ReadableResponse(Protocol):
+    def __enter__(self) -> _ReadableResponse: ...
+
+    def __exit__(self, *args: object) -> object: ...
+
+    def read(self, amount: int = -1) -> bytes: ...
+
+    def geturl(self) -> str: ...
+
+
+OpenUrl = Callable[..., _ReadableResponse]
+
+
+@dataclass(frozen=True)
+class MaterializedSource:
+    source_id: str
+    title: str
+    url: str
+    published_at: str
+    content_sha256: str
+    media_type: str
+    content_encoding: str
+    content: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "source_id": self.source_id,
+            "title": self.title,
+            "url": self.url,
+            "published_at": self.published_at,
+            "content_sha256": self.content_sha256,
+            "media_type": self.media_type,
+            "content_encoding": self.content_encoding,
+            "content": self.content,
+        }
+
+
+def _required_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SourcePacketError(f"{field} must be a non-empty string")
+    return value
+
+
+def _source_metadata(source: Mapping[str, object]) -> dict[str, str]:
+    metadata = {
+        field: _required_text(source.get(field), f"source.{field}")
+        for field in ("source_id", "title", "url", "published_at", "content_sha256")
+    }
+    parsed = urlparse(metadata["url"])
+    if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
+        raise SourcePacketError("source.url must be credential-free HTTPS")
+    if not re.fullmatch(r"[0-9a-f]{64}", metadata["content_sha256"]):
+        raise SourcePacketError("source.content_sha256 must be lowercase SHA-256")
+    return metadata
+
+
+def fetch_source(
+    source: Mapping[str, object],
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_source_bytes: int = DEFAULT_MAX_SOURCE_BYTES,
+    open_url: OpenUrl = urlopen,
+) -> MaterializedSource:
+    """Fetch one pinned source and verify its exact bytes before decoding."""
+
+    metadata = _source_metadata(source)
+    if timeout_seconds <= 0:
+        raise SourcePacketError("timeout_seconds must be positive")
+    if max_source_bytes <= 0:
+        raise SourcePacketError("max_source_bytes must be positive")
+
+    request = Request(
+        metadata["url"],
+        headers={"User-Agent": SOURCE_USER_AGENT},
+        method="GET",
+    )
+    try:
+        with open_url(request, timeout=timeout_seconds) as response:
+            final_url = response.geturl()
+            parsed_final = urlparse(final_url)
+            if (
+                parsed_final.scheme != "https"
+                or not parsed_final.netloc
+                or parsed_final.username
+                or parsed_final.password
+            ):
+                raise SourcePacketError(
+                    f"source {metadata['source_id']} redirected outside credential-free HTTPS"
+                )
+            raw = response.read(max_source_bytes + 1)
+    except SourcePacketError:
+        raise
+    except (HTTPError, URLError, OSError, TimeoutError) as exc:
+        raise SourcePacketError(
+            f"source {metadata['source_id']} fetch failed ({type(exc).__name__})"
+        ) from exc
+
+    if len(raw) > max_source_bytes:
+        raise SourcePacketError(f"source {metadata['source_id']} exceeds {max_source_bytes} bytes")
+    digest = hashlib.sha256(raw).hexdigest()
+    if digest != metadata["content_sha256"]:
+        raise SourcePacketError(
+            f"source {metadata['source_id']} hash mismatch: expected "
+            f"{metadata['content_sha256']}, got {digest}"
+        )
+    if raw.startswith(b"%PDF-"):
+        media_type = "application/pdf"
+        content_encoding = "base64"
+        content = base64.b64encode(raw).decode("ascii")
+    else:
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise SourcePacketError(
+                f"source {metadata['source_id']} is neither PDF nor valid UTF-8"
+            ) from exc
+        media_type = "text/plain; charset=utf-8"
+        content_encoding = "utf-8"
+    return MaterializedSource(
+        content=content,
+        media_type=media_type,
+        content_encoding=content_encoding,
+        **metadata,
+    )
+
+
+def _reject_outcome_keys(value: object, path: str = "packet") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if key in _OUTCOME_KEYS:
+                raise SourcePacketError(f"outcome-only key {key!r} found at {path}")
+            _reject_outcome_keys(child, f"{path}.{key}")
+    elif isinstance(value, list | tuple):
+        for index, child in enumerate(value):
+            _reject_outcome_keys(child, f"{path}[{index}]")
+
+
+def render_case_packet(
+    case: Mapping[str, object],
+    sources: Sequence[MaterializedSource],
+) -> dict[str, object]:
+    """Render one deterministic packet without any outcome-sidecar fields."""
+
+    case_id = _required_text(case.get("case_id"), "case.case_id")
+    if not _SAFE_ID_RE.fullmatch(case_id):
+        raise SourcePacketError(f"unsafe case_id: {case_id!r}")
+    split = _required_text(case.get("split"), "case.split")
+    if split not in {"development", "holdout"}:
+        raise SourcePacketError(f"unsupported case split: {split}")
+
+    visible_case = dict(case)
+    declared_sources = visible_case.pop("sources", None)
+    if not isinstance(declared_sources, list) or not declared_sources:
+        raise SourcePacketError(f"case {case_id} must declare at least one source")
+    declared_ids = [
+        _required_text(source.get("source_id"), "source.source_id")
+        for source in declared_sources
+        if isinstance(source, Mapping)
+    ]
+    materialized = sorted(sources, key=lambda source: source.source_id)
+    actual_ids = [source.source_id for source in materialized]
+    if sorted(declared_ids) != actual_ids or len(declared_ids) != len(declared_sources):
+        raise SourcePacketError(
+            f"case {case_id} source set mismatch: declared={sorted(declared_ids)}, "
+            f"materialized={actual_ids}"
+        )
+
+    payload: dict[str, object] = {
+        "schema_version": SOURCE_PACKET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "case": visible_case,
+        "sources": [source.to_dict() for source in materialized],
+    }
+    _reject_outcome_keys(payload)
+    payload["packet_sha256"] = canonical_json_sha256(payload)
+    return payload
+
+
+def _collect_source_metadata(cases: Sequence[Mapping[str, object]]) -> dict[str, dict[str, str]]:
+    collected: dict[str, dict[str, str]] = {}
+    for case in cases:
+        case_id = _required_text(case.get("case_id"), "case.case_id")
+        sources = case.get("sources")
+        if not isinstance(sources, list) or not sources:
+            raise SourcePacketError(f"case {case_id} must declare at least one source")
+        for source in sources:
+            if not isinstance(source, Mapping):
+                raise SourcePacketError(f"case {case_id} contains a non-object source")
+            metadata = _source_metadata(source)
+            source_id = metadata["source_id"]
+            previous = collected.get(source_id)
+            if previous is not None and previous != metadata:
+                raise SourcePacketError(f"source_id {source_id!r} has conflicting metadata")
+            collected[source_id] = metadata
+    return collected
+
+
+def build_packet_set(
+    cases: Sequence[Mapping[str, object]],
+    *,
+    split: str,
+    fetch: Callable[[Mapping[str, object]], MaterializedSource] = fetch_source,
+) -> tuple[dict[str, object], dict[str, dict[str, object]]]:
+    """Build a deterministic split-specific packet set in memory."""
+
+    if split not in {"development", "holdout"}:
+        raise SourcePacketError("split must be development or holdout")
+    selected = [case for case in cases if case.get("split") == split]
+    expected = 16 if split == "development" else 8
+    if len(selected) != expected:
+        raise SourcePacketError(f"expected {expected} {split} cases, found {len(selected)}")
+    selected.sort(key=lambda case: _required_text(case.get("case_id"), "case.case_id"))
+
+    metadata = _collect_source_metadata(selected)
+    materialized = {source_id: fetch(source) for source_id, source in sorted(metadata.items())}
+    packets: dict[str, dict[str, object]] = {}
+    for case in selected:
+        case_id = _required_text(case.get("case_id"), "case.case_id")
+        sources = case.get("sources")
+        if not isinstance(sources, list):
+            raise SourcePacketError(f"case {case_id} sources changed after validation")
+        packets[case_id] = render_case_packet(
+            case,
+            [materialized[str(source["source_id"])] for source in sources],
+        )
+
+    packet_entries = [
+        {"case_id": case_id, "packet_sha256": packet["packet_sha256"]}
+        for case_id, packet in sorted(packets.items())
+    ]
+    manifest: dict[str, object] = {
+        "schema_version": PACKET_SET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "split": split,
+        "packet_count": len(packets),
+        "source_count": len(materialized),
+        "packets": packet_entries,
+    }
+    manifest["packet_set_sha256"] = canonical_json_sha256(manifest)
+    return manifest, packets
+
+
+def write_packet_set(
+    output_dir: Path | str,
+    manifest: Mapping[str, object],
+    packets: Mapping[str, Mapping[str, object]],
+) -> None:
+    """Write one packet set atomically while refusing stale packet residue."""
+
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    expected = {f"{case_id}.packet.json" for case_id in packets}
+    stale = sorted(path.name for path in root.glob("*.packet.json") if path.name not in expected)
+    if stale:
+        raise SourcePacketError(f"output directory contains stale packets: {', '.join(stale)}")
+
+    documents: dict[str, Mapping[str, object]] = {
+        **{f"{case_id}.packet.json": packet for case_id, packet in packets.items()},
+        "packet-set.json": manifest,
+    }
+    for name, document in sorted(documents.items()):
+        target = root / name
+        temporary = target.with_suffix(target.suffix + ".tmp")
+        temporary.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        temporary.replace(target)
+
+
+def materialize_source_packets(
+    corpus_dir: Path | str,
+    output_dir: Path | str,
+    *,
+    split: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_source_bytes: int = DEFAULT_MAX_SOURCE_BYTES,
+    open_url: OpenUrl = urlopen,
+) -> dict[str, object]:
+    """Load visible cases, fetch pinned evidence, and persist deterministic packets."""
+
+    cases = load_visible_cases(corpus_dir)
+
+    def fetch(metadata: Mapping[str, object]) -> MaterializedSource:
+        return fetch_source(
+            metadata,
+            timeout_seconds=timeout_seconds,
+            max_source_bytes=max_source_bytes,
+            open_url=open_url,
+        )
+
+    manifest, packets = build_packet_set(cases, split=split, fetch=fetch)
+    write_packet_set(output_dir, manifest, packets)
+    return manifest

--- a/scripts/build_outcome_backed_source_packets.py
+++ b/scripts/build_outcome_backed_source_packets.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Materialize hash-verified, outcome-blind decision-quality source packets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.evaluation.outcome_backed_packets import (
+    DEFAULT_MAX_SOURCE_BYTES,
+    DEFAULT_TIMEOUT_SECONDS,
+    SourcePacketError,
+    materialize_source_packets,
+)
+
+
+DEFAULT_CORPUS_DIR = Path("docs/benchmarks/decision_quality/tranches")
+DEFAULT_OUTPUT_ROOT = Path(".aragora/outcome_backed/source_packets")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--split", required=True, choices=("development", "holdout"))
+    parser.add_argument("--corpus-dir", type=Path, default=DEFAULT_CORPUS_DIR)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="target directory (default: .aragora/outcome_backed/source_packets/<split>)",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--max-source-bytes", type=int, default=DEFAULT_MAX_SOURCE_BYTES)
+    parser.add_argument("--json", action="store_true", help="emit the packet-set manifest")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    output_dir = args.output_dir or DEFAULT_OUTPUT_ROOT / args.split
+    try:
+        manifest = materialize_source_packets(
+            args.corpus_dir,
+            output_dir,
+            split=args.split,
+            timeout_seconds=args.timeout_seconds,
+            max_source_bytes=args.max_source_bytes,
+        )
+    except (OSError, SourcePacketError, ValueError) as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {"ok": True, "output_dir": str(output_dir), **manifest}, indent=2, sort_keys=True
+            )
+        )
+    else:
+        print(
+            f"PASS: wrote {manifest['packet_count']} {args.split} packets "
+            f"from {manifest['source_count']} verified sources to {output_dir}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/evaluation/test_outcome_backed_packets.py
+++ b/tests/evaluation/test_outcome_backed_packets.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import hashlib
+from http.client import HTTPMessage
+from io import BytesIO
 import json
 from pathlib import Path
+import socket
 from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import Request
 
 import pytest
 
+import aragora.evaluation.outcome_backed_packets as packets_module
 from aragora.evaluation.outcome_backed_corpus import load_visible_cases
 from aragora.evaluation.outcome_backed_packets import (
     MaterializedSource,
+    SOURCE_HOST_ALLOWLIST,
     SourcePacketError,
+    _SourceRedirectHandler,
     build_packet_set,
     fetch_source,
     render_case_packet,
@@ -22,7 +31,7 @@ CORPUS_DIR = Path("docs/benchmarks/decision_quality/tranches")
 
 
 class FakeResponse:
-    def __init__(self, body: bytes, *, final_url: str = "https://example.test/source") -> None:
+    def __init__(self, body: bytes, *, final_url: str = "https://www.sec.gov/source") -> None:
         self.body = body
         self.final_url = final_url
 
@@ -39,11 +48,22 @@ class FakeResponse:
         return self.final_url
 
 
+def _install_opener(
+    monkeypatch: pytest.MonkeyPatch,
+    open_url: Callable[..., FakeResponse],
+) -> None:
+    class FakeOpener:
+        def open(self, request: Request, *, timeout: float) -> FakeResponse:
+            return open_url(request, timeout=timeout)
+
+    monkeypatch.setattr(packets_module, "build_opener", lambda _handler: FakeOpener())
+
+
 def _source(body: bytes = b"source body") -> dict[str, str]:
     return {
         "source_id": "source-1",
         "title": "Frozen source",
-        "url": "https://example.test/source",
+        "url": "https://www.sec.gov/source",
         "published_at": "2025-01-01T00:00:00Z",
         "content_sha256": hashlib.sha256(body).hexdigest(),
     }
@@ -76,6 +96,17 @@ def _materialized(body: bytes = b"source body") -> MaterializedSource:
     )
 
 
+@pytest.fixture(autouse=True)
+def public_source_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        packets_module.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ],
+    )
+
+
 def test_visible_loader_never_reads_outcome_sidecars(monkeypatch: pytest.MonkeyPatch) -> None:
     original = Path.read_text
     reads: list[str] = []
@@ -95,21 +126,36 @@ def test_visible_loader_never_reads_outcome_sidecars(monkeypatch: pytest.MonkeyP
     assert all(name.endswith(".corpus.json") for name in reads)
 
 
-def test_fetch_source_verifies_exact_bytes_before_decoding() -> None:
+def test_source_host_allowlist_matches_frozen_corpus() -> None:
+    cases = load_visible_cases(CORPUS_DIR)
+    corpus_hosts: set[str] = set()
+    for case in cases:
+        for source in case["sources"]:
+            hostname = urlparse(str(source["url"])).hostname
+            assert hostname is not None
+            corpus_hosts.add(hostname)
+
+    assert corpus_hosts == SOURCE_HOST_ALLOWLIST
+
+
+def test_fetch_source_verifies_exact_bytes_before_decoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     body = "verified source\n".encode()
     opened: list[tuple[str, float]] = []
 
-    def open_url(request: object, *, timeout: float) -> FakeResponse:
-        opened.append((request.full_url, timeout))  # type: ignore[attr-defined]
+    def open_url(request: Request, *, timeout: float) -> FakeResponse:
+        opened.append((request.full_url, timeout))
         return FakeResponse(body)
 
-    result = fetch_source(_source(body), timeout_seconds=2.5, open_url=open_url)
+    _install_opener(monkeypatch, open_url)
+    result = fetch_source(_source(body), timeout_seconds=2.5)
 
     assert result.content == "verified source\n"
     assert result.media_type == "text/plain; charset=utf-8"
     assert result.content_encoding == "utf-8"
     assert result.content_sha256 == hashlib.sha256(body).hexdigest()
-    assert opened == [("https://example.test/source", 2.5)]
+    assert opened == [("https://www.sec.gov/source", 2.5)]
 
 
 @pytest.mark.parametrize(
@@ -118,37 +164,160 @@ def test_fetch_source_verifies_exact_bytes_before_decoding() -> None:
         (_source(), FakeResponse(b"changed"), "hash mismatch"),
         (
             _source(),
-            FakeResponse(b"source body", final_url="http://example.test/source"),
-            "redirected outside",
+            FakeResponse(b"source body", final_url="http://www.sec.gov/source"),
+            "credential-free HTTPS",
         ),
         (_source(b"\xff"), FakeResponse(b"\xff"), "neither PDF nor valid UTF-8"),
     ],
 )
 def test_fetch_source_fails_closed_on_integrity_defects(
-    source: dict[str, str], response: FakeResponse, match: str
+    monkeypatch: pytest.MonkeyPatch,
+    source: dict[str, str],
+    response: FakeResponse,
+    match: str,
 ) -> None:
+    _install_opener(monkeypatch, lambda *_args, **_kwargs: response)
     with pytest.raises(SourcePacketError, match=match):
-        fetch_source(source, open_url=lambda *_args, **_kwargs: response)
+        fetch_source(source)
 
 
-def test_fetch_source_sanitizes_transport_failure() -> None:
+def test_fetch_source_sanitizes_transport_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     def fail(*_args: object, **_kwargs: object) -> FakeResponse:
         raise URLError("token=super-secret")
 
+    _install_opener(monkeypatch, fail)
     with pytest.raises(SourcePacketError) as exc_info:
-        fetch_source(_source(), open_url=fail)
+        fetch_source(_source())
 
     assert "URLError" in str(exc_info.value)
     assert "super-secret" not in str(exc_info.value)
 
 
-def test_fetch_source_preserves_pdf_bytes_losslessly() -> None:
+def test_fetch_source_rejects_unresolvable_host_before_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened = False
+
+    def build_opener(*_args: object, **_kwargs: object) -> object:
+        nonlocal opened
+        opened = True
+        raise AssertionError("opener should not be built")
+
+    monkeypatch.setattr(packets_module, "build_opener", build_opener)
+    monkeypatch.setattr(packets_module.socket, "getaddrinfo", lambda *_args, **_kwargs: [])
+
+    with pytest.raises(SourcePacketError, match="DNS resolution returned no addresses"):
+        fetch_source(_source())
+
+    assert opened is False
+
+
+def test_fetch_source_rejects_hostname_outside_frozen_allowlist() -> None:
+    source = _source()
+    source["url"] = "https://unreviewed.example/source"
+
+    with pytest.raises(SourcePacketError, match="hostname is not in the frozen allowlist"):
+        fetch_source(source)
+
+
+def test_fetch_source_rejects_private_address_before_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened = False
+
+    def build_opener(*_args: object, **_kwargs: object) -> object:
+        nonlocal opened
+        opened = True
+        raise AssertionError("opener should not be built")
+
+    monkeypatch.setattr(packets_module, "build_opener", build_opener)
+    monkeypatch.setattr(
+        packets_module.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.8", 443))],
+    )
+
+    with pytest.raises(SourcePacketError, match="resolved to a non-public address"):
+        fetch_source(_source())
+
+    assert opened is False
+
+
+def test_fetch_source_revalidates_redirect_before_following(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolutions = iter(
+        [
+            [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+            [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))],
+        ]
+    )
+    monkeypatch.setattr(
+        packets_module.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: next(resolutions),
+    )
+
+    class RedirectingOpener:
+        def __init__(self, handler: _SourceRedirectHandler) -> None:
+            self.handler = handler
+
+        def open(self, request: Request, *, timeout: float) -> FakeResponse:
+            del timeout
+            self.handler.redirect_request(
+                request,
+                BytesIO(),
+                302,
+                "Found",
+                HTTPMessage(),
+                "https://www.sec.gov/internal",
+            )
+            raise AssertionError("redirect target should not be opened")
+
+    monkeypatch.setattr(
+        packets_module,
+        "build_opener",
+        lambda handler: RedirectingOpener(handler),
+    )
+
+    with pytest.raises(SourcePacketError, match="resolved to a non-public address"):
+        fetch_source(_source())
+
+
+def test_fetch_source_rejects_cross_host_redirect_before_following(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RedirectingOpener:
+        def __init__(self, handler: _SourceRedirectHandler) -> None:
+            self.handler = handler
+
+        def open(self, request: Request, *, timeout: float) -> FakeResponse:
+            del timeout
+            self.handler.redirect_request(
+                request,
+                BytesIO(),
+                302,
+                "Found",
+                HTTPMessage(),
+                "https://www.nasa.gov/internal",
+            )
+            raise AssertionError("redirect target should not be opened")
+
+    monkeypatch.setattr(
+        packets_module,
+        "build_opener",
+        lambda handler: RedirectingOpener(handler),
+    )
+
+    with pytest.raises(SourcePacketError, match="redirect changed hostname"):
+        fetch_source(_source())
+
+
+def test_fetch_source_preserves_pdf_bytes_losslessly(monkeypatch: pytest.MonkeyPatch) -> None:
     body = b"%PDF-1.7\nopaque\x00bytes\xff"
 
-    result = fetch_source(
-        _source(body),
-        open_url=lambda *_args, **_kwargs: FakeResponse(body),
-    )
+    _install_opener(monkeypatch, lambda *_args, **_kwargs: FakeResponse(body))
+    result = fetch_source(_source(body))
 
     assert result.media_type == "application/pdf"
     assert result.content_encoding == "base64"

--- a/tests/evaluation/test_outcome_backed_packets.py
+++ b/tests/evaluation/test_outcome_backed_packets.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+from aragora.evaluation.outcome_backed_corpus import load_visible_cases
+from aragora.evaluation.outcome_backed_packets import (
+    MaterializedSource,
+    SourcePacketError,
+    build_packet_set,
+    fetch_source,
+    render_case_packet,
+    write_packet_set,
+)
+
+
+CORPUS_DIR = Path("docs/benchmarks/decision_quality/tranches")
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, *, final_url: str = "https://example.test/source") -> None:
+        self.body = body
+        self.final_url = final_url
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self, amount: int = -1) -> bytes:
+        return self.body if amount < 0 else self.body[:amount]
+
+    def geturl(self) -> str:
+        return self.final_url
+
+
+def _source(body: bytes = b"source body") -> dict[str, str]:
+    return {
+        "source_id": "source-1",
+        "title": "Frozen source",
+        "url": "https://example.test/source",
+        "published_at": "2025-01-01T00:00:00Z",
+        "content_sha256": hashlib.sha256(body).hexdigest(),
+    }
+
+
+def _case(index: int, *, split: str = "development") -> dict[str, object]:
+    return {
+        "case_id": f"case-{index:02d}",
+        "domain": "software_engineering",
+        "split": split,
+        "title": f"Case {index}",
+        "decision_prompt": "Choose one bounded action.",
+        "forecast_question": "What is the probability option A is outcome-aligned?",
+        "forecast_option_id": "option-a",
+        "options": [
+            {"option_id": "option-a", "label": "A", "description": "Action A"},
+            {"option_id": "option-b", "label": "B", "description": "Action B"},
+        ],
+        "information_cutoff": "2025-01-02T00:00:00Z",
+        "sources": [_source()],
+    }
+
+
+def _materialized(body: bytes = b"source body") -> MaterializedSource:
+    return MaterializedSource(
+        content=body.decode(),
+        media_type="text/plain; charset=utf-8",
+        content_encoding="utf-8",
+        **_source(body),
+    )
+
+
+def test_visible_loader_never_reads_outcome_sidecars(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = Path.read_text
+    reads: list[str] = []
+
+    def tracked(path: Path, *args: object, **kwargs: object) -> str:
+        reads.append(path.name)
+        if path.name.endswith(".outcomes.json"):
+            raise AssertionError("visible loader opened an outcome sidecar")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked)
+
+    cases = load_visible_cases(CORPUS_DIR)
+
+    assert len(cases) == 24
+    assert sum(case["split"] == "development" for case in cases) == 16
+    assert all(name.endswith(".corpus.json") for name in reads)
+
+
+def test_fetch_source_verifies_exact_bytes_before_decoding() -> None:
+    body = "verified source\n".encode()
+    opened: list[tuple[str, float]] = []
+
+    def open_url(request: object, *, timeout: float) -> FakeResponse:
+        opened.append((request.full_url, timeout))  # type: ignore[attr-defined]
+        return FakeResponse(body)
+
+    result = fetch_source(_source(body), timeout_seconds=2.5, open_url=open_url)
+
+    assert result.content == "verified source\n"
+    assert result.media_type == "text/plain; charset=utf-8"
+    assert result.content_encoding == "utf-8"
+    assert result.content_sha256 == hashlib.sha256(body).hexdigest()
+    assert opened == [("https://example.test/source", 2.5)]
+
+
+@pytest.mark.parametrize(
+    ("source", "response", "match"),
+    [
+        (_source(), FakeResponse(b"changed"), "hash mismatch"),
+        (
+            _source(),
+            FakeResponse(b"source body", final_url="http://example.test/source"),
+            "redirected outside",
+        ),
+        (_source(b"\xff"), FakeResponse(b"\xff"), "neither PDF nor valid UTF-8"),
+    ],
+)
+def test_fetch_source_fails_closed_on_integrity_defects(
+    source: dict[str, str], response: FakeResponse, match: str
+) -> None:
+    with pytest.raises(SourcePacketError, match=match):
+        fetch_source(source, open_url=lambda *_args, **_kwargs: response)
+
+
+def test_fetch_source_sanitizes_transport_failure() -> None:
+    def fail(*_args: object, **_kwargs: object) -> FakeResponse:
+        raise URLError("token=super-secret")
+
+    with pytest.raises(SourcePacketError) as exc_info:
+        fetch_source(_source(), open_url=fail)
+
+    assert "URLError" in str(exc_info.value)
+    assert "super-secret" not in str(exc_info.value)
+
+
+def test_fetch_source_preserves_pdf_bytes_losslessly() -> None:
+    body = b"%PDF-1.7\nopaque\x00bytes\xff"
+
+    result = fetch_source(
+        _source(body),
+        open_url=lambda *_args, **_kwargs: FakeResponse(body),
+    )
+
+    assert result.media_type == "application/pdf"
+    assert result.content_encoding == "base64"
+    assert result.content == "JVBERi0xLjcKb3BhcXVlAGJ5dGVz/w=="
+
+
+def test_packet_is_deterministic_and_outcome_blind() -> None:
+    case = _case(1)
+
+    first = render_case_packet(case, [_materialized()])
+    second = render_case_packet(dict(reversed(list(case.items()))), [_materialized()])
+
+    assert first == second
+    encoded = json.dumps(first, sort_keys=True)
+    for forbidden in (
+        "authoritative_sources",
+        "correct_option_id",
+        "cruxes",
+        "resolution_summary",
+        "resolved_at",
+    ):
+        assert forbidden not in encoded
+    assert first["packet_sha256"] == second["packet_sha256"]
+
+
+def test_packet_rejects_structural_outcome_fields() -> None:
+    case = _case(1)
+    case["correct_option_id"] = "option-a"
+
+    with pytest.raises(SourcePacketError, match="outcome-only key"):
+        render_case_packet(case, [_materialized()])
+
+
+def test_build_packet_set_fetches_shared_source_once() -> None:
+    calls: list[str] = []
+
+    def fetch(source: dict[str, object]) -> MaterializedSource:
+        calls.append(str(source["source_id"]))
+        return _materialized()
+
+    manifest, packets = build_packet_set(
+        [_case(index) for index in range(16)],
+        split="development",
+        fetch=fetch,
+    )
+
+    assert calls == ["source-1"]
+    assert manifest["packet_count"] == 16
+    assert manifest["source_count"] == 1
+    assert list(packets) == [f"case-{index:02d}" for index in range(16)]
+
+
+def test_build_packet_set_requires_complete_split() -> None:
+    with pytest.raises(SourcePacketError, match="expected 16 development cases"):
+        build_packet_set([_case(1)], split="development", fetch=lambda _: _materialized())
+
+
+def test_write_packet_set_refuses_stale_packet_residue(tmp_path: Path) -> None:
+    (tmp_path / "old.packet.json").write_text("{}\n")
+    manifest, packets = build_packet_set(
+        [_case(index) for index in range(16)],
+        split="development",
+        fetch=lambda _: _materialized(),
+    )
+
+    with pytest.raises(SourcePacketError, match="stale packets"):
+        write_packet_set(tmp_path, manifest, packets)

--- a/tests/scripts/test_build_outcome_backed_source_packets.py
+++ b/tests/scripts/test_build_outcome_backed_source_packets.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_cli_requires_explicit_split() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/build_outcome_backed_source_packets.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "--split" in result.stderr
+
+
+def test_cli_help_declares_outcome_blind_contract() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/build_outcome_backed_source_packets.py", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "outcome-blind" in result.stdout
+    assert "development" in result.stdout
+    assert "holdout" in result.stdout


### PR DESCRIPTION
## Summary
- add a corpus-only loader that never opens outcome sidecars
- fetch frozen pre-cutoff sources with exact raw-byte SHA-256 verification and bounded transport handling
- render deterministic split-specific source packets, preserving PDFs losslessly with explicit base64/media disclosure
- require explicit development/holdout selection and refuse stale packet residue

## Live proof
- materialized all 16 development cases from 20 live sources twice
- stable packet-set SHA-256: `ab09fd09ff788593daf6a6bf25988799353c50193cbd2a07ab6dcb473a431088`
- no outcome sidecar was opened and no model inference was run

## Validation
- `python3 -m pytest tests/evaluation/test_outcome_backed_*.py tests/scripts/test_build_outcome_backed_source_packets.py -q` (95 passed)
- `python3 scripts/validate_outcome_backed_corpus.py --json`
- real development source materialization + idempotent rerun
- Ruff check/format
- locked mypy on touched modules
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

Part of the Outcome-Backed Decision Quality Convergence goal. This PR performs no model calls, scoring, evidence posting, settlement, or benchmark-result interpretation.