### PR TITLE
fix(swarm): scope new-branch preflight pushes to base delta (#7209)

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -54,6 +54,9 @@ class PreflightResult:
     branch_lease_owner_session_id: str = ""
     branch_lease_work_id: str = ""
     branch_lease_released: bool = False
+    publication_base_sha: str = ""
+    remote_branch_seeded: bool = False
+    cleanup_remote_branch_removed: bool = False
 
     @property
     def failure_terminal_class(self) -> TerminalClass | None:
@@ -85,6 +88,9 @@ class PreflightResult:
             "branch_lease_owner_session_id": self.branch_lease_owner_session_id,
             "branch_lease_work_id": self.branch_lease_work_id,
             "branch_lease_released": self.branch_lease_released,
+            "publication_base_sha": self.publication_base_sha,
+            "remote_branch_seeded": self.remote_branch_seeded,
+            "cleanup_remote_branch_removed": self.cleanup_remote_branch_removed,
         }
 
 
@@ -547,6 +553,14 @@ def _command_stage(cmd: list[str]) -> str:
         return "gh_pr_create"
     if cmd[:3] == ["gh", "pr", "close"]:
         return "gh_pr_close"
+    if cmd[:4] == ["gh", "api", "--method", "POST"] and any(
+        part.endswith("/git/refs") for part in cmd
+    ):
+        return "gh_remote_branch_seed"
+    if cmd[:4] == ["gh", "api", "--method", "DELETE"] and any(
+        "/git/refs/heads/" in part for part in cmd
+    ):
+        return "gh_remote_branch_delete"
     return "_".join(cmd[:2]) if cmd else "preflight_command"
 
 
@@ -610,6 +624,73 @@ def _run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> Non
             stdout=stdout,
             stderr=stderr,
         )
+
+
+def _resolve_ref_sha(repo_root: Path, ref: str) -> str:
+    cmd = ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            env=git_safe_env(),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise PreflightOperationError(
+            stage="git_base_ref_resolve",
+            detail=sanitize_error(str(exc), max_length=4000),
+            command=cmd,
+        ) from exc
+    sha = (result.stdout or "").strip()
+    if result.returncode != 0 or re.fullmatch(r"[0-9a-fA-F]{40,64}", sha) is None:
+        detail, stdout, stderr = _operation_failure_detail(
+            cmd=cmd,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+        raise PreflightOperationError(
+            stage="git_base_ref_resolve",
+            detail=detail,
+            command=cmd,
+            returncode=result.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    return sha.lower()
+
+
+def _seed_remote_branch_at_base(repo_root: Path, branch: str, base_sha: str) -> None:
+    _run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            "repos/synaptent/aragora/git/refs",
+            "-f",
+            f"ref=refs/heads/{branch}",
+            "-f",
+            f"sha={base_sha}",
+        ],
+        cwd=repo_root,
+    )
+
+
+def _delete_seeded_remote_branch(repo_root: Path, branch: str) -> None:
+    _run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "DELETE",
+            f"repos/synaptent/aragora/git/refs/heads/{branch}",
+        ],
+        cwd=repo_root,
+    )
 
 
 def _claim_branch_write_lease(
@@ -1290,6 +1371,9 @@ def _save_contract_preflight_receipt(
         "branch_lease_owner_session_id": str(result.branch_lease_owner_session_id or "").strip(),
         "branch_lease_work_id": str(result.branch_lease_work_id or "").strip(),
         "branch_lease_released": bool(result.branch_lease_released),
+        "publication_base_sha": str(result.publication_base_sha or "").strip(),
+        "remote_branch_seeded": bool(result.remote_branch_seeded),
+        "cleanup_remote_branch_removed": bool(result.cleanup_remote_branch_removed),
     }
     receipt = _finalize_preflight_receipt(
         repo_root=resolved_repo_root,
@@ -1904,8 +1988,14 @@ def run_preflight(
     branch_lease: _BranchWriteLease | None = None
     branch_lease_released = False
     operation_failure: PreflightOperationError | None = None
+    cleanup_failure: PreflightOperationError | None = None
+    publication_base_sha = ""
+    remote_branch_seeded = False
+    cleanup_remote_branch_removed = False
 
     try:
+        if not skip_publication:
+            publication_base_sha = _resolve_ref_sha(resolved_repo_root, normalized_base_ref)
         _run(
             ["git", "worktree", "add", "-b", branch, str(worktree_path), normalized_base_ref],
             cwd=resolved_repo_root,
@@ -1939,15 +2029,29 @@ def run_preflight(
                 worktree_path=worktree_path,
                 agent=normalized_agent,
             )
+            _seed_remote_branch_at_base(
+                resolved_repo_root,
+                branch,
+                publication_base_sha,
+            )
+            remote_branch_seeded = True
             _run(["git", "push", "origin", "HEAD"], cwd=worktree_path, env=git_safe_env())
             published = True
             _create_pr(resolved_repo_root, branch, normalized_base_ref)
             pull_request_created = True
             _close_pr(resolved_repo_root, branch)
             pull_request_closed = True
+            cleanup_remote_branch_removed = True
     except PreflightOperationError as exc:
         operation_failure = exc
     finally:
+        if remote_branch_seeded and not published:
+            try:
+                _delete_seeded_remote_branch(resolved_repo_root, branch)
+            except PreflightOperationError as exc:
+                cleanup_failure = exc
+            else:
+                cleanup_remote_branch_removed = True
         if branch_lease is not None:
             try:
                 _release_branch_write_lease(branch_lease)
@@ -1975,19 +2079,20 @@ def run_preflight(
             cleanup_branch_removed = branch_remove.returncode == 0
 
     checks: list[dict[str, Any]] = []
-    if operation_failure is not None:
-        checks.append(operation_failure.to_check())
+    failures = [failure for failure in (operation_failure, cleanup_failure) if failure is not None]
+    if failures:
+        checks.extend(failure.to_check() for failure in failures)
         failure_class = classify_preflight_failure(passed=False, checks=checks)
         dispatch_gate = GateEvaluation(
             gate_type=GateType.DISPATCH_READY.value,
             verdict=GateVerdict.BLOCKED.value,
             failure_classes=[(failure_class or TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED).value],
             required_evidence=["preflight_receipt"],
-            notes=f"Preflight operation failed at {operation_failure.stage}.",
+            notes=f"Preflight operation failed at {failures[0].stage}.",
         ).to_dict()
 
     passed = False
-    if dispatch_gate and operation_failure is None:
+    if dispatch_gate and not failures:
         passed = str(dispatch_gate.get("verdict", "")).strip() == GateVerdict.PASS.value
     duration = time.monotonic() - start
     result = PreflightResult(
@@ -2013,6 +2118,9 @@ def run_preflight(
         ),
         branch_lease_work_id=branch_lease.work_id if branch_lease is not None else "",
         branch_lease_released=branch_lease_released,
+        publication_base_sha=publication_base_sha,
+        remote_branch_seeded=remote_branch_seeded,
+        cleanup_remote_branch_removed=cleanup_remote_branch_removed,
     )
     if normalized_contract_path is not None:
         envelope_for_receipt = CredentialEnvelope.from_environment(os.environ)

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -81,12 +82,15 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     commands: list[list[str]] = []
     cleanup_commands: list[list[str]] = []
     publication_events: list[str] = []
+    base_sha = "a" * 40
 
     async def fake_run_worker(**_: object) -> WorkerProcess:
         return _worker(branch=branch)
 
     def fake_run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
         commands.append(list(cmd))
+        if cmd[:4] == ["gh", "api", "--method", "POST"]:
+            publication_events.append("seed")
         if cmd[:3] == ["git", "push", "origin"]:
             publication_events.append("push")
 
@@ -97,6 +101,7 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     monkeypatch.setattr(mod, "_branch_name", lambda: branch)
     monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
     monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_: base_sha)
     monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
     lease = mod._BranchWriteLease(
         store=object(),
@@ -133,10 +138,21 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
         str(expected_worktree),
         "origin/main",
     ]
-    assert commands[1] == ["git", "push", "origin", "HEAD"]
-    assert "--base" in commands[2]
-    assert commands[2][commands[2].index("--base") + 1] == "origin/main"
-    assert commands[3][:4] == ["gh", "pr", "close", "--repo"]
+    assert commands[1] == [
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        "repos/synaptent/aragora/git/refs",
+        "-f",
+        f"ref=refs/heads/{branch}",
+        "-f",
+        f"sha={base_sha}",
+    ]
+    assert commands[2] == ["git", "push", "origin", "HEAD"]
+    assert "--base" in commands[3]
+    assert commands[3][commands[3].index("--base") + 1] == "origin/main"
+    assert commands[4][:4] == ["gh", "pr", "close", "--repo"]
     assert result.published is True
     assert result.pull_request_created is True
     assert result.pull_request_closed is True
@@ -147,10 +163,13 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     assert result.worker["worker_contract_checksum"] == checksum_contract_payload(
         result.worker["worker_contract"]
     )
-    assert publication_events == ["claim", "push", "release"]
+    assert publication_events == ["claim", "seed", "push", "release"]
     assert result.branch_lease_id == "lease-preflight-1"
     assert result.branch_lease_work_id == f"branch:{branch}"
     assert result.branch_lease_released is True
+    assert result.publication_base_sha == base_sha
+    assert result.remote_branch_seeded is True
+    assert result.cleanup_remote_branch_removed is True
     assert cleanup_commands[0] == [
         "git",
         "worktree",
@@ -159,6 +178,141 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
         str(expected_worktree),
     ]
     assert cleanup_commands[1] == ["git", "branch", "-D", branch]
+
+
+def test_run_preflight_new_branch_push_preserves_hook_and_scopes_to_base_delta(
+    monkeypatch, tmp_path: Path
+) -> None:
+    branch = "preflight/20260831-delta-scope"
+    repo_root = tmp_path / "repo"
+    origin = tmp_path / "origin.git"
+    hook_log = tmp_path / "pre-push-files.txt"
+
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    subprocess.run(["git", "init", "-b", "main", str(repo_root)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "config", "user.email", "preflight@example.test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo_root), "config", "user.name", "Preflight Test"], check=True
+    )
+    (repo_root / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo_root), "add", "README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", "base"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo_root), "remote", "add", "origin", str(origin)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo_root), "push", "origin", "main"],
+        check=True,
+        capture_output=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    hook = repo_root / ".git" / "hooks" / "pre-push"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "read local_ref local_sha remote_ref remote_sha\n"
+        f"log={hook_log!s}\n"
+        'case "$remote_sha" in 0000000000000000000000000000000000000000) '
+        'echo ALL_ZERO > "$log"; exit 41 ;; esac\n'
+        'git diff --name-only "$remote_sha" "$local_sha" > "$log"\n'
+        'test "$(cat "$log")" = "scratch/preflight_worker_check.txt"\n',
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+
+    async def fake_run_worker(**kwargs: object) -> WorkerProcess:
+        worktree_path = Path(str(kwargs["worktree_path"]))
+        scratch_file = worktree_path / "scratch" / "preflight_worker_check.txt"
+        scratch_file.parent.mkdir(parents=True, exist_ok=True)
+        scratch_file.write_text("worker delta\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(worktree_path), "add", "scratch/preflight_worker_check.txt"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(worktree_path), "commit", "-m", "worker delta"],
+            check=True,
+            capture_output=True,
+        )
+        commit_sha = subprocess.run(
+            ["git", "-C", str(worktree_path), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        worker = _worker(branch=branch)
+        worker.worktree_path = str(worktree_path)
+        worker.commit_shas = [commit_sha]
+        return worker
+
+    def fake_seed(_: Path, actual_branch: str, actual_base_sha: str) -> None:
+        assert actual_branch == branch
+        assert actual_base_sha == base_sha
+        subprocess.run(
+            [
+                "git",
+                "--git-dir",
+                str(origin),
+                "update-ref",
+                f"refs/heads/{branch}",
+                actual_base_sha,
+            ],
+            check=True,
+        )
+
+    def fake_close(_: Path, actual_branch: str) -> None:
+        subprocess.run(
+            [
+                "git",
+                "--git-dir",
+                str(origin),
+                "update-ref",
+                "-d",
+                f"refs/heads/{actual_branch}",
+            ],
+            check=True,
+        )
+
+    lease = mod._BranchWriteLease(
+        store=object(),
+        lease_id="lease-delta-scope",
+        owner_session_id="session-delta-scope",
+        work_id=f"branch:{branch}",
+    )
+    monkeypatch.setattr(mod, "_branch_name", lambda: branch)
+    monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
+    monkeypatch.setattr(mod, "_seed_remote_branch_at_base", fake_seed)
+    monkeypatch.setattr(mod, "_create_pr", lambda *_: None)
+    monkeypatch.setattr(mod, "_close_pr", fake_close)
+    monkeypatch.setattr(mod, "_claim_branch_write_lease", lambda **_: lease)
+    monkeypatch.setattr(mod, "_release_branch_write_lease", lambda _: None)
+
+    result = mod.run_preflight(
+        repo_root=repo_root,
+        agent="codex",
+        base_ref="main",
+        skip_publication=False,
+    )
+
+    assert result.passed is True
+    assert result.publication_base_sha == base_sha
+    assert result.remote_branch_seeded is True
+    assert result.cleanup_remote_branch_removed is True
+    assert hook_log.read_text(encoding="utf-8").splitlines() == [
+        "scratch/preflight_worker_check.txt"
+    ]
 
 
 def test_main_reports_structured_failure_and_exits_nonzero(monkeypatch, capsys) -> None:
@@ -195,11 +349,15 @@ def test_contract_preflight_receipt_preserves_push_failure_and_releases_lease(
     contract_path = tmp_path / "worker_contract.json"
     contract_path.write_text(json.dumps(contract_payload), encoding="utf-8")
     publication_events: list[str] = []
+    base_sha = "b" * 40
 
     async def fake_run_worker(**_: object) -> WorkerProcess:
         return _worker(branch=branch)
 
     def fake_subprocess_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd[:4] == ["gh", "api", "--method", "POST"]:
+            publication_events.append("seed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
         if cmd[:3] == ["git", "push", "origin"]:
             publication_events.append("push")
             return SimpleNamespace(
@@ -209,6 +367,9 @@ def test_contract_preflight_receipt_preserves_push_failure_and_releases_lease(
                 ),
                 stderr="error: failed to push some refs to origin",
             )
+        if cmd[:4] == ["gh", "api", "--method", "DELETE"]:
+            publication_events.append("delete")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     lease = mod._BranchWriteLease(
@@ -228,6 +389,7 @@ def test_contract_preflight_receipt_preserves_push_failure_and_releases_lease(
 
     monkeypatch.setattr(mod, "_branch_name", lambda: branch)
     monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_: base_sha)
     monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
     monkeypatch.setattr(mod, "_claim_branch_write_lease", fake_claim)
     monkeypatch.setattr(mod, "_release_branch_write_lease", fake_release)
@@ -241,7 +403,7 @@ def test_contract_preflight_receipt_preserves_push_failure_and_releases_lease(
         envelope=_envelope(),
     )
 
-    assert publication_events == ["claim", "push", "release"]
+    assert publication_events == ["claim", "seed", "push", "delete", "release"]
     assert receipt.passed is False
     assert receipt.failure_terminal_class == TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
     assert receipt.artifacts["branch"] == branch
@@ -249,6 +411,9 @@ def test_contract_preflight_receipt_preserves_push_failure_and_releases_lease(
     assert receipt.artifacts["branch_lease_id"] == "lease-preflight-failure"
     assert receipt.artifacts["branch_lease_work_id"] == f"branch:{branch}"
     assert receipt.artifacts["branch_lease_released"] is True
+    assert receipt.artifacts["publication_base_sha"] == base_sha
+    assert receipt.artifacts["remote_branch_seeded"] is True
+    assert receipt.artifacts["cleanup_remote_branch_removed"] is True
     push_check = next(check for check in receipt.checks if check["name"] == "git_push")
     assert push_check["returncode"] == 1
     assert "branch write lease metadata is missing" in push_check["stdout"]
@@ -368,6 +533,7 @@ async def test_run_preflight_succeeds_inside_running_event_loop(
     monkeypatch.setattr(mod, "_branch_name", lambda: branch)
     monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
     monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_: "c" * 40)
     monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
 
     result = mod.run_preflight(
@@ -406,6 +572,7 @@ def test_run_preflight_fails_closed_on_contract_checksum_mismatch(
     monkeypatch.setattr(mod, "_branch_name", lambda: branch)
     monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
     monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_: "c" * 40)
     monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
 
     with pytest.raises(RuntimeError, match="checksum"):


### PR DESCRIPTION
## Summary

- seed the temporary remote preflight branch at the exact resolved base SHA through the GitHub ref API
- push the worker commit normally so every pre-push hook runs against the real base-to-worker delta
- delete a base-only seed before releasing the branch lease when the worker push fails
- persist the base SHA, seed state, and remote cleanup state in structured preflight receipts

This productizes the `remote_publish_new_branch_pre_push_scope` failure recorded by the bounded #5754 Foreman run under #7209. It does not bypass or weaken pre-push hooks.

## Validation

- `pytest -q tests/swarm/test_preflight.py` (42 passed)
- `pytest -q tests/swarm/test_boss_loop.py -k 'preflight or dispatch_contract' --maxfail=1` (1 passed, 228 deselected)
- `ruff check aragora/swarm/preflight.py tests/swarm/test_preflight.py`
- `ruff format --check aragora/swarm/preflight.py tests/swarm/test_preflight.py`
- `mypy --follow-imports=skip aragora/swarm/preflight.py`
- `python3 scripts/report_code_quality.py --check` (900/900 ratchet)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check origin/main...HEAD`
- real leased seed-then-normal-push dogfood: full pre-push hook suite passed, including changed-file mypy

## Scope

Only `aragora/swarm/preflight.py` and `tests/swarm/test_preflight.py` change. No workflow, branch-protection, CI-rerun, evidence, settlement, or merge mutation is included.
