### PR TITLE
fix(examples): patch high-severity Vite alerts

### DIFF
--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -23,6 +23,11 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.4.0",
-    "vite": "^5.0.0"
+    "vite": "^6.4.3"
+  },
+  "overrides": {
+    "@vanilla-extract/integration": {
+      "vite": "6.4.3"
+    }
   }
 }

--- a/examples/typescript-web/package.json
+++ b/examples/typescript-web/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^6.4.3"
   }
 }


### PR DESCRIPTION
## Summary

- raise both example apps from Vite 5 to the patched Vite 6.4.3 floor
- force Remix's nested @vanilla-extract/integration Vite copy to 6.4.3
- address Dependabot alerts #258 and #262 without changing application code

## Validation

- npm view vite@6.4.3 version dist.integrity: verified published 6.4.3 artifact
- Remix clean install: passed
- Remix npm ls vite --all: every resolved Vite copy is 6.4.3
- Remix generated-lock npm audit: no Vite vulnerability
- TypeScript web Vite build: passed with the tracked local SDK substituted only for validation
- Remix Vite 6 client build: passed; SSR proceeds to the existing unresolved ~/aragora.server import
- current-main Vite 5 reproduces the same tracked CLAUDE.md route parse failure and unresolved ~/aragora.server import
- full TypeScript web build remains blocked on pre-existing SDK API drift; its Vite phase passes
- JSON/pre-commit hooks: passed
- bash scripts/automation_pr_preflight.sh origin/main HEAD: passed
- git diff --check: passed

## Scope

This PR intentionally does not repair the examples' existing unpublished aragora-js dependency, SDK API drift, tracked route Markdown, or missing Remix server module. Those defects predate and reproduce independently of this Vite security update.

Draft only. No workflow, evidence, settlement, merge, or branch-protection changes.
