### PR TITLE
fix(docs): patch high-severity js-yaml advisories

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -9899,9 +9899,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -11137,9 +11137,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -45,9 +45,13 @@
     "picomatch": "^4.0.4",
     "postcss": "^8.5.22",
     "yaml": "^1.10.3",
+    "js-yaml": "4.3.1",
     "brace-expansion": "^2.0.3",
+    "gray-matter": {
+      "js-yaml": "3.15.1"
+    },
     "openapi-to-postmanv2": {
-      "js-yaml": "4.1.1",
+      "js-yaml": "4.3.1",
       "lodash": "^4.18.0"
     },
     "postman-code-generators": {


### PR DESCRIPTION
## Summary\n\n- pin shared docs-site js-yaml 4.x consumers to 4.3.1\n- preserve gray-matter's 3.x compatibility while moving it to 3.15.1\n- refresh only docs-site/package.json and docs-site/package-lock.json\n\n## Security scope\n\nThis addresses open Dependabot alerts #374, #375, #301, and #302 for js-yaml prototype-pollution advisories. The Docusaurus major upgrade and unrelated nanoid/image-size advisories remain out of scope.\n\n## Validation\n\n- npm audit --package-lock-only --json: no js-yaml vulnerability entry\n- npm ls js-yaml --all: 4.x consumers resolve to 4.3.1; gray-matter resolves to 3.15.1\n- npm ci --ignore-scripts\n- npm run build\n- lockfile regeneration repeated with identical SHA-256\n- bash scripts/automation_pr_preflight.sh origin/main HEAD\n- git diff --check origin/main...HEAD\n\nThe existing docs-site typecheck script currently invokes tsc without a selected project and prints help while exiting zero, so it is not claimed as substantive proof here.\n\nDraft only. No workflow, branch-protection, settlement, or merge changes are included.