### PR TITLE
feat(evaluation): add canonical development batch planner v2

### DIFF
--- a/aragora/evaluation/outcome_backed_batch.py
+++ b/aragora/evaluation/outcome_backed_batch.py
@@ -1,0 +1,312 @@
+"""Deterministic, outcome-blind development batching for the benchmark."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from aragora.evaluation.outcome_backed_corpus import (
+    BENCHMARK_ID,
+    SPLIT_COUNTS,
+    canonical_json_sha256,
+)
+from aragora.evaluation.outcome_backed_packets import PACKET_SET_SCHEMA
+
+
+DEVELOPMENT_PLAN_SCHEMA = "outcome-backed-development-plan/1.0"
+DEFAULT_BATCH_SIZE = 4
+
+_PACKET_SET_KEYS = frozenset(
+    {
+        "schema_version",
+        "benchmark_id",
+        "split",
+        "packet_count",
+        "source_count",
+        "packets",
+        "packet_set_sha256",
+    }
+)
+_PACKET_ENTRY_KEYS = frozenset({"case_id", "packet_sha256"})
+_PLAN_KEYS = frozenset(
+    {
+        "schema_version",
+        "benchmark_id",
+        "split",
+        "packet_set_sha256",
+        "case_count",
+        "batch_size",
+        "batch_count",
+        "batches",
+        "plan_sha256",
+    }
+)
+_BATCH_KEYS = frozenset({"batch_id", "case_ids"})
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+
+class DevelopmentBatchPlanError(ValueError):
+    """Raised when a development packet set cannot be planned safely."""
+
+
+def _object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DevelopmentBatchPlanError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _mapping(value: object, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise DevelopmentBatchPlanError(f"{field} must be an object")
+    return value
+
+
+def _integer(value: object, field: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise DevelopmentBatchPlanError(f"{field} must be an integer >= {minimum}")
+    return value
+
+
+def _text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DevelopmentBatchPlanError(f"{field} must be a non-empty string")
+    return value
+
+
+def _sha256(value: object, field: str) -> str:
+    digest = _text(value, field)
+    if not _SHA256_RE.fullmatch(digest):
+        raise DevelopmentBatchPlanError(f"{field} must be a lowercase SHA-256")
+    return digest
+
+
+def _canonical_batch_sizes(case_count: int, batch_size: int) -> tuple[int, ...]:
+    """Return the only valid batch geometry for a case count and batch size."""
+
+    batch_count = (case_count + batch_size - 1) // batch_size
+    final_size = case_count - batch_size * (batch_count - 1)
+    return (batch_size,) * (batch_count - 1) + (final_size,)
+
+
+def load_packet_set_manifest(path: Path | str) -> Mapping[str, Any]:
+    """Load one packet-set manifest while rejecting duplicate JSON keys."""
+
+    source = Path(path)
+    try:
+        value = json.loads(source.read_text(encoding="utf-8"), object_pairs_hook=_object_pairs)
+    except DevelopmentBatchPlanError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DevelopmentBatchPlanError(f"cannot load packet-set manifest {source}: {exc}") from exc
+    return _mapping(value, "packet-set manifest")
+
+
+def validate_development_packet_set(manifest: Mapping[str, Any]) -> tuple[str, tuple[str, ...]]:
+    """Validate and return the development packet-set digest and case IDs."""
+
+    if set(manifest) != _PACKET_SET_KEYS:
+        raise DevelopmentBatchPlanError("packet-set manifest has unexpected or missing fields")
+    if manifest.get("schema_version") != PACKET_SET_SCHEMA:
+        raise DevelopmentBatchPlanError("packet-set schema version mismatch")
+    if manifest.get("benchmark_id") != BENCHMARK_ID:
+        raise DevelopmentBatchPlanError("packet-set benchmark mismatch")
+    if manifest.get("split") != "development":
+        raise DevelopmentBatchPlanError("packet-set split must be development")
+
+    expected = SPLIT_COUNTS["development"]
+    if _integer(manifest.get("packet_count"), "packet_count") != expected:
+        raise DevelopmentBatchPlanError(f"packet-set must contain exactly {expected} packets")
+    _integer(manifest.get("source_count"), "source_count", minimum=1)
+
+    raw_packets = manifest.get("packets")
+    if not isinstance(raw_packets, list) or len(raw_packets) != expected:
+        raise DevelopmentBatchPlanError(f"packets must contain exactly {expected} entries")
+    case_ids: list[str] = []
+    for index, raw_entry in enumerate(raw_packets):
+        entry = _mapping(raw_entry, f"packets[{index}]")
+        if set(entry) != _PACKET_ENTRY_KEYS:
+            raise DevelopmentBatchPlanError(f"packets[{index}] has unexpected or missing fields")
+        case_id = _text(entry.get("case_id"), f"packets[{index}].case_id")
+        if not _SAFE_ID_RE.fullmatch(case_id):
+            raise DevelopmentBatchPlanError(f"packets[{index}].case_id is unsafe")
+        _sha256(entry.get("packet_sha256"), f"packets[{index}].packet_sha256")
+        case_ids.append(case_id)
+    if case_ids != sorted(case_ids) or len(set(case_ids)) != len(case_ids):
+        raise DevelopmentBatchPlanError("packet case IDs must be unique and sorted")
+
+    claimed_hash = _sha256(manifest.get("packet_set_sha256"), "packet_set_sha256")
+    unhashed = dict(manifest)
+    unhashed.pop("packet_set_sha256")
+    if canonical_json_sha256(unhashed) != claimed_hash:
+        raise DevelopmentBatchPlanError("packet-set manifest hash mismatch")
+    return claimed_hash, tuple(case_ids)
+
+
+def _visible_case_ids(
+    cases: Sequence[Mapping[str, Any]],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    development: list[str] = []
+    holdout: list[str] = []
+    all_ids: set[str] = set()
+    for index, case in enumerate(cases):
+        case_id = _text(case.get("case_id"), f"cases[{index}].case_id")
+        if case_id in all_ids:
+            raise DevelopmentBatchPlanError(f"duplicate visible case ID: {case_id}")
+        all_ids.add(case_id)
+        split = case.get("split")
+        if split == "development":
+            development.append(case_id)
+        elif split == "holdout":
+            holdout.append(case_id)
+        else:
+            raise DevelopmentBatchPlanError(f"unsupported split for visible case {case_id}")
+    for split, values in (("development", development), ("holdout", holdout)):
+        expected = SPLIT_COUNTS[split]
+        if len(values) != expected:
+            raise DevelopmentBatchPlanError(
+                f"visible corpus must contain exactly {expected} {split} cases"
+            )
+    return tuple(sorted(development)), tuple(sorted(holdout))
+
+
+def build_development_plan(
+    cases: Sequence[Mapping[str, Any]],
+    packet_set: Mapping[str, Any],
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> dict[str, object]:
+    """Build a deterministic plan for development cases without opening outcomes."""
+
+    expected = SPLIT_COUNTS["development"]
+    if (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or not 1 <= batch_size <= expected
+    ):
+        raise DevelopmentBatchPlanError(f"batch_size must be an integer from 1 to {expected}")
+
+    packet_set_sha256, packet_case_ids = validate_development_packet_set(packet_set)
+    development_ids, holdout_ids = _visible_case_ids(cases)
+    if packet_case_ids != development_ids:
+        raise DevelopmentBatchPlanError(
+            "packet-set case IDs do not match the visible development corpus"
+        )
+    if set(packet_case_ids) & set(holdout_ids):
+        raise DevelopmentBatchPlanError("development packet set contains a holdout case")
+
+    batches = [
+        {
+            "batch_id": f"development-{index // batch_size + 1:02d}",
+            "case_ids": list(development_ids[index : index + batch_size]),
+        }
+        for index in range(0, len(development_ids), batch_size)
+    ]
+    plan: dict[str, object] = {
+        "schema_version": DEVELOPMENT_PLAN_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "split": "development",
+        "packet_set_sha256": packet_set_sha256,
+        "case_count": len(development_ids),
+        "batch_size": batch_size,
+        "batch_count": len(batches),
+        "batches": batches,
+    }
+    plan["plan_sha256"] = canonical_json_sha256(plan)
+    return plan
+
+
+def validate_development_plan(
+    plan: Mapping[str, Any],
+    *,
+    cases: Sequence[Mapping[str, Any]] | None = None,
+    packet_set: Mapping[str, Any] | None = None,
+) -> str:
+    """Validate a plan and optionally rebind it to its source artifacts."""
+
+    if set(plan) != _PLAN_KEYS:
+        raise DevelopmentBatchPlanError("development plan has unexpected or missing fields")
+    if plan.get("schema_version") != DEVELOPMENT_PLAN_SCHEMA:
+        raise DevelopmentBatchPlanError("development plan schema version mismatch")
+    if plan.get("benchmark_id") != BENCHMARK_ID or plan.get("split") != "development":
+        raise DevelopmentBatchPlanError("development plan identity mismatch")
+    _sha256(plan.get("packet_set_sha256"), "packet_set_sha256")
+    case_count = _integer(plan.get("case_count"), "case_count")
+    if case_count != SPLIT_COUNTS["development"]:
+        raise DevelopmentBatchPlanError("development plan case count mismatch")
+    batch_size = _integer(plan.get("batch_size"), "batch_size", minimum=1)
+    if batch_size > case_count:
+        raise DevelopmentBatchPlanError(
+            f"batch_size must not exceed {case_count} development cases"
+        )
+
+    expected_sizes = _canonical_batch_sizes(case_count, batch_size)
+    batch_count = _integer(plan.get("batch_count"), "batch_count", minimum=1)
+    if batch_count != len(expected_sizes):
+        raise DevelopmentBatchPlanError(
+            f"development plan must contain exactly {len(expected_sizes)} canonical batches"
+        )
+    raw_batches = plan.get("batches")
+    if not isinstance(raw_batches, list) or len(raw_batches) != batch_count:
+        raise DevelopmentBatchPlanError("development plan batch count mismatch")
+
+    planned_ids: list[str] = []
+    for index, (raw_batch, expected_size) in enumerate(
+        zip(raw_batches, expected_sizes, strict=True), start=1
+    ):
+        batch = _mapping(raw_batch, f"batches[{index - 1}]")
+        if set(batch) != _BATCH_KEYS or batch.get("batch_id") != f"development-{index:02d}":
+            raise DevelopmentBatchPlanError(f"invalid development batch at index {index - 1}")
+        case_ids = batch.get("case_ids")
+        if not isinstance(case_ids, list) or len(case_ids) != expected_size:
+            raise DevelopmentBatchPlanError(
+                f"batch {index} must contain exactly {expected_size} case IDs"
+            )
+        for case_index, value in enumerate(case_ids):
+            case_id = _text(value, f"batches[{index - 1}].case_ids[{case_index}]")
+            if not _SAFE_ID_RE.fullmatch(case_id):
+                raise DevelopmentBatchPlanError(f"unsafe case ID in batch {index}")
+            planned_ids.append(case_id)
+    if len(planned_ids) != case_count or planned_ids != sorted(planned_ids):
+        raise DevelopmentBatchPlanError("planned case IDs must be complete, unique, and sorted")
+    if len(set(planned_ids)) != len(planned_ids):
+        raise DevelopmentBatchPlanError("development plan contains duplicate case IDs")
+
+    claimed_hash = _sha256(plan.get("plan_sha256"), "plan_sha256")
+    unhashed = dict(plan)
+    unhashed.pop("plan_sha256")
+    if canonical_json_sha256(unhashed) != claimed_hash:
+        raise DevelopmentBatchPlanError("development plan hash mismatch")
+
+    if (cases is None) != (packet_set is None):
+        raise DevelopmentBatchPlanError(
+            "independent plan verification requires both cases and packet_set"
+        )
+    if cases is not None and packet_set is not None:
+        canonical = build_development_plan(cases, packet_set, batch_size=batch_size)
+        if dict(plan) != canonical:
+            raise DevelopmentBatchPlanError("development plan does not match canonical batching")
+    return claimed_hash
+
+
+def write_development_plan(
+    path: Path | str,
+    plan: Mapping[str, Any],
+    *,
+    cases: Sequence[Mapping[str, Any]] | None = None,
+    packet_set: Mapping[str, Any] | None = None,
+) -> None:
+    """Validate and atomically write a development plan."""
+
+    validate_development_plan(plan, cases=cases, packet_set=packet_set)
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_suffix(target.suffix + ".tmp")
+    temporary.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(target)

--- a/scripts/plan_outcome_backed_development.py
+++ b/scripts/plan_outcome_backed_development.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Build an outcome-blind deterministic plan for development benchmark cases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.evaluation.outcome_backed_batch import (  # noqa: E402
+    DEFAULT_BATCH_SIZE,
+    DevelopmentBatchPlanError,
+    build_development_plan,
+    load_packet_set_manifest,
+    write_development_plan,
+)
+from aragora.evaluation.outcome_backed_corpus import (  # noqa: E402
+    VisibleCorpusError,
+    load_visible_cases,
+)
+
+
+DEFAULT_CORPUS_DIR = Path("docs/benchmarks/decision_quality/tranches")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus-dir", type=Path, default=DEFAULT_CORPUS_DIR)
+    parser.add_argument("--packet-set", type=Path, required=True)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--json", action="store_true", help="emit the complete plan")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        cases = load_visible_cases(args.corpus_dir)
+        packet_set = load_packet_set_manifest(args.packet_set)
+        plan = build_development_plan(cases, packet_set, batch_size=args.batch_size)
+        if args.output is not None:
+            write_development_plan(args.output, plan, cases=cases, packet_set=packet_set)
+    except (DevelopmentBatchPlanError, VisibleCorpusError, OSError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        destination = f" -> {args.output}" if args.output is not None else ""
+        print(
+            f"PASS: planned {plan['case_count']} development cases in "
+            f"{plan['batch_count']} batches{destination}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/evaluation/test_outcome_backed_batch.py
+++ b/tests/evaluation/test_outcome_backed_batch.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.evaluation.outcome_backed_batch import (
+    DevelopmentBatchPlanError,
+    build_development_plan,
+    load_packet_set_manifest,
+    validate_development_plan,
+)
+from aragora.evaluation.outcome_backed_corpus import (
+    BENCHMARK_ID,
+    canonical_json_sha256,
+    load_visible_cases,
+)
+from aragora.evaluation.outcome_backed_packets import PACKET_SET_SCHEMA
+
+
+CORPUS_DIR = Path("docs/benchmarks/decision_quality/tranches")
+
+
+def _cases() -> list[dict[str, str]]:
+    return [{"case_id": f"dev-{index:02d}", "split": "development"} for index in range(16)] + [
+        {"case_id": f"hold-{index:02d}", "split": "holdout"} for index in range(8)
+    ]
+
+
+def _packet_set(case_ids: list[str] | None = None) -> dict[str, object]:
+    ids = case_ids or [f"dev-{index:02d}" for index in range(16)]
+    manifest: dict[str, object] = {
+        "schema_version": PACKET_SET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "split": "development",
+        "packet_count": len(ids),
+        "source_count": 20,
+        "packets": [
+            {"case_id": case_id, "packet_sha256": f"{index + 1:064x}"}
+            for index, case_id in enumerate(ids)
+        ],
+    }
+    manifest["packet_set_sha256"] = canonical_json_sha256(manifest)
+    return manifest
+
+
+def _rehash(plan: dict[str, object]) -> None:
+    plan["plan_sha256"] = canonical_json_sha256(
+        {key: value for key, value in plan.items() if key != "plan_sha256"}
+    )
+
+
+def test_build_development_plan_is_deterministic_and_outcome_blind() -> None:
+    forward = build_development_plan(_cases(), _packet_set())
+    reverse = build_development_plan(list(reversed(_cases())), _packet_set())
+
+    assert forward == reverse
+    assert forward["case_count"] == 16
+    assert forward["batch_count"] == 4
+    assert [batch["batch_id"] for batch in forward["batches"]] == [
+        "development-01",
+        "development-02",
+        "development-03",
+        "development-04",
+    ]
+    assert all(
+        str(case_id).startswith("dev-")
+        for batch in forward["batches"]
+        for case_id in batch["case_ids"]
+    )
+    assert validate_development_plan(forward) == forward["plan_sha256"]
+    assert (
+        validate_development_plan(forward, cases=_cases(), packet_set=_packet_set())
+        == forward["plan_sha256"]
+    )
+
+
+def test_current_corpus_defines_the_canonical_first_batch() -> None:
+    cases = load_visible_cases(CORPUS_DIR)
+    development_ids = sorted(
+        str(case["case_id"]) for case in cases if case["split"] == "development"
+    )
+    plan = build_development_plan(cases, _packet_set(development_ids))
+
+    assert plan["batches"][0]["case_ids"] == [
+        "biz-dev-adobe-figma-close",
+        "biz-dev-jetblue-spirit-close",
+        "biz-dev-microsoft-activision-close",
+        "biz-dev-twitter-merger-close",
+    ]
+
+
+def test_build_development_plan_supports_bounded_final_batch() -> None:
+    plan = build_development_plan(_cases(), _packet_set(), batch_size=6)
+
+    assert [len(batch["case_ids"]) for batch in plan["batches"]] == [6, 6, 4]
+    assert plan["batch_count"] == 3
+    assert validate_development_plan(plan) == plan["plan_sha256"]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda manifest: manifest.update(split="holdout"), "split must be development"),
+        (lambda manifest: manifest.update(packet_set_sha256="0" * 64), "hash mismatch"),
+        (
+            lambda manifest: manifest["packets"].reverse(),
+            "case IDs must be unique and sorted",
+        ),
+    ],
+)
+def test_packet_set_validation_fails_closed(mutate, match: str) -> None:
+    manifest = _packet_set()
+    mutate(manifest)
+
+    with pytest.raises(DevelopmentBatchPlanError, match=match):
+        build_development_plan(_cases(), manifest)
+
+
+def test_build_rejects_packet_case_set_drift_even_with_valid_manifest_hash() -> None:
+    ids = [f"dev-{index:02d}" for index in range(15)] + ["unknown-case"]
+    manifest = _packet_set(sorted(ids))
+
+    with pytest.raises(DevelopmentBatchPlanError, match="do not match"):
+        build_development_plan(_cases(), manifest)
+
+
+def test_build_rejects_holdout_case_in_development_packets() -> None:
+    ids = [f"dev-{index:02d}" for index in range(15)] + ["hold-00"]
+    manifest = _packet_set(sorted(ids))
+
+    with pytest.raises(DevelopmentBatchPlanError, match="do not match"):
+        build_development_plan(_cases(), manifest)
+
+
+def test_validate_development_plan_rejects_tampering() -> None:
+    plan = build_development_plan(_cases(), _packet_set())
+    plan["batches"][0]["case_ids"][0] = "dev-tampered"
+
+    with pytest.raises(DevelopmentBatchPlanError):
+        validate_development_plan(plan)
+
+
+def test_source_less_validation_rejects_rehashed_noncanonical_batch_count() -> None:
+    plan = build_development_plan(_cases(), _packet_set())
+    case_ids = [case_id for batch in plan["batches"] for case_id in batch["case_ids"]]
+    boundaries = (1, 5, 9, 13, 16)
+    plan["batches"] = [
+        {
+            "batch_id": f"development-{index + 1:02d}",
+            "case_ids": case_ids[start:end],
+        }
+        for index, (start, end) in enumerate(zip((0, *boundaries[:-1]), boundaries, strict=True))
+    ]
+    plan["batch_count"] = len(plan["batches"])
+    _rehash(plan)
+
+    with pytest.raises(DevelopmentBatchPlanError, match="exactly 4 canonical batches"):
+        validate_development_plan(plan)
+
+
+def test_source_less_validation_rejects_rehashed_noncanonical_batch_sizes() -> None:
+    plan = build_development_plan(_cases(), _packet_set(), batch_size=6)
+    case_ids = [case_id for batch in plan["batches"] for case_id in batch["case_ids"]]
+    boundaries = (5, 11, 16)
+    plan["batches"] = [
+        {
+            "batch_id": f"development-{index + 1:02d}",
+            "case_ids": case_ids[start:end],
+        }
+        for index, (start, end) in enumerate(zip((0, *boundaries[:-1]), boundaries, strict=True))
+    ]
+    _rehash(plan)
+
+    with pytest.raises(DevelopmentBatchPlanError, match="batch 1 must contain exactly 6"):
+        validate_development_plan(plan)
+
+
+def test_independent_validation_rebinds_cases_and_packet_set() -> None:
+    packet_set = _packet_set()
+    plan = build_development_plan(_cases(), packet_set)
+    plan["batches"][0]["case_ids"][0] = "dev-00-replaced"
+    _rehash(plan)
+
+    with pytest.raises(DevelopmentBatchPlanError, match="canonical batching"):
+        validate_development_plan(plan, cases=_cases(), packet_set=packet_set)
+
+
+def test_validation_rejects_batch_size_above_development_count() -> None:
+    packet_set = _packet_set()
+    plan = build_development_plan(_cases(), packet_set)
+    case_ids = [case_id for batch in plan["batches"] for case_id in batch["case_ids"]]
+    plan["batch_size"] = 999
+    plan["batch_count"] = 1
+    plan["batches"] = [{"batch_id": "development-01", "case_ids": case_ids}]
+    _rehash(plan)
+
+    with pytest.raises(DevelopmentBatchPlanError, match="must not exceed 16"):
+        validate_development_plan(plan, cases=_cases(), packet_set=packet_set)
+
+
+def test_independent_validation_requires_both_source_artifacts() -> None:
+    plan = build_development_plan(_cases(), _packet_set())
+
+    with pytest.raises(DevelopmentBatchPlanError, match="requires both"):
+        validate_development_plan(plan, cases=_cases())
+
+
+def test_manifest_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    path = tmp_path / "packet-set.json"
+    path.write_text('{"schema_version":"a","schema_version":"b"}\n', encoding="utf-8")
+
+    with pytest.raises(DevelopmentBatchPlanError, match="duplicate JSON key"):
+        load_packet_set_manifest(path)

--- a/tests/scripts/test_plan_outcome_backed_development.py
+++ b/tests/scripts/test_plan_outcome_backed_development.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from aragora.evaluation.outcome_backed_corpus import (
+    BENCHMARK_ID,
+    canonical_json_sha256,
+    load_visible_cases,
+)
+from aragora.evaluation.outcome_backed_packets import PACKET_SET_SCHEMA
+
+
+CORPUS_DIR = Path("docs/benchmarks/decision_quality/tranches")
+SCRIPT = Path("scripts/plan_outcome_backed_development.py")
+
+
+def _write_manifest(path: Path) -> None:
+    case_ids = sorted(
+        str(case["case_id"])
+        for case in load_visible_cases(CORPUS_DIR)
+        if case["split"] == "development"
+    )
+    manifest: dict[str, object] = {
+        "schema_version": PACKET_SET_SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "split": "development",
+        "packet_count": len(case_ids),
+        "source_count": 20,
+        "packets": [
+            {"case_id": case_id, "packet_sha256": f"{index + 1:064x}"}
+            for index, case_id in enumerate(case_ids)
+        ],
+    }
+    manifest["packet_set_sha256"] = canonical_json_sha256(manifest)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_cli_writes_the_canonical_development_plan(tmp_path: Path) -> None:
+    packet_set = tmp_path / "packet-set.json"
+    output = tmp_path / "development-plan.json"
+    _write_manifest(packet_set)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--corpus-dir",
+            str(CORPUS_DIR),
+            "--packet-set",
+            str(packet_set),
+            "--batch-size",
+            "4",
+            "--output",
+            str(output),
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    rendered = json.loads(result.stdout)
+    persisted = json.loads(output.read_text(encoding="utf-8"))
+    assert persisted == rendered
+    assert rendered["case_count"] == 16
+    assert rendered["batch_count"] == 4
+    assert rendered["batches"][0]["case_ids"] == [
+        "biz-dev-adobe-figma-close",
+        "biz-dev-jetblue-spirit-close",
+        "biz-dev-microsoft-activision-close",
+        "biz-dev-twitter-merger-close",
+    ]
+
+
+def test_cli_fails_closed_on_holdout_packet_set(tmp_path: Path) -> None:
+    packet_set = tmp_path / "packet-set.json"
+    _write_manifest(packet_set)
+    manifest = json.loads(packet_set.read_text(encoding="utf-8"))
+    manifest["split"] = "holdout"
+    manifest["packet_set_sha256"] = canonical_json_sha256(
+        {key: value for key, value in manifest.items() if key != "packet_set_sha256"}
+    )
+    packet_set.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--packet-set", str(packet_set)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "packet-set split must be development" in result.stderr


### PR DESCRIPTION
## Summary
- replace parked #9916 with a current-main deterministic development-batch planner
- enforce canonical batch count and exact non-final/final sizes during standalone validation
- bind plans to the visible development corpus and packet-set digest without opening outcomes
- pin `development-01` to the four sorted business cases

## Validation
- `python3 -m pytest tests/evaluation/test_outcome_backed_*.py tests/scripts/test_*outcome_backed*.py -q` (168 passed)
- `uv run --locked --extra dev python -m mypy aragora/evaluation/outcome_backed_batch.py scripts/plan_outcome_backed_development.py`
- Ruff check and format
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

Replacement for parked PR #9916. Do not close #9916 until this replacement merges. No inference, result-contract, receipt, or runner behavior is included.