### PR TITLE
fix(debate): bind majority decisions to immutable voter snapshot

### DIFF
--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -24,11 +24,13 @@ __all__ = [
 ]
 
 import asyncio
+import copy
 import logging
 import math
 import time
 from collections import Counter
 from dataclasses import dataclass, field, replace
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
@@ -46,6 +48,7 @@ from aragora.debate.phases.vote_collector import (
     VoteCollector,
     VoteCollectorConfig,
     VoterSlot,
+    get_complexity_governor,
 )
 from aragora.debate.phases.weight_calculator import WeightCalculator
 from aragora.debate.phases.winner_selector import WinnerSelector
@@ -102,6 +105,98 @@ class ConsensusCallbacks:
 
 
 @dataclass(frozen=True, slots=True)
+class _UserVoteContribution:
+    """One user-vote contribution resolved before agent voting begins."""
+
+    choice: str
+    intensity: Any
+    user_id: str
+    weight: float
+
+
+@dataclass(frozen=True, slots=True)
+class _VoteWeightPolicy:
+    """Frozen vote-dependent bias controls for one majority decision."""
+
+    enable_self_vote_mitigation: bool
+    self_vote_mode: str
+    self_vote_downweight: float
+    enable_verbosity_normalization: bool
+    verbosity_target_length: int
+    verbosity_penalty_threshold: float
+    verbosity_max_penalty: float
+
+    @classmethod
+    def from_protocol(cls, protocol: Any) -> "_VoteWeightPolicy":
+        return cls(
+            enable_self_vote_mitigation=bool(
+                getattr(protocol, "enable_self_vote_mitigation", False)
+            ),
+            self_vote_mode=str(getattr(protocol, "self_vote_mode", "downweight")),
+            self_vote_downweight=float(getattr(protocol, "self_vote_downweight", 0.5)),
+            enable_verbosity_normalization=bool(
+                getattr(protocol, "enable_verbosity_normalization", False)
+            ),
+            verbosity_target_length=int(getattr(protocol, "verbosity_target_length", 1000)),
+            verbosity_penalty_threshold=float(
+                getattr(protocol, "verbosity_penalty_threshold", 3.0)
+            ),
+            verbosity_max_penalty=float(getattr(protocol, "verbosity_max_penalty", 0.3)),
+        )
+
+    @property
+    def vote_dependent(self) -> bool:
+        return self.enable_self_vote_mitigation or self.enable_verbosity_normalization
+
+    def resolve_slot_weights(
+        self,
+        slots: tuple[VoterSlot, ...],
+        base_slot_weights: tuple[float, ...],
+        ballots: tuple[SlotVote, ...],
+        proposals: dict[str, str],
+    ) -> tuple[float, ...]:
+        """Apply existing bias factors without consulting mutable weight sources."""
+        if not self.vote_dependent:
+            return base_slot_weights
+
+        from aragora.debate.phases.weight_calculator import WeightCalculatorConfig
+
+        config = WeightCalculatorConfig(
+            enable_reputation=False,
+            enable_reliability=True,
+            enable_consistency=False,
+            enable_calibration=False,
+            enable_elo_skill=False,
+            enable_self_vote_mitigation=self.enable_self_vote_mitigation,
+            self_vote_mode=self.self_vote_mode,
+            self_vote_downweight=self.self_vote_downweight,
+            enable_verbosity_normalization=self.enable_verbosity_normalization,
+            verbosity_target_length=self.verbosity_target_length,
+            verbosity_penalty_threshold=self.verbosity_penalty_threshold,
+            verbosity_max_penalty=self.verbosity_max_penalty,
+        )
+        ballots_by_slot = {ballot.slot.index: ballot for ballot in ballots}
+        resolved: list[float] = []
+        for slot, base_weight in zip(slots, base_slot_weights, strict=True):
+            ballot = ballots_by_slot.get(slot.index)
+            if ballot is None:
+                resolved.append(base_weight)
+                continue
+            calculator = WeightCalculator(
+                agent_weights={slot.name: base_weight},
+                config=config,
+                enable_cache=False,
+            )
+            weight = calculator.compute_weights_with_context(
+                [slot],
+                [ballot.vote],
+                proposals,
+            )[slot.name]
+            resolved.append(weight)
+        return tuple(resolved)
+
+
+@dataclass(frozen=True, slots=True)
 class _MajoritySnapshot:
     """Immutable decision inputs for one majority-consensus attempt."""
 
@@ -110,7 +205,30 @@ class _MajoritySnapshot:
     min_participation_count: int
     required_participation: int
     slots: tuple[VoterSlot, ...]
+    proposal_items: tuple[tuple[str, str], ...]
+    protocol: Any = field(repr=False, compare=False)
+    task: str
+    domain: str
+    base_slot_weights: tuple[float, ...]
     fixed_slot_weights: tuple[float, ...] | None
+    vote_weight_policy: _VoteWeightPolicy
+    user_vote_contributions: tuple[_UserVoteContribution, ...]
+    calibration_summaries: tuple[tuple[str, Any], ...] = field(repr=False, compare=False)
+    evidence_pack: Any = field(repr=False, compare=False)
+    initial_process_verification: Any = field(repr=False, compare=False)
+    had_initial_process_verification: bool
+    initial_verification_results: Any = field(repr=False, compare=False)
+    initial_verification_bonuses: Any = field(repr=False, compare=False)
+    group_similar_votes: Callable | None = field(repr=False, compare=False)
+    verify_claims: Callable | None = field(repr=False, compare=False)
+    position_shuffling_enabled: bool
+    position_shuffling_permutations: int
+    position_shuffling_seed: int | None
+    agent_timeout: float
+    collection_timeout: float
+    rlm_early_termination_enabled: bool
+    rlm_early_termination_threshold: float
+    rlm_majority_lead_threshold: float
 
     @classmethod
     def capture(
@@ -120,7 +238,26 @@ class _MajoritySnapshot:
         agents: tuple[Any, ...],
         min_participation_ratio: float,
         min_participation_count: int,
-        fixed_weights_by_name: dict[str, float] | None,
+        proposals: dict[str, str],
+        protocol: Any,
+        task: str,
+        domain: str,
+        base_weights_by_name: dict[str, float],
+        tally_inputs_fixed: bool,
+        user_vote_contributions: tuple[_UserVoteContribution, ...],
+        calibration_summaries: tuple[tuple[str, Any], ...],
+        evidence_pack: Any,
+        result: Any,
+        group_similar_votes: Callable | None,
+        verify_claims: Callable | None,
+        position_shuffling_enabled: bool,
+        position_shuffling_permutations: int,
+        position_shuffling_seed: int | None,
+        agent_timeout: float,
+        collection_timeout: float,
+        rlm_early_termination_enabled: bool,
+        rlm_early_termination_threshold: float,
+        rlm_majority_lead_threshold: float,
     ) -> "_MajoritySnapshot":
         slots = tuple(
             VoterSlot(index=index, name=str(getattr(agent, "name", "")))
@@ -131,21 +268,51 @@ class _MajoritySnapshot:
             math.ceil(len(slots) * min_participation_ratio),
         )
         required = min(required, max(len(slots), 1))
+        result_metadata = getattr(result, "metadata", {})
+        had_process_verification = (
+            isinstance(result_metadata, dict) and "process_verification" in result_metadata
+        )
         snapshot = cls(
             effective_threshold=effective_threshold,
             min_participation_ratio=min_participation_ratio,
             min_participation_count=min_participation_count,
             required_participation=required,
             slots=slots,
+            proposal_items=tuple(copy.deepcopy(proposals).items()),
+            protocol=copy.deepcopy(protocol),
+            task=str(task),
+            domain=str(domain),
+            base_slot_weights=(),
             fixed_slot_weights=None,
+            vote_weight_policy=_VoteWeightPolicy.from_protocol(protocol),
+            user_vote_contributions=user_vote_contributions,
+            calibration_summaries=calibration_summaries,
+            evidence_pack=copy.deepcopy(evidence_pack),
+            initial_process_verification=copy.deepcopy(
+                result_metadata.get("process_verification")
+                if isinstance(result_metadata, dict)
+                else None
+            ),
+            had_initial_process_verification=had_process_verification,
+            initial_verification_results=copy.deepcopy(getattr(result, "verification_results", {})),
+            initial_verification_bonuses=copy.deepcopy(getattr(result, "verification_bonuses", {})),
+            group_similar_votes=group_similar_votes,
+            verify_claims=verify_claims,
+            position_shuffling_enabled=position_shuffling_enabled,
+            position_shuffling_permutations=position_shuffling_permutations,
+            position_shuffling_seed=position_shuffling_seed,
+            agent_timeout=agent_timeout,
+            collection_timeout=collection_timeout,
+            rlm_early_termination_enabled=rlm_early_termination_enabled,
+            rlm_early_termination_threshold=rlm_early_termination_threshold,
+            rlm_majority_lead_threshold=rlm_majority_lead_threshold,
         )
-        if fixed_weights_by_name is None:
-            return snapshot
-        try:
-            slot_weights = snapshot.align_weights(fixed_weights_by_name)
-        except ValueError:
-            slot_weights = None
-        return replace(snapshot, fixed_slot_weights=slot_weights)
+        base_slot_weights = snapshot.align_weights(base_weights_by_name)
+        return replace(
+            snapshot,
+            base_slot_weights=base_slot_weights,
+            fixed_slot_weights=base_slot_weights if tally_inputs_fixed else None,
+        )
 
     @property
     def eligible_count(self) -> int:
@@ -154,6 +321,47 @@ class _MajoritySnapshot:
     @property
     def agent_names(self) -> tuple[str, ...]:
         return tuple(slot.name for slot in self.slots)
+
+    def proposals(self) -> dict[str, str]:
+        """Return a new mutable view of the frozen proposal mapping."""
+        return dict(self.proposal_items)
+
+    def calibration_summary_map(self) -> dict[str, Any]:
+        """Return detached calibration inputs captured at the decision boundary."""
+        return copy.deepcopy(dict(self.calibration_summaries))
+
+    def make_context_view(self, ctx: "DebateContext") -> "DebateContext":
+        """Build an isolated context view for post-await decision helpers."""
+        view = copy.copy(ctx)
+        view.proposals = self.proposals()
+        view.agents = list(self.slots)
+        view.env = SimpleNamespace(task=self.task)
+        view.domain = self.domain
+        view.evidence_pack = copy.deepcopy(self.evidence_pack)
+        return view
+
+    def restore_result_inputs(self, result: Any) -> None:
+        """Discard callback mutations to result fields that affect the tally."""
+        if hasattr(result, "metadata"):
+            metadata = result.metadata if isinstance(result.metadata, dict) else {}
+            if self.had_initial_process_verification:
+                metadata["process_verification"] = copy.deepcopy(self.initial_process_verification)
+            else:
+                metadata.pop("process_verification", None)
+            result.metadata = metadata
+        if hasattr(result, "verification_results"):
+            result.verification_results = copy.deepcopy(self.initial_verification_results)
+        if hasattr(result, "verification_bonuses"):
+            result.verification_bonuses = copy.deepcopy(self.initial_verification_bonuses)
+
+    def resolve_slot_weights(self, ballots: tuple[SlotVote, ...]) -> tuple[float, ...]:
+        """Resolve final exact-slot weights from frozen base factors and policy."""
+        return self.vote_weight_policy.resolve_slot_weights(
+            self.slots,
+            self.base_slot_weights,
+            ballots,
+            self.proposals(),
+        )
 
     def align_weights(self, weights_by_name: dict[str, float]) -> tuple[float, ...]:
         """Expand name-keyed legacy weights onto every exact voter slot."""
@@ -745,8 +953,12 @@ class ConsensusPhase:
     ) -> None:
         """Handle 'majority' consensus mode - weighted voting."""
         result = require_phase_result(ctx)
-        proposals = ctx.proposals
         eligible_agents = tuple(ctx.agents)
+
+        # User-event ingestion is part of the decision boundary. Anything that
+        # arrives after this synchronous drain belongs to a later decision.
+        if self._drain_user_events:
+            self._drain_user_events()
 
         # Compute adaptive threshold when enabled and no explicit override
         if threshold_override is None and self._adaptive_consensus is not None:
@@ -781,44 +993,100 @@ class ConsensusPhase:
         )
         min_participation_ratio = getattr(self.protocol, "min_participation_ratio", 0.5)
         min_participation_count = getattr(self.protocol, "min_participation_count", 1)
-        fixed_weights_by_name = None
-        if self._rlm_tally_inputs_are_fixed():
-            fixed_weights_by_name = self._compute_vote_weights(
-                ctx,
-                agents=eligible_agents,
-            )
+
+        # Capture every decision input before the first voter callback can run.
+        decision_protocol = copy.deepcopy(self.protocol)
+        frozen_proposals = copy.deepcopy(ctx.proposals)
+        frozen_task = str(ctx.env.task if ctx.env else "")
+        frozen_domain = str(getattr(ctx, "domain", None) or "general")
+        collector = self._vote_collector
+        collector_config = collector.config
+        position_shuffling_enabled = bool(collector_config.enable_position_shuffling)
+        position_shuffling_permutations = int(collector_config.position_shuffling_permutations)
+        position_shuffling_seed = collector_config.position_shuffling_seed
+        effective_agent_timeout = get_complexity_governor().get_scaled_timeout(
+            float(collector_config.agent_timeout)
+        )
+        collection_timeout = float(collector_config.vote_collection_timeout)
+        rlm_early_termination_enabled = bool(collector_config.enable_rlm_early_termination)
+        rlm_early_termination_threshold = float(collector_config.rlm_early_termination_threshold)
+        rlm_majority_lead_threshold = float(collector_config.rlm_majority_lead_threshold)
+        user_vote_contributions = self._capture_user_vote_contributions(decision_protocol)
+        provisional_slots = tuple(
+            VoterSlot(index=index, name=str(getattr(agent, "name", "")))
+            for index, agent in enumerate(eligible_agents)
+        )
+        calibration_summaries = self._capture_calibration_summaries(provisional_slots)
+        base_weights_by_name = self._compute_vote_weights(
+            ctx,
+            agents=eligible_agents,
+            protocol=decision_protocol,
+            proposals=frozen_proposals,
+            domain=frozen_domain,
+        )
+        tally_inputs_fixed = self._rlm_tally_inputs_are_fixed(
+            protocol=decision_protocol,
+            user_vote_contributions=user_vote_contributions,
+            group_similar_votes=self._group_similar_votes,
+            position_shuffling_enabled=position_shuffling_enabled,
+        )
         majority_snapshot = _MajoritySnapshot.capture(
             effective_threshold=effective_threshold,
             agents=eligible_agents,
             min_participation_ratio=min_participation_ratio,
             min_participation_count=min_participation_count,
-            fixed_weights_by_name=fixed_weights_by_name,
+            proposals=frozen_proposals,
+            protocol=decision_protocol,
+            task=frozen_task,
+            domain=frozen_domain,
+            base_weights_by_name=base_weights_by_name,
+            tally_inputs_fixed=tally_inputs_fixed,
+            user_vote_contributions=user_vote_contributions,
+            calibration_summaries=calibration_summaries,
+            evidence_pack=getattr(ctx, "evidence_pack", None),
+            result=result,
+            group_similar_votes=self._group_similar_votes,
+            verify_claims=self._verify_claims,
+            position_shuffling_enabled=position_shuffling_enabled,
+            position_shuffling_permutations=position_shuffling_permutations,
+            position_shuffling_seed=position_shuffling_seed,
+            agent_timeout=effective_agent_timeout,
+            collection_timeout=collection_timeout,
+            rlm_early_termination_enabled=rlm_early_termination_enabled,
+            rlm_early_termination_threshold=rlm_early_termination_threshold,
+            rlm_majority_lead_threshold=rlm_majority_lead_threshold,
         )
         roster = tuple(zip(majority_snapshot.slots, eligible_agents, strict=True))
 
         should_stop = None
         if (
-            self._vote_collector.config.enable_rlm_early_termination
+            majority_snapshot.rlm_early_termination_enabled
             and majority_snapshot.fixed_slot_weights is not None
         ):
 
             def should_stop(ballots: tuple[SlotVote, ...]) -> tuple[bool, str | None]:
                 return majority_snapshot.decisive_leader(
                     ballots,
-                    minimum_collection_ratio=(
-                        self._vote_collector.config.rlm_early_termination_threshold
-                    ),
-                    minimum_lead_ratio=self._vote_collector.config.rlm_majority_lead_threshold,
+                    minimum_collection_ratio=majority_snapshot.rlm_early_termination_threshold,
+                    minimum_lead_ratio=majority_snapshot.rlm_majority_lead_threshold,
                 )
 
-        collection = await self._vote_collector.collect_majority_votes(
-            ctx,
+        decision_ctx = majority_snapshot.make_context_view(ctx)
+        collection = await collector.collect_majority_votes(
+            decision_ctx,
             roster,
+            proposals=majority_snapshot.proposals(),
             should_stop=should_stop,
+            position_shuffling_enabled=majority_snapshot.position_shuffling_enabled,
+            position_shuffling_permutations=(majority_snapshot.position_shuffling_permutations),
+            position_shuffling_seed=majority_snapshot.position_shuffling_seed,
+            agent_timeout=majority_snapshot.agent_timeout,
+            collection_timeout=majority_snapshot.collection_timeout,
         )
+        majority_snapshot.restore_result_inputs(result)
         self._record_vote_participation(ctx, collection, majority_snapshot)
         if not self._ensure_quorum(
-            ctx,
+            decision_ctx,
             len(collection.ballots),
             required=majority_snapshot.required_participation,
             total_agents=majority_snapshot.eligible_count,
@@ -826,7 +1094,11 @@ class ConsensusPhase:
             return
 
         # Apply calibration adjustments to vote confidences
-        votes = self._apply_calibration_to_votes(collection.votes, ctx)
+        votes = self._apply_calibration_to_votes(
+            copy.deepcopy(collection.votes),
+            decision_ctx,
+            calibration_summaries=majority_snapshot.calibration_summary_map(),
+        )
         ballots = tuple(
             replace(ballot, vote=vote)
             for ballot, vote in zip(collection.ballots, votes, strict=True)
@@ -835,18 +1107,14 @@ class ConsensusPhase:
         result.votes.extend(votes)
 
         # Group similar votes
-        vote_groups, choice_mapping = self._compute_vote_groups(votes)
+        vote_groups, choice_mapping = self._compute_vote_groups(
+            copy.deepcopy(votes),
+            group_similar_votes=majority_snapshot.group_similar_votes,
+        )
 
-        # Vote-dependent weighting is delayed until every slot has reached a
-        # terminal outcome; fixed weighting reuses the capture-time values.
-        slot_weights = majority_snapshot.fixed_slot_weights
-        if slot_weights is None:
-            vote_weight_cache = self._compute_vote_weights(
-                ctx,
-                votes=votes,
-                agents=majority_snapshot.slots,
-            )
-            slot_weights = majority_snapshot.align_weights(vote_weight_cache)
+        # Vote-dependent bias factors are resolved against captured base
+        # weights, policy scalars, exact slots, and frozen proposals only.
+        slot_weights = majority_snapshot.resolve_slot_weights(ballots)
 
         # Missing, failed, and early-stopped slots remain in the denominator.
         vote_counts, total_weighted = self._count_snapshot_votes(
@@ -856,47 +1124,69 @@ class ConsensusPhase:
         )
 
         # Include user votes
-        vote_counts, total_weighted = self._add_user_votes(
-            vote_counts, total_weighted, choice_mapping
+        vote_counts, total_weighted = self._add_snapshot_user_votes(
+            vote_counts,
+            total_weighted,
+            choice_mapping,
+            majority_snapshot.user_vote_contributions,
         )
 
+        consensus_verifier = ConsensusVerifier(
+            protocol=majority_snapshot.protocol,
+            elo_system=self.elo_system,
+            verify_claims=majority_snapshot.verify_claims,
+            extract_debate_domain=self._extract_debate_domain,
+        )
+        vote_bonus_calculator = VoteBonusCalculator(protocol=majority_snapshot.protocol)
+        winner_selector = WinnerSelector(
+            protocol=majority_snapshot.protocol,
+            position_tracker=self.position_tracker,
+            calibration_tracker=self.calibration_tracker,
+            recorder=self.recorder,
+            notify_spectator=self._notify_spectator,
+            extract_debate_domain=self._extract_debate_domain,
+            get_belief_analyzer=self._get_belief_analyzer,
+        )
+        proposals = majority_snapshot.proposals()
+
         # Apply verification bonuses if enabled
-        vote_counts = await self._consensus_verifier.apply_verification_bonuses(
-            ctx, vote_counts, proposals, choice_mapping
+        vote_counts = await consensus_verifier.apply_verification_bonuses(
+            decision_ctx, vote_counts, proposals, choice_mapping
         )
 
         # Adjust individual vote confidences based on verification results
         # This cross-pollinates formal verification with vote confidence
         if hasattr(result, "verification_results") and result.verification_results:
-            self._consensus_verifier.adjust_vote_confidence_from_verification(
+            consensus_verifier.adjust_vote_confidence_from_verification(
                 votes, result.verification_results, proposals
             )
 
         # Apply evidence citation bonuses if enabled
-        vote_counts = self._vote_bonus_calculator.apply_evidence_citation_bonuses(
-            ctx, votes, vote_counts, choice_mapping
+        vote_counts = vote_bonus_calculator.apply_evidence_citation_bonuses(
+            decision_ctx, votes, vote_counts, choice_mapping
         )
 
         # Apply process-based evaluation bonuses if enabled (Agent-as-a-Judge)
-        vote_counts = await self._vote_bonus_calculator.apply_process_evaluation_bonuses(
-            ctx, vote_counts, choice_mapping
+        vote_counts = await vote_bonus_calculator.apply_process_evaluation_bonuses(
+            decision_ctx, vote_counts, choice_mapping
         )
 
         # Apply epistemic hygiene penalties if enabled
-        vote_counts = self._vote_bonus_calculator.apply_epistemic_hygiene_penalties(
-            ctx, vote_counts, choice_mapping
+        vote_counts = vote_bonus_calculator.apply_epistemic_hygiene_penalties(
+            decision_ctx, vote_counts, choice_mapping
         )
 
         # Apply truth ratio bonuses if enabled
-        vote_counts = self._vote_bonus_calculator.apply_truth_ratio_bonuses(
-            ctx, vote_counts, choice_mapping
+        vote_counts = vote_bonus_calculator.apply_truth_ratio_bonuses(
+            decision_ctx, vote_counts, choice_mapping
         )
 
         ctx.vote_tally = dict(vote_counts)
+        decision_ctx.vote_tally = dict(vote_counts)
 
         # Determine winner using WinnerSelector
-        self._winner_selector.determine_majority_winner(
-            ctx,
+        winner_selector.determine_majority_winner(
+            decision_ctx,
             vote_counts,
             total_weighted,
             choice_mapping,
@@ -904,17 +1194,21 @@ class ConsensusPhase:
                 self._normalize_choice_to_names(
                     choice,
                     majority_snapshot.agent_names,
-                    current_proposals,
+                    majority_snapshot.proposals(),
                 )
             ),
             threshold_override=majority_snapshot.effective_threshold,
         )
+        ctx.winner_agent = decision_ctx.winner_agent
 
         # Apply process verification gate if enabled
-        self._apply_process_verification_gate(ctx)
+        self._apply_process_verification_gate(
+            decision_ctx,
+            protocol=majority_snapshot.protocol,
+        )
 
         # Analyze belief network for cruxes
-        self._winner_selector.analyze_belief_network(ctx)
+        winner_selector.analyze_belief_network(decision_ctx)
 
     async def _handle_unanimous_consensus(self, ctx: "DebateContext") -> None:
         """Handle 'unanimous' consensus mode - all must agree."""
@@ -977,9 +1271,17 @@ class ConsensusPhase:
             result.consensus_reached = False
             result.confidence = 0.5
 
-    def _apply_process_verification_gate(self, ctx: "DebateContext") -> None:
+    def _apply_process_verification_gate(
+        self,
+        ctx: "DebateContext",
+        *,
+        protocol: Any | None = None,
+    ) -> None:
         """Gate consensus based on process verification scores."""
-        if not self.protocol or not getattr(self.protocol, "enable_process_verification", False):
+        decision_protocol = self.protocol if protocol is None else protocol
+        if not decision_protocol or not getattr(
+            decision_protocol, "enable_process_verification", False
+        ):
             return
         result = require_phase_result(ctx)
         if not result or not result.metadata:
@@ -989,12 +1291,12 @@ class ConsensusPhase:
         if average is None:
             return
 
-        threshold = float(getattr(self.protocol, "process_verification_threshold", 0.6))
+        threshold = float(getattr(decision_protocol, "process_verification_threshold", 0.6))
         metadata["threshold"] = threshold
         metadata["passed"] = average >= threshold
 
         if not metadata["passed"] and getattr(
-            self.protocol, "process_verification_hard_gate", False
+            decision_protocol, "process_verification_hard_gate", False
         ):
             result.consensus_reached = False
             result.consensus_strength = "process_blocked"
@@ -1779,13 +2081,36 @@ class ConsensusPhase:
         return await self._vote_collector.collect_votes_with_errors(ctx)
 
     def _compute_vote_groups(
-        self, votes: list["Vote"]
+        self,
+        votes: list["Vote"],
+        *,
+        group_similar_votes: Callable | None | object = ...,
     ) -> tuple[dict[str, list[str]], dict[str, str]]:
         """Group similar votes and create choice mapping."""
-        return self._vote_collector.compute_vote_groups(votes)
+        return self._vote_collector.compute_vote_groups(
+            votes,
+            group_similar_votes=group_similar_votes,
+        )
 
-    def _rlm_tally_inputs_are_fixed(self) -> bool:
+    def _rlm_tally_inputs_are_fixed(
+        self,
+        *,
+        protocol: Any | None = None,
+        user_vote_contributions: tuple[_UserVoteContribution, ...] | None = None,
+        group_similar_votes: Callable | None | object = ...,
+        position_shuffling_enabled: bool | None = None,
+    ) -> bool:
         """Return whether collection-time weights can safely authorize a final decision."""
+        decision_protocol = self.protocol if protocol is None else protocol
+        contributions = (
+            self.user_votes if user_vote_contributions is None else user_vote_contributions
+        )
+        grouping = self._group_similar_votes if group_similar_votes is ... else group_similar_votes
+        position_shuffling = (
+            getattr(decision_protocol, "enable_position_shuffling", False)
+            if position_shuffling_enabled is None
+            else position_shuffling_enabled
+        )
         vote_dependent_features = (
             "enable_self_vote_mitigation",
             "enable_verbosity_normalization",
@@ -1796,11 +2121,12 @@ class ConsensusPhase:
             "enable_truth_ratio_weighting",
         )
         return not (
-            self._drain_user_events
-            or self.user_votes
-            or self._group_similar_votes
-            or getattr(self.protocol, "enable_position_shuffling", False)
-            or any(getattr(self.protocol, feature, False) for feature in vote_dependent_features)
+            contributions
+            or grouping
+            or position_shuffling
+            or any(
+                getattr(decision_protocol, feature, False) for feature in vote_dependent_features
+            )
         )
 
     def _compute_vote_weights(
@@ -1809,6 +2135,9 @@ class ConsensusPhase:
         votes: list["Vote"] | None = None,
         *,
         agents: tuple[Any, ...] | None = None,
+        protocol: Any | None = None,
+        proposals: dict[str, str] | None = None,
+        domain: str | None = None,
     ) -> dict[str, float]:
         """Pre-compute vote weights for all agents.
 
@@ -1821,23 +2150,27 @@ class ConsensusPhase:
         """
         from aragora.debate.phases.weight_calculator import WeightCalculatorConfig
 
-        # Get bias mitigation config from protocol
-        enable_self_vote = getattr(self.protocol, "enable_self_vote_mitigation", False)
-        enable_verbosity = getattr(self.protocol, "enable_verbosity_normalization", False)
+        decision_protocol = self.protocol if protocol is None else protocol
+
+        # Get bias mitigation config from the decision snapshot.
+        enable_self_vote = getattr(decision_protocol, "enable_self_vote_mitigation", False)
+        enable_verbosity = getattr(decision_protocol, "enable_verbosity_normalization", False)
 
         config = WeightCalculatorConfig(
             # Agent-as-a-Judge bias mitigation
             enable_self_vote_mitigation=enable_self_vote,
-            self_vote_mode=getattr(self.protocol, "self_vote_mode", "downweight"),
-            self_vote_downweight=getattr(self.protocol, "self_vote_downweight", 0.5),
+            self_vote_mode=getattr(decision_protocol, "self_vote_mode", "downweight"),
+            self_vote_downweight=getattr(decision_protocol, "self_vote_downweight", 0.5),
             enable_verbosity_normalization=enable_verbosity,
-            verbosity_target_length=getattr(self.protocol, "verbosity_target_length", 1000),
-            verbosity_penalty_threshold=getattr(self.protocol, "verbosity_penalty_threshold", 3.0),
-            verbosity_max_penalty=getattr(self.protocol, "verbosity_max_penalty", 0.3),
+            verbosity_target_length=getattr(decision_protocol, "verbosity_target_length", 1000),
+            verbosity_penalty_threshold=getattr(
+                decision_protocol, "verbosity_penalty_threshold", 3.0
+            ),
+            verbosity_max_penalty=getattr(decision_protocol, "verbosity_max_penalty", 0.3),
         )
 
         # Get domain from context for domain-specific ELO weighting
-        domain = getattr(ctx, "domain", None) or "general"
+        decision_domain = domain or getattr(ctx, "domain", None) or "general"
 
         calculator = WeightCalculator(
             memory=self.memory,
@@ -1847,17 +2180,18 @@ class ConsensusPhase:
             calibration_tracker=self.calibration_tracker,
             get_calibration_weight=self._get_calibration_weight,
             config=config,
-            domain=domain,
+            domain=decision_domain,
         )
 
         eligible_agents = list(ctx.agents if agents is None else agents)
 
         # Use bias-aware computation if votes and proposals available
-        if votes and ctx.proposals and (enable_self_vote or enable_verbosity):
+        decision_proposals = ctx.proposals if proposals is None else proposals
+        if votes and decision_proposals and (enable_self_vote or enable_verbosity):
             return calculator.compute_weights_with_context(
                 eligible_agents,
                 votes,
-                ctx.proposals,
+                decision_proposals,
             )
 
         return calculator.compute_weights(eligible_agents)
@@ -1931,9 +2265,11 @@ class ConsensusPhase:
         self,
         votes: list["Vote"],
         ctx: "DebateContext",
+        *,
+        calibration_summaries: dict[str, Any] | None = None,
     ) -> list["Vote"]:
         """Apply calibration adjustments to vote confidences."""
-        if not self.calibration_tracker:
+        if calibration_summaries is None and not self.calibration_tracker:
             return votes
 
         from aragora.agents.calibration import adjust_agent_confidence
@@ -1945,7 +2281,13 @@ class ConsensusPhase:
                 continue
 
             try:
-                summary = self.calibration_tracker.get_calibration_summary(vote.agent)
+                if calibration_summaries is None:
+                    summary = self.calibration_tracker.get_calibration_summary(vote.agent)
+                else:
+                    summary = calibration_summaries.get(vote.agent)
+                    if summary is None:
+                        adjusted_votes.append(vote)
+                        continue
                 original_conf = vote.confidence
                 adjusted_conf = adjust_agent_confidence(original_conf, summary)
 
@@ -1975,6 +2317,29 @@ class ConsensusPhase:
                 adjusted_votes.append(vote)
 
         return adjusted_votes
+
+    def _capture_calibration_summaries(
+        self,
+        slots: tuple[VoterSlot, ...],
+    ) -> tuple[tuple[str, Any], ...]:
+        """Copy calibration inputs before any voter callback can mutate them."""
+        if not self.calibration_tracker:
+            return ()
+        summaries: dict[str, Any] = {}
+        for slot in slots:
+            if slot.name in summaries:
+                continue
+            try:
+                summaries[slot.name] = copy.deepcopy(
+                    self.calibration_tracker.get_calibration_summary(slot.name)
+                )
+            except (ValueError, KeyError, TypeError, AttributeError) as error:
+                logger.debug(
+                    "Calibration snapshot failed for %s: %s",
+                    slot.name,
+                    error,
+                )
+        return tuple(summaries.items())
 
     def _count_weighted_votes(
         self,
@@ -2044,6 +2409,54 @@ class ConsensusPhase:
                     final_weight,
                 )
 
+        return vote_counts, total_weighted
+
+    def _capture_user_vote_contributions(
+        self,
+        protocol: Any,
+    ) -> tuple[_UserVoteContribution, ...]:
+        """Resolve user-vote weights at the immutable decision boundary."""
+        base_user_weight = float(getattr(protocol, "user_vote_weight", 0.5))
+        contributions: list[_UserVoteContribution] = []
+        for user_vote in tuple(copy.deepcopy(self.user_votes)):
+            choice = user_vote.get("choice", "")
+            if not choice:
+                continue
+            intensity = user_vote.get("intensity", 5)
+            multiplier = (
+                self._user_vote_multiplier(intensity, copy.deepcopy(protocol))
+                if self._user_vote_multiplier
+                else 1.0
+            )
+            contributions.append(
+                _UserVoteContribution(
+                    choice=str(choice),
+                    intensity=copy.deepcopy(intensity),
+                    user_id=str(user_vote.get("user_id", "anonymous")),
+                    weight=base_user_weight * float(multiplier),
+                )
+            )
+        return tuple(contributions)
+
+    @staticmethod
+    def _add_snapshot_user_votes(
+        vote_counts: dict[str, float],
+        total_weighted: float,
+        choice_mapping: dict[str, str],
+        contributions: tuple[_UserVoteContribution, ...],
+    ) -> tuple[dict[str, float], float]:
+        """Add only the user-vote contributions captured by the snapshot."""
+        for contribution in contributions:
+            canonical = choice_mapping.get(contribution.choice, contribution.choice)
+            vote_counts[canonical] = vote_counts.get(canonical, 0.0) + contribution.weight
+            total_weighted += contribution.weight
+            logger.debug(
+                "user_vote user=%s choice=%s intensity=%s weight=%s",
+                contribution.user_id,
+                contribution.choice,
+                contribution.intensity,
+                contribution.weight,
+            )
         return vote_counts, total_weighted
 
     def _normalize_choice_to_agent(

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -28,7 +28,7 @@ import logging
 import math
 import time
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
@@ -40,7 +40,13 @@ from aragora.debate.phases._phase_invariant import require_phase_result
 from aragora.debate.phases.consensus_verification import ConsensusVerifier
 from aragora.debate.phases.synthesis_generator import SynthesisGenerator
 from aragora.debate.phases.vote_bonus_calculator import VoteBonusCalculator
-from aragora.debate.phases.vote_collector import VoteCollector, VoteCollectorConfig
+from aragora.debate.phases.vote_collector import (
+    MajorityVoteCollection,
+    SlotVote,
+    VoteCollector,
+    VoteCollectorConfig,
+    VoterSlot,
+)
 from aragora.debate.phases.weight_calculator import WeightCalculator
 from aragora.debate.phases.winner_selector import WinnerSelector
 from aragora.events.context import streaming_task_context
@@ -93,6 +99,128 @@ class ConsensusCallbacks:
     get_belief_analyzer: Callable | None = None
     user_vote_multiplier: Callable | None = None
     verify_claims: Callable | None = None  # Optional verification callback
+
+
+@dataclass(frozen=True, slots=True)
+class _MajoritySnapshot:
+    """Immutable decision inputs for one majority-consensus attempt."""
+
+    effective_threshold: float
+    min_participation_ratio: float
+    min_participation_count: int
+    required_participation: int
+    slots: tuple[VoterSlot, ...]
+    fixed_slot_weights: tuple[float, ...] | None
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        effective_threshold: float,
+        agents: tuple[Any, ...],
+        min_participation_ratio: float,
+        min_participation_count: int,
+        fixed_weights_by_name: dict[str, float] | None,
+    ) -> "_MajoritySnapshot":
+        slots = tuple(
+            VoterSlot(index=index, name=str(getattr(agent, "name", "")))
+            for index, agent in enumerate(agents)
+        )
+        required = max(
+            min_participation_count,
+            math.ceil(len(slots) * min_participation_ratio),
+        )
+        required = min(required, max(len(slots), 1))
+        snapshot = cls(
+            effective_threshold=effective_threshold,
+            min_participation_ratio=min_participation_ratio,
+            min_participation_count=min_participation_count,
+            required_participation=required,
+            slots=slots,
+            fixed_slot_weights=None,
+        )
+        if fixed_weights_by_name is None:
+            return snapshot
+        try:
+            slot_weights = snapshot.align_weights(fixed_weights_by_name)
+        except ValueError:
+            slot_weights = None
+        return replace(snapshot, fixed_slot_weights=slot_weights)
+
+    @property
+    def eligible_count(self) -> int:
+        return len(self.slots)
+
+    @property
+    def agent_names(self) -> tuple[str, ...]:
+        return tuple(slot.name for slot in self.slots)
+
+    def align_weights(self, weights_by_name: dict[str, float]) -> tuple[float, ...]:
+        """Expand name-keyed legacy weights onto every exact voter slot."""
+        weights: list[float] = []
+        for slot in self.slots:
+            raw_weight = weights_by_name.get(slot.name, 1.0)
+            if (
+                isinstance(raw_weight, bool)
+                or not isinstance(raw_weight, (int, float))
+                or not math.isfinite(raw_weight)
+                or raw_weight < 0.0
+            ):
+                raise ValueError(f"Invalid vote weight for slot {slot.index}")
+            weights.append(float(raw_weight))
+        if weights and (not math.isfinite(sum(weights)) or sum(weights) <= 0.0):
+            raise ValueError("Invalid aggregate voter weight")
+        return tuple(weights)
+
+    def decisive_leader(
+        self,
+        ballots: tuple[SlotVote, ...],
+        *,
+        minimum_collection_ratio: float,
+        minimum_lead_ratio: float,
+    ) -> tuple[bool, str | None]:
+        """Return a winner only when no allocation of pending weight can overtake it."""
+        weights = self.fixed_slot_weights
+        if weights is None or not self.slots or not ballots:
+            return False, None
+        minimum_ballots = int(self.eligible_count * minimum_collection_ratio)
+        if len(ballots) < minimum_ballots:
+            return False, None
+
+        seen_slots: set[int] = set()
+        counts: dict[str, float] = {}
+        received_weight = 0.0
+        for ballot in ballots:
+            slot_index = ballot.slot.index
+            choice = getattr(ballot.vote, "choice", None)
+            if (
+                slot_index in seen_slots
+                or slot_index < 0
+                or slot_index >= self.eligible_count
+                or self.slots[slot_index] != ballot.slot
+                or not isinstance(choice, str)
+                or not choice
+            ):
+                return False, None
+            seen_slots.add(slot_index)
+            weight = weights[slot_index]
+            counts[choice] = counts.get(choice, 0.0) + weight
+            received_weight += weight
+
+        total_weight = sum(weights)
+        leader, leader_weight = max(counts.items(), key=lambda item: item[1])
+        runner_up = max(
+            (weight for choice, weight in counts.items() if choice != leader), default=0.0
+        )
+        pending_weight = max(0.0, total_weight - received_weight)
+        strongest_possible_competitor = runner_up + pending_weight
+        if leader_weight / total_weight < self.effective_threshold:
+            return False, None
+        if leader_weight <= strongest_possible_competitor:
+            return False, None
+        if leader_weight - strongest_possible_competitor < total_weight * minimum_lead_ratio:
+            return False, None
+        return True, leader
 
 
 class ConsensusPhase:
@@ -618,14 +746,14 @@ class ConsensusPhase:
         """Handle 'majority' consensus mode - weighted voting."""
         result = require_phase_result(ctx)
         proposals = ctx.proposals
+        eligible_agents = tuple(ctx.agents)
 
         # Compute adaptive threshold when enabled and no explicit override
         if threshold_override is None and self._adaptive_consensus is not None:
             try:
-                agents = ctx.agents or []
                 threshold_override, explanation = (
                     self._adaptive_consensus.compute_threshold_with_explanation(
-                        agents,
+                        list(eligible_agents),
                         elo_system=self.elo_system,
                         calibration_tracker=self.calibration_tracker,
                     )
@@ -640,31 +768,91 @@ class ConsensusPhase:
                 logger.info(
                     "adaptive_consensus_threshold=%.4f for %d agents",
                     threshold_override,
-                    len(agents),
+                    len(eligible_agents),
                 )
             except (TypeError, ValueError, AttributeError) as e:
                 logger.debug("Adaptive consensus computation failed: %s", e)
                 threshold_override = None
 
-        # Cast votes from all agents
-        votes = await self._collect_votes(ctx)
-        if not self._ensure_quorum(ctx, len(votes)):
+        effective_threshold = (
+            threshold_override
+            if threshold_override is not None
+            else getattr(self.protocol, "consensus_threshold", 0.5)
+        )
+        min_participation_ratio = getattr(self.protocol, "min_participation_ratio", 0.5)
+        min_participation_count = getattr(self.protocol, "min_participation_count", 1)
+        fixed_weights_by_name = None
+        if self._rlm_tally_inputs_are_fixed():
+            fixed_weights_by_name = self._compute_vote_weights(
+                ctx,
+                agents=eligible_agents,
+            )
+        majority_snapshot = _MajoritySnapshot.capture(
+            effective_threshold=effective_threshold,
+            agents=eligible_agents,
+            min_participation_ratio=min_participation_ratio,
+            min_participation_count=min_participation_count,
+            fixed_weights_by_name=fixed_weights_by_name,
+        )
+        roster = tuple(zip(majority_snapshot.slots, eligible_agents, strict=True))
+
+        should_stop = None
+        if (
+            self._vote_collector.config.enable_rlm_early_termination
+            and majority_snapshot.fixed_slot_weights is not None
+        ):
+
+            def should_stop(ballots: tuple[SlotVote, ...]) -> tuple[bool, str | None]:
+                return majority_snapshot.decisive_leader(
+                    ballots,
+                    minimum_collection_ratio=(
+                        self._vote_collector.config.rlm_early_termination_threshold
+                    ),
+                    minimum_lead_ratio=self._vote_collector.config.rlm_majority_lead_threshold,
+                )
+
+        collection = await self._vote_collector.collect_majority_votes(
+            ctx,
+            roster,
+            should_stop=should_stop,
+        )
+        self._record_vote_participation(ctx, collection, majority_snapshot)
+        if not self._ensure_quorum(
+            ctx,
+            len(collection.ballots),
+            required=majority_snapshot.required_participation,
+            total_agents=majority_snapshot.eligible_count,
+        ):
             return
 
         # Apply calibration adjustments to vote confidences
-        votes = self._apply_calibration_to_votes(votes, ctx)
+        votes = self._apply_calibration_to_votes(collection.votes, ctx)
+        ballots = tuple(
+            replace(ballot, vote=vote)
+            for ballot, vote in zip(collection.ballots, votes, strict=True)
+        )
 
         result.votes.extend(votes)
 
         # Group similar votes
         vote_groups, choice_mapping = self._compute_vote_groups(votes)
 
-        # Pre-compute vote weights (pass votes for bias mitigation)
-        vote_weight_cache = self._compute_vote_weights(ctx, votes=votes)
+        # Vote-dependent weighting is delayed until every slot has reached a
+        # terminal outcome; fixed weighting reuses the capture-time values.
+        slot_weights = majority_snapshot.fixed_slot_weights
+        if slot_weights is None:
+            vote_weight_cache = self._compute_vote_weights(
+                ctx,
+                votes=votes,
+                agents=majority_snapshot.slots,
+            )
+            slot_weights = majority_snapshot.align_weights(vote_weight_cache)
 
-        # Count weighted votes
-        vote_counts, total_weighted = self._count_weighted_votes(
-            votes, choice_mapping, vote_weight_cache
+        # Missing, failed, and early-stopped slots remain in the denominator.
+        vote_counts, total_weighted = self._count_snapshot_votes(
+            ballots,
+            choice_mapping,
+            slot_weights,
         )
 
         # Include user votes
@@ -712,8 +900,14 @@ class ConsensusPhase:
             vote_counts,
             total_weighted,
             choice_mapping,
-            normalize_choice=self._normalize_choice_to_agent,
-            threshold_override=threshold_override,
+            normalize_choice=lambda choice, _agents, current_proposals: (
+                self._normalize_choice_to_names(
+                    choice,
+                    majority_snapshot.agent_names,
+                    current_proposals,
+                )
+            ),
+            threshold_override=majority_snapshot.effective_threshold,
         )
 
         # Apply process verification gate if enabled
@@ -1590,10 +1784,31 @@ class ConsensusPhase:
         """Group similar votes and create choice mapping."""
         return self._vote_collector.compute_vote_groups(votes)
 
+    def _rlm_tally_inputs_are_fixed(self) -> bool:
+        """Return whether collection-time weights can safely authorize a final decision."""
+        vote_dependent_features = (
+            "enable_self_vote_mitigation",
+            "enable_verbosity_normalization",
+            "verify_claims_during_consensus",
+            "enable_evidence_weighting",
+            "enable_process_evaluation",
+            "enable_epistemic_hygiene",
+            "enable_truth_ratio_weighting",
+        )
+        return not (
+            self._drain_user_events
+            or self.user_votes
+            or self._group_similar_votes
+            or getattr(self.protocol, "enable_position_shuffling", False)
+            or any(getattr(self.protocol, feature, False) for feature in vote_dependent_features)
+        )
+
     def _compute_vote_weights(
         self,
         ctx: "DebateContext",
         votes: list["Vote"] | None = None,
+        *,
+        agents: tuple[Any, ...] | None = None,
     ) -> dict[str, float]:
         """Pre-compute vote weights for all agents.
 
@@ -1635,11 +1850,17 @@ class ConsensusPhase:
             domain=domain,
         )
 
+        eligible_agents = list(ctx.agents if agents is None else agents)
+
         # Use bias-aware computation if votes and proposals available
         if votes and ctx.proposals and (enable_self_vote or enable_verbosity):
-            return calculator.compute_weights_with_context(ctx.agents, votes, ctx.proposals)
+            return calculator.compute_weights_with_context(
+                eligible_agents,
+                votes,
+                ctx.proposals,
+            )
 
-        return calculator.compute_weights(ctx.agents)
+        return calculator.compute_weights(eligible_agents)
 
     def _required_participation(self, total_agents: int) -> int:
         """Compute minimum required votes to proceed with consensus."""
@@ -1649,10 +1870,17 @@ class ConsensusPhase:
         # Never require more votes than agents available
         return min(required, max(total_agents, 1))
 
-    def _ensure_quorum(self, ctx: "DebateContext", vote_count: int) -> bool:
+    def _ensure_quorum(
+        self,
+        ctx: "DebateContext",
+        vote_count: int,
+        *,
+        required: int | None = None,
+        total_agents: int | None = None,
+    ) -> bool:
         """Ensure enough agents participated to make consensus meaningful."""
-        total_agents = len(ctx.agents)
-        required = self._required_participation(total_agents)
+        total_agents = len(ctx.agents) if total_agents is None else total_agents
+        required = self._required_participation(total_agents) if required is None else required
         if vote_count >= required:
             return True
 
@@ -1681,6 +1909,23 @@ class ConsensusPhase:
             )
 
         return False
+
+    def _record_vote_participation(
+        self,
+        ctx: "DebateContext",
+        collection: MajorityVoteCollection,
+        snapshot: _MajoritySnapshot,
+    ) -> None:
+        """Publish exact per-slot majority outcomes as additive result metadata."""
+        result = require_phase_result(ctx)
+        metadata = result.metadata if isinstance(result.metadata, dict) else {}
+        metadata["vote_participation"] = {
+            "eligible": snapshot.eligible_count,
+            "received": len(collection.ballots),
+            "failed": len(collection.failed_slots),
+            "skipped": len(collection.skipped_slots),
+        }
+        result.metadata = metadata
 
     def _apply_calibration_to_votes(
         self,
@@ -1750,6 +1995,20 @@ class ConsensusPhase:
 
         return vote_counts, total_weighted
 
+    def _count_snapshot_votes(
+        self,
+        ballots: tuple[SlotVote, ...],
+        choice_mapping: dict[str, str],
+        slot_weights: tuple[float, ...],
+    ) -> tuple[dict[str, float], float]:
+        """Count received ballots while retaining every eligible slot in the denominator."""
+        vote_counts: dict[str, float] = {}
+        for ballot in ballots:
+            canonical = choice_mapping.get(ballot.vote.choice, ballot.vote.choice)
+            weight = slot_weights[ballot.slot.index]
+            vote_counts[canonical] = vote_counts.get(canonical, 0.0) + weight
+        return vote_counts, sum(slot_weights)
+
     def _add_user_votes(
         self,
         vote_counts: dict[str, float],
@@ -1794,6 +2053,19 @@ class ConsensusPhase:
         proposals: dict[str, str],
     ) -> str:
         """Normalize a vote choice to an agent name."""
+        return self._normalize_choice_to_names(
+            choice,
+            tuple(agent.name for agent in agents),
+            proposals,
+        )
+
+    def _normalize_choice_to_names(
+        self,
+        choice: str,
+        agent_names: tuple[str, ...],
+        proposals: dict[str, str],
+    ) -> str:
+        """Normalize a choice against copied names rather than mutable agents."""
         if not choice:
             return choice
 
@@ -1806,8 +2078,7 @@ class ConsensusPhase:
             if agent_name.lower() == choice_lower:
                 return agent_name
 
-        for agent in agents:
-            agent_name = agent.name
+        for agent_name in agent_names:
             agent_lower = agent_name.lower()
 
             if agent_lower == choice_lower:
@@ -1824,7 +2095,7 @@ class ConsensusPhase:
                 if base_name == choice_lower or choice_lower.startswith(base_name):
                     return agent_name
 
-        logger.debug("vote_choice_no_match choice=%s agents=%s", choice, [a.name for a in agents])
+        logger.debug("vote_choice_no_match choice=%s agents=%s", choice, agent_names)
         return choice
 
     async def _verify_consensus_formally(self, ctx: "DebateContext") -> None:

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -668,6 +668,8 @@ class VoteCollector:
         *,
         should_stop: Callable[[tuple[SlotVote, ...]], tuple[bool, str | None]] | None,
         handle_success: bool,
+        agent_timeout: float | None = None,
+        collection_timeout: float | None = None,
     ) -> tuple[MajorityVoteCollection, str | None]:
         """Collect one ballot per frozen slot without re-reading ``ctx.agents``."""
         slots = tuple(slot for slot, _agent in roster)
@@ -677,6 +679,14 @@ class VoteCollector:
 
         task_text = ctx.env.task if ctx.env else ""
         with_timeout = self._with_timeout
+        effective_agent_timeout = (
+            get_complexity_governor().get_scaled_timeout(float(self.config.agent_timeout))
+            if agent_timeout is None
+            else agent_timeout
+        )
+        effective_collection_timeout = (
+            self.VOTE_COLLECTION_TIMEOUT if collection_timeout is None else collection_timeout
+        )
         ballots: list[SlotVote] = []
         failed_ids: set[int] = set()
         early_leader: str | None = None
@@ -684,16 +694,14 @@ class VoteCollector:
         async def cast_vote(slot: VoterSlot, agent: Agent) -> Any:
             logger.debug("agent_voting agent=%s slot=%s", slot.name, slot.index)
             try:
-                timeout = get_complexity_governor().get_scaled_timeout(
-                    float(self.config.agent_timeout)
-                )
+                proposal_view = dict(proposals)
                 if with_timeout:
                     return await with_timeout(
-                        vote_with_agent(agent, proposals, task_text),
+                        vote_with_agent(agent, proposal_view, task_text),
                         slot.name,
-                        timeout_seconds=timeout,
+                        timeout_seconds=effective_agent_timeout,
                     )
-                return await vote_with_agent(agent, proposals, task_text)
+                return await vote_with_agent(agent, proposal_view, task_text)
             except (ValueError, KeyError, TypeError) as error:  # noqa: BLE001
                 logger.warning(
                     "vote_exception agent=%s slot=%s error=%s: %s",
@@ -773,7 +781,7 @@ class VoteCollector:
         timed_out = False
         early_terminated = False
         try:
-            async with asyncio.timeout(self.VOTE_COLLECTION_TIMEOUT):
+            async with asyncio.timeout(effective_collection_timeout):
                 early_terminated = await owner.run(consume_vote, stop_at_decision_boundary)
         except TimeoutError:
             timed_out = True
@@ -781,7 +789,7 @@ class VoteCollector:
                 "vote_collection_timeout collected=%s expected=%s timeout=%ss",
                 len(ballots),
                 len(roster),
-                self.VOTE_COLLECTION_TIMEOUT,
+                effective_collection_timeout,
             )
 
         skipped_ids: set[int] = set()
@@ -806,23 +814,47 @@ class VoteCollector:
         roster: tuple[tuple[VoterSlot, Agent], ...],
         *,
         should_stop: Callable[[tuple[SlotVote, ...]], tuple[bool, str | None]] | None = None,
+        proposals: dict[str, str] | None = None,
+        position_shuffling_enabled: bool | None = None,
+        position_shuffling_permutations: int | None = None,
+        position_shuffling_seed: int | None | object = ...,
+        agent_timeout: float | None = None,
+        collection_timeout: float | None = None,
     ) -> MajorityVoteCollection:
         """Collect majority ballots against one exact immutable slot roster."""
-        if self.config.enable_position_shuffling and ctx.proposals:
+        decision_proposals = dict(ctx.proposals if proposals is None else proposals)
+        shuffle_enabled = (
+            self.config.enable_position_shuffling
+            if position_shuffling_enabled is None
+            else position_shuffling_enabled
+        )
+        shuffle_permutations = (
+            self.config.position_shuffling_permutations
+            if position_shuffling_permutations is None
+            else position_shuffling_permutations
+        )
+        shuffle_seed = (
+            self.config.position_shuffling_seed
+            if position_shuffling_seed is ...
+            else position_shuffling_seed
+        )
+        if shuffle_enabled and decision_proposals:
             votes_by_slot: dict[int, list[Vote]] = {slot.index: [] for slot, _agent in roster}
-            for permutation_index, proposals in enumerate(
+            for permutation_index, proposal_permutation in enumerate(
                 generate_permutations(
-                    ctx.proposals,
-                    num_permutations=self.config.position_shuffling_permutations,
-                    base_seed=self.config.position_shuffling_seed,
+                    decision_proposals,
+                    num_permutations=shuffle_permutations,
+                    base_seed=shuffle_seed if isinstance(shuffle_seed, int) else None,
                 )
             ):
                 collection, _leader = await self._collect_majority_once(
                     ctx,
                     roster,
-                    proposals,
+                    proposal_permutation,
                     should_stop=None,
                     handle_success=False,
+                    agent_timeout=agent_timeout,
+                    collection_timeout=collection_timeout,
                 )
                 for ballot in collection.ballots:
                     votes_by_slot[ballot.slot.index].append(ballot.vote)
@@ -837,7 +869,7 @@ class VoteCollector:
                 slot_votes = votes_by_slot[slot.index]
                 if not slot_votes:
                     continue
-                averaged = average_permutation_votes({slot.name: slot_votes}, ctx.proposals)
+                averaged = average_permutation_votes({slot.name: slot_votes}, decision_proposals)
                 if not averaged:
                     continue
                 vote = averaged[0]
@@ -856,9 +888,11 @@ class VoteCollector:
         collection, leader = await self._collect_majority_once(
             ctx,
             roster,
-            ctx.proposals,
+            decision_proposals,
             should_stop=should_stop,
             handle_success=True,
+            agent_timeout=agent_timeout,
+            collection_timeout=collection_timeout,
         )
         if collection.skipped_slots:
             if self._notify_spectator:
@@ -1048,7 +1082,12 @@ class VoteCollector:
             except (RuntimeError, AttributeError, TypeError) as e:  # noqa: BLE001
                 logger.debug("Position tracking error for vote: %s", e)
 
-    def compute_vote_groups(self, votes: list[Vote]) -> tuple[dict[str, list[str]], dict[str, str]]:
+    def compute_vote_groups(
+        self,
+        votes: list[Vote],
+        *,
+        group_similar_votes: Callable | None | object = ...,
+    ) -> tuple[dict[str, list[str]], dict[str, str]]:
         """Group similar votes and create choice mapping.
 
         Args:
@@ -1059,12 +1098,15 @@ class VoteCollector:
             - vote_groups: canonical choice -> list of variant choices
             - choice_mapping: variant choice -> canonical choice
         """
-        if not self._group_similar_votes:
+        grouping_callback = (
+            self._group_similar_votes if group_similar_votes is ... else group_similar_votes
+        )
+        if not callable(grouping_callback):
             # No grouping, identity mapping
             choices = set(v.choice for v in votes if not isinstance(v, Exception))
             return {c: [c] for c in choices}, {c: c for c in choices}
 
-        vote_groups = self._group_similar_votes(votes)
+        vote_groups = grouping_callback(votes)
 
         choice_mapping: dict[str, str] = {}
         for canonical, variants in vote_groups.items():

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
@@ -189,6 +189,35 @@ class _VoteTaskOwner:
         except BaseException:  # noqa: BLE001 - make sibling tasks safe before propagation
             self.settle(consumer, propagate=False)
             raise
+
+
+@dataclass(frozen=True, slots=True)
+class VoterSlot:
+    """Immutable identity for one position in an eligible voter roster."""
+
+    index: int
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class SlotVote:
+    """A successful ballot attributed to its exact voter slot."""
+
+    slot: VoterSlot
+    vote: Vote
+
+
+@dataclass(frozen=True, slots=True)
+class MajorityVoteCollection:
+    """Complete per-slot outcome of one majority collection decision."""
+
+    ballots: tuple[SlotVote, ...]
+    failed_slots: tuple[VoterSlot, ...]
+    skipped_slots: tuple[VoterSlot, ...]
+
+    @property
+    def votes(self) -> list[Vote]:
+        return [ballot.vote for ballot in self.ballots]
 
 
 @dataclass
@@ -631,6 +660,225 @@ class VoteCollector:
 
         return votes
 
+    async def _collect_majority_once(
+        self,
+        ctx: DebateContext,
+        roster: tuple[tuple[VoterSlot, Agent], ...],
+        proposals: dict[str, str],
+        *,
+        should_stop: Callable[[tuple[SlotVote, ...]], tuple[bool, str | None]] | None,
+        handle_success: bool,
+    ) -> tuple[MajorityVoteCollection, str | None]:
+        """Collect one ballot per frozen slot without re-reading ``ctx.agents``."""
+        slots = tuple(slot for slot, _agent in roster)
+        vote_with_agent = self._vote_with_agent
+        if vote_with_agent is None:
+            return MajorityVoteCollection((), slots, ()), None
+
+        task_text = ctx.env.task if ctx.env else ""
+        with_timeout = self._with_timeout
+        ballots: list[SlotVote] = []
+        failed_ids: set[int] = set()
+        early_leader: str | None = None
+
+        async def cast_vote(slot: VoterSlot, agent: Agent) -> Any:
+            logger.debug("agent_voting agent=%s slot=%s", slot.name, slot.index)
+            try:
+                timeout = get_complexity_governor().get_scaled_timeout(
+                    float(self.config.agent_timeout)
+                )
+                if with_timeout:
+                    return await with_timeout(
+                        vote_with_agent(agent, proposals, task_text),
+                        slot.name,
+                        timeout_seconds=timeout,
+                    )
+                return await vote_with_agent(agent, proposals, task_text)
+            except (ValueError, KeyError, TypeError) as error:  # noqa: BLE001
+                logger.warning(
+                    "vote_exception agent=%s slot=%s error=%s: %s",
+                    slot.name,
+                    slot.index,
+                    type(error).__name__,
+                    error,
+                )
+                return error
+
+        tasks = [asyncio.create_task(cast_vote(slot, agent)) for slot, agent in roster]
+        binding_by_task = {task: roster[index] for index, task in enumerate(tasks)}
+        owner = _VoteTaskOwner(tasks)
+
+        def consume_vote(completed_task: asyncio.Task[Any]) -> None:
+            slot, agent = binding_by_task[completed_task]
+            try:
+                vote_result = completed_task.result()
+            except asyncio.CancelledError:
+                raise
+            except BaseException as error:  # noqa: BLE001 - preserve control flow
+                if not isinstance(error, Exception):
+                    raise
+                logger.error(
+                    "task_exception phase=majority_vote slot=%s error=%s", slot.index, error
+                )
+                failed_ids.add(slot.index)
+                return
+
+            if isinstance(vote_result, BaseException) and not isinstance(vote_result, Exception):
+                raise vote_result
+            if vote_result is None or isinstance(vote_result, Exception):
+                failed_ids.add(slot.index)
+                if isinstance(vote_result, Exception):
+                    logger.error(
+                        "vote_error agent=%s slot=%s error=%s",
+                        slot.name,
+                        slot.index,
+                        vote_result,
+                    )
+                else:
+                    logger.error(
+                        "vote_error agent=%s slot=%s error=vote returned None",
+                        slot.name,
+                        slot.index,
+                    )
+                return
+
+            if getattr(vote_result, "agent", None) != slot.name:
+                try:
+                    vote_result = replace(vote_result, agent=slot.name)
+                except TypeError:
+                    logger.warning(
+                        "vote_agent_not_rebindable slot=%s expected=%s actual=%s",
+                        slot.index,
+                        slot.name,
+                        getattr(vote_result, "agent", None),
+                    )
+            ballots.append(SlotVote(slot=slot, vote=vote_result))
+            if handle_success:
+                self._handle_vote_success(
+                    ctx,
+                    agent,
+                    vote_result,
+                    agent_name=slot.name,
+                )
+
+        def stop_at_decision_boundary() -> bool:
+            nonlocal early_leader
+            if should_stop is None:
+                return False
+            decisive, leader = should_stop(tuple(ballots))
+            if decisive:
+                early_leader = leader
+            return decisive
+
+        timed_out = False
+        early_terminated = False
+        try:
+            async with asyncio.timeout(self.VOTE_COLLECTION_TIMEOUT):
+                early_terminated = await owner.run(consume_vote, stop_at_decision_boundary)
+        except TimeoutError:
+            timed_out = True
+            logger.warning(
+                "vote_collection_timeout collected=%s expected=%s timeout=%ss",
+                len(ballots),
+                len(roster),
+                self.VOTE_COLLECTION_TIMEOUT,
+            )
+
+        skipped_ids: set[int] = set()
+        for task, (slot, _agent) in binding_by_task.items():
+            if owner.classification(task) == "detached":
+                if early_terminated and not timed_out:
+                    skipped_ids.add(slot.index)
+                else:
+                    failed_ids.add(slot.index)
+
+        ordered_ballots = tuple(sorted(ballots, key=lambda ballot: ballot.slot.index))
+        failed_slots = tuple(slot for slot in slots if slot.index in failed_ids)
+        skipped_slots = tuple(slot for slot in slots if slot.index in skipped_ids)
+        return (
+            MajorityVoteCollection(ordered_ballots, failed_slots, skipped_slots),
+            early_leader,
+        )
+
+    async def collect_majority_votes(
+        self,
+        ctx: DebateContext,
+        roster: tuple[tuple[VoterSlot, Agent], ...],
+        *,
+        should_stop: Callable[[tuple[SlotVote, ...]], tuple[bool, str | None]] | None = None,
+    ) -> MajorityVoteCollection:
+        """Collect majority ballots against one exact immutable slot roster."""
+        if self.config.enable_position_shuffling and ctx.proposals:
+            votes_by_slot: dict[int, list[Vote]] = {slot.index: [] for slot, _agent in roster}
+            for permutation_index, proposals in enumerate(
+                generate_permutations(
+                    ctx.proposals,
+                    num_permutations=self.config.position_shuffling_permutations,
+                    base_seed=self.config.position_shuffling_seed,
+                )
+            ):
+                collection, _leader = await self._collect_majority_once(
+                    ctx,
+                    roster,
+                    proposals,
+                    should_stop=None,
+                    handle_success=False,
+                )
+                for ballot in collection.ballots:
+                    votes_by_slot[ballot.slot.index].append(ballot.vote)
+                logger.debug(
+                    "position_shuffling_permutation_done perm=%s votes=%s",
+                    permutation_index,
+                    len(collection.ballots),
+                )
+
+            averaged_ballots: list[SlotVote] = []
+            for slot, agent in roster:
+                slot_votes = votes_by_slot[slot.index]
+                if not slot_votes:
+                    continue
+                averaged = average_permutation_votes({slot.name: slot_votes}, ctx.proposals)
+                if not averaged:
+                    continue
+                vote = averaged[0]
+                averaged_ballots.append(SlotVote(slot=slot, vote=vote))
+                self._handle_vote_success(ctx, agent, vote, agent_name=slot.name)
+
+            received_ids = {ballot.slot.index for ballot in averaged_ballots}
+            return MajorityVoteCollection(
+                ballots=tuple(averaged_ballots),
+                failed_slots=tuple(
+                    slot for slot, _agent in roster if slot.index not in received_ids
+                ),
+                skipped_slots=(),
+            )
+
+        collection, leader = await self._collect_majority_once(
+            ctx,
+            roster,
+            ctx.proposals,
+            should_stop=should_stop,
+            handle_success=True,
+        )
+        if collection.skipped_slots:
+            if self._notify_spectator:
+                self._notify_spectator(
+                    "rlm_early_termination",
+                    details=(
+                        f"Clear majority for '{leader}' "
+                        f"({len(collection.ballots)}/{len(roster)} votes)"
+                    ),
+                    metric=len(collection.ballots) / len(roster) if roster else 0.0,
+                    agent="system",
+                )
+            if "on_rlm_early_termination" in self.hooks:
+                self.hooks["on_rlm_early_termination"](
+                    leader=leader,
+                    votes_collected=len(collection.ballots),
+                    total_agents=len(roster),
+                )
+        return collection
+
     async def collect_votes_with_errors(self, ctx: DebateContext) -> tuple[list[Vote], int]:
         """Collect votes with error tracking for unanimity mode.
 
@@ -745,6 +993,7 @@ class VoteCollector:
         agent: Agent,
         vote: Vote,
         unanimous: bool = False,
+        agent_name: str | None = None,
     ) -> None:
         """Handle successful vote: notifications, hooks, recording.
 
@@ -756,8 +1005,9 @@ class VoteCollector:
         """
         result = require_phase_result(ctx)
 
+        recorded_name = agent_name if agent_name is not None else agent.name
         logger.debug(
-            f"vote_cast{'_unanimous' if unanimous else ''} agent={agent.name} "
+            f"vote_cast{'_unanimous' if unanimous else ''} agent={recorded_name} "
             f"choice={vote.choice} confidence={vote.confidence:.0%}"
         )
 
@@ -765,19 +1015,19 @@ class VoteCollector:
         if self._notify_spectator:
             self._notify_spectator(
                 "vote",
-                agent=agent.name,
+                agent=recorded_name,
                 details=f"Voted for {vote.choice}",
                 metric=vote.confidence,
             )
 
         # Emit vote hook
         if "on_vote" in self.hooks:
-            self.hooks["on_vote"](agent.name, vote.choice, vote.confidence)
+            self.hooks["on_vote"](recorded_name, vote.choice, vote.confidence)
 
         # Record vote
         if self.recorder:
             try:
-                self.recorder.record_vote(agent.name, vote.choice, vote.reasoning)
+                self.recorder.record_vote(recorded_name, vote.choice, vote.reasoning)
             except (RuntimeError, AttributeError, TypeError) as e:  # noqa: BLE001
                 logger.debug("Recorder error for vote: %s", e)
 
@@ -789,7 +1039,7 @@ class VoteCollector:
                 )
                 self.position_tracker.record_position(
                     debate_id=debate_id,
-                    agent_name=agent.name,
+                    agent_name=recorded_name,
                     position_type="vote",
                     position_text=vote.choice,
                     round_num=result.rounds_used,

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -1887,6 +1887,116 @@ class TestImmutableMajoritySnapshot:
         }
         hook.assert_called_once_with(leader="agent0", votes_collected=8, total_agents=10)
 
+    @pytest.mark.asyncio
+    async def test_freezes_proposals_through_shuffling_and_final_answer(self):
+        agents = [MockAgent(name=name) for name in ("voter-a", "voter-b", "voter-c")]
+        ctx, protocol = make_context(
+            agents=agents,
+            proposals={"alpha": "Original Alpha", "beta": "Original Beta"},
+            consensus_mode="majority",
+        )
+        protocol.consensus_threshold = 0.6
+        protocol.min_participation_count = 2
+        protocol.enable_rlm_early_termination = False
+        protocol.enable_position_shuffling = True
+        protocol.position_shuffling_permutations = 2
+        seen_proposals: list[dict[str, str]] = []
+        mutated = False
+
+        async def vote_with_agent(agent, proposals, task):
+            nonlocal mutated
+            seen_proposals.append(dict(proposals))
+            if not mutated:
+                mutated = True
+                proposals.clear()
+                proposals["injected"] = "Callback-local mutation"
+                ctx.proposals.clear()
+                ctx.proposals.update({"beta": "Mutated Beta", "injected": "Live-context mutation"})
+            return make_vote(agent=agent.name, choice="alpha")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert len(seen_proposals) == len(agents) * 2
+        assert all(set(proposals) == {"alpha", "beta"} for proposals in seen_proposals)
+        assert ctx.proposals == {
+            "beta": "Mutated Beta",
+            "injected": "Live-context mutation",
+        }
+        assert ctx.result.winner == "alpha"
+        assert ctx.result.final_answer == "Original Alpha"
+        assert ctx.result.consensus_reached is True
+
+    @pytest.mark.asyncio
+    async def test_freezes_tally_policy_user_votes_and_verification(self):
+        agents = [MockAgent(name=name) for name in ("voter-a", "voter-b", "voter-c")]
+        ctx, protocol = make_context(
+            agents=agents,
+            proposals={"alpha": "Alpha", "beta": "Beta"},
+            consensus_mode="majority",
+        )
+        protocol.consensus_threshold = 0.6
+        protocol.min_participation_count = 2
+        protocol.enable_rlm_early_termination = False
+        protocol.verify_claims_during_consensus = False
+        user_votes: list[dict[str, Any]] = []
+        verify_claims = AsyncMock(return_value={"verified": 10, "disproven": 0})
+        mutated = False
+        phase: ConsensusPhase
+
+        async def vote_with_agent(agent, proposals, task):
+            nonlocal mutated
+            if not mutated:
+                mutated = True
+                protocol.enable_self_vote_mitigation = True
+                protocol.self_vote_mode = "exclude"
+                protocol.self_vote_downweight = 0.0
+                protocol.user_vote_weight = 100.0
+                protocol.verify_claims_during_consensus = True
+                protocol.verification_weight_bonus = 100.0
+                protocol.enable_process_verification = True
+                protocol.process_verification_hard_gate = True
+                protocol.process_verification_threshold = 1.0
+                phase.agent_weights["voter-c"] = 100.0
+                ctx.result.verification_results["alpha"] = {
+                    "verified": 100,
+                    "disproven": 0,
+                }
+                ctx.result.verification_bonuses["alpha"] = 100.0
+                ctx.result.metadata["process_verification"] = {"average": 0.0}
+                user_votes.append({"choice": "beta", "intensity": 10, "user_id": "late-user"})
+            choice = "beta" if agent.name == "voter-c" else "alpha"
+            return make_vote(agent=agent.name, choice=choice)
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(
+                protocol=protocol,
+                agent_weights={agent.name: 1.0 for agent in agents},
+                user_votes=user_votes,
+            ),
+            callbacks=ConsensusCallbacks(
+                vote_with_agent=vote_with_agent,
+                verify_claims=verify_claims,
+            ),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        verify_claims.assert_not_awaited()
+        assert len(user_votes) == 1
+        assert ctx.result.winner == "alpha"
+        assert ctx.result.final_answer == "Alpha"
+        assert ctx.result.consensus_reached is True
+        assert ctx.result.confidence == pytest.approx(2 / 3)
+        assert ctx.vote_tally == {"alpha": 2.0, "beta": 1.0}
+        assert ctx.result.verification_results == {}
+        assert ctx.result.verification_bonuses == {}
+        assert "process_verification" not in ctx.result.metadata
+
 
 # =============================================================================
 # Additional Coverage: Formal Verification Tests

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -1743,6 +1743,151 @@ class TestQuorumEnsure:
         assert ctx.result.status == "insufficient_participation"
 
 
+class TestImmutableMajoritySnapshot:
+    """Regression coverage for the per-slot majority decision boundary."""
+
+    @pytest.mark.asyncio
+    async def test_freezes_roster_threshold_quorum_and_winner_names(self):
+        agents = [
+            MockAgent(name="alpha-model"),
+            MockAgent(name="beta-model"),
+            MockAgent(name="gamma-model"),
+            MockAgent(name="delta-model"),
+        ]
+        original_names = {id(agent): agent.name for agent in agents}
+        original_agent_ids = set(original_names)
+        ctx, protocol = make_context(
+            agents=agents,
+            proposals={"alpha-model": "Alpha", "beta-model": "Beta"},
+            consensus_mode="majority",
+        )
+        protocol.consensus_threshold = 0.75
+        protocol.min_participation_ratio = 0.75
+        protocol.min_participation_count = 3
+        protocol.enable_rlm_early_termination = False
+        protocol.enable_self_vote_mitigation = True
+        seen_agents: set[int] = set()
+        mutated = False
+
+        async def vote_with_agent(agent, proposals, task):
+            nonlocal mutated
+            seen_agents.add(id(agent))
+            original_name = original_names[id(agent)]
+            if not mutated:
+                mutated = True
+                protocol.consensus_threshold = 0.99
+                protocol.min_participation_ratio = 1.0
+                protocol.min_participation_count = 99
+                for original_agent in agents:
+                    original_agent.name = f"renamed-{original_names[id(original_agent)]}"
+                ctx.agents.extend(MockAgent(name=f"late-{index}") for index in range(6))
+            choice = "alpha" if original_name != "delta-model" else "beta-model"
+            return make_vote(agent=original_name, choice=choice)
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(
+                protocol=protocol,
+                agent_weights={
+                    "alpha-model": 2.0,
+                    "beta-model": 1.0,
+                    "gamma-model": 1.0,
+                    "delta-model": 1.0,
+                },
+            ),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert seen_agents == original_agent_ids
+        assert len(ctx.agents) == 10
+        assert ctx.result.winner == "alpha-model"
+        assert ctx.result.final_answer == "Alpha"
+        assert ctx.result.consensus_reached is True
+        assert ctx.result.confidence == pytest.approx(0.8)
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 4,
+            "received": 4,
+            "failed": 0,
+            "skipped": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_duplicate_names_remain_distinct_missing_weight_slots(self):
+        first_duplicate = MockAgent(name="duplicate")
+        second_duplicate = MockAgent(name="duplicate")
+        agents = [first_duplicate, second_duplicate, MockAgent(name="b"), MockAgent(name="c")]
+        ctx, protocol = make_context(
+            agents=agents,
+            proposals={"proposal-a": "Alpha", "proposal-b": "Beta"},
+            consensus_mode="majority",
+        )
+        protocol.consensus_threshold = 0.6
+        protocol.min_participation_ratio = 0.5
+        protocol.min_participation_count = 2
+        protocol.enable_rlm_early_termination = False
+        protocol.enable_position_shuffling = True
+        protocol.position_shuffling_permutations = 2
+
+        async def vote_with_agent(agent, proposals, task):
+            if agent is second_duplicate:
+                raise RuntimeError("duplicate slot failed")
+            choice = "proposal-b" if agent.name == "c" else "proposal-a"
+            return make_vote(agent=agent.name, choice=choice)
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+        phase._compute_vote_weights = MagicMock(return_value={"duplicate": 2.0, "b": 1.0, "c": 1.0})
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert ctx.result.winner == "proposal-a"
+        assert ctx.result.consensus_reached is False
+        assert ctx.result.confidence == pytest.approx(0.5)
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 4,
+            "received": 3,
+            "failed": 1,
+            "skipped": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_weighted_rlm_waits_for_effective_threshold(self):
+        agents = [MockAgent(name=f"agent{index}") for index in range(10)]
+        ctx, protocol = make_context(agents=agents, consensus_mode="majority")
+        protocol.consensus_threshold = 0.75
+        protocol.min_participation_ratio = 0.5
+        protocol.min_participation_count = 1
+        hook = MagicMock()
+
+        async def vote_with_agent(agent, proposals, task):
+            if int(agent.name.removeprefix("agent")) >= 8:
+                await asyncio.sleep(10)
+            return make_vote(agent=agent.name, choice="agent0")
+
+        phase = ConsensusPhase(
+            deps=ConsensusDependencies(protocol=protocol, hooks={"on_rlm_early_termination": hook}),
+            callbacks=ConsensusCallbacks(vote_with_agent=vote_with_agent),
+        )
+        phase._compute_vote_weights = MagicMock(return_value={agent.name: 1.0 for agent in agents})
+        phase._vote_collector.config.rlm_early_termination_threshold = 0.5
+        phase._vote_collector.config.rlm_majority_lead_threshold = 0.1
+
+        await phase._handle_majority_consensus(ctx)
+
+        assert ctx.result.consensus_reached is True
+        assert ctx.result.confidence == pytest.approx(0.8)
+        assert ctx.result.metadata["vote_participation"] == {
+            "eligible": 10,
+            "received": 8,
+            "failed": 0,
+            "skipped": 2,
+        }
+        hook.assert_called_once_with(leader="agent0", votes_collected=8, total_agents=10)
+
+
 # =============================================================================
 # Additional Coverage: Formal Verification Tests
 # =============================================================================


### PR DESCRIPTION
## Summary

- capture one immutable per-slot majority decision snapshot before voter callbacks run
- bind roster, threshold, quorum, proposals, weighting, user votes, verification, bonuses/penalties, participation, and winner selection to that snapshot
- isolate each voter proposal mapping and preserve duplicate-name slots, position shuffling, and threshold-aware weighted early termination

## Scope and provenance

This is the second bounded Tier-2 replacement for parked PR #9912. PR #9935 already landed vote-task lifecycle ownership; this PR supplies the separate immutable-majority-snapshot contract from fresh main. It selectively reuses the defect model and tests, not the cumulative #9912 branch.

The change remains limited to three files. The cumulative 3-file, +1,302/-71 scope exceeds the campaign target because exact-slot lifecycle collection and every tally/final-answer input must be frozen atomically after the terminal review proved the narrower roster/threshold snapshot incomplete. It introduces no endpoint, subsystem, dependency, workflow, governance, receipt, evidence, or merge-tool change.

## Authorized terminal repair

The first terminal review of `06f07fac4eb7ac1fa9fc829c9fecc202ddd45766` found two P1 blockers:

1. post-await weighting, bonus, and user-vote logic still observed mutable live state;
2. proposals were not frozen through collection, shuffling, averaging, normalization, winner selection, and final-answer selection.

The operator authorized one bounded repair covering exactly those findings. Exact repair head: `44880ef37189cac939b921cf2c3554bf998241e4`.

The repair captures a detached protocol and decision context, base slot weights and bias policy, user-vote contributions, calibration/evidence/verification/process inputs, collector timeouts and shuffling/RLM configuration, grouping and verification callbacks, and the original proposal/task/domain mapping before the first await. Voter callbacks receive per-task proposal copies. Snapshot-local verifier, bonus, and winner helpers consume only the detached inputs.

## Validation

- mutation tests failed against the authorized baseline for both P1 categories, then passed after repair
- focused consensus and collector suites: 162 passed
- cumulative consensus/vote/integration/orchestrator suites: 568 passed
- Ruff format and lint: passed
- targeted mypy for both changed source files: passed
- code-quality ratchet, `git diff --check`, pre-commit, and pre-push hooks: passed
- automation branch preflight: passed
- exact-head GitHub check runs: terminal success or allowed skipped state
- current-main overlap across the three files: empty at `0ad4c5dcda2df9f12e2b19de32727fca9f25033c`

## Terminal review and park state

The one authorized fresh independent non-countable review of exact head `44880ef37189cac939b921cf2c3554bf998241e4` found one P1 blocker:

- `_collect_majority_once.cast_vote()` returns its vote result directly, while `_retrieve_detached_result()` only inspects tuple results. A detached vote task that ignores cancellation and later returns a custom non-`Exception` `BaseException` can therefore be silently discarded instead of being forwarded to the event-loop exception handler. The review reproduced a `VoteAbort` result with zero event-loop exception contexts.

The checked-out, remote-branch, and PR heads remained exact throughout review, and the reviewer modified no files. Under the explicit authorization, any P0-P2 is a hard stop with no further repair. This draft PR is parked at the exact head. No evidence, ready-state transition, settlement, or merge was performed or is authorized.

Related to #9912.
