### PR TITLE
fix(swarm): preserve test-create scope in micro decomposition

### DIFF
--- a/aragora/swarm/micro_decomposer.py
+++ b/aragora/swarm/micro_decomposer.py
@@ -254,9 +254,14 @@ def _resolve_file_hints(hints: list[str], root: Path) -> list[str]:
 
 
 def _is_creatable_file_hint(hint: str, root: Path) -> bool:
-    """Accept a missing explicit file only when its existing parent bounds it."""
+    """Accept a missing test file only when its existing parent bounds it."""
     relative = Path(hint)
-    if relative.is_absolute() or ".." in relative.parts or not relative.suffix:
+    if (
+        relative.is_absolute()
+        or ".." in relative.parts
+        or not relative.suffix
+        or not _is_test_file(hint)
+    ):
         return False
     return (root / relative).parent.is_dir()
 

--- a/aragora/swarm/micro_decomposer.py
+++ b/aragora/swarm/micro_decomposer.py
@@ -66,6 +66,10 @@ def build_micro_work_orders(
 
     work_orders: list[dict] = []
     order_idx = 0
+    requires_test_only = _requires_test_only_resolution(
+        goal=goal,
+        acceptance_criteria=acceptance_criteria,
+    )
     prefers_test_first = _prefers_test_first_resolution(
         goal=goal,
         acceptance_criteria=acceptance_criteria,
@@ -118,7 +122,7 @@ def build_micro_work_orders(
         validation_wo = _build_validation_work_order(
             index=order_idx,
             acceptance_criteria=acceptance_criteria,
-            file_scope=file_scope_hints,
+            file_scope=test_files if requires_test_only and test_files else file_scope_hints,
             dependency_ids=[wo["pipeline_task_id"] for wo in work_orders],
         )
         work_orders.append(validation_wo)
@@ -158,10 +162,14 @@ def _prefers_test_first_resolution(
     if not acceptance_criteria or not impl_files or not test_files:
         return False
 
-    lowered = " ".join(
-        part.strip().lower() for part in [goal, *acceptance_criteria] if part and part.strip()
+    lowered = _normalized_resolution_text(
+        goal=goal,
+        acceptance_criteria=acceptance_criteria,
     )
-    prefers_test_only = any(
+    prefers_test_only = _requires_test_only_resolution(
+        goal=goal,
+        acceptance_criteria=acceptance_criteria,
+    ) or any(
         marker in lowered
         for marker in (
             "prefer a test-only fix",
@@ -188,8 +196,44 @@ def _prefers_test_first_resolution(
     return prefers_test_only or (conditional_impl and test_led_acceptance)
 
 
+def _normalized_resolution_text(
+    *,
+    goal: str,
+    acceptance_criteria: list[str] | None,
+) -> str:
+    return " ".join(
+        part.strip().lower()
+        for part in [goal, *(acceptance_criteria or [])]
+        if part and part.strip()
+    )
+
+
+def _requires_test_only_resolution(
+    *,
+    goal: str,
+    acceptance_criteria: list[str] | None,
+) -> bool:
+    """Return true when the issue explicitly forbids implementation edits."""
+    lowered = _normalized_resolution_text(
+        goal=goal,
+        acceptance_criteria=acceptance_criteria,
+    )
+    return any(
+        marker in lowered
+        for marker in (
+            "only create/modify test files",
+            "only create or modify test files",
+            "no modifications to the source module",
+            "no modifications to source module",
+            "no source modifications",
+            "do not modify the source module",
+            "do not modify source files",
+        )
+    )
+
+
 def _resolve_file_hints(hints: list[str], root: Path) -> list[str]:
-    """Resolve file scope hints to actual file paths."""
+    """Resolve existing scope hints and explicit create targets."""
     resolved: list[str] = []
     for hint in hints:
         hint = hint.strip().removeprefix("./")
@@ -204,7 +248,17 @@ def _resolve_file_hints(hints: list[str], root: Path) -> list[str]:
                 rel = str(py_file.relative_to(root))
                 if "__pycache__" not in rel and not rel.endswith("__init__.py"):
                     resolved.append(rel)
+        elif _is_creatable_file_hint(hint, root):
+            resolved.append(hint)
     return resolved[:15]  # Hard cap
+
+
+def _is_creatable_file_hint(hint: str, root: Path) -> bool:
+    """Accept a missing explicit file only when its existing parent bounds it."""
+    relative = Path(hint)
+    if relative.is_absolute() or ".." in relative.parts or not relative.suffix:
+        return False
+    return (root / relative).parent.is_dir()
 
 
 def _is_test_file(filepath: str) -> bool:

--- a/tests/swarm/test_micro_decomposer.py
+++ b/tests/swarm/test_micro_decomposer.py
@@ -71,6 +71,28 @@ def test_nonexistent_file_with_missing_parent_returns_empty(tmp_path: Path) -> N
     assert orders == []
 
 
+@pytest.mark.parametrize(
+    ("goal", "missing_path"),
+    [
+        ("Remove the obsolete module", "aragora/routing/obsolete.py"),
+        ("Update references after renaming this module", "aragora/routing/renamed.py"),
+    ],
+)
+def test_missing_non_test_hint_does_not_create_work_order(
+    repo_root: Path,
+    goal: str,
+    missing_path: str,
+) -> None:
+    orders = build_micro_work_orders(
+        goal=goal,
+        file_scope_hints=[missing_path],
+        repo_root=repo_root,
+    )
+
+    assert not (repo_root / missing_path).exists()
+    assert orders == []
+
+
 def test_work_order_has_required_fields(repo_root: Path) -> None:
     orders = build_micro_work_orders(
         goal="Add feature",

--- a/tests/swarm/test_micro_decomposer.py
+++ b/tests/swarm/test_micro_decomposer.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import pytest
 
+from aragora.swarm.boss_validation import extract_issue_validation_contract
 from aragora.swarm.micro_decomposer import build_micro_work_orders
+from aragora.swarm.spec import SwarmSpec
+from aragora.swarm.task_sanitizer import TaskSanitizer
 
 
 @pytest.fixture
@@ -54,6 +57,15 @@ def test_nonexistent_path_returns_empty(tmp_path: Path) -> None:
     orders = build_micro_work_orders(
         goal="Fix nonexistent",
         file_scope_hints=["aragora/does_not_exist/"],
+        repo_root=tmp_path,
+    )
+    assert orders == []
+
+
+def test_nonexistent_file_with_missing_parent_returns_empty(tmp_path: Path) -> None:
+    orders = build_micro_work_orders(
+        goal="Create a missing test",
+        file_scope_hints=["tests/missing/test_new.py"],
         repo_root=tmp_path,
     )
     assert orders == []
@@ -185,3 +197,48 @@ def test_prefers_test_first_for_conditional_test_only_issue(tmp_path: Path) -> N
         "tests/cli/test_swarm_command.py",
         "aragora/cli/parser.py",
     ]
+
+
+def test_new_test_target_and_no_source_edits_emit_test_only_orders(tmp_path: Path) -> None:
+    (tmp_path / "aragora" / "swarm").mkdir(parents=True)
+    (tmp_path / "tests" / "swarm").mkdir(parents=True)
+    (tmp_path / "aragora" / "swarm" / "supervisor_workers.py").write_text(
+        "def dispatch_worker():\n    pass\n"
+    )
+
+    title = "Add unit tests for swarm/supervisor_workers.py"
+    body = """## Scope
+Add comprehensive unit tests for `aragora/swarm/supervisor_workers.py`.
+
+## Why
+This module handles worker lifecycle in the supervisor. No tests exist today.
+
+## Acceptance criteria
+- Test file at `tests/swarm/test_supervisor_workers.py` (new file)
+- Cover worker dispatch, lease management, and failure handling
+- All tests pass with `pytest tests/swarm/test_supervisor_workers.py -v`
+- No modifications to the source module
+"""
+    sanitization = TaskSanitizer(repo_root=tmp_path).sanitize(title, body)
+    sanitized_body = sanitization.sanitized_text.removeprefix(title).strip()
+    file_scope_hints = SwarmSpec.infer_file_scope_hints(sanitized_body)
+    acceptance_criteria = extract_issue_validation_contract(sanitized_body)
+
+    source_path = "aragora/swarm/supervisor_workers.py"
+    test_path = "tests/swarm/test_supervisor_workers.py"
+    orders = build_micro_work_orders(
+        goal=f"{title}\n\n{sanitized_body}",
+        file_scope_hints=file_scope_hints,
+        acceptance_criteria=acceptance_criteria,
+        repo_root=tmp_path,
+    )
+
+    assert file_scope_hints == [source_path, test_path]
+    assert not (tmp_path / test_path).exists()
+    assert [order["title"] for order in orders] == [
+        "Write tests for supervisor_workers.py",
+        "Run validation and fix failures",
+    ]
+    assert orders[0]["file_scope"] == [test_path]
+    assert orders[1]["file_scope"] == [test_path]
+    assert all(source_path not in order["file_scope"] for order in orders)


### PR DESCRIPTION
## Summary

- preserve explicit missing file-scope hints when their parent directory exists, so workers can create bounded new files
- distinguish hard test-only constraints from conditional test-first preferences
- keep validation scope test-only when an issue explicitly forbids source edits
- add a regression fixture for the exact #5749 sanitizer-to-micro-decomposer path

## Root cause

Foreman run `boss-2199752293a1` inferred both `aragora/swarm/supervisor_workers.py` and the requested new `tests/swarm/test_supervisor_workers.py`. `micro_decomposer._resolve_file_hints()` discarded the missing create target, leaving an implementation-only work order that contradicted the issue's no-source-edit constraint.

This productizes the repeated rescue class tracked by #7209. It does not change workflows, settlement policy, or reviewer behavior.

## Validation

- `python3 -m pytest -q tests/swarm/test_micro_decomposer.py tests/swarm/test_issue_upgrader.py tests/swarm/test_dispatch_followups.py tests/swarm/test_decomposition_bridge.py` (111 passed)
- `ruff check aragora/swarm/micro_decomposer.py tests/swarm/test_micro_decomposer.py`
- `ruff format --check aragora/swarm/micro_decomposer.py tests/swarm/test_micro_decomposer.py`
- `python3 -m mypy aragora/swarm/micro_decomposer.py --no-error-summary`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check origin/main...HEAD`

Refs #7209
Unblocks #5749
