### PR TITLE
feat(evaluation): freeze outcome-blind prompt contract

### DIFF
--- a/aragora/evaluation/outcome_backed_prompt.py
+++ b/aragora/evaluation/outcome_backed_prompt.py
@@ -39,6 +39,9 @@ _OUTCOME_BEARING_KEYS = frozenset(
         "resolved_at",
     }
 )
+_NORMALIZED_OUTCOME_BEARING_KEYS = frozenset(
+    re.sub(r"[^a-z0-9]", "", key.casefold()) for key in _OUTCOME_BEARING_KEYS
+)
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -78,7 +81,8 @@ def _reject_outcome_keys(value: object, *, path: str = "packet") -> None:
         for key, child in value.items():
             if not isinstance(key, str):
                 raise OutcomeBackedPromptError(f"{path} contains a non-string key")
-            if key.casefold() in _OUTCOME_BEARING_KEYS:
+            normalized_key = re.sub(r"[^a-z0-9]", "", key.casefold())
+            if normalized_key in _NORMALIZED_OUTCOME_BEARING_KEYS:
                 raise OutcomeBackedPromptError(f"outcome-bearing key {key!r} found at {path}")
             _reject_outcome_keys(child, path=f"{path}.{key}")
     elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
@@ -90,6 +94,16 @@ def _required_text(value: object, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise OutcomeBackedPromptError(f"{field} must be a non-empty string")
     return value
+
+
+def _canonical_json_text(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
 
 
 def _validate_packet(
@@ -291,9 +305,9 @@ def _task_content(
         "source-keyed falsifiable rationale. Every substantive claim must cite source_ids "
         "from the packet.",
         "SOURCE PACKET (canonical JSON)",
-        json.dumps(packet, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+        _canonical_json_text(packet),
         "RESPONSE CONTRACT (return one JSON object and no surrounding prose)",
-        json.dumps(response_contract, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+        _canonical_json_text(response_contract),
     ]
     return "\n".join(sections)
 

--- a/aragora/evaluation/outcome_backed_prompt.py
+++ b/aragora/evaluation/outcome_backed_prompt.py
@@ -1,0 +1,361 @@
+"""Deterministic, outcome-blind prompts for the outcome-backed benchmark."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import json
+import re
+from typing import Any
+
+from aragora.evaluation.outcome_backed_conditions import (
+    ARAGORA_TEAM,
+    CLAUDE_SINGLE,
+    FROZEN_CONDITION_ROSTER,
+    GEMINI_SINGLE,
+    OPENAI_SINGLE,
+    ConditionSpec,
+    preflight_condition_roster,
+)
+from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID, canonical_json_sha256
+from aragora.evaluation.outcome_backed_packets import PACKET_SET_SCHEMA, SOURCE_PACKET_SCHEMA
+
+
+PROMPT_SCHEMA = "outcome-backed-prompt/1.0"
+
+_FROZEN_CONDITION_IDS = (CLAUDE_SINGLE, OPENAI_SINGLE, GEMINI_SINGLE, ARAGORA_TEAM)
+_OUTCOME_BEARING_KEYS = frozenset(
+    {
+        "answer_key",
+        "authoritative_sources",
+        "correct_option_id",
+        "cruxes",
+        "outcome",
+        "outcome_sidecar",
+        "outcomes",
+        "resolution",
+        "resolution_summary",
+        "resolved_at",
+    }
+)
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class OutcomeBackedPromptError(ValueError):
+    """Raised when a benchmark prompt cannot be rendered fail-closed."""
+
+
+@dataclass(frozen=True)
+class RenderedOutcomeBackedPrompt:
+    """Exact prompt bytes plus the bindings needed to verify them later."""
+
+    condition_id: str
+    packet_sha256: str
+    packet_set_sha256: str
+    roster_sha256: str
+    identity_binding: str
+    task_content: str
+    prompt_text: str
+    prompt_sha256: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "schema_version": PROMPT_SCHEMA,
+            "condition_id": self.condition_id,
+            "packet_sha256": self.packet_sha256,
+            "packet_set_sha256": self.packet_set_sha256,
+            "roster_sha256": self.roster_sha256,
+            "identity_binding": self.identity_binding,
+            "task_content": self.task_content,
+            "prompt_text": self.prompt_text,
+            "prompt_sha256": self.prompt_sha256,
+        }
+
+
+def _reject_outcome_keys(value: object, *, path: str = "packet") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise OutcomeBackedPromptError(f"{path} contains a non-string key")
+            if key.casefold() in _OUTCOME_BEARING_KEYS:
+                raise OutcomeBackedPromptError(f"outcome-bearing key {key!r} found at {path}")
+            _reject_outcome_keys(child, path=f"{path}.{key}")
+    elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for index, child in enumerate(value):
+            _reject_outcome_keys(child, path=f"{path}[{index}]")
+
+
+def _required_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OutcomeBackedPromptError(f"{field} must be a non-empty string")
+    return value
+
+
+def _validate_packet(
+    packet: Mapping[str, object],
+) -> tuple[str, str, tuple[str, str], str, tuple[str, ...]]:
+    _reject_outcome_keys(packet)
+    expected_keys = {
+        "schema_version",
+        "benchmark_id",
+        "case",
+        "sources",
+        "packet_sha256",
+    }
+    if set(packet) != expected_keys:
+        raise OutcomeBackedPromptError("source packet has unexpected or missing fields")
+    if packet.get("schema_version") != SOURCE_PACKET_SCHEMA:
+        raise OutcomeBackedPromptError("source packet schema mismatch")
+    if packet.get("benchmark_id") != BENCHMARK_ID:
+        raise OutcomeBackedPromptError("source packet benchmark mismatch")
+
+    claimed_hash = packet.get("packet_sha256")
+    if not isinstance(claimed_hash, str) or not _SHA256_RE.fullmatch(claimed_hash):
+        raise OutcomeBackedPromptError("source packet has an invalid packet_sha256")
+    unhashed = dict(packet)
+    unhashed.pop("packet_sha256")
+    if canonical_json_sha256(unhashed) != claimed_hash:
+        raise OutcomeBackedPromptError("source packet hash mismatch")
+
+    case = packet.get("case")
+    if not isinstance(case, Mapping):
+        raise OutcomeBackedPromptError("source packet case must be an object")
+    case_id = _required_text(case.get("case_id"), "case.case_id")
+    split = _required_text(case.get("split"), "case.split")
+    if split not in {"development", "holdout"}:
+        raise OutcomeBackedPromptError(f"case {case_id} has an unsupported split")
+    options = case.get("options")
+    if not isinstance(options, list) or len(options) != 2:
+        raise OutcomeBackedPromptError(f"case {case_id} must contain exactly two actions")
+    option_ids: list[str] = []
+    for index, option in enumerate(options):
+        if not isinstance(option, Mapping):
+            raise OutcomeBackedPromptError(f"case.options[{index}] must be an object")
+        option_ids.append(
+            _required_text(option.get("option_id"), f"case.options[{index}].option_id")
+        )
+    if len(set(option_ids)) != 2:
+        raise OutcomeBackedPromptError(f"case {case_id} action IDs must be unique")
+    forecast_option_id = _required_text(case.get("forecast_option_id"), "case.forecast_option_id")
+    if forecast_option_id not in option_ids:
+        raise OutcomeBackedPromptError(
+            "case.forecast_option_id must identify one of the two actions"
+        )
+
+    sources = packet.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise OutcomeBackedPromptError(f"case {case_id} must contain at least one source")
+    source_ids: list[str] = []
+    for index, source in enumerate(sources):
+        if not isinstance(source, Mapping):
+            raise OutcomeBackedPromptError(f"packet.sources[{index}] must be an object")
+        source_ids.append(
+            _required_text(source.get("source_id"), f"packet.sources[{index}].source_id")
+        )
+    if len(set(source_ids)) != len(source_ids):
+        raise OutcomeBackedPromptError(f"case {case_id} source IDs must be unique")
+    return case_id, split, (option_ids[0], option_ids[1]), forecast_option_id, tuple(source_ids)
+
+
+def _validate_packet_set(
+    packet_set: Mapping[str, object],
+    *,
+    case_id: str,
+    split: str,
+    packet_sha256: str,
+) -> str:
+    _reject_outcome_keys(packet_set, path="packet_set")
+    expected_keys = {
+        "schema_version",
+        "benchmark_id",
+        "split",
+        "packet_count",
+        "source_count",
+        "packets",
+        "packet_set_sha256",
+    }
+    if set(packet_set) != expected_keys:
+        raise OutcomeBackedPromptError("packet-set manifest has unexpected or missing fields")
+    if packet_set.get("schema_version") != PACKET_SET_SCHEMA:
+        raise OutcomeBackedPromptError("packet-set manifest schema mismatch")
+    if packet_set.get("benchmark_id") != BENCHMARK_ID:
+        raise OutcomeBackedPromptError("packet-set manifest benchmark mismatch")
+    if packet_set.get("split") != split:
+        raise OutcomeBackedPromptError("packet and packet-set split mismatch")
+
+    expected_count = 16 if split == "development" else 8
+    entries = packet_set.get("packets")
+    if packet_set.get("packet_count") != expected_count or not isinstance(entries, list):
+        raise OutcomeBackedPromptError(
+            f"packet-set manifest must contain {expected_count} {split} packets"
+        )
+    if len(entries) != expected_count:
+        raise OutcomeBackedPromptError(
+            f"packet-set manifest must contain {expected_count} {split} packet entries"
+        )
+    source_count = packet_set.get("source_count")
+    if isinstance(source_count, bool) or not isinstance(source_count, int) or source_count <= 0:
+        raise OutcomeBackedPromptError("packet-set source_count must be a positive integer")
+
+    parsed_entries: list[tuple[str, str]] = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, Mapping) or set(entry) != {"case_id", "packet_sha256"}:
+            raise OutcomeBackedPromptError(f"invalid packet-set entry at index {index}")
+        entry_case_id = _required_text(entry.get("case_id"), f"packet_set.packets[{index}].case_id")
+        entry_hash = entry.get("packet_sha256")
+        if not isinstance(entry_hash, str) or not _SHA256_RE.fullmatch(entry_hash):
+            raise OutcomeBackedPromptError(f"invalid packet hash at packet-set index {index}")
+        parsed_entries.append((entry_case_id, entry_hash))
+    if parsed_entries != sorted(parsed_entries) or len({item[0] for item in parsed_entries}) != len(
+        parsed_entries
+    ):
+        raise OutcomeBackedPromptError("packet-set case IDs must be unique and sorted")
+    if (case_id, packet_sha256) not in parsed_entries:
+        raise OutcomeBackedPromptError("source packet is not bound to the packet-set manifest")
+
+    claimed_hash = packet_set.get("packet_set_sha256")
+    if not isinstance(claimed_hash, str) or not _SHA256_RE.fullmatch(claimed_hash):
+        raise OutcomeBackedPromptError("packet-set manifest has an invalid packet_set_sha256")
+    unhashed = dict(packet_set)
+    unhashed.pop("packet_set_sha256")
+    if canonical_json_sha256(unhashed) != claimed_hash:
+        raise OutcomeBackedPromptError("packet-set manifest hash mismatch")
+    return claimed_hash
+
+
+def _condition(condition_id: str) -> ConditionSpec:
+    if condition_id not in _FROZEN_CONDITION_IDS:
+        raise OutcomeBackedPromptError(f"unknown frozen condition ID: {condition_id!r}")
+    for condition in FROZEN_CONDITION_ROSTER:
+        if condition.condition_id == condition_id:
+            return condition
+    raise OutcomeBackedPromptError(f"frozen condition is unavailable: {condition_id!r}")
+
+
+def _identity_binding(condition: ConditionSpec, *, roster_sha256: str) -> str:
+    binding = {
+        "benchmark_id": BENCHMARK_ID,
+        "condition_id": condition.condition_id,
+        "members": [member.to_dict() for member in condition.members],
+        "roster_sha256": roster_sha256,
+        "schema_version": PROMPT_SCHEMA,
+    }
+    return json.dumps(binding, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _task_content(
+    packet: Mapping[str, object],
+    *,
+    packet_set_sha256: str,
+    case_id: str,
+    option_ids: tuple[str, str],
+    forecast_option_id: str,
+    source_ids: tuple[str, ...],
+) -> str:
+    packet_sha256 = str(packet["packet_sha256"])
+    response_contract: dict[str, Any] = {
+        "case_id": case_id,
+        "selected_option_id": f"exactly one of {list(option_ids)!r}",
+        "probability_forecast": {
+            "option_id": forecast_option_id,
+            "probability": "finite number from 0.0 through 1.0",
+        },
+        "confidence": "finite number from 0.0 through 1.0",
+        "rationale": {
+            "summary": "concise reasoning based only on the source packet",
+            "falsifiable_claims": [
+                {
+                    "claim": "a decision-relevant claim",
+                    "would_falsify": "specific observable evidence that would overturn it",
+                    "source_ids": f"one or more values from {list(source_ids)!r}",
+                }
+            ],
+        },
+        "cruxes": [
+            {
+                "crux": "a condition that could change the selected action",
+                "direction": "how the decision changes if the crux is false",
+                "source_ids": f"one or more values from {list(source_ids)!r}",
+            }
+        ],
+    }
+    sections = [
+        "OUTCOME-BACKED DECISION TASK",
+        f"Packet SHA-256: {packet_sha256}",
+        f"Packet-set SHA-256: {packet_set_sha256}",
+        "Use only evidence present in the packet and available at its information cutoff. "
+        "Do not use outcomes, post-cutoff knowledge, or unstated external facts.",
+        "Choose exactly one of the two actions. Return a probability for the packet's "
+        "forecast option, a calibrated confidence, three to five decision cruxes, and "
+        "source-keyed falsifiable rationale. Every substantive claim must cite source_ids "
+        "from the packet.",
+        "SOURCE PACKET (canonical JSON)",
+        json.dumps(packet, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+        "RESPONSE CONTRACT (return one JSON object and no surrounding prose)",
+        json.dumps(response_contract, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+    ]
+    return "\n".join(sections)
+
+
+def _team_protocol() -> str:
+    return "\n".join(
+        (
+            "TEAM PROTOCOL",
+            "1. Proposal phase: each frozen family independently produces the response contract.",
+            "2. Adversarial phase: run exactly one round in which each family critiques one "
+            "decision-relevant claim from another proposal using packet source_ids.",
+            "3. Synthesis phase: produce one final response-contract JSON that explicitly "
+            "resolves the critiques. Do not run another critique or revision round.",
+        )
+    )
+
+
+def render_outcome_backed_prompt(
+    packet: Mapping[str, object],
+    *,
+    packet_set: Mapping[str, object],
+    condition_id: str,
+) -> RenderedOutcomeBackedPrompt:
+    """Render one exact, content-bound prompt without constructing a model client."""
+
+    case_id, split, option_ids, forecast_option_id, source_ids = _validate_packet(packet)
+    packet_set_sha256 = _validate_packet_set(
+        packet_set,
+        case_id=case_id,
+        split=split,
+        packet_sha256=str(packet["packet_sha256"]),
+    )
+    condition = _condition(condition_id)
+    roster = preflight_condition_roster()
+    identity_binding = _identity_binding(condition, roster_sha256=roster.roster_sha256)
+    task_content = _task_content(
+        packet,
+        packet_set_sha256=packet_set_sha256,
+        case_id=case_id,
+        option_ids=option_ids,
+        forecast_option_id=forecast_option_id,
+        source_ids=source_ids,
+    )
+    sections = ["IDENTITY BINDING", identity_binding, task_content]
+    if condition_id == ARAGORA_TEAM:
+        sections.append(_team_protocol())
+    prompt_text = "\n\n".join(sections) + "\n"
+    return RenderedOutcomeBackedPrompt(
+        condition_id=condition_id,
+        packet_sha256=str(packet["packet_sha256"]),
+        packet_set_sha256=packet_set_sha256,
+        roster_sha256=roster.roster_sha256,
+        identity_binding=identity_binding,
+        task_content=task_content,
+        prompt_text=prompt_text,
+        prompt_sha256=hashlib.sha256(prompt_text.encode("utf-8")).hexdigest(),
+    )
+
+
+__all__ = [
+    "PROMPT_SCHEMA",
+    "OutcomeBackedPromptError",
+    "RenderedOutcomeBackedPrompt",
+    "render_outcome_backed_prompt",
+]

--- a/tests/evaluation/test_outcome_backed_prompt.py
+++ b/tests/evaluation/test_outcome_backed_prompt.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import json
+
+import pytest
+
+from aragora.evaluation.outcome_backed_conditions import (
+    ARAGORA_TEAM,
+    CLAUDE_SINGLE,
+    GEMINI_SINGLE,
+    OPENAI_SINGLE,
+)
+from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID, canonical_json_sha256
+from aragora.evaluation.outcome_backed_packets import PACKET_SET_SCHEMA, SOURCE_PACKET_SCHEMA
+from aragora.evaluation.outcome_backed_prompt import (
+    PROMPT_SCHEMA,
+    OutcomeBackedPromptError,
+    render_outcome_backed_prompt,
+)
+
+
+def _packet(*, source_content: str = "Evidence available before the cutoff.") -> dict[str, object]:
+    content_sha256 = hashlib.sha256(source_content.encode()).hexdigest()
+    packet: dict[str, object] = {
+        "schema_version": SOURCE_PACKET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "case": {
+            "case_id": "se-dev-example",
+            "domain": "software_engineering",
+            "split": "development",
+            "title": "Example decision",
+            "decision_prompt": "Choose the safer migration plan.",
+            "forecast_question": "What is the probability option A is outcome-aligned?",
+            "forecast_option_id": "option-a",
+            "options": [
+                {"option_id": "option-a", "label": "A", "description": "Migrate now."},
+                {"option_id": "option-b", "label": "B", "description": "Defer migration."},
+            ],
+            "information_cutoff": "2025-01-02T00:00:00Z",
+        },
+        "sources": [
+            {
+                "source_id": "source-1",
+                "title": "Frozen source",
+                "url": "https://www.sec.gov/source",
+                "published_at": "2025-01-01T00:00:00Z",
+                "content_sha256": content_sha256,
+                "media_type": "text/plain; charset=utf-8",
+                "content_encoding": "utf-8",
+                "content": source_content,
+            }
+        ],
+    }
+    packet["packet_sha256"] = canonical_json_sha256(packet)
+    return packet
+
+
+def _packet_set(packet: dict[str, object]) -> dict[str, object]:
+    assert isinstance(packet["case"], dict)
+    case_id = str(packet["case"]["case_id"])
+    entries = [
+        {
+            "case_id": case_id if index == 0 else f"zz-dev-{index:02d}",
+            "packet_sha256": packet["packet_sha256"] if index == 0 else f"{index:064x}",
+        }
+        for index in range(16)
+    ]
+    manifest: dict[str, object] = {
+        "schema_version": PACKET_SET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "split": "development",
+        "packet_count": 16,
+        "source_count": 16,
+        "packets": sorted(entries, key=lambda item: str(item["case_id"])),
+    }
+    manifest["packet_set_sha256"] = canonical_json_sha256(manifest)
+    return manifest
+
+
+def test_rendering_is_byte_deterministic_and_self_hashing() -> None:
+    packet = _packet()
+    packet_set = _packet_set(packet)
+
+    first = render_outcome_backed_prompt(packet, packet_set=packet_set, condition_id=CLAUDE_SINGLE)
+    reordered = dict(reversed(list(packet.items())))
+    second = render_outcome_backed_prompt(
+        reordered,
+        packet_set=dict(reversed(list(packet_set.items()))),
+        condition_id=CLAUDE_SINGLE,
+    )
+
+    assert first == second
+    assert first.prompt_text.endswith("\n")
+    assert first.prompt_sha256 == hashlib.sha256(first.prompt_text.encode()).hexdigest()
+    assert first.to_dict()["schema_version"] == PROMPT_SCHEMA
+
+
+def test_prompt_digest_changes_with_valid_packet_hash_change() -> None:
+    first_packet = _packet()
+    second_packet = _packet(source_content="Different frozen pre-cutoff evidence.")
+    first = render_outcome_backed_prompt(
+        first_packet,
+        packet_set=_packet_set(first_packet),
+        condition_id=OPENAI_SINGLE,
+    )
+    second = render_outcome_backed_prompt(
+        second_packet,
+        packet_set=_packet_set(second_packet),
+        condition_id=OPENAI_SINGLE,
+    )
+
+    assert first.packet_sha256 != second.packet_sha256
+    assert first.prompt_sha256 != second.prompt_sha256
+    assert first.packet_sha256 in first.prompt_text
+    assert second.packet_sha256 in second.prompt_text
+    assert first.packet_set_sha256 in first.prompt_text
+
+
+def test_unknown_condition_is_rejected() -> None:
+    packet = _packet()
+    with pytest.raises(OutcomeBackedPromptError, match="unknown frozen condition ID"):
+        render_outcome_backed_prompt(
+            packet, packet_set=_packet_set(packet), condition_id="other-single"
+        )
+
+
+@pytest.mark.parametrize(
+    ("path", "key"),
+    [
+        (("case",), "correct_option_id"),
+        (("sources", 0), "resolution_summary"),
+        (("case",), "cruxes"),
+    ],
+)
+def test_outcome_bearing_keys_are_rejected(path: tuple[str | int, ...], key: str) -> None:
+    packet = _packet()
+    target: object = packet
+    for part in path:
+        assert isinstance(target, dict | list)
+        target = target[part]  # type: ignore[index]
+    assert isinstance(target, dict)
+    target[key] = "hidden answer"
+    packet["packet_sha256"] = canonical_json_sha256(
+        {name: value for name, value in packet.items() if name != "packet_sha256"}
+    )
+
+    with pytest.raises(OutcomeBackedPromptError, match="outcome-bearing key"):
+        render_outcome_backed_prompt(
+            packet, packet_set=_packet_set(packet), condition_id=GEMINI_SINGLE
+        )
+
+
+def test_team_has_exactly_one_adversarial_round_and_synthesis() -> None:
+    packet = _packet()
+    packet_set = _packet_set(packet)
+    team = render_outcome_backed_prompt(packet, packet_set=packet_set, condition_id=ARAGORA_TEAM)
+    single = render_outcome_backed_prompt(packet, packet_set=packet_set, condition_id=CLAUDE_SINGLE)
+
+    assert team.task_content == single.task_content
+    assert team.prompt_text.count("Adversarial phase") == 1
+    assert team.prompt_text.count("Synthesis phase") == 1
+    assert "Do not run another critique or revision round" in team.prompt_text
+    assert "TEAM PROTOCOL" not in single.prompt_text
+
+
+def test_single_conditions_differ_only_in_identity_binding() -> None:
+    packet = _packet()
+    rendered = [
+        render_outcome_backed_prompt(
+            packet, packet_set=_packet_set(packet), condition_id=condition_id
+        )
+        for condition_id in (CLAUDE_SINGLE, OPENAI_SINGLE, GEMINI_SINGLE)
+    ]
+
+    assert len({item.identity_binding for item in rendered}) == 3
+    assert len({item.task_content for item in rendered}) == 1
+    assert all("TEAM PROTOCOL" not in item.prompt_text for item in rendered)
+
+
+def test_prompt_contract_requires_two_actions_sources_and_valid_packet_hash() -> None:
+    one_action = _packet()
+    assert isinstance(one_action["case"], dict)
+    one_action["case"]["options"] = one_action["case"]["options"][:1]
+    one_action["packet_sha256"] = canonical_json_sha256(
+        {name: value for name, value in one_action.items() if name != "packet_sha256"}
+    )
+    with pytest.raises(OutcomeBackedPromptError, match="exactly two actions"):
+        render_outcome_backed_prompt(
+            one_action, packet_set=_packet_set(one_action), condition_id=CLAUDE_SINGLE
+        )
+
+    no_sources = _packet()
+    no_sources["sources"] = []
+    no_sources["packet_sha256"] = canonical_json_sha256(
+        {name: value for name, value in no_sources.items() if name != "packet_sha256"}
+    )
+    with pytest.raises(OutcomeBackedPromptError, match="at least one source"):
+        render_outcome_backed_prompt(
+            no_sources, packet_set=_packet_set(no_sources), condition_id=CLAUDE_SINGLE
+        )
+
+    tampered = deepcopy(_packet())
+    assert isinstance(tampered["case"], dict)
+    tampered["case"]["title"] = "Tampered without rehash"
+    with pytest.raises(OutcomeBackedPromptError, match="packet hash mismatch"):
+        render_outcome_backed_prompt(
+            tampered, packet_set=_packet_set(_packet()), condition_id=CLAUDE_SINGLE
+        )
+
+
+def test_packet_must_belong_to_a_complete_hash_verified_packet_set() -> None:
+    packet = _packet()
+    packet_set = _packet_set(packet)
+    assert isinstance(packet_set["packets"], list)
+    assert isinstance(packet_set["packets"][0], dict)
+    packet_set["packets"][0]["packet_sha256"] = "f" * 64
+    packet_set["packet_set_sha256"] = canonical_json_sha256(
+        {name: value for name, value in packet_set.items() if name != "packet_set_sha256"}
+    )
+
+    with pytest.raises(OutcomeBackedPromptError, match="not bound to the packet-set"):
+        render_outcome_backed_prompt(packet, packet_set=packet_set, condition_id=CLAUDE_SINGLE)
+
+    incomplete = _packet_set(packet)
+    assert isinstance(incomplete["packets"], list)
+    incomplete["packets"] = incomplete["packets"][:-1]
+    incomplete["packet_count"] = 15
+    incomplete["packet_set_sha256"] = canonical_json_sha256(
+        {name: value for name, value in incomplete.items() if name != "packet_set_sha256"}
+    )
+    with pytest.raises(OutcomeBackedPromptError, match="must contain 16 development packets"):
+        render_outcome_backed_prompt(packet, packet_set=incomplete, condition_id=CLAUDE_SINGLE)
+
+
+def test_response_contract_requires_cruxes_forecast_confidence_and_source_ids() -> None:
+    packet = _packet()
+    rendered = render_outcome_backed_prompt(
+        packet, packet_set=_packet_set(packet), condition_id=OPENAI_SINGLE
+    )
+
+    assert '"probability_forecast"' in rendered.task_content
+    assert '"confidence"' in rendered.task_content
+    assert '"cruxes"' in rendered.task_content
+    assert '"falsifiable_claims"' in rendered.task_content
+    assert '"source_ids"' in rendered.task_content
+    packet_json = json.dumps(_packet(), sort_keys=True, separators=(",", ":"))
+    assert packet_json in rendered.task_content

--- a/tests/evaluation/test_outcome_backed_prompt.py
+++ b/tests/evaluation/test_outcome_backed_prompt.py
@@ -97,6 +97,32 @@ def test_rendering_is_byte_deterministic_and_self_hashing() -> None:
     assert first.to_dict()["schema_version"] == PROMPT_SCHEMA
 
 
+def test_non_ascii_packet_embedding_matches_digest_canonicalization() -> None:
+    packet = _packet(
+        source_content="The claimant was \u201cliable\u201d \u2014 exposure was \u20ac2m."
+    )
+    rendered = render_outcome_backed_prompt(
+        packet,
+        packet_set=_packet_set(packet),
+        condition_id=CLAUDE_SINGLE,
+    )
+
+    embedded = rendered.task_content.split("SOURCE PACKET (canonical JSON)\n", 1)[1].split(
+        "\nRESPONSE CONTRACT", 1
+    )[0]
+    assert embedded == json.dumps(
+        packet,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    assert "\u201cliable\u201d \u2014 exposure was \u20ac2m" in embedded
+    unhashed = json.loads(embedded)
+    claimed_hash = unhashed.pop("packet_sha256")
+    assert canonical_json_sha256(unhashed) == claimed_hash
+
+
 def test_prompt_digest_changes_with_valid_packet_hash_change() -> None:
     first_packet = _packet()
     second_packet = _packet(source_content="Different frozen pre-cutoff evidence.")
@@ -142,6 +168,30 @@ def test_outcome_bearing_keys_are_rejected(path: tuple[str | int, ...], key: str
         target = target[part]  # type: ignore[index]
     assert isinstance(target, dict)
     target[key] = "hidden answer"
+    packet["packet_sha256"] = canonical_json_sha256(
+        {name: value for name, value in packet.items() if name != "packet_sha256"}
+    )
+
+    with pytest.raises(OutcomeBackedPromptError, match="outcome-bearing key"):
+        render_outcome_backed_prompt(
+            packet, packet_set=_packet_set(packet), condition_id=GEMINI_SINGLE
+        )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "correctOptionId",
+        "correct-option-id",
+        "CORRECT OPTION ID",
+        "outcomeSidecar",
+        "resolvedAt",
+    ],
+)
+def test_outcome_bearing_key_variants_are_rejected(key: str) -> None:
+    packet = _packet()
+    assert isinstance(packet["case"], dict)
+    packet["case"][key] = "hidden answer"
     packet["packet_sha256"] = canonical_json_sha256(
         {name: value for name, value in packet.items() if name != "packet_sha256"}
     )


### PR DESCRIPTION
## Summary
- bind deterministic benchmark prompts to the frozen condition roster
- require canonical source-packet and complete packet-set digests before rendering
- keep single-model task content identical while adding exactly one adversarial round plus synthesis for the team condition

## Integrity chain
`frozen roster -> hash-verified packet set -> exact case packet -> prompt bytes -> prompt SHA-256`

The renderer rejects outcome-bearing keys, unknown conditions, packet tampering, incomplete packet sets, and packets not present in their split manifest. It performs no model or network call.

## Validation
- `ANTHROPIC_API_KEY=test-only-not-used python -m pytest tests/evaluation/ -q` (`302 passed`)
- focused Ruff lint and format checks
- changed-file mypy
- `python scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- commit and push hooks
- `git diff --check`

## Explicit exclusions
Parked scopes remain untouched: `outcome_backed_contract.py` (#9901), `outcome_backed_report.py` (#9911), `outcome_backed_batch.py` (#9916), and Tier-3 manifest semantics (#9889). No holdout outcomes, paid inference, report/result/batch abstractions, evidence collection, settlement, or merge are included.

Co-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>