### PR TITLE
fix(debate): own vote task lifecycles

### DIFF
--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -61,6 +61,136 @@ def get_complexity_governor() -> Any:
     return _get_governor()
 
 
+class _VoteTaskOwner:
+    """Own vote tasks until each is consumed or safely detached exactly once."""
+
+    def __init__(self, tasks: list[asyncio.Task[Any]]):
+        self._tasks = tuple(tasks)
+        self._order = {task: index for index, task in enumerate(tasks)}
+        self._classifications: dict[asyncio.Task[Any], str] = {}
+        self._loop = asyncio.get_running_loop()
+
+    def classification(self, task: asyncio.Task[Any]) -> str | None:
+        """Return the task's terminal ownership classification, if assigned."""
+        return self._classifications.get(task)
+
+    def _report_detached_failure(
+        self,
+        task: asyncio.Task[Any],
+        error: BaseException,
+    ) -> None:
+        if isinstance(error, Exception):
+            logger.warning(
+                "detached_vote_task_failed error=%s: %s",
+                type(error).__name__,
+                error,
+            )
+            return
+        self._loop.call_exception_handler(
+            {
+                "message": "Detached vote task raised a control-flow exception",
+                "exception": error,
+                "task": task,
+            }
+        )
+
+    def _retrieve_detached_result(self, task: asyncio.Task[Any]) -> None:
+        try:
+            result = task.result()
+        except BaseException as error:  # noqa: BLE001 - retrieve every off-path result
+            if isinstance(error, asyncio.CancelledError):
+                return
+            self._report_detached_failure(task, error)
+            return
+
+        if isinstance(result, tuple) and len(result) == 2:
+            vote_result = result[1]
+            if isinstance(vote_result, BaseException) and not isinstance(vote_result, Exception):
+                self._report_detached_failure(task, vote_result)
+
+    def _detach(self, task: asyncio.Task[Any]) -> None:
+        if task in self._classifications:
+            return
+        self._classifications[task] = "detached"
+        task.add_done_callback(self._retrieve_detached_result)
+
+    def consume(
+        self,
+        task: asyncio.Task[Any],
+        consumer: Callable[[asyncio.Task[Any]], None],
+    ) -> None:
+        """Claim and synchronously consume one completed task once."""
+        if task in self._classifications:
+            return
+        self._classifications[task] = "consumed"
+        consumer(task)
+
+    def settle(
+        self,
+        consumer: Callable[[asyncio.Task[Any]], None],
+        *,
+        propagate: bool,
+    ) -> None:
+        """Drain completed tasks, then cancel and observe all unfinished tasks."""
+        first_error: BaseException | None = None
+
+        def consume_or_record(task: asyncio.Task[Any]) -> None:
+            nonlocal first_error
+            try:
+                self.consume(task, consumer)
+            except BaseException as error:  # noqa: BLE001 - ownership must finish first
+                if propagate and first_error is None:
+                    first_error = error
+                else:
+                    self._report_detached_failure(task, error)
+
+        # Preserve work that was already complete at the decision boundary.
+        for task in self._tasks:
+            if task not in self._classifications and task.done():
+                consume_or_record(task)
+
+        # A failed cancel can mean completion won the race; re-check before
+        # detaching so that result is classified as completed work.
+        for task in self._tasks:
+            if task in self._classifications:
+                continue
+            if task.cancel():
+                self._detach(task)
+            elif task.done():
+                consume_or_record(task)
+            else:
+                self._detach(task)
+
+        if first_error is not None:
+            raise first_error
+
+    async def run(
+        self,
+        consumer: Callable[[asyncio.Task[Any]], None],
+        should_stop: Callable[[], bool] | None = None,
+    ) -> bool:
+        """Consume completions until exhaustion or a caller-defined stop boundary."""
+        pending = set(self._tasks)
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in sorted(done, key=self._order.__getitem__):
+                    self.consume(task, consumer)
+                    if should_stop is not None and should_stop():
+                        self.settle(consumer, propagate=True)
+                        return True
+            return False
+        except asyncio.CancelledError:
+            self.settle(consumer, propagate=False)
+            raise
+        except BaseException:  # noqa: BLE001 - make sibling tasks safe before propagation
+            self.settle(consumer, propagate=False)
+            raise
+
+
 @dataclass
 class VoteCollectorConfig:
     """Configuration for VoteCollector."""
@@ -253,17 +383,21 @@ class VoteCollector:
                 return (agent, e)
 
         vote_tasks = [asyncio.create_task(cast_vote(agent)) for agent in ctx.agents]
+        owner = _VoteTaskOwner(vote_tasks)
 
-        for completed_task in asyncio.as_completed(vote_tasks):
+        def consume_vote(completed_task: asyncio.Task[Any]) -> None:
             try:
-                agent, vote_result = await completed_task
+                agent, vote_result = completed_task.result()
             except asyncio.CancelledError:
                 raise
             except Exception as e:  # noqa: BLE001 - phase isolation
                 logger.error(
                     "task_exception phase=vote_permutation perm=%s error=%s", permutation_idx, e
                 )
-                continue
+                return
+
+            if isinstance(vote_result, BaseException) and not isinstance(vote_result, Exception):
+                raise vote_result
 
             if vote_result is None or isinstance(vote_result, Exception):
                 if isinstance(vote_result, Exception):
@@ -272,6 +406,8 @@ class VoteCollector:
                     )
             else:
                 votes.append(vote_result)
+
+        await owner.run(consume_vote)
 
         return votes
 
@@ -414,16 +550,22 @@ class VoteCollector:
             """Collect votes from all agents concurrently with RLM early termination."""
             total_agents = len(ctx.agents)
             vote_tasks = [asyncio.create_task(cast_vote(agent)) for agent in ctx.agents]
-            early_terminated = False
+            owner = _VoteTaskOwner(vote_tasks)
+            early_leader: str | None = None
 
-            for completed_task in asyncio.as_completed(vote_tasks):
+            def consume_vote(completed_task: asyncio.Task[Any]) -> None:
                 try:
-                    agent, vote_result = await completed_task
+                    agent, vote_result = completed_task.result()
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:  # noqa: BLE001 - phase isolation
                     logger.error("task_exception phase=vote error=%s", e)
-                    continue
+                    return
+
+                if isinstance(vote_result, BaseException) and not isinstance(
+                    vote_result, Exception
+                ):
+                    raise vote_result
 
                 if vote_result is None or isinstance(vote_result, Exception):
                     if isinstance(vote_result, Exception):
@@ -441,35 +583,34 @@ class VoteCollector:
                     votes.append(vote_result)
                     self._handle_vote_success(ctx, agent, vote_result)
 
-                    # RLM early termination check
-                    has_majority, leader = self._check_clear_majority(votes, total_agents)
-                    if has_majority:
-                        # Cancel remaining tasks - we have a clear winner
-                        for task in vote_tasks:
-                            if not task.done():
-                                task.cancel()
-                        early_terminated = True
+            def should_stop() -> bool:
+                nonlocal early_leader
+                has_majority, leader = self._check_clear_majority(votes, total_agents)
+                if has_majority:
+                    early_leader = leader
+                return has_majority
 
-                        # Notify spectator about early termination
-                        if self._notify_spectator:
-                            self._notify_spectator(
-                                "rlm_early_termination",
-                                details=f"Clear majority for '{leader}' ({len(votes)}/{total_agents} votes)",
-                                metric=len(votes) / total_agents,
-                                agent="system",
-                            )
-
-                        # Emit hook for WebSocket clients
-                        if "on_rlm_early_termination" in self.hooks:
-                            self.hooks["on_rlm_early_termination"](
-                                leader=leader,
-                                votes_collected=len(votes),
-                                total_agents=total_agents,
-                            )
-
-                        break  # Exit collection loop
+            early_terminated = await owner.run(consume_vote, should_stop)
 
             if early_terminated:
+                if self._notify_spectator:
+                    self._notify_spectator(
+                        "rlm_early_termination",
+                        details=(
+                            f"Clear majority for '{early_leader}' "
+                            f"({len(votes)}/{total_agents} votes)"
+                        ),
+                        metric=len(votes) / total_agents,
+                        agent="system",
+                    )
+
+                if "on_rlm_early_termination" in self.hooks:
+                    self.hooks["on_rlm_early_termination"](
+                        leader=early_leader,
+                        votes_collected=len(votes),
+                        total_agents=total_agents,
+                    )
+
                 logger.info(
                     "vote_collection_early_terminated collected=%s total_agents=%s",
                     len(votes),
@@ -542,16 +683,23 @@ class VoteCollector:
             """Collect votes from all agents with error counting for unanimity checks."""
             nonlocal voting_errors
             vote_tasks = [asyncio.create_task(cast_vote(agent)) for agent in ctx.agents]
+            owner = _VoteTaskOwner(vote_tasks)
 
-            for completed_task in asyncio.as_completed(vote_tasks):
+            def consume_vote(completed_task: asyncio.Task[Any]) -> None:
+                nonlocal voting_errors
                 try:
-                    agent, vote_result = await completed_task
+                    agent, vote_result = completed_task.result()
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:  # noqa: BLE001 - phase isolation
                     logger.error("task_exception phase=unanimous_vote error=%s", e)
                     voting_errors += 1
-                    continue
+                    return
+
+                if isinstance(vote_result, BaseException) and not isinstance(
+                    vote_result, Exception
+                ):
+                    raise vote_result
 
                 if vote_result is None or isinstance(vote_result, Exception):
                     if isinstance(vote_result, Exception):
@@ -571,6 +719,8 @@ class VoteCollector:
                 else:
                     votes.append(vote_result)
                     self._handle_vote_success(ctx, agent, vote_result, unanimous=True)
+
+            await owner.run(consume_vote)
 
         # Apply outer timeout to prevent N*agent_timeout runaway
         try:

--- a/tests/debate/phases/test_vote_collector.py
+++ b/tests/debate/phases/test_vote_collector.py
@@ -29,6 +29,7 @@ from aragora.debate.phases.vote_collector import (
     RLM_EARLY_TERMINATION_THRESHOLD,
     RLM_MAJORITY_LEAD_THRESHOLD,
     VOTE_COLLECTION_TIMEOUT,
+    _VoteTaskOwner,
     VoteCollector,
     VoteCollectorConfig,
     create_vote_collector,
@@ -426,6 +427,156 @@ class TestTimeoutHandling:
         # agent1 vote should be returned, agent2 timed out
         assert len(votes) >= 0  # At least tried
 
+    @pytest.mark.asyncio
+    async def test_timeout_observes_late_task_failures(self, mock_governor):
+        """Timeout detaches every child and reports only late control flow."""
+
+        class VoteAbort(BaseException):
+            pass
+
+        release = asyncio.Event()
+        loop_contexts: list[dict[str, Any]] = []
+
+        async def delayed_failure(agent, proposals, task):
+            if agent.name == "agent0":
+                return make_vote(agent=agent.name)
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                await release.wait()
+            if agent.name == "agent1":
+                raise RuntimeError("late ordinary failure")
+            raise VoteAbort("late control flow")
+
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=delayed_failure,
+                vote_collection_timeout=0.02,
+                enable_rlm_early_termination=False,
+            )
+        )
+        ctx = make_context(agents=[MockAgent(name=f"agent{i}") for i in range(3)])
+        loop = asyncio.get_running_loop()
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+
+        try:
+            with patch(
+                "aragora.debate.phases.vote_collector.get_complexity_governor",
+                return_value=mock_governor,
+            ):
+                votes = await asyncio.wait_for(collector.collect_votes(ctx), timeout=0.2)
+
+            assert [vote.agent for vote in votes] == ["agent0"]
+            release.set()
+            await asyncio.sleep(0.02)
+            assert [type(context.get("exception")) for context in loop_contexts] == [VoteAbort]
+            assert all(
+                context.get("message") != "Task exception was never retrieved"
+                for context in loop_contexts
+            )
+        finally:
+            release.set()
+            await asyncio.sleep(0)
+            loop.set_exception_handler(old_handler)
+
+    @pytest.mark.asyncio
+    async def test_caller_cancellation_observes_owned_vote_tasks(self, mock_governor):
+        """Caller cancellation is prompt while child outcomes remain observed."""
+
+        class VoteAbort(BaseException):
+            pass
+
+        release = asyncio.Event()
+        all_started = asyncio.Event()
+        started = 0
+        loop_contexts: list[dict[str, Any]] = []
+
+        async def delayed_failure(agent, proposals, task):
+            nonlocal started
+            started += 1
+            if started == 2:
+                all_started.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                await release.wait()
+            if agent.name == "agent0":
+                raise RuntimeError("late ordinary failure")
+            raise VoteAbort("late control flow")
+
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=delayed_failure,
+                enable_rlm_early_termination=False,
+            )
+        )
+        ctx = make_context(agents=[MockAgent(name=f"agent{i}") for i in range(2)])
+        loop = asyncio.get_running_loop()
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+
+        try:
+            with patch(
+                "aragora.debate.phases.vote_collector.get_complexity_governor",
+                return_value=mock_governor,
+            ):
+                collection = asyncio.create_task(collector.collect_votes(ctx))
+                await asyncio.wait_for(all_started.wait(), timeout=0.2)
+                collection.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(collection, timeout=0.2)
+
+            release.set()
+            await asyncio.sleep(0.02)
+            assert [type(context.get("exception")) for context in loop_contexts] == [VoteAbort]
+            assert all(
+                context.get("message") != "Task exception was never retrieved"
+                for context in loop_contexts
+            )
+        finally:
+            release.set()
+            await asyncio.sleep(0)
+            loop.set_exception_handler(old_handler)
+
+
+class TestVoteTaskOwnership:
+    """Exact-once lifecycle tests independent of vote semantics."""
+
+    @pytest.mark.asyncio
+    async def test_completion_winning_cancel_race_is_consumed_once(self):
+        """A task that completes while cancel loses is consumed, not detached."""
+        task = MagicMock(spec=asyncio.Task)
+        task.done.side_effect = [False, True]
+        task.cancel.return_value = False
+        consume = MagicMock()
+        owner = _VoteTaskOwner([task])
+
+        owner.settle(consume, propagate=True)
+        owner.settle(consume, propagate=True)
+
+        consume.assert_called_once_with(task)
+        task.add_done_callback.assert_not_called()
+        assert owner.classification(task) == "consumed"
+
+    @pytest.mark.asyncio
+    async def test_completed_control_flow_propagates(self):
+        """A completed control-flow failure is never downgraded to a skip."""
+
+        class VoteAbort(BaseException):
+            pass
+
+        async def abort():
+            raise VoteAbort("completed control flow")
+
+        task = asyncio.create_task(abort())
+        await asyncio.sleep(0)
+        owner = _VoteTaskOwner([task])
+
+        with pytest.raises(VoteAbort, match="completed control flow"):
+            owner.settle(lambda completed: completed.result(), propagate=True)
+        assert owner.classification(task) == "consumed"
+
 
 # =============================================================================
 # RLM Early Termination Tests
@@ -675,6 +826,65 @@ class TestRLMEarlyTermination:
         early_term_notifs = [n for n in notifications if n[0] == "rlm_early_termination"]
         assert len(early_term_notifs) == 1
 
+    @pytest.mark.asyncio
+    async def test_early_stop_observes_delayed_cancellation_cleanup(self):
+        """Early stop returns promptly and observes every detached voter."""
+
+        class VoteAbort(BaseException):
+            pass
+
+        release_cleanup = asyncio.Event()
+        loop_contexts: list[dict[str, Any]] = []
+        hook = MagicMock()
+
+        async def mock_vote(agent, proposals, task):
+            agent_number = int(agent.name.removeprefix("agent"))
+            if agent_number < 6:
+                return make_vote(agent=agent.name, choice="winner")
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await release_cleanup.wait()
+            if agent_number == 6:
+                return make_vote(agent=agent.name, choice="late")
+            if agent_number == 7:
+                raise RuntimeError("late cleanup")
+            if agent_number == 8:
+                raise VoteAbort("late control flow")
+            return None
+
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=mock_vote,
+                hooks={"on_rlm_early_termination": hook},
+                enable_rlm_early_termination=True,
+                rlm_early_termination_threshold=0.5,
+                rlm_majority_lead_threshold=0.1,
+                vote_collection_timeout=1.0,
+            )
+        )
+        ctx = make_context(agents=[MockAgent(name=f"agent{i}") for i in range(10)])
+        loop = asyncio.get_running_loop()
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+
+        try:
+            votes = await asyncio.wait_for(collector.collect_votes(ctx), timeout=0.2)
+            assert len(votes) == 6
+            hook.assert_called_once_with(leader="winner", votes_collected=6, total_agents=10)
+
+            release_cleanup.set()
+            await asyncio.sleep(0.02)
+            assert [type(context.get("exception")) for context in loop_contexts] == [VoteAbort]
+            assert all(
+                context.get("message") != "Task exception was never retrieved"
+                for context in loop_contexts
+            )
+        finally:
+            release_cleanup.set()
+            await asyncio.sleep(0)
+            loop.set_exception_handler(old_handler)
+
 
 # =============================================================================
 # Position Shuffling Tests
@@ -809,6 +1019,52 @@ class TestPositionShuffling:
 
         # Should timeout and return empty
         assert votes == []
+
+    @pytest.mark.asyncio
+    async def test_position_shuffling_timeout_observes_child_task(self, mock_governor):
+        """The outer shuffling timeout cannot orphan a permutation voter."""
+
+        class VoteAbort(BaseException):
+            pass
+
+        release = asyncio.Event()
+        loop_contexts: list[dict[str, Any]] = []
+
+        async def late_abort(agent, proposals, task):
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                await release.wait()
+            raise VoteAbort("late shuffled control flow")
+
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=late_abort,
+                vote_collection_timeout=0.01,
+                enable_position_shuffling=True,
+                position_shuffling_permutations=1,
+            )
+        )
+        loop = asyncio.get_running_loop()
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+
+        try:
+            with patch(
+                "aragora.debate.phases.vote_collector.get_complexity_governor",
+                return_value=mock_governor,
+            ):
+                assert await collector.collect_votes(make_context()) == []
+            release.set()
+            await asyncio.sleep(0.02)
+            assert [context.get("message") for context in loop_contexts] == [
+                "Detached vote task raised a control-flow exception",
+                "Detached vote task raised a control-flow exception",
+            ]
+        finally:
+            release.set()
+            await asyncio.sleep(0)
+            loop.set_exception_handler(old_handler)
 
 
 # =============================================================================
@@ -1113,6 +1369,53 @@ class TestCollectVotesWithErrors:
 
         # The slow agent should timeout
         assert errors >= 1
+
+    @pytest.mark.asyncio
+    async def test_unanimous_timeout_observes_late_control_flow(self, mock_governor):
+        """Unanimous timeout counts the missing vote and observes its task."""
+
+        class VoteAbort(BaseException):
+            pass
+
+        release = asyncio.Event()
+        loop_contexts: list[dict[str, Any]] = []
+
+        async def vote_or_abort(agent, proposals, task):
+            if agent.name == "agent0":
+                return make_vote(agent=agent.name)
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                await release.wait()
+            raise VoteAbort("late unanimous control flow")
+
+        collector = VoteCollector(
+            VoteCollectorConfig(
+                vote_with_agent=vote_or_abort,
+                vote_collection_timeout=0.01,
+            )
+        )
+        ctx = make_context(agents=[MockAgent(name=f"agent{i}") for i in range(2)])
+        loop = asyncio.get_running_loop()
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+
+        try:
+            with patch(
+                "aragora.debate.phases.vote_collector.get_complexity_governor",
+                return_value=mock_governor,
+            ):
+                votes, errors = await collector.collect_votes_with_errors(ctx)
+            assert ([vote.agent for vote in votes], errors) == (["agent0"], 1)
+            release.set()
+            await asyncio.sleep(0.02)
+            assert [context.get("message") for context in loop_contexts] == [
+                "Detached vote task raised a control-flow exception"
+            ]
+        finally:
+            release.set()
+            await asyncio.sleep(0)
+            loop.set_exception_handler(old_handler)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Own the lifecycle of vote tasks created by `VoteCollector` so every task is
consumed or intentionally detached exactly once across completion, early stop,
timeout, caller cancellation, and cancellation races.

This is the first of two bounded replacements for parked PR #9912. It deliberately
does not implement the separately authorized immutable-majority-snapshot contract.

## Scope

- centralize task ownership and result observation inside `vote_collector.py`
- preserve completed vote work at terminal collection boundaries
- retrieve late ordinary exceptions and report late control-flow failures safely
- deterministic regression and mutation coverage in the existing focused tests

## Explicit non-scope

- roster or identity snapshots
- threshold, quorum, weighting, normalization, participation, or winner changes
- PR #9912 mutation
- workflows, governance, dependencies, evidence, settlement, or merge

## Validation

- focused collector suites: 80 passed
- expanded collector/consensus suites: 355 passed
- debate orchestrator/integration suites: 408 passed
- mutation breaks: detached observer, cancel-race consumption, and completed
  control-flow propagation each failed when removed, then were reverted
- Ruff format/lint, changed-file mypy, diff hygiene, and code-quality ratchet: pass
- version, SDK parity, cross-SDK parity, generated OpenAPI, and route validation: pass
- the legacy local `make ci-required` target stops at its unbaselined full-mypy
  invocation with 1,756 ambient errors in 467 untouched files; the CI-aligned
  changed-file mypy command passes for the only touched source file

## Independent terminal review

At exact head `5ee051b2bc485578730f24152dff8d7a1c59d0fe`, the independent
non-countable reviewer found no P0-P3 issues. The reviewer independently verified
66 focused tests, Ruff, changed-source mypy, diff hygiene, and unchanged local,
remote, and PR heads before and after review.

All five non-quorum protected checks are green. The PR remains draft,
mergeable, and `CLEAN` for exact-head OWNER settlement; no evidence collection,
settlement, or merge was performed by this lane.

## Authority

OWNER explicitly classified and authorized this bounded replacement as Tier 2.
