### PR TITLE
[AGT-04] Batch market emitter for synthetic GitHub markets

### DIFF
--- a/aragora/markets/emitter.py
+++ b/aragora/markets/emitter.py
@@ -1,0 +1,175 @@
+"""Batch market emitter for synthetic GitHub markets (AGT-04, issue #6065).
+
+Flag-gated via ``ARAGORA_SYNTHETIC_MARKETS_ENABLED``. Idempotently creates
+markets for open PRs or issues; existing markets are skipped. Scheduling
+is out of scope — the caller decides when to invoke.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from aragora.connectors.prediction_markets.synthetic_github import (
+    SYNTHETIC_MARKETS_FLAG,
+    SyntheticGitHubAdapter,
+    SyntheticGitHubError,
+    synthetic_markets_enabled,
+)
+from aragora.markets.types import Market
+
+logger = logging.getLogger(__name__)
+
+
+class BatchEmitError(RuntimeError):
+    """Raised when the feature flag is off."""
+
+
+@dataclass(frozen=True)
+class PrEntry:
+    """Pull request for which a prediction market should be created."""
+
+    repo: str
+    number: int
+    title: str = ""
+
+    def __post_init__(self) -> None:
+        if not str(self.repo).strip():
+            raise ValueError("PrEntry.repo must be non-empty")
+        if not isinstance(self.number, int) or self.number < 1:
+            raise ValueError("PrEntry.number must be a positive int")
+
+
+@dataclass(frozen=True)
+class IssueEntry:
+    """Issue for which a prediction market should be created."""
+
+    repo: str
+    number: int
+    title: str = ""
+
+    def __post_init__(self) -> None:
+        if not str(self.repo).strip():
+            raise ValueError("IssueEntry.repo must be non-empty")
+        if not isinstance(self.number, int) or self.number < 1:
+            raise ValueError("IssueEntry.number must be a positive int")
+
+
+@dataclass
+class BatchEmitResult:
+    """Outcome of a single ``emit_markets_for_*`` call."""
+
+    created: list[Market] = field(default_factory=list)
+    skipped_ids: list[str] = field(default_factory=list)
+    errors: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def created_count(self) -> int:
+        return len(self.created)
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.skipped_ids)
+
+    @property
+    def error_count(self) -> int:
+        return len(self.errors)
+
+    @property
+    def total_seen(self) -> int:
+        return self.created_count + self.skipped_count + self.error_count
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "created_count": self.created_count,
+            "skipped_count": self.skipped_count,
+            "error_count": self.error_count,
+            "total_seen": self.total_seen,
+            "created": [m.to_json() for m in self.created],
+            "skipped_ids": list(self.skipped_ids),
+            "errors": [{"target": t, "error": e} for t, e in self.errors],
+        }
+
+
+def emit_markets_for_prs(
+    adapter: SyntheticGitHubAdapter,
+    prs: list[PrEntry],
+    *,
+    resolution_window_days: int = 7,
+) -> BatchEmitResult:
+    """Create markets for PRs that don't already have one; skip others."""
+    if not synthetic_markets_enabled():
+        raise BatchEmitError(
+            f"batch market emission is disabled; set {SYNTHETIC_MARKETS_FLAG}=1 to enable"
+        )
+    result = BatchEmitResult()
+    for pr in prs:
+        label = f"{pr.repo}#PR{pr.number}"
+        try:
+            probe = Market.create(
+                question_kind="pr_merge",
+                target={"repo": pr.repo, "number": pr.number},
+                description=f"Will PR #{pr.number} in {pr.repo} merge within {resolution_window_days}d?",
+                resolution_window_days=resolution_window_days,
+            )
+            if adapter.store.get_market(probe.market_id) is not None:
+                result.skipped_ids.append(probe.market_id)
+                continue
+            desc = f"{pr.title} — will merge within {resolution_window_days}d?" if pr.title else ""
+            result.created.append(
+                adapter.create_pr_merge_market(
+                    repo=pr.repo,
+                    pr_number=pr.number,
+                    resolution_window_days=resolution_window_days,
+                    description=desc,
+                )
+            )
+        except (SyntheticGitHubError, ValueError) as exc:
+            result.errors.append((label, str(exc)))
+            logger.warning("emit_prs: error for %s: %s", label, exc)
+    return result
+
+
+def emit_markets_for_issues(
+    adapter: SyntheticGitHubAdapter,
+    issues: list[IssueEntry],
+    *,
+    resolution_window_days: int = 30,
+) -> BatchEmitResult:
+    """Create markets for issues that don't already have one; skip others."""
+    if not synthetic_markets_enabled():
+        raise BatchEmitError(
+            f"batch market emission is disabled; set {SYNTHETIC_MARKETS_FLAG}=1 to enable"
+        )
+    result = BatchEmitResult()
+    for issue in issues:
+        label = f"{issue.repo}#I{issue.number}"
+        try:
+            probe = Market.create(
+                question_kind="issue_close",
+                target={"repo": issue.repo, "number": issue.number},
+                description=f"Will issue #{issue.number} in {issue.repo} close within {resolution_window_days}d?",
+                resolution_window_days=resolution_window_days,
+            )
+            if adapter.store.get_market(probe.market_id) is not None:
+                result.skipped_ids.append(probe.market_id)
+                continue
+            desc = (
+                f"{issue.title} — will close within {resolution_window_days}d?" if issue.title else ""
+            )
+            result.created.append(
+                adapter.create_issue_close_market(
+                    repo=issue.repo,
+                    issue_number=issue.number,
+                    resolution_window_days=resolution_window_days,
+                    description=desc,
+                )
+            )
+        except (SyntheticGitHubError, ValueError) as exc:
+            result.errors.append((label, str(exc)))
+            logger.warning("emit_issues: error for %s: %s", label, exc)
+    return result
+
+
+__all__ = ["BatchEmitError", "BatchEmitResult", "IssueEntry", "PrEntry", "emit_markets_for_issues", "emit_markets_for_prs"]

--- a/aragora/markets/emitter.py
+++ b/aragora/markets/emitter.py
@@ -156,7 +156,9 @@ def emit_markets_for_issues(
                 result.skipped_ids.append(probe.market_id)
                 continue
             desc = (
-                f"{issue.title} — will close within {resolution_window_days}d?" if issue.title else ""
+                f"{issue.title} — will close within {resolution_window_days}d?"
+                if issue.title
+                else ""
             )
             result.created.append(
                 adapter.create_issue_close_market(
@@ -172,4 +174,11 @@ def emit_markets_for_issues(
     return result
 
 
-__all__ = ["BatchEmitError", "BatchEmitResult", "IssueEntry", "PrEntry", "emit_markets_for_issues", "emit_markets_for_prs"]
+__all__ = [
+    "BatchEmitError",
+    "BatchEmitResult",
+    "IssueEntry",
+    "PrEntry",
+    "emit_markets_for_issues",
+    "emit_markets_for_prs",
+]

--- a/tests/markets/test_batch_market_emitter.py
+++ b/tests/markets/test_batch_market_emitter.py
@@ -1,0 +1,139 @@
+"""Tests for the AGT-04 batch market emitter.
+
+Uses a real MarketStore backed by tmp_path (no live GitHub calls).
+gh_runner=None on the adapter so no subprocess is ever started.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.connectors.prediction_markets.synthetic_github import (
+    SYNTHETIC_MARKETS_FLAG,
+    SyntheticGitHubAdapter,
+)
+from aragora.markets.emitter import (
+    BatchEmitError,
+    IssueEntry,
+    PrEntry,
+    emit_markets_for_issues,
+    emit_markets_for_prs,
+)
+from aragora.markets.store import MarketStore
+
+
+@pytest.fixture()
+def adapter(tmp_path: Path) -> SyntheticGitHubAdapter:
+    return SyntheticGitHubAdapter(
+        store=MarketStore(tmp_path / "markets"), gh_runner=None, require_expiry=False
+    )
+
+
+class TestEntryValidation:
+    def test_pr_entry_rejects_empty_repo(self) -> None:
+        with pytest.raises(ValueError, match="repo"):
+            PrEntry(repo="", number=1)
+
+    def test_pr_entry_rejects_zero_number(self) -> None:
+        with pytest.raises(ValueError, match="positive int"):
+            PrEntry(repo="owner/repo", number=0)
+
+
+class TestFlagGate:
+    def test_prs_raises_when_disabled(
+        self, adapter: SyntheticGitHubAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(SYNTHETIC_MARKETS_FLAG, raising=False)
+        with pytest.raises(BatchEmitError, match="disabled"):
+            emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)])
+
+    def test_issues_raises_when_disabled(
+        self, adapter: SyntheticGitHubAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(SYNTHETIC_MARKETS_FLAG, raising=False)
+        with pytest.raises(BatchEmitError, match="disabled"):
+            emit_markets_for_issues(adapter, [IssueEntry(repo="owner/repo", number=1)])
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", ""])
+    def test_prs_falsy_values_raise(
+        self, val: str, adapter: SyntheticGitHubAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, val)
+        with pytest.raises(BatchEmitError):
+            emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)])
+
+    def test_truthy_value_enables(
+        self, adapter: SyntheticGitHubAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
+        assert emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)]).created_count == 1
+
+
+class TestEmitPrs:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
+
+    def test_empty_input(self, adapter: SyntheticGitHubAdapter) -> None:
+        assert emit_markets_for_prs(adapter, []).total_seen == 0
+
+    def test_creates_pr_market(self, adapter: SyntheticGitHubAdapter) -> None:
+        r = emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)])
+        assert r.created_count == 1
+        assert r.created[0].question_kind == "pr_merge"
+        assert r.created[0].target["number"] == 1
+
+    def test_idempotent(self, adapter: SyntheticGitHubAdapter) -> None:
+        prs = [PrEntry(repo="owner/repo", number=1)]
+        emit_markets_for_prs(adapter, prs)
+        r = emit_markets_for_prs(adapter, prs)
+        assert r.created_count == 0 and r.skipped_count == 1
+
+    def test_partial_overlap(self, adapter: SyntheticGitHubAdapter) -> None:
+        emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)])
+        r = emit_markets_for_prs(
+            adapter, [PrEntry(repo="owner/repo", number=1), PrEntry(repo="owner/repo", number=2)]
+        )
+        assert r.created_count == 1 and r.skipped_count == 1
+
+    def test_title_in_description(self, adapter: SyntheticGitHubAdapter) -> None:
+        r = emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=7, title="Add X")])
+        assert "Add X" in r.created[0].description
+
+    def test_invalid_repo_is_error(self, adapter: SyntheticGitHubAdapter) -> None:
+        r = emit_markets_for_prs(adapter, [PrEntry(repo="badrepo", number=1)])
+        assert r.error_count == 1 and r.created_count == 0
+
+    def test_error_does_not_abort_batch(self, adapter: SyntheticGitHubAdapter) -> None:
+        r = emit_markets_for_prs(
+            adapter, [PrEntry(repo="bad", number=1), PrEntry(repo="owner/repo", number=2)]
+        )
+        assert r.error_count == 1 and r.created_count == 1
+
+    def test_to_json_shape(self, adapter: SyntheticGitHubAdapter) -> None:
+        j = emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)]).to_json()
+        assert {"created_count", "skipped_count", "error_count", "total_seen"} <= j.keys()
+
+
+class TestEmitIssues:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
+
+    def test_creates_issue_market(self, adapter: SyntheticGitHubAdapter) -> None:
+        r = emit_markets_for_issues(adapter, [IssueEntry(repo="owner/repo", number=42)])
+        assert r.created_count == 1
+        assert r.created[0].question_kind == "issue_close"
+
+    def test_idempotent(self, adapter: SyntheticGitHubAdapter) -> None:
+        issues = [IssueEntry(repo="owner/repo", number=10)]
+        emit_markets_for_issues(adapter, issues)
+        r = emit_markets_for_issues(adapter, issues)
+        assert r.created_count == 0 and r.skipped_count == 1
+
+    def test_pr_and_issue_markets_are_distinct(self, adapter: SyntheticGitHubAdapter) -> None:
+        emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=5)])
+        r = emit_markets_for_issues(adapter, [IssueEntry(repo="owner/repo", number=5)])
+        assert r.created_count == 1

--- a/tests/markets/test_batch_market_emitter.py
+++ b/tests/markets/test_batch_market_emitter.py
@@ -68,7 +68,9 @@ class TestFlagGate:
         self, adapter: SyntheticGitHubAdapter, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
-        assert emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)]).created_count == 1
+        assert (
+            emit_markets_for_prs(adapter, [PrEntry(repo="owner/repo", number=1)]).created_count == 1
+        )
 
 
 class TestEmitPrs:


### PR DESCRIPTION
## Summary

Adds `aragora/markets/emitter.py` with two idempotent batch-creation functions advancing AGT-04 (synthetic GitHub prediction markets, issue #6065):

- `emit_markets_for_prs(adapter, prs, ...)` — creates `pr_merge` markets for a list of `PrEntry` items; skips PRs that already have a market in the store
- `emit_markets_for_issues(adapter, issues, ...)` — creates `issue_close` markets for a list of `IssueEntry` items; same idempotency guarantee

Both functions:
- Are gated behind the existing `ARAGORA_SYNTHETIC_MARKETS_ENABLED` flag (default OFF); raise `BatchEmitError` when the flag is absent or falsy
- Collect per-entry errors into `BatchEmitResult.errors` without aborting the batch
- Return a `BatchEmitResult` (created / skipped / errors) with a `to_json()` serializer for receipt/provenance wiring
- Do not touch dispatch, boss loop, or any live queue path

Scheduling, credit bookkeeping, and per-agent Brier scoring remain explicitly out of scope (AGT-05).

## What this is NOT

- Not `boss-ready` — planning track, gated by `ARAGORA_SYNTHETIC_MARKETS_ENABLED=0` default
- No live GitHub API calls in any code path; the adapter's `gh_runner` is `None` in tests
- No changes to existing files (pure addition)

## Test plan

- 20 focused tests in `tests/markets/test_batch_market_emitter.py`
- Flag-gate: enabled/disabled/falsy values all tested
- Idempotency: second call with same inputs returns skipped, not created
- Partial overlap: mixed new + existing entries in one call
- Error isolation: a bad repo format is captured per-entry; rest of batch continues
- PR vs issue markets are distinct (different `question_kind` → different `market_id`)
- `ruff check` — clean
- `mypy --ignore-missing-imports` — clean

## Slice metadata

| Field | Value |
|-------|-------|
| Track | AGT-04 (issue #6065) |
| Net diff | 314 LOC (2 new files) |
| Flag gate | `ARAGORA_SYNTHETIC_MARKETS_ENABLED` (default OFF) |
| Live queue effect | None |
| Depends on | Existing `SyntheticGitHubAdapter`, `MarketStore`, `Market` types |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012V38yfVvoYroj4PMZnPQ7p

---
_Generated by [Claude Code](https://claude.ai/code/session_012V38yfVvoYroj4PMZnPQ7p)_