### PR TITLE
test(cdg): make the historical PR head fetch opt-in with a deterministic offline skip

### DIFF
--- a/tests/scripts/_contract_drift_historical_git.py
+++ b/tests/scripts/_contract_drift_historical_git.py
@@ -6,6 +6,7 @@ from pathlib import Path
 PR_9320_HEAD_REF = "refs/pull/9320/head"
 PR_9320_LOCAL_REF = "refs/cdg-historical-backfill/9320/head"
 PR_9320_HEAD_SHA = "aba6b14c94eca3a9c825b1a303ea67684d5f8daa"
+HISTORICAL_HEAD_FETCH_ENV = "ARAGORA_CDG_FETCH_HISTORICAL_HEAD"
 
 
 def ensure_pr_9320_head(

--- a/tests/scripts/_contract_drift_historical_git.py
+++ b/tests/scripts/_contract_drift_historical_git.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
+
+import pytest
 
 PR_9320_HEAD_REF = "refs/pull/9320/head"
 PR_9320_LOCAL_REF = "refs/cdg-historical-backfill/9320/head"
 PR_9320_HEAD_SHA = "aba6b14c94eca3a9c825b1a303ea67684d5f8daa"
 HISTORICAL_HEAD_FETCH_ENV = "ARAGORA_CDG_FETCH_HISTORICAL_HEAD"
+
+
+def _historical_head_fetch_allowed() -> bool:
+    # The historical head is squash-merged, so ordinary clones (including the
+    # default actions/checkout) never carry it; fetching refs/pull/*/head is a
+    # live-network step that must stay opt-in outside CI.
+    if os.environ.get(HISTORICAL_HEAD_FETCH_ENV) == "1":
+        return True
+    return os.environ.get("GITHUB_ACTIONS") == "true"
 
 
 def ensure_pr_9320_head(
@@ -15,13 +27,25 @@ def ensure_pr_9320_head(
     remote: str = "origin",
     expected_sha: str = PR_9320_HEAD_SHA,
 ) -> str:
-    """Fetch and authenticate the historical PR head missing from ordinary clones."""
+    """Fetch and authenticate the historical PR head missing from ordinary clones.
+
+    When the object is absent locally, the fetch of ``refs/pull/9320/head``
+    runs only under ``ARAGORA_CDG_FETCH_HISTORICAL_HEAD=1`` or
+    ``GITHUB_ACTIONS=true``; otherwise the calling test skips with a reason
+    naming the opt-in instead of dialing the network.
+    """
     probe = subprocess.run(
         ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{expected_sha}^{{commit}}"],
         capture_output=True,
         text=True,
     )
     if probe.returncode != 0:
+        if not _historical_head_fetch_allowed():
+            pytest.skip(
+                f"historical head {expected_sha} is absent locally and fetching "
+                f"{PR_9320_HEAD_REF} from {remote!r} needs the network; set "
+                f"{HISTORICAL_HEAD_FETCH_ENV}=1 to opt in (CI opts in via GITHUB_ACTIONS=true)"
+            )
         subprocess.run(
             [
                 "git",

--- a/tests/scripts/_contract_drift_historical_git.py
+++ b/tests/scripts/_contract_drift_historical_git.py
@@ -37,7 +37,7 @@ def ensure_pr_9320_head(
         )
         ref = PR_9320_LOCAL_REF
     else:
-        ref = PR_9320_HEAD_SHA
+        ref = expected_sha
     resolved = subprocess.check_output(
         ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{ref}^{{commit}}"],
         text=True,

--- a/tests/scripts/test_contract_drift_workflow.py
+++ b/tests/scripts/test_contract_drift_workflow.py
@@ -23,6 +23,7 @@ from scripts.verify_contract_drift_workflow_state import (
     verify_workflow_state,
 )
 from tests.scripts._contract_drift_historical_git import (
+    HISTORICAL_HEAD_FETCH_ENV,
     PR_9320_HEAD_REF,
     PR_9320_LOCAL_REF,
     ensure_pr_9320_head,
@@ -795,7 +796,8 @@ def test_historical_backfill_fetches_the_exact_pull_request_head_before_receipt(
     assert "refs/heads/" not in run and "refs/tags/" not in run
 
 
-def test_historical_backfill_fetch_succeeds_from_a_clean_runner_fixture(tmp_path: Path):
+def _scratch_clone_missing_historical_head(tmp_path: Path) -> tuple[Path, str]:
+    """Clone a file:// origin whose historical head exists only under refs/pull/9320/head."""
     source = tmp_path / "source"
     source.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=source, check=True)
@@ -855,6 +857,112 @@ def test_historical_backfill_fetch_succeeds_from_a_clean_runner_fixture(tmp_path
         ).returncode
         != 0
     )
+    return checkout, head_sha
+
+
+def _local_backfill_ref_present(checkout: Path) -> bool:
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", PR_9320_LOCAL_REF],
+            cwd=checkout,
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def _ensure_head_or_fail(checkout: Path, expected_sha: str) -> str:
+    # A stray skip inside the helper would report the test as skipped rather
+    # than failed, so convert it into a hard failure for fetch-path tests.
+    try:
+        return ensure_pr_9320_head(checkout, expected_sha=expected_sha)
+    except pytest.skip.Exception as exc:
+        pytest.fail(f"ensure_pr_9320_head skipped unexpectedly: {exc}")
+
+
+def _unset_historical_fetch_opt_ins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(HISTORICAL_HEAD_FETCH_ENV, raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+
+def test_missing_historical_head_skips_without_fetching_when_no_opt_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    checkout, head_sha = _scratch_clone_missing_historical_head(tmp_path)
+    _unset_historical_fetch_opt_ins(monkeypatch)
+
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        ensure_pr_9320_head(checkout, expected_sha=head_sha)
+
+    reason = str(excinfo.value)
+    assert HISTORICAL_HEAD_FETCH_ENV in reason
+    assert head_sha in reason
+    assert PR_9320_HEAD_REF in reason
+    assert not _local_backfill_ref_present(checkout)
+    assert (
+        subprocess.run(
+            ["git", "cat-file", "-e", f"{head_sha}^{{commit}}"],
+            cwd=checkout,
+            capture_output=True,
+        ).returncode
+        != 0
+    )
+
+
+def test_missing_historical_head_fetches_when_opt_in_flag_is_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    checkout, head_sha = _scratch_clone_missing_historical_head(tmp_path)
+    _unset_historical_fetch_opt_ins(monkeypatch)
+    monkeypatch.setenv(HISTORICAL_HEAD_FETCH_ENV, "1")
+
+    assert _ensure_head_or_fail(checkout, head_sha) == head_sha
+    assert (
+        subprocess.check_output(
+            ["git", "rev-parse", PR_9320_LOCAL_REF],
+            cwd=checkout,
+            text=True,
+        ).strip()
+        == head_sha
+    )
+
+
+def test_missing_historical_head_fetches_under_github_actions_without_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    checkout, head_sha = _scratch_clone_missing_historical_head(tmp_path)
+    _unset_historical_fetch_opt_ins(monkeypatch)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    assert _ensure_head_or_fail(checkout, head_sha) == head_sha
+    assert (
+        subprocess.check_output(
+            ["git", "rev-parse", PR_9320_LOCAL_REF],
+            cwd=checkout,
+            text=True,
+        ).strip()
+        == head_sha
+    )
+
+
+def test_present_historical_head_honors_caller_expected_sha_without_fetching(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    checkout, _ = _scratch_clone_missing_historical_head(tmp_path)
+    _unset_historical_fetch_opt_ins(monkeypatch)
+    present_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=checkout, text=True
+    ).strip()
+
+    assert ensure_pr_9320_head(checkout, expected_sha=present_sha) == present_sha
+    assert not _local_backfill_ref_present(checkout)
+
+
+def test_historical_backfill_fetch_succeeds_from_a_clean_runner_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    checkout, head_sha = _scratch_clone_missing_historical_head(tmp_path)
+    monkeypatch.setenv(HISTORICAL_HEAD_FETCH_ENV, "1")
     assert ensure_pr_9320_head(checkout, expected_sha=head_sha) == head_sha
     assert (
         subprocess.check_output(


### PR DESCRIPTION
## Source

P3 advisory raised on both reviews of the PR #9750 capsule branch (original 3384cd50 review, openai re-raise at f1eabfce88, claude recurrence at a98210bc11): `ensure_pr_9320_head()` in `tests/scripts/_contract_drift_historical_git.py` performed a live network `git fetch origin refs/pull/9320/head` whenever the squash-merged historical object `aba6b14c94eca3a9c825b1a303ea67684d5f8daa` was absent locally, making fresh-clone test runs network-dependent.

Mission feature: `misc-cdg-backfill-test-network-independence` (structex, Tier 0 tests-only, prepare-only parked draft).

## Behavior

- **Object absent locally:** the fetch now runs only when `ARAGORA_CDG_FETCH_HISTORICAL_HEAD=1` (exact match, mirroring the existing `ARAGORA_RUN_LIVE_CDG_WORKFLOW_TEST` precedent) or `GITHUB_ACTIONS=true`. Otherwise the calling test skips with a deterministic reason naming the flag, the expected sha, and `refs/pull/9320/head`. A fresh offline clone no longer dials the network.
- **CI real-path coverage preserved with no workflow edit:** `actions/checkout@v4` on `test.yml` does not fetch `refs/pull/*`, so CI has never had the object; it passes the three real-caller tests only via the live fetch, and `GITHUB_ACTIONS=true` keeps that path exercised.
- **Latent bug fixed (own commit + pin):** the present-object branch resolved the hardcoded `PR_9320_HEAD_SHA` constant instead of the caller's `expected_sha`, so a custom `expected_sha` whose object IS present raised `CalledProcessError`. Now `ref = expected_sha`.
- The existing `file://` scratch-clone fetch-path test stays network-free and now opts in via `monkeypatch.setenv(HISTORICAL_HEAD_FETCH_ENV, "1")`.

Files: `tests/scripts/_contract_drift_historical_git.py`, `tests/scripts/test_contract_drift_workflow.py` only. No workflow, checker, or inventory edits.

## Red-first proof

Stage A (commit 1, tests + env constant only, helper behavior unchanged):

```
FAILED tests/scripts/test_contract_drift_workflow.py::test_missing_historical_head_skips_without_fetching_when_no_opt_in - Failed: DID NOT RAISE <class 'Skipped'>
FAILED tests/scripts/test_contract_drift_workflow.py::test_present_historical_head_honors_caller_expected_sha_without_fetching - subprocess.CalledProcessError: Command '['git', '-C', '...', 'rev-parse', '--verify', 'aba6b14c94eca3a9c825b1a303ea67684d5f8daa^{commit}']' returned non-zero exit status 128.
2 failed, 3 passed, 44 deselected
```

Stage B1 (commit 2, `ref = expected_sha`): `1 failed, 4 passed` (only the no-opt-in skip pin still red).

Stage B2 red proof for the `GITHUB_ACTIONS` pin against a flag-only gate (GITHUB_ACTIONS clause temporarily removed, not committed):

```
FAILED tests/scripts/test_contract_drift_workflow.py::test_missing_historical_head_fetches_under_github_actions_without_flag - Failed: ensure_pr_9320_head skipped unexpectedly: historical head ... is absent locally and fetching refs/pull/9320/head from 'origin' needs the network; set ARAGORA_CDG_FETCH_HISTORICAL_HEAD=1 to opt in (CI opts in via GITHUB_ACTIONS=true)
1 failed, 4 passed
```

Stage B2 green (commit 3, full gate): `5 passed, 44 deselected`.

## Validation

```
python3 -m pytest tests/scripts/test_contract_drift_workflow.py -k "historical_head or clean_runner_fixture" -p no:randomly -q --timeout=120
  -> 5 passed, 44 deselected
env -u ARAGORA_CDG_FETCH_HISTORICAL_HEAD -u GITHUB_ACTIONS python3 -m pytest tests/scripts/test_build_contract_drift_historical_backfill.py tests/scripts/test_check_contract_drift_ratchet.py -k "9320" -p no:randomly -q
  -> 2 passed (object present in the shared object store; present-object branch)
direct offline proof: default expected_sha on an object-absent scratch repo with both env vars unset -> pytest.skip with the flag/sha/ref reason, no fetch attempted
seed sweep tests/scripts/test_contract_drift_workflow.py (seeds 1,42,100,2024,12345) -> 48 passed, 1 skipped each (the pre-existing ARAGORA_RUN_LIVE_CDG_WORKFLOW_TEST skip)
make lint -> All checks passed!; ruff format --check aragora/ tests/ scripts/ -> already formatted
bash scripts/preflight_mypy.sh --diff-base origin/main -> Success: no issues found in 2 source files
python3 scripts/audit_test_skips.py --count-only -> 91 (baseline 91, unchanged; the helper module is not in the audit's rglob scope)
```

## Risks

- The new `pytest.skip` in the helper is outside `scripts/audit_test_skips.py` scope (it rglobs `tests/**/test_*.py` and `conftest.py`); the baseline stays 91. Disclosed rather than hidden.
- Offline developers running the three real-caller tests on a fresh clone now see a skip with an actionable reason instead of a network call; opt in with `ARAGORA_CDG_FETCH_HISTORICAL_HEAD=1`.

## Governance

Tier 0 tests-only. Prepare-only parked draft: labeled `operator-review-required`, evidence rounds collected `apply=False` and UNPOSTED, settlement packet in the mission library. No ready, posting, settlement, or merge in this lane.
