### PR TITLE
feat(evaluation): preflight outcome-backed development runs

### DIFF
--- a/aragora/evaluation/outcome_backed_preflight.py
+++ b/aragora/evaluation/outcome_backed_preflight.py
@@ -1,0 +1,459 @@
+"""Fail-closed readiness checks for outcome-backed development inference."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from aragora.config.secrets import get_secret_presence_report
+
+from aragora.evaluation.outcome_backed_budget import (
+    DAILY_BUDGET_CAP_USD,
+    BudgetLedgerError,
+    OutcomeBackedBudgetLedger,
+)
+from aragora.evaluation.outcome_backed_conditions import (
+    ConditionRosterError,
+    preflight_condition_roster,
+)
+from aragora.evaluation.outcome_backed_corpus import (
+    BENCHMARK_ID,
+    VisibleCorpusError,
+    canonical_json_sha256,
+    load_visible_cases,
+    validate_corpus_directory,
+)
+from aragora.evaluation.outcome_backed_prompt import (
+    OutcomeBackedPromptError,
+    render_outcome_backed_prompt,
+)
+
+
+DEVELOPMENT_PREFLIGHT_SCHEMA = "outcome-backed-development-preflight/1.0"
+EXPECTED_DEVELOPMENT_CASES = 16
+EXPECTED_CONDITIONS = 4
+EXPECTED_PROMPTS = EXPECTED_DEVELOPMENT_CASES * EXPECTED_CONDITIONS
+_IMPLEMENTATION_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_CREDENTIAL_ENV_VARS = {
+    "claude": ("ANTHROPIC_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+}
+
+
+class OutcomeBackedPreflightError(ValueError):
+    """Raised when preflight inputs cannot be represented safely."""
+
+
+@dataclass(frozen=True)
+class PreflightBlocker:
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"code": self.code, "message": self.message}
+
+
+@dataclass(frozen=True)
+class DevelopmentPreflightReport:
+    implementation_sha: str
+    corpus_sha256: str | None
+    packet_set_sha256: str | None
+    roster_sha256: str | None
+    case_ids: tuple[str, ...]
+    condition_ids: tuple[str, ...]
+    prompt_set_sha256: str | None
+    credential_readiness: tuple[Mapping[str, object], ...]
+    budget: Mapping[str, object] | None
+    blockers: tuple[PreflightBlocker, ...]
+
+    @property
+    def ready(self) -> bool:
+        return not self.blockers
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": DEVELOPMENT_PREFLIGHT_SCHEMA,
+            "benchmark_id": BENCHMARK_ID,
+            "implementation_sha": self.implementation_sha,
+            "corpus_sha256": self.corpus_sha256,
+            "packet_set_sha256": self.packet_set_sha256,
+            "roster_sha256": self.roster_sha256,
+            "development_case_ids": list(self.case_ids),
+            "case_count": len(self.case_ids),
+            "condition_ids": list(self.condition_ids),
+            "condition_count": len(self.condition_ids),
+            "prompt_count": EXPECTED_PROMPTS if self.prompt_set_sha256 else 0,
+            "prompt_set_sha256": self.prompt_set_sha256,
+            "credential_readiness": [dict(item) for item in self.credential_readiness],
+            "budget": dict(self.budget) if self.budget is not None else None,
+            "blockers": [blocker.to_dict() for blocker in self.blockers],
+            "ready": self.ready,
+        }
+
+
+def _reject_duplicate_key(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise OutcomeBackedPreflightError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite(value: str) -> None:
+    raise OutcomeBackedPreflightError(f"non-finite JSON number: {value}")
+
+
+def _load_json_object(path: Path) -> Mapping[str, object]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_key,
+            parse_constant=_reject_nonfinite,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise OutcomeBackedPreflightError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(value, Mapping):
+        raise OutcomeBackedPreflightError(f"{path} must contain one JSON object")
+    return value
+
+
+def _tree_sha256(root: Path) -> str:
+    paths = sorted(root.glob("*.json"))
+    if not paths:
+        raise OutcomeBackedPreflightError(f"no corpus JSON files found in {root}")
+    entries = [
+        {"name": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+        for path in paths
+    ]
+    return canonical_json_sha256(entries)
+
+
+def _packet_content_bytes(source: Mapping[str, object], *, case_id: str) -> bytes:
+    content = source.get("content")
+    encoding = source.get("content_encoding")
+    media_type = source.get("media_type")
+    if not isinstance(content, str):
+        raise OutcomeBackedPreflightError(f"case {case_id} packet source content must be text")
+    if encoding == "utf-8" and media_type == "text/plain; charset=utf-8":
+        return content.encode("utf-8")
+    if encoding == "base64" and media_type == "application/pdf":
+        try:
+            decoded = base64.b64decode(content, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise OutcomeBackedPreflightError(
+                f"case {case_id} packet source contains invalid base64"
+            ) from exc
+        if not decoded.startswith(b"%PDF-"):
+            raise OutcomeBackedPreflightError(
+                f"case {case_id} packet PDF source lacks a PDF signature"
+            )
+        return decoded
+    raise OutcomeBackedPreflightError(
+        f"case {case_id} packet source has an unsupported media type or encoding"
+    )
+
+
+def _validate_packet_against_case(
+    packet: Mapping[str, object],
+    case: Mapping[str, object],
+) -> None:
+    case_id = str(case.get("case_id", ""))
+    expected_case = dict(case)
+    expected_sources = expected_case.pop("sources", None)
+    if packet.get("case") != expected_case:
+        raise OutcomeBackedPreflightError(
+            f"case {case_id} packet is not bound to the visible corpus case"
+        )
+    if not isinstance(expected_sources, list):
+        raise OutcomeBackedPreflightError(f"case {case_id} has invalid source metadata")
+    packet_sources = packet.get("sources")
+    if not isinstance(packet_sources, list) or len(packet_sources) != len(expected_sources):
+        raise OutcomeBackedPreflightError(f"case {case_id} packet source set mismatch")
+
+    metadata_fields = ("source_id", "title", "url", "published_at", "content_sha256")
+    expected_by_id: dict[str, Mapping[str, object]] = {}
+    for source in expected_sources:
+        if not isinstance(source, Mapping) or not isinstance(source.get("source_id"), str):
+            raise OutcomeBackedPreflightError(f"case {case_id} has invalid source metadata")
+        source_id = str(source["source_id"])
+        if source_id in expected_by_id:
+            raise OutcomeBackedPreflightError(f"case {case_id} has duplicate source IDs")
+        expected_by_id[source_id] = source
+
+    seen: set[str] = set()
+    for packet_source in packet_sources:
+        if not isinstance(packet_source, Mapping) or not isinstance(
+            packet_source.get("source_id"), str
+        ):
+            raise OutcomeBackedPreflightError(f"case {case_id} packet has invalid source metadata")
+        source_id = str(packet_source["source_id"])
+        expected = expected_by_id.get(source_id)
+        if expected is None or source_id in seen:
+            raise OutcomeBackedPreflightError(f"case {case_id} packet source set mismatch")
+        seen.add(source_id)
+        if any(packet_source.get(field) != expected.get(field) for field in metadata_fields):
+            raise OutcomeBackedPreflightError(
+                f"case {case_id} packet source {source_id} metadata mismatch"
+            )
+        digest = hashlib.sha256(_packet_content_bytes(packet_source, case_id=case_id)).hexdigest()
+        if digest != packet_source.get("content_sha256"):
+            raise OutcomeBackedPreflightError(
+                f"case {case_id} packet source {source_id} content hash mismatch"
+            )
+
+
+def _credential_readiness(
+    roster_members: tuple[Mapping[str, object], ...],
+    environ: Mapping[str, str] | None,
+) -> tuple[tuple[Mapping[str, object], ...], tuple[PreflightBlocker, ...]]:
+    readiness: list[Mapping[str, object]] = []
+    blockers: list[PreflightBlocker] = []
+    env_names = tuple(
+        name for member in roster_members for name in _CREDENTIAL_ENV_VARS[str(member["family"])]
+    )
+    if environ is None:
+        try:
+            credential_sources = {
+                status.name: status.source for status in get_secret_presence_report(env_names)
+            }
+        except (OSError, RuntimeError, ValueError) as exc:
+            credential_sources = {}
+            blockers.append(
+                PreflightBlocker(
+                    "credential_discovery_failed",
+                    f"credential presence discovery failed ({type(exc).__name__})",
+                )
+            )
+    else:
+        credential_sources = {
+            name: "provided_environment" if environ.get(name, "").strip() else "missing"
+            for name in env_names
+        }
+
+    for member in roster_members:
+        family = str(member["family"])
+        accepted = _CREDENTIAL_ENV_VARS[family]
+        available_name = next(
+            (
+                name
+                for name in accepted
+                if credential_sources.get(name) in {"aws", "env", "provided_environment"}
+            ),
+            None,
+        )
+        available = available_name is not None
+        readiness.append(
+            {
+                "family": family,
+                "agent_type": member["agent_type"],
+                "requested_model": member["requested_model"],
+                "expected_resolved_model": member["expected_resolved_model"],
+                "transport": member["transport"],
+                "allow_fallback": member["allow_fallback"],
+                "accepted_environment_variables": list(accepted),
+                "credential_available": available,
+                "credential_source": (
+                    credential_sources.get(available_name, "missing")
+                    if available_name
+                    else "missing"
+                ),
+            }
+        )
+        if not available:
+            blockers.append(
+                PreflightBlocker(
+                    "missing_provider_credential",
+                    f"{family} direct-api credential is unavailable",
+                )
+            )
+    return tuple(readiness), tuple(blockers)
+
+
+def preflight_development_run(
+    corpus_dir: Path | str,
+    packet_dir: Path | str,
+    budget_ledger_path: Path | str,
+    *,
+    implementation_sha: str,
+    environ: Mapping[str, str] | None = None,
+    utc_date: date | None = None,
+) -> DevelopmentPreflightReport:
+    """Attest development-run readiness without model calls or ledger writes."""
+
+    if not _IMPLEMENTATION_SHA_RE.fullmatch(implementation_sha):
+        raise OutcomeBackedPreflightError("implementation_sha must be a lowercase 40-hex SHA")
+
+    blockers: list[PreflightBlocker] = []
+    corpus_sha256: str | None = None
+    packet_set_sha256: str | None = None
+    roster_sha256: str | None = None
+    prompt_set_sha256: str | None = None
+    case_ids: tuple[str, ...] = ()
+    condition_ids: tuple[str, ...] = ()
+    credential_readiness: tuple[Mapping[str, object], ...] = ()
+    budget: Mapping[str, object] | None = None
+    root = Path(corpus_dir)
+
+    report = validate_corpus_directory(root)
+    if not report.valid:
+        blockers.append(
+            PreflightBlocker(
+                "invalid_corpus",
+                f"frozen corpus has {len(report.issues)} integrity issue(s)",
+            )
+        )
+    else:
+        corpus_sha256 = _tree_sha256(root)
+
+    cases: tuple[Mapping[str, Any], ...] = ()
+    try:
+        visible = load_visible_cases(root)
+        cases = tuple(case for case in visible if case.get("split") == "development")
+        case_ids = tuple(str(case.get("case_id", "")) for case in cases)
+        if len(cases) != EXPECTED_DEVELOPMENT_CASES:
+            blockers.append(
+                PreflightBlocker(
+                    "development_case_count",
+                    f"expected {EXPECTED_DEVELOPMENT_CASES} development cases, found {len(cases)}",
+                )
+            )
+    except VisibleCorpusError as exc:
+        blockers.append(PreflightBlocker("visible_corpus_invalid", str(exc)))
+
+    roster = None
+    try:
+        roster = preflight_condition_roster()
+        roster_sha256 = roster.roster_sha256
+        condition_ids = tuple(condition.condition_id for condition in roster.conditions)
+        if len(condition_ids) != EXPECTED_CONDITIONS:
+            blockers.append(
+                PreflightBlocker(
+                    "condition_count",
+                    f"expected {EXPECTED_CONDITIONS} conditions, found {len(condition_ids)}",
+                )
+            )
+    except ConditionRosterError as exc:
+        blockers.append(PreflightBlocker("invalid_condition_roster", str(exc)))
+
+    if roster is not None:
+        unique_members: dict[str, Mapping[str, object]] = {}
+        for condition in roster.conditions:
+            for member in condition.members:
+                unique_members.setdefault(member.family, member.to_dict())
+        credential_readiness, credential_blockers = _credential_readiness(
+            tuple(unique_members.values()), environ
+        )
+        blockers.extend(credential_blockers)
+
+    packet_root = Path(packet_dir)
+    prompt_entries: list[dict[str, str]] = []
+    if len(cases) == EXPECTED_DEVELOPMENT_CASES and len(condition_ids) == EXPECTED_CONDITIONS:
+        try:
+            packet_set = _load_json_object(packet_root / "packet-set.json")
+            expected_case_ids = set(case_ids)
+            packet_entries = packet_set.get("packets")
+            if not isinstance(packet_entries, list):
+                raise OutcomeBackedPreflightError("packet-set packets must be a list")
+            manifest_case_ids = {
+                str(entry.get("case_id"))
+                for entry in packet_entries
+                if isinstance(entry, Mapping) and isinstance(entry.get("case_id"), str)
+            }
+            if manifest_case_ids != expected_case_ids:
+                raise OutcomeBackedPreflightError(
+                    "packet-set case IDs do not match the frozen development corpus"
+                )
+            cases_by_id = {str(case["case_id"]): case for case in cases}
+            rendered_packet_set_sha: str | None = None
+            for case_id in case_ids:
+                packet = _load_json_object(packet_root / f"{case_id}.packet.json")
+                _validate_packet_against_case(packet, cases_by_id[case_id])
+                for condition_id in condition_ids:
+                    rendered = render_outcome_backed_prompt(
+                        packet,
+                        packet_set=packet_set,
+                        condition_id=condition_id,
+                    )
+                    if rendered_packet_set_sha is None:
+                        rendered_packet_set_sha = rendered.packet_set_sha256
+                    elif rendered.packet_set_sha256 != rendered_packet_set_sha:
+                        raise OutcomeBackedPreflightError(
+                            "rendered prompts disagree on packet-set identity"
+                        )
+                    prompt_entries.append(
+                        {
+                            "case_id": case_id,
+                            "condition_id": condition_id,
+                            "prompt_sha256": rendered.prompt_sha256,
+                        }
+                    )
+            if len(prompt_entries) != EXPECTED_PROMPTS:
+                raise OutcomeBackedPreflightError(
+                    f"expected {EXPECTED_PROMPTS} prompts, rendered {len(prompt_entries)}"
+                )
+            if len({entry["prompt_sha256"] for entry in prompt_entries}) != EXPECTED_PROMPTS:
+                raise OutcomeBackedPreflightError("development prompts are not all unique")
+            packet_set_sha256 = rendered_packet_set_sha
+            prompt_set_sha256 = canonical_json_sha256(prompt_entries)
+        except (OSError, OutcomeBackedPreflightError, OutcomeBackedPromptError) as exc:
+            blockers.append(PreflightBlocker("development_packets_not_ready", str(exc)))
+
+    try:
+        snapshot = OutcomeBackedBudgetLedger(budget_ledger_path).snapshot(utc_date=utc_date)
+        budget = snapshot.to_dict()
+        if snapshot.cap_usd != DAILY_BUDGET_CAP_USD:
+            blockers.append(
+                PreflightBlocker(
+                    "budget_cap_mismatch",
+                    f"expected daily cap ${DAILY_BUDGET_CAP_USD}, found ${snapshot.cap_usd}",
+                )
+            )
+        if snapshot.exceeded:
+            blockers.append(PreflightBlocker("budget_exceeded", "daily budget is exceeded"))
+        if snapshot.open_reservations:
+            blockers.append(
+                PreflightBlocker(
+                    "open_budget_reservations",
+                    f"{snapshot.open_reservations} budget reservation(s) remain open",
+                )
+            )
+        if snapshot.remaining_usd <= 0:
+            blockers.append(PreflightBlocker("budget_exhausted", "no paid-call budget remains"))
+    except (BudgetLedgerError, OSError, ValueError) as exc:
+        blockers.append(PreflightBlocker("budget_ledger_invalid", str(exc)))
+
+    unique_blockers = tuple(
+        PreflightBlocker(code, message)
+        for code, message in dict.fromkeys((item.code, item.message) for item in blockers)
+    )
+    return DevelopmentPreflightReport(
+        implementation_sha=implementation_sha,
+        corpus_sha256=corpus_sha256,
+        packet_set_sha256=packet_set_sha256,
+        roster_sha256=roster_sha256,
+        case_ids=case_ids,
+        condition_ids=condition_ids,
+        prompt_set_sha256=prompt_set_sha256,
+        credential_readiness=credential_readiness,
+        budget=budget,
+        blockers=unique_blockers,
+    )
+
+
+__all__ = [
+    "DEVELOPMENT_PREFLIGHT_SCHEMA",
+    "DevelopmentPreflightReport",
+    "OutcomeBackedPreflightError",
+    "PreflightBlocker",
+    "preflight_development_run",
+]

--- a/scripts/preflight_outcome_backed_development.py
+++ b/scripts/preflight_outcome_backed_development.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Preflight the frozen development benchmark without making model calls."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.evaluation.outcome_backed_preflight import (
+    OutcomeBackedPreflightError,
+    preflight_development_run,
+)
+
+
+DEFAULT_CORPUS_DIR = Path("docs/benchmarks/decision_quality/tranches")
+DEFAULT_PACKET_DIR = Path(".aragora/outcome_backed/source_packets/development")
+DEFAULT_BUDGET_LEDGER = Path(".aragora/outcome_backed/budget.jsonl")
+
+
+def _current_head() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise OutcomeBackedPreflightError("cannot resolve current git HEAD")
+    return result.stdout.strip()
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus-dir", type=Path, default=DEFAULT_CORPUS_DIR)
+    parser.add_argument("--packet-dir", type=Path, default=DEFAULT_PACKET_DIR)
+    parser.add_argument("--budget-ledger", type=Path, default=DEFAULT_BUDGET_LEDGER)
+    parser.add_argument("--implementation-sha", help="exact 40-hex implementation SHA")
+    parser.add_argument("--output", type=Path, help="optional atomic JSON artifact path")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = preflight_development_run(
+            args.corpus_dir,
+            args.packet_dir,
+            args.budget_ledger,
+            implementation_sha=args.implementation_sha or _current_head(),
+        )
+    except (OSError, OutcomeBackedPreflightError, ValueError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        return 2
+
+    payload = report.to_dict()
+    payload["ok"] = report.ready
+    if args.output is not None:
+        try:
+            _write_json(args.output, payload)
+        except OSError as exc:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+            return 2
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if report.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/evaluation/test_outcome_backed_preflight.py
+++ b/tests/evaluation/test_outcome_backed_preflight.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import aragora.evaluation.outcome_backed_preflight as preflight_module
+from aragora.evaluation.outcome_backed_conditions import FROZEN_CONDITION_ROSTER
+from aragora.config.secrets import SecretPresence
+from aragora.evaluation.outcome_backed_corpus import (
+    BENCHMARK_ID,
+    CorpusIntegrityReport,
+    canonical_json_sha256,
+)
+from aragora.evaluation.outcome_backed_packets import PACKET_SET_SCHEMA, SOURCE_PACKET_SCHEMA
+from aragora.evaluation.outcome_backed_preflight import (
+    OutcomeBackedPreflightError,
+    preflight_development_run,
+)
+
+
+HEAD = "a" * 40
+TODAY = date(2026, 8, 31)
+ENV = {
+    "ANTHROPIC_API_KEY": "anthropic-secret",
+    "OPENAI_API_KEY": "openai-secret",
+    "GEMINI_API_KEY": "gemini-secret",
+}
+
+
+def _case(index: int) -> dict[str, object]:
+    content = f"Frozen pre-cutoff evidence for case {index}."
+    return {
+        "case_id": f"case-{index:02d}",
+        "domain": "software_engineering",
+        "split": "development",
+        "title": f"Case {index}",
+        "decision_prompt": "Choose one bounded action.",
+        "forecast_question": "What is the probability option A is outcome-aligned?",
+        "forecast_option_id": "option-a",
+        "options": [
+            {"option_id": "option-a", "label": "A", "description": "Action A"},
+            {"option_id": "option-b", "label": "B", "description": "Action B"},
+        ],
+        "information_cutoff": "2025-01-02T00:00:00Z",
+        "sources": [
+            {
+                "source_id": f"source-{index:02d}",
+                "title": "Frozen source",
+                "url": "https://www.sec.gov/source",
+                "published_at": "2025-01-01T00:00:00Z",
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            }
+        ],
+        "_content": content,
+    }
+
+
+def _packet(case: dict[str, object]) -> dict[str, object]:
+    visible = {key: value for key, value in case.items() if key not in {"sources", "_content"}}
+    sources = case["sources"]
+    assert isinstance(sources, list)
+    assert isinstance(sources[0], dict)
+    source = dict(sources[0])
+    source.update(
+        {
+            "media_type": "text/plain; charset=utf-8",
+            "content_encoding": "utf-8",
+            "content": case["_content"],
+        }
+    )
+    packet: dict[str, object] = {
+        "schema_version": SOURCE_PACKET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "case": visible,
+        "sources": [source],
+    }
+    packet["packet_sha256"] = canonical_json_sha256(packet)
+    return packet
+
+
+def _install_valid_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, Path, Path]:
+    corpus_dir = tmp_path / "corpus"
+    packet_dir = tmp_path / "packets"
+    ledger_path = tmp_path / "budget.jsonl"
+    corpus_dir.mkdir()
+    packet_dir.mkdir()
+    corpus_dir.joinpath("fixture.json").write_text("{}\n")
+    cases = tuple(_case(index) for index in range(16))
+    clean_cases = tuple(
+        {key: value for key, value in case.items() if key != "_content"} for case in cases
+    )
+    monkeypatch.setattr(
+        preflight_module,
+        "validate_corpus_directory",
+        lambda _path: CorpusIntegrityReport(
+            benchmark_id=BENCHMARK_ID,
+            corpus_files=8,
+            outcome_files=8,
+            case_count=24,
+            split_counts={"development": 16, "holdout": 8},
+            domain_counts={"software_engineering": 6},
+            issues=(),
+        ),
+    )
+    monkeypatch.setattr(preflight_module, "load_visible_cases", lambda _path: clean_cases)
+
+    packets = {str(case["case_id"]): _packet(case) for case in cases}
+    entries = [
+        {"case_id": case_id, "packet_sha256": packet["packet_sha256"]}
+        for case_id, packet in sorted(packets.items())
+    ]
+    manifest: dict[str, object] = {
+        "schema_version": PACKET_SET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "split": "development",
+        "packet_count": 16,
+        "source_count": 16,
+        "packets": entries,
+    }
+    manifest["packet_set_sha256"] = canonical_json_sha256(manifest)
+    packet_dir.joinpath("packet-set.json").write_text(json.dumps(manifest) + "\n")
+    for case_id, packet in packets.items():
+        packet_dir.joinpath(f"{case_id}.packet.json").write_text(json.dumps(packet) + "\n")
+    return corpus_dir, packet_dir, ledger_path
+
+
+def test_preflight_renders_all_prompts_without_mutating_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
+
+    first = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        environ=ENV,
+        utc_date=TODAY,
+    )
+    second = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        environ=ENV,
+        utc_date=TODAY,
+    )
+
+    assert first.ready is True
+    assert first == second
+    assert first.to_dict()["prompt_count"] == 64
+    assert first.prompt_set_sha256 is not None
+    assert len(first.case_ids) == 16
+    assert first.condition_ids == tuple(item.condition_id for item in FROZEN_CONDITION_ROSTER)
+    assert not ledger_path.exists()
+    serialized = json.dumps(first.to_dict())
+    assert "anthropic-secret" not in serialized
+    assert "openai-secret" not in serialized
+    assert "gemini-secret" not in serialized
+
+
+def test_missing_credential_blocks_without_exposing_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
+    env = {**ENV, "OPENAI_API_KEY": ""}
+
+    report = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        environ=env,
+        utc_date=TODAY,
+    )
+
+    assert report.ready is False
+    assert [item.code for item in report.blockers] == ["missing_provider_credential"]
+    openai = next(item for item in report.credential_readiness if item["family"] == "openai")
+    assert openai["credential_available"] is False
+
+
+def test_canonical_secret_presence_accepts_aws_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        preflight_module,
+        "get_secret_presence_report",
+        lambda names: [
+            SecretPresence(name=name, source="aws", critical=True, managed=True) for name in names
+        ],
+    )
+
+    report = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        utc_date=TODAY,
+    )
+
+    assert report.ready is True
+    assert {item["credential_source"] for item in report.credential_readiness} == {"aws"}
+
+
+def test_packet_tampering_blocks_before_inference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
+    path = packet_dir / "case-00.packet.json"
+    packet = json.loads(path.read_text())
+    packet["sources"][0]["content"] = "tampered"
+    packet["packet_sha256"] = canonical_json_sha256(
+        {key: value for key, value in packet.items() if key != "packet_sha256"}
+    )
+    path.write_text(json.dumps(packet) + "\n")
+
+    report = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        environ=ENV,
+        utc_date=TODAY,
+    )
+
+    assert report.ready is False
+    assert any(item.code == "development_packets_not_ready" for item in report.blockers)
+    assert report.prompt_set_sha256 is None
+
+
+def test_open_budget_reservation_blocks_and_snapshot_is_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
+    ledger = preflight_module.OutcomeBackedBudgetLedger(ledger_path)
+    ledger.reserve(
+        reservation_id="reservation-1",
+        logical_call_id="logical-1",
+        run_id="development-run",
+        case_id="case-00",
+        condition_id="claude-single",
+        attempt=1,
+        estimated_cost_usd="2",
+        recorded_at=datetime(2026, 8, 31, 12, tzinfo=timezone.utc),
+    )
+    before = ledger_path.read_bytes()
+
+    report = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        environ=ENV,
+        utc_date=TODAY,
+    )
+
+    assert any(item.code == "open_budget_reservations" for item in report.blockers)
+    assert ledger_path.read_bytes() == before
+
+
+@pytest.mark.parametrize("sha", ["", "A" * 40, "a" * 39, "not-a-sha"])
+def test_invalid_implementation_sha_fails_closed(
+    tmp_path: Path,
+    sha: str,
+) -> None:
+    with pytest.raises(OutcomeBackedPreflightError, match="lowercase 40-hex"):
+        preflight_development_run(
+            tmp_path,
+            tmp_path,
+            tmp_path / "budget.jsonl",
+            implementation_sha=sha,
+            environ=ENV,
+            utc_date=TODAY,
+        )

--- a/tests/scripts/test_preflight_outcome_backed_development.py
+++ b/tests/scripts/test_preflight_outcome_backed_development.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import scripts.preflight_outcome_backed_development as cli
+from aragora.evaluation.outcome_backed_preflight import DevelopmentPreflightReport
+
+
+HEAD = "a" * 40
+
+
+def test_cli_help_runs_from_checkout() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/preflight_outcome_backed_development.py", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "without making model calls" in result.stdout
+
+
+def _report(*, ready: bool) -> DevelopmentPreflightReport:
+    from aragora.evaluation.outcome_backed_preflight import PreflightBlocker
+
+    blockers = () if ready else (PreflightBlocker("blocked", "not ready"),)
+    return DevelopmentPreflightReport(
+        implementation_sha=HEAD,
+        corpus_sha256="b" * 64,
+        packet_set_sha256="c" * 64,
+        roster_sha256="d" * 64,
+        case_ids=tuple(f"case-{index:02d}" for index in range(16)),
+        condition_ids=("claude-single", "openai-single", "gemini-single", "aragora-team"),
+        prompt_set_sha256="e" * 64,
+        credential_readiness=(),
+        budget={"remaining_usd": "25"},
+        blockers=blockers,
+    )
+
+
+def test_cli_writes_ready_artifact_atomically(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        cli, "preflight_development_run", lambda *_args, **_kwargs: _report(ready=True)
+    )
+    output = tmp_path / "proof" / "preflight.json"
+
+    result = cli.main(["--implementation-sha", HEAD, "--output", str(output)])
+
+    assert result == 0
+    payload = json.loads(output.read_text())
+    assert payload["ok"] is True
+    assert payload["ready"] is True
+    assert json.loads(capsys.readouterr().out) == payload
+    assert not output.with_suffix(".json.tmp").exists()
+
+
+def test_cli_returns_one_for_truthful_blocker(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        cli, "preflight_development_run", lambda *_args, **_kwargs: _report(ready=False)
+    )
+
+    result = cli.main(["--implementation-sha", HEAD])
+
+    assert result == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["blockers"] == [{"code": "blocked", "message": "not ready"}]
+
+
+def test_cli_rejects_invalid_sha(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "_current_head", lambda: "invalid")
+
+    result = cli.main([])
+
+    assert result == 2
+    assert json.loads(capsys.readouterr().out)["ok"] is False


### PR DESCRIPTION
## Summary
- add a fail-closed, no-inference development-run preflight for the outcome-backed benchmark
- bind all 16 development cases to verified source packets and render the fixed 4-condition / 64-prompt set deterministically
- attest canonical provider credential presence and the append-only $25 UTC-day budget without exposing secrets or mutating the ledger
- add an atomic JSON CLI artifact and focused regression coverage

## Live current-main finding
At `4244e31806bc5d312c01f76548e57f9d2bcf1248`, the preflight reports the frozen corpus and roster valid, the full budget untouched, Gemini configured, and blocks on missing development source packets plus unavailable direct Anthropic/OpenAI credentials. It makes no model calls.

## Validation
- merged Outcome contract tests: 91 passed
- focused preflight tests: 13 passed
- Ruff check and format
- mypy on touched source and CLI
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- pre-commit and pre-push hooks
- `git diff --check`

This PR does not call providers, alter budget state, modify parked Outcome contracts, or expose outcome sidecars to prompts.
