### PR TITLE
[AGT-06] DIC-20 → VIAH bridge: count failed-claim decay as negative signal

### DIFF
--- a/aragora/evaluation/viah_decay_signals.py
+++ b/aragora/evaluation/viah_decay_signals.py
@@ -1,0 +1,60 @@
+"""AGT-06 sidecar signal bridge: DIC-20 EpistemicDecayBatchReport → VIAH counters.
+
+Supplies ``failed_claims_promoted_without_repair`` — the sidecar parameter that
+:func:`aragora.evaluation.viah.compute_viah` accepts for the VIAH negative signal.
+
+A code unit is counted when its :class:`~aragora.epistemic.decay_monitor.DecaySignal`
+meets both conditions:
+
+1. ``recommended_action`` is ``"fail_closed"`` or ``"repair_required"``
+2. At least one reason has ``kind`` of ``"failed_claim"`` or ``"verifier_error"``
+
+Stale-evidence-only and unresolved-crux-only units are excluded: those decay classes
+carry their own repair pathways and do not constitute "promoted without repair."
+
+Flag: ``ARAGORA_VIAH_TREND_ENABLED`` (default off, same gate as viah_signals.py).
+All computation is side-effect-free; no queue mutation.
+
+Advances issue #6067 (AGT-06) — wires DIC-20 decay output into VIAH negative signal,
+closing the loop between epistemic claim decay and the productivity metric.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aragora.epistemic.decay_monitor import EpistemicDecayBatchReport
+
+_VIAH_FLAG = "ARAGORA_VIAH_TREND_ENABLED"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_ACTIONABLE_ACTIONS = frozenset({"fail_closed", "repair_required"})
+_CLAIM_FAILURE_KINDS = frozenset({"failed_claim", "verifier_error"})
+
+
+def _viah_enabled() -> bool:
+    return os.environ.get(_VIAH_FLAG, "").strip().lower() in _TRUTHY
+
+
+def count_failed_claims_from_decay(
+    report: "EpistemicDecayBatchReport",
+) -> int:
+    """Count code units with actionable claim failures from a batch decay report.
+
+    Returns the number of units where the recommended action is ``"fail_closed"``
+    or ``"repair_required"`` AND at least one reason is a claim failure
+    (``"failed_claim"`` or ``"verifier_error"``).
+
+    Returns 0 when ``ARAGORA_VIAH_TREND_ENABLED`` is not set so the sidecar
+    produces no signal until the operator opts in.
+    """
+    if not _viah_enabled():
+        return 0
+    count = 0
+    for signal in report.signals:
+        if signal.recommended_action not in _ACTIONABLE_ACTIONS:
+            continue
+        if any(r.kind in _CLAIM_FAILURE_KINDS for r in signal.reasons):
+            count += 1
+    return count

--- a/tests/metrics/test_viah_decay_signals.py
+++ b/tests/metrics/test_viah_decay_signals.py
@@ -1,0 +1,208 @@
+"""Tests for viah_decay_signals — DIC-20 EpistemicDecayBatchReport → AGT-06 VIAH bridge.
+
+Verifies count_failed_claims_from_decay with synthetic DecaySignal fixtures:
+flag gate, reason-kind filtering, recommended_action threshold, and multi-unit batches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.decay_monitor import (
+    DecayReason,
+    DecaySignal,
+    EpistemicDecayBatchReport,
+)
+from aragora.evaluation.viah_decay_signals import count_failed_claims_from_decay
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _reason(kind: str, detail: str = "") -> DecayReason:
+    return DecayReason(kind=kind, detail=detail or f"synthetic {kind}")
+
+
+def _signal(
+    *,
+    recommended_action: str = "report_only",
+    reason_kinds: list[str] | None = None,
+    code_unit_id: str = "unit.test",
+    integrity_score: float = 0.7,
+) -> DecaySignal:
+    return DecaySignal(
+        code_unit_id=code_unit_id,
+        integrity_score=integrity_score,
+        reasons=[_reason(k) for k in (reason_kinds or [])],
+        recommended_action=recommended_action,
+    )
+
+
+def _report(*signals: DecaySignal) -> EpistemicDecayBatchReport:
+    return EpistemicDecayBatchReport(
+        signals=list(signals),
+        generated_at="2026-09-02T00:00:00+00:00",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGate:
+    def test_returns_zero_without_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_VIAH_TREND_ENABLED", raising=False)
+        report = _report(_signal(recommended_action="fail_closed", reason_kinds=["failed_claim"]))
+        assert count_failed_claims_from_decay(report) == 0
+
+    def test_counts_when_flag_set_to_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_VIAH_TREND_ENABLED", "1")
+        report = _report(_signal(recommended_action="fail_closed", reason_kinds=["failed_claim"]))
+        assert count_failed_claims_from_decay(report) == 1
+
+    def test_counts_when_flag_set_to_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_VIAH_TREND_ENABLED", "true")
+        report = _report(_signal(recommended_action="fail_closed", reason_kinds=["failed_claim"]))
+        assert count_failed_claims_from_decay(report) == 1
+
+    def test_returns_zero_for_empty_string_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_VIAH_TREND_ENABLED", "")
+        report = _report(_signal(recommended_action="fail_closed", reason_kinds=["failed_claim"]))
+        assert count_failed_claims_from_decay(report) == 0
+
+
+# ---------------------------------------------------------------------------
+# Recommended-action threshold
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedAction:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_VIAH_TREND_ENABLED", "1")
+
+    def test_report_only_not_counted(self) -> None:
+        report = _report(_signal(recommended_action="report_only", reason_kinds=["failed_claim"]))
+        assert count_failed_claims_from_decay(report) == 0
+
+    def test_repair_required_with_claim_failure_counted(self) -> None:
+        report = _report(
+            _signal(recommended_action="repair_required", reason_kinds=["failed_claim"])
+        )
+        assert count_failed_claims_from_decay(report) == 1
+
+    def test_fail_closed_with_claim_failure_counted(self) -> None:
+        report = _report(
+            _signal(recommended_action="fail_closed", reason_kinds=["failed_claim"])
+        )
+        assert count_failed_claims_from_decay(report) == 1
+
+    def test_fail_closed_with_verifier_error_counted(self) -> None:
+        report = _report(
+            _signal(recommended_action="fail_closed", reason_kinds=["verifier_error"])
+        )
+        assert count_failed_claims_from_decay(report) == 1
+
+
+# ---------------------------------------------------------------------------
+# Reason-kind filtering
+# ---------------------------------------------------------------------------
+
+
+class TestReasonKindFiltering:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_VIAH_TREND_ENABLED", "1")
+
+    def test_stale_evidence_only_excluded(self) -> None:
+        report = _report(
+            _signal(recommended_action="repair_required", reason_kinds=["stale_evidence"])
+        )
+        assert count_failed_claims_from_decay(report) == 0
+
+    def test_unresolved_crux_only_excluded(self) -> None:
+        report = _report(
+            _signal(recommended_action="fail_closed", reason_kinds=["unresolved_crux"])
+        )
+        assert count_failed_claims_from_decay(report) == 0
+
+    def test_missing_receipt_only_excluded(self) -> None:
+        report = _report(
+            _signal(recommended_action="fail_closed", reason_kinds=["missing_receipt"])
+        )
+        assert count_failed_claims_from_decay(report) == 0
+
+    def test_mixed_reasons_counted_when_claim_kind_present(self) -> None:
+        report = _report(
+            _signal(
+                recommended_action="repair_required",
+                reason_kinds=["stale_evidence", "failed_claim"],
+            )
+        )
+        assert count_failed_claims_from_decay(report) == 1
+
+    def test_no_reasons_not_counted(self) -> None:
+        report = _report(_signal(recommended_action="fail_closed", reason_kinds=[]))
+        assert count_failed_claims_from_decay(report) == 0
+
+
+# ---------------------------------------------------------------------------
+# Batch / multi-unit
+# ---------------------------------------------------------------------------
+
+
+class TestBatch:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_VIAH_TREND_ENABLED", "1")
+
+    def test_empty_report_returns_zero(self) -> None:
+        assert count_failed_claims_from_decay(_report()) == 0
+
+    def test_multiple_units_counted_correctly(self) -> None:
+        report = _report(
+            _signal(
+                code_unit_id="u1",
+                recommended_action="fail_closed",
+                reason_kinds=["failed_claim"],
+            ),
+            _signal(
+                code_unit_id="u2",
+                recommended_action="repair_required",
+                reason_kinds=["verifier_error"],
+            ),
+            _signal(
+                code_unit_id="u3",
+                recommended_action="report_only",
+                reason_kinds=["failed_claim"],
+            ),
+            _signal(
+                code_unit_id="u4",
+                recommended_action="fail_closed",
+                reason_kinds=["stale_evidence"],
+            ),
+        )
+        assert count_failed_claims_from_decay(report) == 2
+
+    def test_all_healthy_returns_zero(self) -> None:
+        report = _report(
+            _signal(code_unit_id="u1", recommended_action="report_only", reason_kinds=[]),
+            _signal(code_unit_id="u2", recommended_action="report_only", reason_kinds=[]),
+        )
+        assert count_failed_claims_from_decay(report) == 0
+
+    def test_all_actionable_claim_failures_counted(self) -> None:
+        report = _report(
+            *[
+                _signal(
+                    code_unit_id=f"u{i}",
+                    recommended_action="fail_closed",
+                    reason_kinds=["failed_claim"],
+                )
+                for i in range(5)
+            ]
+        )
+        assert count_failed_claims_from_decay(report) == 5

--- a/tests/metrics/test_viah_decay_signals.py
+++ b/tests/metrics/test_viah_decay_signals.py
@@ -95,15 +95,11 @@ class TestRecommendedAction:
         assert count_failed_claims_from_decay(report) == 1
 
     def test_fail_closed_with_claim_failure_counted(self) -> None:
-        report = _report(
-            _signal(recommended_action="fail_closed", reason_kinds=["failed_claim"])
-        )
+        report = _report(_signal(recommended_action="fail_closed", reason_kinds=["failed_claim"]))
         assert count_failed_claims_from_decay(report) == 1
 
     def test_fail_closed_with_verifier_error_counted(self) -> None:
-        report = _report(
-            _signal(recommended_action="fail_closed", reason_kinds=["verifier_error"])
-        )
+        report = _report(_signal(recommended_action="fail_closed", reason_kinds=["verifier_error"]))
         assert count_failed_claims_from_decay(report) == 1
 
 


### PR DESCRIPTION
## Slice

Adds `aragora/evaluation/viah_decay_signals.py` with `count_failed_claims_from_decay(report: EpistemicDecayBatchReport) -> int` — a flag-gated bridge that converts DIC-20 decay monitor output into the `failed_claims_promoted_without_repair` sidecar that `compute_viah()` already accepts as a parameter (defaulting to zero until wired).

A unit is counted when its `DecaySignal` has `recommended_action` of `"fail_closed"` or `"repair_required"` AND at least one reason with kind `"failed_claim"` or `"verifier_error"`. Stale-evidence-only and unresolved-crux-only units are excluded — those decay classes carry their own repair paths and do not constitute "promoted without repair."

## Gating

- Default: OFF (flag: `ARAGORA_VIAH_TREND_ENABLED`, same gate as `viah_signals.py`)
- Live queue effect: none — all computation is side-effect-free
- Advances issue: #6067 (AGT-06)

## Tests

- `TestFlagGate` — 4 tests: returns 0 without flag, counts with flag=1, flag=true, returns 0 on empty string
- `TestRecommendedAction` — 4 tests: `report_only` excluded; `repair_required` and `fail_closed` with claim failures counted
- `TestReasonKindFiltering` — 5 tests: stale evidence, unresolved crux, missing receipt excluded; mixed reasons with claim kind counted; empty reasons excluded
- `TestBatch` — 4 tests: empty report, multi-unit counting, all healthy, all actionable

## Validation

- `pytest tests/metrics/test_viah_decay_signals.py --noconftest` — 17 passed
- `ruff check aragora/evaluation/viah_decay_signals.py tests/metrics/test_viah_decay_signals.py` — clean
- `mypy aragora/evaluation/viah_decay_signals.py --ignore-missing-imports` — clean

## Out of scope

- Wiring `count_failed_claims_from_decay` into the `aragora metrics viah` CLI invocation (separate slice; caller of `compute_viah()` supplies the count)
- AGT-05 settlement signals (crux resolutions, Brier scores) — those remain in `viah_signals.py`
- Any write to ShiftLedger, queue, or issue system

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lkg5CFRBC21C9cQVfwpVeJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkg5CFRBC21C9cQVfwpVeJ)_