### PR TITLE
feat(evaluation): freeze decision benchmark conditions

### DIFF
--- a/aragora/evaluation/outcome_backed_conditions.py
+++ b/aragora/evaluation/outcome_backed_conditions.py
@@ -1,0 +1,183 @@
+"""Frozen, no-inference condition roster for the outcome-backed benchmark."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID, canonical_json_sha256
+
+
+CONDITION_ROSTER_SCHEMA = "outcome-backed-condition-roster/1.0"
+CLAUDE_SINGLE = "claude-single"
+OPENAI_SINGLE = "openai-single"
+GEMINI_SINGLE = "gemini-single"
+ARAGORA_TEAM = "aragora-team"
+
+
+class ConditionRosterError(ValueError):
+    """Raised when a condition roster cannot be bound without substitution."""
+
+
+@dataclass(frozen=True)
+class ModelIdentity:
+    """An exact model binding; aliases and fallback are intentionally forbidden."""
+
+    family: str
+    agent_type: str
+    requested_model: str
+    expected_resolved_model: str
+    transport: str = "direct-api"
+    allow_fallback: bool = False
+
+    def to_dict(self) -> dict[str, str | bool]:
+        return {
+            "family": self.family,
+            "agent_type": self.agent_type,
+            "requested_model": self.requested_model,
+            "expected_resolved_model": self.expected_resolved_model,
+            "transport": self.transport,
+            "allow_fallback": self.allow_fallback,
+        }
+
+
+@dataclass(frozen=True)
+class ConditionSpec:
+    condition_id: str
+    members: tuple[ModelIdentity, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "condition_id": self.condition_id,
+            "members": [member.to_dict() for member in self.members],
+        }
+
+
+@dataclass(frozen=True)
+class ConditionRosterAttestation:
+    """Canonical roster payload and its content-bound digest."""
+
+    benchmark_id: str
+    conditions: tuple[ConditionSpec, ...]
+    roster_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": CONDITION_ROSTER_SCHEMA,
+            "benchmark_id": self.benchmark_id,
+            "conditions": [condition.to_dict() for condition in self.conditions],
+            "roster_sha256": self.roster_sha256,
+        }
+
+
+CLAUDE_IDENTITY = ModelIdentity(
+    family="claude",
+    agent_type="anthropic-api",
+    requested_model="claude-opus-5",
+    expected_resolved_model="claude-opus-5",
+)
+OPENAI_IDENTITY = ModelIdentity(
+    family="openai",
+    agent_type="openai-api",
+    requested_model="gpt-5.6-sol",
+    expected_resolved_model="gpt-5.6-sol",
+)
+GEMINI_IDENTITY = ModelIdentity(
+    family="gemini",
+    agent_type="gemini",
+    requested_model="gemini-3.1-pro-preview",
+    expected_resolved_model="gemini-3.1-pro-preview",
+)
+
+FROZEN_CONDITION_ROSTER = (
+    ConditionSpec(CLAUDE_SINGLE, (CLAUDE_IDENTITY,)),
+    ConditionSpec(OPENAI_SINGLE, (OPENAI_IDENTITY,)),
+    ConditionSpec(GEMINI_SINGLE, (GEMINI_IDENTITY,)),
+    ConditionSpec(ARAGORA_TEAM, (CLAUDE_IDENTITY, OPENAI_IDENTITY, GEMINI_IDENTITY)),
+)
+
+_EXPECTED_IDENTITIES = {
+    identity.family: identity for identity in (CLAUDE_IDENTITY, OPENAI_IDENTITY, GEMINI_IDENTITY)
+}
+_EXPECTED_CONDITIONS = {
+    CLAUDE_SINGLE: ("claude",),
+    OPENAI_SINGLE: ("openai",),
+    GEMINI_SINGLE: ("gemini",),
+    ARAGORA_TEAM: ("claude", "openai", "gemini"),
+}
+_EXPECTED_CONDITION_ORDER = tuple(_EXPECTED_CONDITIONS)
+
+
+def _validate_member(member: ModelIdentity, *, path: str) -> None:
+    expected = _EXPECTED_IDENTITIES.get(member.family)
+    if expected is None:
+        raise ConditionRosterError(f"{path} has unknown model family {member.family!r}")
+    if member != expected:
+        raise ConditionRosterError(
+            f"{path} must use the exact frozen {member.family!r} identity; "
+            "aliases, substitutions, alternate transports, and fallback are forbidden"
+        )
+
+
+def preflight_condition_roster(
+    conditions: Sequence[ConditionSpec] = FROZEN_CONDITION_ROSTER,
+) -> ConditionRosterAttestation:
+    """Validate and attest the fixed roster without constructing model clients."""
+
+    frozen = tuple(conditions)
+    condition_ids = tuple(condition.condition_id for condition in frozen)
+    if len(set(condition_ids)) != len(condition_ids):
+        raise ConditionRosterError("condition roster contains duplicate condition IDs")
+    if condition_ids != _EXPECTED_CONDITION_ORDER:
+        missing = sorted(set(_EXPECTED_CONDITION_ORDER) - set(condition_ids))
+        unknown = sorted(set(condition_ids) - set(_EXPECTED_CONDITION_ORDER))
+        detail: list[str] = []
+        if missing:
+            detail.append(f"missing={missing}")
+        if unknown:
+            detail.append(f"unknown={unknown}")
+        if not detail:
+            detail.append("condition order differs from the frozen order")
+        raise ConditionRosterError("invalid condition set: " + "; ".join(detail))
+
+    for condition in frozen:
+        expected_families = _EXPECTED_CONDITIONS[condition.condition_id]
+        actual_families = tuple(member.family for member in condition.members)
+        if len(set(actual_families)) != len(actual_families):
+            raise ConditionRosterError(
+                f"condition {condition.condition_id!r} contains a duplicate model family"
+            )
+        if actual_families != expected_families:
+            raise ConditionRosterError(
+                f"condition {condition.condition_id!r} must use ordered families "
+                f"{expected_families!r}, got {actual_families!r}"
+            )
+        for index, member in enumerate(condition.members):
+            _validate_member(member, path=f"{condition.condition_id}.members[{index}]")
+
+    unhashed = {
+        "schema_version": CONDITION_ROSTER_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "conditions": [condition.to_dict() for condition in frozen],
+    }
+    return ConditionRosterAttestation(
+        benchmark_id=BENCHMARK_ID,
+        conditions=frozen,
+        roster_sha256=canonical_json_sha256(unhashed),
+    )
+
+
+__all__ = [
+    "ARAGORA_TEAM",
+    "CLAUDE_SINGLE",
+    "CONDITION_ROSTER_SCHEMA",
+    "FROZEN_CONDITION_ROSTER",
+    "GEMINI_SINGLE",
+    "OPENAI_SINGLE",
+    "ConditionRosterAttestation",
+    "ConditionRosterError",
+    "ConditionSpec",
+    "ModelIdentity",
+    "preflight_condition_roster",
+]

--- a/tests/evaluation/test_outcome_backed_conditions.py
+++ b/tests/evaluation/test_outcome_backed_conditions.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from aragora.evaluation.outcome_backed_conditions import (
+    ARAGORA_TEAM,
+    CLAUDE_SINGLE,
+    CONDITION_ROSTER_SCHEMA,
+    FROZEN_CONDITION_ROSTER,
+    GEMINI_SINGLE,
+    OPENAI_SINGLE,
+    ConditionRosterError,
+    ConditionSpec,
+    preflight_condition_roster,
+)
+from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID, canonical_json_sha256
+
+
+MODULE_PATH = Path("aragora/evaluation/outcome_backed_conditions.py")
+
+
+def _replace_condition(condition_id: str, replacement: ConditionSpec) -> tuple[ConditionSpec, ...]:
+    return tuple(
+        replacement if condition.condition_id == condition_id else condition
+        for condition in FROZEN_CONDITION_ROSTER
+    )
+
+
+def test_frozen_roster_preflight_is_stable_and_content_bound() -> None:
+    first = preflight_condition_roster()
+    second = preflight_condition_roster()
+
+    assert first == second
+    assert [condition.condition_id for condition in first.conditions] == [
+        CLAUDE_SINGLE,
+        OPENAI_SINGLE,
+        GEMINI_SINGLE,
+        ARAGORA_TEAM,
+    ]
+    assert [member.family for member in first.conditions[-1].members] == [
+        "claude",
+        "openai",
+        "gemini",
+    ]
+    payload = first.to_dict()
+    digest = payload.pop("roster_sha256")
+    assert payload["schema_version"] == CONDITION_ROSTER_SCHEMA
+    assert payload["benchmark_id"] == BENCHMARK_ID
+    assert digest == canonical_json_sha256(payload)
+
+
+@pytest.mark.parametrize("remove_index", range(4))
+def test_preflight_rejects_every_missing_condition(remove_index: int) -> None:
+    roster = FROZEN_CONDITION_ROSTER[:remove_index] + FROZEN_CONDITION_ROSTER[remove_index + 1 :]
+
+    with pytest.raises(ConditionRosterError, match="missing="):
+        preflight_condition_roster(roster)
+
+
+def test_preflight_rejects_unknown_and_duplicate_conditions() -> None:
+    unknown = replace(FROZEN_CONDITION_ROSTER[0], condition_id="other-single")
+    with pytest.raises(ConditionRosterError, match="unknown="):
+        preflight_condition_roster(_replace_condition(CLAUDE_SINGLE, unknown))
+
+    with pytest.raises(ConditionRosterError, match="duplicate condition IDs"):
+        preflight_condition_roster(FROZEN_CONDITION_ROSTER[:-1] + (FROZEN_CONDITION_ROSTER[0],))
+
+
+def test_preflight_rejects_condition_reordering() -> None:
+    roster = (FROZEN_CONDITION_ROSTER[1], FROZEN_CONDITION_ROSTER[0]) + FROZEN_CONDITION_ROSTER[2:]
+
+    with pytest.raises(ConditionRosterError, match="condition order"):
+        preflight_condition_roster(roster)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("requested_model", "claude-opus-latest"),
+        ("expected_resolved_model", "claude-opus-4-8"),
+        ("agent_type", "claude"),
+        ("transport", "vibeproxy"),
+        ("allow_fallback", True),
+    ],
+)
+def test_preflight_rejects_alias_substitution_transport_and_fallback(
+    field: str, value: object
+) -> None:
+    condition = FROZEN_CONDITION_ROSTER[0]
+    changed_member = replace(condition.members[0], **{field: value})
+    changed = replace(condition, members=(changed_member,))
+
+    with pytest.raises(ConditionRosterError, match="exact frozen"):
+        preflight_condition_roster(_replace_condition(CLAUDE_SINGLE, changed))
+
+
+def test_preflight_rejects_unknown_or_duplicate_team_family() -> None:
+    team = FROZEN_CONDITION_ROSTER[-1]
+    unknown = replace(team.members[-1], family="other")
+    with pytest.raises(ConditionRosterError, match="ordered families"):
+        preflight_condition_roster(
+            _replace_condition(ARAGORA_TEAM, replace(team, members=team.members[:-1] + (unknown,)))
+        )
+
+    duplicate = replace(team, members=(team.members[0], team.members[1], team.members[0]))
+    with pytest.raises(ConditionRosterError, match="duplicate model family"):
+        preflight_condition_roster(_replace_condition(ARAGORA_TEAM, duplicate))
+
+
+def test_condition_module_has_no_provider_or_client_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".")[0])
+
+    assert imports.isdisjoint({"anthropic", "google", "openai", "httpx", "requests"})


### PR DESCRIPTION
## Summary
- freeze the four outcome-backed benchmark condition IDs and exact Claude, OpenAI, and Gemini identities
- add a pure no-inference preflight that rejects aliases, substitutions, alternate transports, fallback, duplicates, and incomplete/reordered rosters
- emit a canonical SHA-256 roster attestation for later execution binding

No model clients are constructed and no inference is performed. This is disjoint from the parked execution/result, report, and batch-planner scopes.

## Validation
- `python3 -m pytest tests/evaluation/test_outcome_backed_conditions.py -q` (14 passed)
- `python3 -m pytest tests/evaluation/test_outcome_backed_*.py -q` (113 passed)
- `uv run --locked --extra dev python -m mypy aragora/evaluation/outcome_backed_conditions.py`
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`