### PR TITLE
fix(deps): patch docs-site nanoid advisory

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -13928,9 +13928,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the docs-site transitive `nanoid` lock entry from 3.3.16 to 3.3.18
- clear Dependabot alert #390 / GHSA-2v37-7h3g-55p8 without changing direct dependencies
- keep the unrelated Docusaurus `image-size` chain unchanged because upstream currently publishes no patched `image-size` release

Program: #9039

## Validation

- Node 24.19.0
- `npm ci --ignore-scripts` (pass)
- `npm audit --json` confirms `nanoid` is absent; total high findings decrease 20 -> 19
- `npm run build` (pass; existing broken-link warnings remain)
- second `npm update nanoid --package-lock-only --ignore-scripts` is byte-identical
- `uv run pre-commit run --files docs-site/package-lock.json` (pass)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` (pass)
- `git diff --check origin/main...HEAD` (pass)

## Known pre-existing limitations

- `npm run typecheck` exits with TypeScript help before analysis because `docs-site` has no `tsconfig.json`; this PR does not change that script.
- `image-size` 2.0.2 remains the latest published version and the current Docusaurus/OpenAPI chain has no compatible patched release. npm's suggested forced change is a major downgrade, so it is intentionally not included here.

Draft only. No readiness, evidence, settlement, or merge authority is implied.
