### PR TITLE
fix(deps): patch high-severity VS Code webview dependencies (#9039)

### DIFF
--- a/ide/vscode-aragora/webview-ui/package-lock.json
+++ b/ide/vscode-aragora/webview-ui/package-lock.json
@@ -974,9 +974,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1685,9 +1685,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -2108,9 +2108,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/ide/vscode-aragora/webview-ui/package.json
+++ b/ide/vscode-aragora/webview-ui/package.json
@@ -30,9 +30,11 @@
     "vite": "^8.0.16"
   },
   "overrides": {
+    "js-yaml": "4.3.1",
     "minimatch@<3.1.5": "3.1.5",
     "minimatch@>=9.0.0 <9.0.7": "9.0.7",
-    "brace-expansion": "^2.0.3",
+    "brace-expansion": "2.1.4",
+    "nanoid": "3.3.18",
     "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

- pin `js-yaml` to 4.3.1 in the isolated VS Code webview package, resolving Dependabot alerts #378 and #311
- update existing `brace-expansion` and new `nanoid` overrides to their fixed versions after the same package's full audit exposed two additional high-severity findings
- regenerate only `ide/vscode-aragora/webview-ui/package-lock.json`

## Scope

This is the security hard-drain exception under #9039. It does not touch the parent VS Code extension manifest owned by #9925 or the docs-site manifest owned by #9915.

## Validation

- `npm ci --ignore-scripts`
- `npm audit --json` -> 0 vulnerabilities
- `npm ls js-yaml brace-expansion nanoid --all` -> 4.3.1 / 2.1.4 / 3.3.18
- `npm run lint`
- `npm run build` (TypeScript, Vite, classic-bundle verification)
- second `npm install --package-lock-only --ignore-scripts` -> byte-identical lockfile
- `pre-commit run --files ide/vscode-aragora/webview-ui/package.json ide/vscode-aragora/webview-ui/package-lock.json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

Draft only. No evidence, settlement, CI rerun, merge, or branch-protection action is included.
