### PR TITLE
feat(evaluation): freeze credentialless benchmark roster

### DIFF
--- a/aragora/evaluation/outcome_backed_conditions.py
+++ b/aragora/evaluation/outcome_backed_conditions.py
@@ -9,7 +9,7 @@ from typing import Any
 from aragora.evaluation.outcome_backed_corpus import BENCHMARK_ID, canonical_json_sha256
 
 
-CONDITION_ROSTER_SCHEMA = "outcome-backed-condition-roster/1.0"
+CONDITION_ROSTER_SCHEMA = "outcome-backed-condition-roster/2.0"
 CLAUDE_SINGLE = "claude-single"
 OPENAI_SINGLE = "openai-single"
 GEMINI_SINGLE = "gemini-single"
@@ -22,22 +22,26 @@ class ConditionRosterError(ValueError):
 
 @dataclass(frozen=True)
 class ModelIdentity:
-    """An exact model binding; aliases and fallback are intentionally forbidden."""
+    """An exact model and credentialless transport binding."""
 
     family: str
-    agent_type: str
     requested_model: str
     expected_resolved_model: str
-    transport: str = "direct-api"
+    transport: str
+    protocol: str
+    catalog_owner: str
+    identity_attestation: str
     allow_fallback: bool = False
 
     def to_dict(self) -> dict[str, str | bool]:
         return {
             "family": self.family,
-            "agent_type": self.agent_type,
             "requested_model": self.requested_model,
             "expected_resolved_model": self.expected_resolved_model,
             "transport": self.transport,
+            "protocol": self.protocol,
+            "catalog_owner": self.catalog_owner,
+            "identity_attestation": self.identity_attestation,
             "allow_fallback": self.allow_fallback,
         }
 
@@ -73,21 +77,30 @@ class ConditionRosterAttestation:
 
 CLAUDE_IDENTITY = ModelIdentity(
     family="claude",
-    agent_type="anthropic-api",
     requested_model="claude-opus-5",
     expected_resolved_model="claude-opus-5",
+    transport="vibeproxy-required",
+    protocol="openai-chat",
+    catalog_owner="anthropic",
+    identity_attestation="catalog-owner+exact-response-model",
 )
 OPENAI_IDENTITY = ModelIdentity(
     family="openai",
-    agent_type="openai-api",
     requested_model="gpt-5.6-sol",
     expected_resolved_model="gpt-5.6-sol",
+    transport="vibeproxy-required",
+    protocol="openai-chat",
+    catalog_owner="openai",
+    identity_attestation="catalog-owner+exact-response-model",
 )
 GEMINI_IDENTITY = ModelIdentity(
     family="gemini",
-    agent_type="gemini",
-    requested_model="gemini-3.1-pro-preview",
-    expected_resolved_model="gemini-3.1-pro-preview",
+    requested_model="gemini-3.1-pro-low",
+    expected_resolved_model="gemini-3.1-pro-low",
+    transport="vibeproxy-required",
+    protocol="openai-chat",
+    catalog_owner="antigravity",
+    identity_attestation="catalog-owner+exact-response-model",
 )
 
 FROZEN_CONDITION_ROSTER = (
@@ -116,7 +129,7 @@ def _validate_member(member: ModelIdentity, *, path: str) -> None:
     if member != expected:
         raise ConditionRosterError(
             f"{path} must use the exact frozen {member.family!r} identity; "
-            "aliases, substitutions, alternate transports, and fallback are forbidden"
+            "model substitutions, owner drift, alternate transports, and fallback are forbidden"
         )
 
 

--- a/aragora/evaluation/outcome_backed_preflight.py
+++ b/aragora/evaluation/outcome_backed_preflight.py
@@ -252,6 +252,7 @@ def _transport_readiness(
                 "outcome-backed inference requires a loopback VibeProxy endpoint",
             )
         )
+        return (), tuple(blockers)
 
     try:
         catalog = resolved_client.catalog(

--- a/aragora/evaluation/outcome_backed_preflight.py
+++ b/aragora/evaluation/outcome_backed_preflight.py
@@ -11,9 +11,15 @@ import hashlib
 import json
 from pathlib import Path
 import re
-from typing import Any
+from typing import Any, Protocol
 
-from aragora.config.secrets import get_secret_presence_report
+from aragora.agents.transports.vibeproxy import (
+    VibeProxyClient,
+    VibeProxyCatalog,
+    VibeProxyConfigurationError,
+    VibeProxyMetadata,
+    VibeProxyUnavailableError,
+)
 
 from aragora.evaluation.outcome_backed_budget import (
     DAILY_BUDGET_CAP_USD,
@@ -37,20 +43,28 @@ from aragora.evaluation.outcome_backed_prompt import (
 )
 
 
-DEVELOPMENT_PREFLIGHT_SCHEMA = "outcome-backed-development-preflight/1.0"
+DEVELOPMENT_PREFLIGHT_SCHEMA = "outcome-backed-development-preflight/2.0"
 EXPECTED_DEVELOPMENT_CASES = 16
 EXPECTED_CONDITIONS = 4
 EXPECTED_PROMPTS = EXPECTED_DEVELOPMENT_CASES * EXPECTED_CONDITIONS
 _IMPLEMENTATION_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-_CREDENTIAL_ENV_VARS = {
-    "claude": ("ANTHROPIC_API_KEY",),
-    "openai": ("OPENAI_API_KEY",),
-    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
-}
+_REQUIRED_VIBEPROXY_ROUTE = "POST /v1/chat/completions"
+_VIBEPROXY_PREFLIGHT_TIMEOUT_SECONDS = 3.0
 
 
 class OutcomeBackedPreflightError(ValueError):
     """Raised when preflight inputs cannot be represented safely."""
+
+
+class VibeProxyReadinessClient(Protocol):
+    """No-inference VibeProxy surface required by development preflight."""
+
+    base_url: str
+    is_loopback: bool
+
+    def catalog(self, *, force: bool, timeout: float) -> VibeProxyCatalog: ...
+
+    def metadata(self, *, timeout: float) -> VibeProxyMetadata: ...
 
 
 @dataclass(frozen=True)
@@ -71,7 +85,7 @@ class DevelopmentPreflightReport:
     case_ids: tuple[str, ...]
     condition_ids: tuple[str, ...]
     prompt_set_sha256: str | None
-    credential_readiness: tuple[Mapping[str, object], ...]
+    transport_readiness: tuple[Mapping[str, object], ...]
     budget: Mapping[str, object] | None
     blockers: tuple[PreflightBlocker, ...]
 
@@ -93,7 +107,7 @@ class DevelopmentPreflightReport:
             "condition_count": len(self.condition_ids),
             "prompt_count": EXPECTED_PROMPTS if self.prompt_set_sha256 else 0,
             "prompt_set_sha256": self.prompt_set_sha256,
-            "credential_readiness": [dict(item) for item in self.credential_readiness],
+            "transport_readiness": [dict(item) for item in self.transport_readiness],
             "budget": dict(self.budget) if self.budget is not None else None,
             "blockers": [blocker.to_dict() for blocker in self.blockers],
             "ready": self.ready,
@@ -212,68 +226,99 @@ def _validate_packet_against_case(
             )
 
 
-def _credential_readiness(
+def _transport_readiness(
     roster_members: tuple[Mapping[str, object], ...],
-    environ: Mapping[str, str] | None,
+    client: VibeProxyReadinessClient | None,
 ) -> tuple[tuple[Mapping[str, object], ...], tuple[PreflightBlocker, ...]]:
     readiness: list[Mapping[str, object]] = []
     blockers: list[PreflightBlocker] = []
-    env_names = tuple(
-        name for member in roster_members for name in _CREDENTIAL_ENV_VARS[str(member["family"])]
-    )
-    if environ is None:
+    resolved_client = client
+    if resolved_client is None:
         try:
-            credential_sources = {
-                status.name: status.source for status in get_secret_presence_report(env_names)
-            }
-        except (OSError, RuntimeError, ValueError) as exc:
-            credential_sources = {}
+            resolved_client = VibeProxyClient()
+        except VibeProxyConfigurationError as exc:
             blockers.append(
                 PreflightBlocker(
-                    "credential_discovery_failed",
-                    f"credential presence discovery failed ({type(exc).__name__})",
+                    "vibeproxy_configuration_invalid",
+                    f"VibeProxy configuration is invalid ({type(exc).__name__})",
                 )
             )
-    else:
-        credential_sources = {
-            name: "provided_environment" if environ.get(name, "").strip() else "missing"
-            for name in env_names
-        }
+            return (), tuple(blockers)
+
+    if not resolved_client.is_loopback:
+        blockers.append(
+            PreflightBlocker(
+                "vibeproxy_not_loopback",
+                "outcome-backed inference requires a loopback VibeProxy endpoint",
+            )
+        )
+
+    try:
+        catalog = resolved_client.catalog(
+            force=True,
+            timeout=_VIBEPROXY_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+        metadata = resolved_client.metadata(timeout=_VIBEPROXY_PREFLIGHT_TIMEOUT_SECONDS)
+    except VibeProxyUnavailableError as exc:
+        blockers.append(
+            PreflightBlocker(
+                "vibeproxy_unavailable",
+                f"VibeProxy readiness probe failed ({type(exc).__name__})",
+            )
+        )
+        return (), tuple(blockers)
+
+    route_available = _REQUIRED_VIBEPROXY_ROUTE in metadata.advertised_routes
+    if not route_available:
+        blockers.append(
+            PreflightBlocker(
+                "vibeproxy_protocol_unavailable",
+                f"VibeProxy does not advertise {_REQUIRED_VIBEPROXY_ROUTE}",
+            )
+        )
 
     for member in roster_members:
         family = str(member["family"])
-        accepted = _CREDENTIAL_ENV_VARS[family]
-        available_name = next(
-            (
-                name
-                for name in accepted
-                if credential_sources.get(name) in {"aws", "env", "provided_environment"}
-            ),
-            None,
+        model = str(member["requested_model"])
+        expected_owner = str(member["catalog_owner"])
+        model_present = model in catalog.models
+        observed_owner = catalog.owner_for(model) if model_present else None
+        ready = (
+            resolved_client.is_loopback
+            and route_available
+            and model_present
+            and observed_owner == expected_owner
         )
-        available = available_name is not None
         readiness.append(
             {
                 "family": family,
-                "agent_type": member["agent_type"],
-                "requested_model": member["requested_model"],
+                "requested_model": model,
                 "expected_resolved_model": member["expected_resolved_model"],
                 "transport": member["transport"],
+                "protocol": member["protocol"],
+                "identity_attestation": member["identity_attestation"],
                 "allow_fallback": member["allow_fallback"],
-                "accepted_environment_variables": list(accepted),
-                "credential_available": available,
-                "credential_source": (
-                    credential_sources.get(available_name, "missing")
-                    if available_name
-                    else "missing"
-                ),
+                "endpoint_loopback": resolved_client.is_loopback,
+                "required_route": _REQUIRED_VIBEPROXY_ROUTE,
+                "route_available": route_available,
+                "catalog_model_present": model_present,
+                "expected_catalog_owner": expected_owner,
+                "observed_catalog_owner": observed_owner,
+                "ready": ready,
             }
         )
-        if not available:
+        if not model_present:
             blockers.append(
                 PreflightBlocker(
-                    "missing_provider_credential",
-                    f"{family} direct-api credential is unavailable",
+                    "vibeproxy_model_unavailable",
+                    f"{family} frozen model is absent from the VibeProxy catalog",
+                )
+            )
+        elif observed_owner != expected_owner:
+            blockers.append(
+                PreflightBlocker(
+                    "vibeproxy_owner_mismatch",
+                    f"{family} frozen model lacks its exact catalog owner",
                 )
             )
     return tuple(readiness), tuple(blockers)
@@ -285,7 +330,7 @@ def preflight_development_run(
     budget_ledger_path: Path | str,
     *,
     implementation_sha: str,
-    environ: Mapping[str, str] | None = None,
+    vibeproxy_client: VibeProxyReadinessClient | None = None,
     utc_date: date | None = None,
 ) -> DevelopmentPreflightReport:
     """Attest development-run readiness without model calls or ledger writes."""
@@ -300,7 +345,7 @@ def preflight_development_run(
     prompt_set_sha256: str | None = None
     case_ids: tuple[str, ...] = ()
     condition_ids: tuple[str, ...] = ()
-    credential_readiness: tuple[Mapping[str, object], ...] = ()
+    transport_readiness: tuple[Mapping[str, object], ...] = ()
     budget: Mapping[str, object] | None = None
     root = Path(corpus_dir)
 
@@ -350,10 +395,10 @@ def preflight_development_run(
         for condition in roster.conditions:
             for member in condition.members:
                 unique_members.setdefault(member.family, member.to_dict())
-        credential_readiness, credential_blockers = _credential_readiness(
-            tuple(unique_members.values()), environ
+        transport_readiness, transport_blockers = _transport_readiness(
+            tuple(unique_members.values()), vibeproxy_client
         )
-        blockers.extend(credential_blockers)
+        blockers.extend(transport_blockers)
 
     packet_root = Path(packet_dir)
     prompt_entries: list[dict[str, str]] = []
@@ -444,7 +489,7 @@ def preflight_development_run(
         case_ids=case_ids,
         condition_ids=condition_ids,
         prompt_set_sha256=prompt_set_sha256,
-        credential_readiness=credential_readiness,
+        transport_readiness=transport_readiness,
         budget=budget,
         blockers=unique_blockers,
     )

--- a/tests/evaluation/test_outcome_backed_conditions.py
+++ b/tests/evaluation/test_outcome_backed_conditions.py
@@ -46,6 +46,18 @@ def test_frozen_roster_preflight_is_stable_and_content_bound() -> None:
         "openai",
         "gemini",
     ]
+    assert {member.transport for member in first.conditions[-1].members} == {"vibeproxy-required"}
+    assert {member.protocol for member in first.conditions[-1].members} == {"openai-chat"}
+    assert [member.catalog_owner for member in first.conditions[-1].members] == [
+        "anthropic",
+        "openai",
+        "antigravity",
+    ]
+    assert first.conditions[2].members[0].requested_model == "gemini-3.1-pro-low"
+    assert all(
+        member.requested_model == member.expected_resolved_model
+        for member in first.conditions[-1].members
+    )
     payload = first.to_dict()
     digest = payload.pop("roster_sha256")
     assert payload["schema_version"] == CONDITION_ROSTER_SCHEMA
@@ -82,8 +94,10 @@ def test_preflight_rejects_condition_reordering() -> None:
     [
         ("requested_model", "claude-opus-latest"),
         ("expected_resolved_model", "claude-opus-4-8"),
-        ("agent_type", "claude"),
-        ("transport", "vibeproxy"),
+        ("transport", "direct-api"),
+        ("protocol", "anthropic-messages"),
+        ("catalog_owner", "other"),
+        ("identity_attestation", "command-line-only"),
         ("allow_fallback", True),
     ],
 )

--- a/tests/evaluation/test_outcome_backed_preflight.py
+++ b/tests/evaluation/test_outcome_backed_preflight.py
@@ -296,7 +296,13 @@ def test_ambiguous_catalog_owner_fails_closed(
 @pytest.mark.parametrize(
     ("client", "blocker"),
     [
-        (FakeVibeProxyClient(loopback=False), "vibeproxy_not_loopback"),
+        (
+            FakeVibeProxyClient(
+                loopback=False,
+                failure=AssertionError("non-loopback endpoint must not be probed"),
+            ),
+            "vibeproxy_not_loopback",
+        ),
         (FakeVibeProxyClient(routes=("GET /v1/models",)), "vibeproxy_protocol_unavailable"),
         (
             FakeVibeProxyClient(failure=VibeProxyUnavailableError("credential detail")),

--- a/tests/evaluation/test_outcome_backed_preflight.py
+++ b/tests/evaluation/test_outcome_backed_preflight.py
@@ -9,7 +9,11 @@ import pytest
 
 import aragora.evaluation.outcome_backed_preflight as preflight_module
 from aragora.evaluation.outcome_backed_conditions import FROZEN_CONDITION_ROSTER
-from aragora.config.secrets import SecretPresence
+from aragora.agents.transports.vibeproxy import (
+    VibeProxyCatalog,
+    VibeProxyMetadata,
+    VibeProxyUnavailableError,
+)
 from aragora.evaluation.outcome_backed_corpus import (
     BENCHMARK_ID,
     CorpusIntegrityReport,
@@ -24,11 +28,51 @@ from aragora.evaluation.outcome_backed_preflight import (
 
 HEAD = "a" * 40
 TODAY = date(2026, 8, 31)
-ENV = {
-    "ANTHROPIC_API_KEY": "anthropic-secret",
-    "OPENAI_API_KEY": "openai-secret",
-    "GEMINI_API_KEY": "gemini-secret",
-}
+REQUIRED_ROUTE = "POST /v1/chat/completions"
+
+
+class FakeVibeProxyClient:
+    base_url = "http://127.0.0.1:8318/v1"
+
+    def __init__(
+        self,
+        *,
+        models: frozenset[str] | None = None,
+        owners: frozenset[tuple[str, str]] | None = None,
+        routes: tuple[str, ...] = ("GET /v1/models", REQUIRED_ROUTE),
+        loopback: bool = True,
+        failure: Exception | None = None,
+    ) -> None:
+        identities = tuple(condition.members for condition in FROZEN_CONDITION_ROSTER[:3])
+        members = tuple(items[0] for items in identities)
+        self._models = models or frozenset(member.requested_model for member in members)
+        self._owners = owners or frozenset(
+            (member.requested_model, member.catalog_owner) for member in members
+        )
+        self._routes = routes
+        self.is_loopback = loopback
+        self._failure = failure
+
+    def catalog(self, *, force: bool, timeout: float) -> VibeProxyCatalog:
+        assert force is True
+        assert timeout > 0
+        if self._failure is not None:
+            raise self._failure
+        return VibeProxyCatalog(
+            models=self._models,
+            fetched_at=0.0,
+            model_owners=self._owners,
+        )
+
+    def metadata(self, *, timeout: float) -> VibeProxyMetadata:
+        assert timeout > 0
+        if self._failure is not None:
+            raise self._failure
+        return VibeProxyMetadata(
+            advertised_routes=self._routes,
+            version=None,
+            version_source="unknown",
+        )
 
 
 def _case(index: int) -> dict[str, object]:
@@ -142,7 +186,7 @@ def test_preflight_renders_all_prompts_without_mutating_budget(
         packet_dir,
         ledger_path,
         implementation_sha=HEAD,
-        environ=ENV,
+        vibeproxy_client=FakeVibeProxyClient(),
         utc_date=TODAY,
     )
     second = preflight_development_run(
@@ -150,7 +194,7 @@ def test_preflight_renders_all_prompts_without_mutating_budget(
         packet_dir,
         ledger_path,
         implementation_sha=HEAD,
-        environ=ENV,
+        vibeproxy_client=FakeVibeProxyClient(),
         utc_date=TODAY,
     )
 
@@ -162,44 +206,48 @@ def test_preflight_renders_all_prompts_without_mutating_budget(
     assert first.condition_ids == tuple(item.condition_id for item in FROZEN_CONDITION_ROSTER)
     assert not ledger_path.exists()
     serialized = json.dumps(first.to_dict())
-    assert "anthropic-secret" not in serialized
-    assert "openai-secret" not in serialized
-    assert "gemini-secret" not in serialized
+    assert "API_KEY" not in serialized
+    assert {item["observed_catalog_owner"] for item in first.transport_readiness} == {
+        "anthropic",
+        "openai",
+        "antigravity",
+    }
+    assert all(item["ready"] is True for item in first.transport_readiness)
 
 
-def test_missing_credential_blocks_without_exposing_values(
+def test_missing_catalog_model_blocks_before_inference(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
-    env = {**ENV, "OPENAI_API_KEY": ""}
+    members = tuple(condition.members[0] for condition in FROZEN_CONDITION_ROSTER[:3])
+    models = frozenset(member.requested_model for member in members if member.family != "openai")
 
     report = preflight_development_run(
         corpus_dir,
         packet_dir,
         ledger_path,
         implementation_sha=HEAD,
-        environ=env,
+        vibeproxy_client=FakeVibeProxyClient(models=models),
         utc_date=TODAY,
     )
 
     assert report.ready is False
-    assert [item.code for item in report.blockers] == ["missing_provider_credential"]
-    openai = next(item for item in report.credential_readiness if item["family"] == "openai")
-    assert openai["credential_available"] is False
+    assert [item.code for item in report.blockers] == ["vibeproxy_model_unavailable"]
+    openai = next(item for item in report.transport_readiness if item["family"] == "openai")
+    assert openai["catalog_model_present"] is False
+    assert openai["ready"] is False
 
 
-def test_canonical_secret_presence_accepts_aws_credentials(
+def test_catalog_owner_must_match_frozen_identity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
-    monkeypatch.setattr(
-        preflight_module,
-        "get_secret_presence_report",
-        lambda names: [
-            SecretPresence(name=name, source="aws", critical=True, managed=True) for name in names
-        ],
+    members = tuple(condition.members[0] for condition in FROZEN_CONDITION_ROSTER[:3])
+    owners = frozenset(
+        (member.requested_model, "other" if member.family == "gemini" else member.catalog_owner)
+        for member in members
     )
 
     report = preflight_development_run(
@@ -207,11 +255,75 @@ def test_canonical_secret_presence_accepts_aws_credentials(
         packet_dir,
         ledger_path,
         implementation_sha=HEAD,
+        vibeproxy_client=FakeVibeProxyClient(owners=owners),
         utc_date=TODAY,
     )
 
-    assert report.ready is True
-    assert {item["credential_source"] for item in report.credential_readiness} == {"aws"}
+    assert report.ready is False
+    assert [item.code for item in report.blockers] == ["vibeproxy_owner_mismatch"]
+    gemini = next(item for item in report.transport_readiness if item["family"] == "gemini")
+    assert gemini["expected_catalog_owner"] == "antigravity"
+    assert gemini["observed_catalog_owner"] == "other"
+    assert gemini["ready"] is False
+
+
+def test_ambiguous_catalog_owner_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
+    members = tuple(condition.members[0] for condition in FROZEN_CONDITION_ROSTER[:3])
+    owners = frozenset(
+        (member.requested_model, member.catalog_owner) for member in members
+    ) | frozenset({(members[0].requested_model, "other")})
+
+    report = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        vibeproxy_client=FakeVibeProxyClient(owners=owners),
+        utc_date=TODAY,
+    )
+
+    assert report.ready is False
+    assert [item.code for item in report.blockers] == ["vibeproxy_owner_mismatch"]
+    claude = next(item for item in report.transport_readiness if item["family"] == "claude")
+    assert claude["observed_catalog_owner"] is None
+    assert claude["ready"] is False
+
+
+@pytest.mark.parametrize(
+    ("client", "blocker"),
+    [
+        (FakeVibeProxyClient(loopback=False), "vibeproxy_not_loopback"),
+        (FakeVibeProxyClient(routes=("GET /v1/models",)), "vibeproxy_protocol_unavailable"),
+        (
+            FakeVibeProxyClient(failure=VibeProxyUnavailableError("credential detail")),
+            "vibeproxy_unavailable",
+        ),
+    ],
+)
+def test_transport_probe_fails_closed_without_exposing_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    client: FakeVibeProxyClient,
+    blocker: str,
+) -> None:
+    corpus_dir, packet_dir, ledger_path = _install_valid_inputs(tmp_path, monkeypatch)
+
+    report = preflight_development_run(
+        corpus_dir,
+        packet_dir,
+        ledger_path,
+        implementation_sha=HEAD,
+        vibeproxy_client=client,
+        utc_date=TODAY,
+    )
+
+    assert report.ready is False
+    assert blocker in {item.code for item in report.blockers}
+    assert "credential detail" not in json.dumps(report.to_dict())
 
 
 def test_packet_tampering_blocks_before_inference(
@@ -232,7 +344,7 @@ def test_packet_tampering_blocks_before_inference(
         packet_dir,
         ledger_path,
         implementation_sha=HEAD,
-        environ=ENV,
+        vibeproxy_client=FakeVibeProxyClient(),
         utc_date=TODAY,
     )
 
@@ -264,7 +376,7 @@ def test_open_budget_reservation_blocks_and_snapshot_is_read_only(
         packet_dir,
         ledger_path,
         implementation_sha=HEAD,
-        environ=ENV,
+        vibeproxy_client=FakeVibeProxyClient(),
         utc_date=TODAY,
     )
 
@@ -283,6 +395,6 @@ def test_invalid_implementation_sha_fails_closed(
             tmp_path,
             tmp_path / "budget.jsonl",
             implementation_sha=sha,
-            environ=ENV,
+            vibeproxy_client=FakeVibeProxyClient(),
             utc_date=TODAY,
         )

--- a/tests/scripts/test_preflight_outcome_backed_development.py
+++ b/tests/scripts/test_preflight_outcome_backed_development.py
@@ -36,7 +36,7 @@ def _report(*, ready: bool) -> DevelopmentPreflightReport:
         case_ids=tuple(f"case-{index:02d}" for index in range(16)),
         condition_ids=("claude-single", "openai-single", "gemini-single", "aragora-team"),
         prompt_set_sha256="e" * 64,
-        credential_readiness=(),
+        transport_readiness=(),
         budget={"remaining_usd": "25"},
         blockers=blockers,
     )


### PR DESCRIPTION
## Summary
- revise the frozen Outcome-Backed Decision Quality roster before first inference to use credentialless, exact-model VibeProxy transport for Claude, OpenAI, and Gemini
- bind each model to one expected catalog owner and require the loopback OpenAI-chat route
- replace provider-secret discovery with a no-inference, fail-closed transport readiness probe

## Frozen identities
- Claude: `claude-opus-5` owned by `anthropic`
- OpenAI: `gpt-5.6-sol` owned by `openai`
- Gemini: `gemini-3.1-pro-low` owned by `antigravity`

The Gemini identity is deliberately revised before any benchmark inference because the previously frozen preview model is absent from the live catalog. Fallback, model substitution, owner ambiguity, non-loopback endpoints, and missing protocol routes all block preflight.

## Security and benchmark integrity
- uses no provider API keys and does not inspect secret values
- performs catalog and metadata probes only; no inference is made
- keeps exact requested/resolved identity and no-fallback requirements
- sanitizes transport failures in the proof artifact
- leaves the historical direct-API materialization proof unchanged as an immutable record of the earlier contract

## Validation
- `python3 -m pytest tests/evaluation -k outcome_backed -q` (145 passed)
- `python3 -m pytest tests/scripts/test_preflight_outcome_backed_development.py -q` (4 passed)
- Ruff and Ruff format checks
- mypy on the two touched production modules
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`
- live no-inference preflight: ready, 16 development packets, 64 prompts, budget untouched at $25

This draft does not run the benchmark, post model evidence, settle, or merge.