### PR TITLE
fix(deps): patch VS Code fast-uri advisory (#9039)

### DIFF
--- a/ide/vscode-aragora/package-lock.json
+++ b/ide/vscode-aragora/package-lock.json
@@ -3911,9 +3911,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/ide/vscode-aragora/package.json
+++ b/ide/vscode-aragora/package.json
@@ -509,6 +509,7 @@
     "minimatch@<3.1.5": "3.1.5",
     "minimatch@>=9.0.0 <9.0.7": "9.0.7",
     "brace-expansion": "^2.0.3",
+    "fast-uri": "3.1.5",
     "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- pin `fast-uri` to patched version `3.1.5` in the VS Code extension override set
- regenerate only `ide/vscode-aragora/package-lock.json`
- resolve high-severity Dependabot alert #364 without changing extension runtime code

Program: #9039
Security alert: #364

## Validation

- `npm ci --ignore-scripts` - pass
- `npm ls fast-uri --all` - pass; all paths resolve to `3.1.5`
- `npm test -- --runInBand` - pass; 4 suites, 116 tests
- second `npm install --package-lock-only --ignore-scripts` - byte-identical diff
- `npm audit --json` - `fast-uri` absent; unrelated existing findings remain (2 high, 1 low)
- `bash scripts/automation_pr_preflight.sh 4244e31806bc5d312c01f76548e57f9d2bcf1248 HEAD` - pass
- `git diff --check` - pass

## Known baseline limitation

`npm run lint` cannot start because `ide/vscode-aragora` has no ESLint configuration. This is pre-existing and outside this two-file dependency repair; no lintable source file changed.

## Scope

No workflows, branch protection, generated documentation, other manifests, or unrelated advisories are changed. The separate multi-version `js-yaml` and `brace-expansion` findings remain for bounded follow-up units.
