### PR TITLE
feat(evaluation): bind outcome-backed team receipts

### DIFF
--- a/aragora/evaluation/outcome_backed_receipt.py
+++ b/aragora/evaluation/outcome_backed_receipt.py
@@ -157,7 +157,7 @@ def verify_team_receipt(
         )
     if receipt.verdict not in {"PASS", "CONDITIONAL"}:
         raise OutcomeBackedReceiptError("team receipt does not contain a successful verdict")
-    if receipt.consensus_proof is None or not receipt.consensus_proof.reached:
+    if receipt.consensus_proof is None or receipt.consensus_proof.reached is not True:
         raise OutcomeBackedReceiptError("team receipt does not prove consensus")
     if not _SHA256_RE.fullmatch(receipt.artifact_hash):
         raise OutcomeBackedReceiptError("receipt artifact_hash must be a lowercase SHA-256")

--- a/aragora/evaluation/outcome_backed_receipt.py
+++ b/aragora/evaluation/outcome_backed_receipt.py
@@ -1,0 +1,201 @@
+"""Canonical DecisionReceipt binding for outcome-backed team results."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import re
+from typing import Any
+
+from aragora.evaluation.outcome_backed_conditions import ARAGORA_TEAM
+from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID
+from aragora.gauntlet.receipt_models import (
+    RECEIPT_SCHEMA_VERSION_EVIDENCE,
+    DecisionReceipt,
+)
+
+
+TEAM_RECEIPT_BINDING_SCHEMA = "outcome-backed-team-receipt-binding/1.0"
+RECEIPT_VERIFIED = "verified"
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_SPLITS = frozenset({"development", "holdout"})
+
+
+class OutcomeBackedReceiptError(ValueError):
+    """Raised when a team receipt cannot be created or verified fail-closed."""
+
+
+def _required_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OutcomeBackedReceiptError(f"{field} must be a non-empty string")
+    return value
+
+
+def _sha256(value: object, field: str) -> str:
+    text = _required_text(value, field)
+    if not _SHA256_RE.fullmatch(text):
+        raise OutcomeBackedReceiptError(f"{field} must be a lowercase SHA-256")
+    return text
+
+
+@dataclass(frozen=True)
+class OutcomeBackedReceiptBinding:
+    """Frozen execution inputs that a team DecisionReceipt must bind.
+
+    ``result_sha256`` is the digest of the successful benchmark result payload
+    before its receipt reference is attached. Keeping that digest external to
+    the receipt avoids a circular hash while still letting an independent
+    verifier bind the receipt to the exact execution record.
+    """
+
+    case_id: str
+    split: str
+    repetition: int
+    manifest_sha256: str
+    implementation_sha: str
+    packet_sha256: str
+    packet_set_sha256: str
+    prompt_sha256: str
+    roster_sha256: str
+    result_sha256: str
+    benchmark_id: str = BENCHMARK_ID
+    condition_id: str = ARAGORA_TEAM
+
+    def validate(self) -> None:
+        if self.benchmark_id != BENCHMARK_ID:
+            raise OutcomeBackedReceiptError("binding benchmark_id does not match the benchmark")
+        if self.condition_id != ARAGORA_TEAM:
+            raise OutcomeBackedReceiptError(
+                "only the frozen Aragora team condition may mint a team receipt"
+            )
+        _required_text(self.case_id, "binding.case_id")
+        if self.split not in _SPLITS:
+            raise OutcomeBackedReceiptError("binding.split must be development or holdout")
+        if isinstance(self.repetition, bool) or not isinstance(self.repetition, int):
+            raise OutcomeBackedReceiptError("binding.repetition must be an integer")
+        maximum_repetition = 1 if self.split == "development" else 2
+        if not 1 <= self.repetition <= maximum_repetition:
+            raise OutcomeBackedReceiptError(
+                f"binding.repetition must be between 1 and {maximum_repetition} for {self.split}"
+            )
+        if not _GIT_SHA_RE.fullmatch(self.implementation_sha):
+            raise OutcomeBackedReceiptError(
+                "binding.implementation_sha must be a 40-character lowercase Git SHA"
+            )
+        for field in (
+            "manifest_sha256",
+            "packet_sha256",
+            "packet_set_sha256",
+            "prompt_sha256",
+            "roster_sha256",
+            "result_sha256",
+        ):
+            _sha256(getattr(self, field), f"binding.{field}")
+
+    def to_dict(self) -> dict[str, str | int]:
+        self.validate()
+        return {
+            "schema_version": TEAM_RECEIPT_BINDING_SCHEMA,
+            "benchmark_id": self.benchmark_id,
+            "case_id": self.case_id,
+            "split": self.split,
+            "repetition": self.repetition,
+            "condition_id": self.condition_id,
+            "manifest_sha256": self.manifest_sha256,
+            "implementation_sha": self.implementation_sha,
+            "packet_sha256": self.packet_sha256,
+            "packet_set_sha256": self.packet_set_sha256,
+            "prompt_sha256": self.prompt_sha256,
+            "roster_sha256": self.roster_sha256,
+            "result_sha256": self.result_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class VerifiedOutcomeBackedReceipt:
+    """Serialized receipt plus the compact reference expected by result rows."""
+
+    receipt: dict[str, Any]
+    receipt_hash: str
+    verification: str = RECEIPT_VERIFIED
+
+    def result_reference(self) -> dict[str, str]:
+        return {"hash": self.receipt_hash, "verification": self.verification}
+
+
+def _decision_payload(binding: OutcomeBackedReceiptBinding) -> dict[str, object]:
+    return {
+        "schema_version": TEAM_RECEIPT_BINDING_SCHEMA,
+        "benchmark_binding": binding.to_dict(),
+    }
+
+
+def verify_team_receipt(
+    receipt_data: Mapping[str, Any],
+    *,
+    expected_binding: OutcomeBackedReceiptBinding,
+) -> VerifiedOutcomeBackedReceipt:
+    """Independently round-trip and verify one benchmark team receipt."""
+
+    expected_binding.validate()
+    try:
+        receipt = DecisionReceipt.from_dict(dict(receipt_data))
+    except (TypeError, ValueError) as exc:
+        raise OutcomeBackedReceiptError(f"receipt cannot be decoded: {exc}") from exc
+
+    if receipt.schema_version != RECEIPT_SCHEMA_VERSION_EVIDENCE:
+        raise OutcomeBackedReceiptError("receipt must use the evidence-linked schema")
+    if not receipt.verify_integrity():
+        raise OutcomeBackedReceiptError("receipt integrity verification failed")
+    if receipt.input_hash != expected_binding.prompt_sha256:
+        raise OutcomeBackedReceiptError("receipt input_hash does not bind the exact prompt")
+    if receipt.decision_payload != _decision_payload(expected_binding):
+        raise OutcomeBackedReceiptError(
+            "receipt decision payload does not match the expected binding"
+        )
+    if receipt.verdict not in {"PASS", "CONDITIONAL"}:
+        raise OutcomeBackedReceiptError("team receipt does not contain a successful verdict")
+    if receipt.consensus_proof is None or not receipt.consensus_proof.reached:
+        raise OutcomeBackedReceiptError("team receipt does not prove consensus")
+    if not _SHA256_RE.fullmatch(receipt.artifact_hash):
+        raise OutcomeBackedReceiptError("receipt artifact_hash must be a lowercase SHA-256")
+
+    serialized = receipt.to_dict()
+    return VerifiedOutcomeBackedReceipt(
+        receipt=serialized,
+        receipt_hash=receipt.artifact_hash,
+    )
+
+
+def build_team_receipt(
+    debate_result: Any,
+    *,
+    binding: OutcomeBackedReceiptBinding,
+    cost_summary: dict[str, Any] | None = None,
+) -> VerifiedOutcomeBackedReceipt:
+    """Create and independently verify a canonical receipt for a team result."""
+
+    binding.validate()
+    if not bool(getattr(debate_result, "consensus_reached", False)):
+        raise OutcomeBackedReceiptError("team result must reach consensus before receipt creation")
+
+    receipt = DecisionReceipt.from_debate_result(
+        debate_result,
+        input_hash=binding.prompt_sha256,
+        cost_summary=cost_summary,
+        decision_payload=_decision_payload(binding),
+    )
+    return verify_team_receipt(receipt.to_dict(), expected_binding=binding)
+
+
+__all__ = [
+    "RECEIPT_VERIFIED",
+    "TEAM_RECEIPT_BINDING_SCHEMA",
+    "OutcomeBackedReceiptBinding",
+    "OutcomeBackedReceiptError",
+    "VerifiedOutcomeBackedReceipt",
+    "build_team_receipt",
+    "verify_team_receipt",
+]

--- a/tests/evaluation/test_outcome_backed_receipt.py
+++ b/tests/evaluation/test_outcome_backed_receipt.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from aragora.core_types import DebateResult, Message
+from aragora.evaluation.outcome_backed_conditions import ARAGORA_TEAM
+from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID
+from aragora.evaluation.outcome_backed_receipt import (
+    TEAM_RECEIPT_BINDING_SCHEMA,
+    OutcomeBackedReceiptBinding,
+    OutcomeBackedReceiptError,
+    build_team_receipt,
+    verify_team_receipt,
+)
+
+
+def _binding(**overrides: object) -> OutcomeBackedReceiptBinding:
+    values: dict[str, object] = {
+        "case_id": "se-dev-01",
+        "split": "development",
+        "repetition": 1,
+        "manifest_sha256": "1" * 64,
+        "implementation_sha": "2" * 40,
+        "packet_sha256": "3" * 64,
+        "packet_set_sha256": "4" * 64,
+        "prompt_sha256": "5" * 64,
+        "roster_sha256": "6" * 64,
+        "result_sha256": "7" * 64,
+    }
+    values.update(overrides)
+    return OutcomeBackedReceiptBinding(**values)  # type: ignore[arg-type]
+
+
+def _team_result(*, final_answer: str | None = None, consensus: bool = True) -> DebateResult:
+    answer = final_answer or (
+        '{"case_id":"se-dev-01","selected_option_id":"option-a",'
+        '"probability_forecast":{"option_id":"option-a","probability":0.72}}'
+    )
+    participants = ["claude", "openai", "gemini"]
+    return DebateResult(
+        debate_id="outcome-backed-se-dev-01",
+        task="Choose one action using only the frozen source packet.",
+        final_answer=answer,
+        confidence=0.82,
+        consensus_reached=consensus,
+        rounds_used=1,
+        participants=participants,
+        messages=[
+            Message(role="proposal", agent=agent, content=f"{agent} supports option A.")
+            for agent in participants
+        ],
+        proposals={agent: f"{agent} proposal" for agent in participants},
+        winner="openai",
+    )
+
+
+def test_builds_canonical_verified_team_receipt() -> None:
+    binding = _binding()
+
+    proof = build_team_receipt(_team_result(), binding=binding)
+
+    assert proof.verification == "verified"
+    assert proof.result_reference() == {
+        "hash": proof.receipt_hash,
+        "verification": "verified",
+    }
+    assert proof.receipt["artifact_hash"] == proof.receipt_hash
+    assert proof.receipt["input_hash"] == binding.prompt_sha256
+    assert proof.receipt["decision_payload"] == {
+        "schema_version": TEAM_RECEIPT_BINDING_SCHEMA,
+        "benchmark_binding": binding.to_dict(),
+    }
+    assert proof.receipt["decision_payload_hash"]
+
+
+def test_independent_round_trip_verifies_the_same_receipt() -> None:
+    binding = _binding()
+    built = build_team_receipt(_team_result(), binding=binding)
+
+    verified = verify_team_receipt(deepcopy(built.receipt), expected_binding=binding)
+
+    assert verified.receipt_hash == built.receipt_hash
+    assert verified.receipt == built.receipt
+
+
+def test_tampered_binding_fails_integrity_verification() -> None:
+    binding = _binding()
+    built = build_team_receipt(_team_result(), binding=binding)
+    tampered = deepcopy(built.receipt)
+    tampered["decision_payload"]["benchmark_binding"]["case_id"] = "tampered"
+
+    with pytest.raises(OutcomeBackedReceiptError, match="integrity verification failed"):
+        verify_team_receipt(tampered, expected_binding=binding)
+
+
+def test_wrong_expected_execution_binding_is_rejected() -> None:
+    built = build_team_receipt(_team_result(), binding=_binding())
+
+    with pytest.raises(OutcomeBackedReceiptError, match="does not match the expected binding"):
+        verify_team_receipt(
+            built.receipt,
+            expected_binding=_binding(result_sha256="8" * 64),
+        )
+
+
+def test_zero_evidence_and_non_consensus_results_fail_closed() -> None:
+    placeholder = _team_result(final_answer="anthropic-api got confused and needs to recalibrate.")
+    placeholder.messages = []
+    placeholder.proposals = {}
+    with pytest.raises(OutcomeBackedReceiptError, match="successful verdict"):
+        build_team_receipt(placeholder, binding=_binding())
+
+    with pytest.raises(OutcomeBackedReceiptError, match="must reach consensus"):
+        build_team_receipt(_team_result(consensus=False), binding=_binding())
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"benchmark_id": "other"}, "benchmark_id"),
+        ({"condition_id": "claude-single"}, "Aragora team condition"),
+        ({"split": "other"}, "development or holdout"),
+        ({"repetition": 2}, "between 1 and 1"),
+        ({"implementation_sha": "not-a-sha"}, "implementation_sha"),
+        ({"prompt_sha256": "not-a-hash"}, "prompt_sha256"),
+    ],
+)
+def test_invalid_bindings_are_rejected(overrides: dict[str, object], message: str) -> None:
+    binding = _binding(**overrides)
+
+    with pytest.raises(OutcomeBackedReceiptError, match=message):
+        build_team_receipt(_team_result(), binding=binding)
+
+
+def test_binding_defaults_to_frozen_benchmark_and_team_condition() -> None:
+    binding = _binding(split="holdout", repetition=2)
+
+    assert binding.benchmark_id == BENCHMARK_ID
+    assert binding.condition_id == ARAGORA_TEAM
+    assert binding.to_dict()["schema_version"] == TEAM_RECEIPT_BINDING_SCHEMA

--- a/tests/evaluation/test_outcome_backed_receipt.py
+++ b/tests/evaluation/test_outcome_backed_receipt.py
@@ -105,6 +105,17 @@ def test_wrong_expected_execution_binding_is_rejected() -> None:
         )
 
 
+@pytest.mark.parametrize("reached", ["false", "true", 1])
+def test_non_boolean_consensus_proof_is_rejected(reached: object) -> None:
+    binding = _binding()
+    built = build_team_receipt(_team_result(), binding=binding)
+    tampered = deepcopy(built.receipt)
+    tampered["consensus_proof"]["reached"] = reached
+
+    with pytest.raises(OutcomeBackedReceiptError, match="does not prove consensus"):
+        verify_team_receipt(tampered, expected_binding=binding)
+
+
 def test_zero_evidence_and_non_consensus_results_fail_closed() -> None:
     placeholder = _team_result(final_answer="anthropic-api got confused and needs to recalibrate.")
     placeholder.messages = []


### PR DESCRIPTION
## Summary
- add a strict benchmark binding for canonical team `DecisionReceipt` creation
- bind manifest, implementation, packet, prompt, roster, and pre-receipt result digests
- independently round-trip and verify receipt integrity before exposing the compact result reference
- fail closed on tampering, invalid bindings, zero-evidence output, or missing consensus

## Validation
- `python3 -m pytest tests/evaluation/test_outcome_backed_*.py tests/gauntlet/test_zero_evidence_receipts.py tests/gauntlet/test_receipt_crux_cards.py -q` (177 passed)
- `bash scripts/test_tiers.sh typecheck`
- `python3 -m ruff check aragora/evaluation/outcome_backed_receipt.py tests/evaluation/test_outcome_backed_receipt.py`
- `python3 -m ruff format --check aragora/evaluation/outcome_backed_receipt.py tests/evaluation/test_outcome_backed_receipt.py`
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check origin/main...HEAD`

Part of the Outcome-Backed Decision Quality Convergence goal. This PR does not run inference or expose holdout outcomes.
