### PR TITLE
ci(cdg): split finalizer dispatch into a least-privilege gated job [Tier 4]

### DIFF
--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -66,9 +66,10 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       checks: read
       contents: read
+    outputs:
+      analyzer_artifact_id: ${{ steps.receipt-upload.outputs.artifact-id }}
     env:
       EVENT_NAME: "${{ github.event_name }}"
       HISTORICAL_BACKFILL: "${{ inputs.historical_backfill || false }}"
@@ -119,13 +120,25 @@ jobs:
         with:
           name: "${{ github.event_name == 'workflow_dispatch' && inputs.historical_backfill && format('contract-drift-main-receipt-analyzer-{0}', github.sha) || format('contract-drift-main-receipt-{0}', github.sha) }}"
           path: "${{ github.event_name == 'workflow_dispatch' && inputs.historical_backfill && 'contract-drift-main-receipt-analyzer.json' || 'contract-drift-main-receipt.json' }}"
+
+  historical-backfill-dispatch:
+    name: contract-drift-historical-backfill-dispatch
+    needs: main-receipt
+    if: success() && github.event_name == 'workflow_dispatch' && inputs.historical_backfill
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+    env:
+      ANALYZER_ARTIFACT_ID: "${{ needs.main-receipt.outputs.analyzer_artifact_id }}"
+      SOURCE_SHA: "${{ github.event_name == 'workflow_dispatch' && inputs.historical_backfill && github.sha || github.event_name == 'push' && github.event.after || github.sha }}"
+    steps:
       - name: Finalize completed historical receipt
-        if: github.event_name == 'workflow_dispatch' && inputs.historical_backfill
         env:
-          ANALYZER_ARTIFACT_ID: ${{ steps.receipt-upload.outputs.artifact-id }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          [[ "$ANALYZER_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
           SOURCE_REF="${GITHUB_REF#refs/heads/}"
           if [[ "$SOURCE_REF" == "$GITHUB_REF" ]]; then
             SOURCE_REF="${GITHUB_REF#refs/tags/}"

--- a/scripts/verify_contract_drift_workflow_state.py
+++ b/scripts/verify_contract_drift_workflow_state.py
@@ -28,6 +28,11 @@ LIVE_CHECK_NAMES = (
     "contract-drift-main-receipt",
     "contract-drift-program-trajectory",
 )
+# The finalizer dispatch runs as its own `actions: write` job so the receipt
+# job stays read-only. It is not a live check: it only ever executes on a
+# historical-backfill dispatch and must appear skipped on routine main runs.
+HISTORICAL_DISPATCH_JOB_NAME = "contract-drift-historical-backfill-dispatch"
+EXPECTED_WORKFLOW_JOB_NAMES = frozenset(LIVE_CHECK_NAMES) | {HISTORICAL_DISPATCH_JOB_NAME}
 PRE_CUTOVER_REQUIRED_CHECKS = (
     ("lint", 15368),
     ("typecheck", 15368),
@@ -243,7 +248,7 @@ def _canonical_workflow(
     if workflow.get("state") != "active":
         raise VerificationError("canonical workflow must be active")
     source = reader.get_bytes(f"repos/{repo}/contents/{CANONICAL_WORKFLOW_PATH}?ref=main")
-    if _workflow_job_names(source) != set(LIVE_CHECK_NAMES):
+    if _workflow_job_names(source) != EXPECTED_WORKFLOW_JOB_NAMES:
         raise VerificationError("canonical workflow does not expose the exact three live checks")
     return workflow, endpoints
 
@@ -427,9 +432,9 @@ def _attempts(reader: ApiReader, *, repo: str, run: dict[str, Any]) -> list[dict
         names = [job.get("name") for job in jobs]
         if len(names) != len(set(names)):
             raise VerificationError("attempt jobs contain duplicate names")
-        if set(names) != set(LIVE_CHECK_NAMES):
+        if set(names) != EXPECTED_WORKFLOW_JOB_NAMES:
             raise VerificationError("attempt jobs do not expose the exact three live checks")
-        checks = {
+        summaries = {
             str(job["name"]): _check_summary(
                 reader,
                 repo=repo,
@@ -440,7 +445,24 @@ def _attempts(reader: ApiReader, *, repo: str, run: dict[str, Any]) -> list[dict
             )
             for job in jobs
         }
-        result.append({"attempt": attempt, "jobs_endpoint": endpoint, "checks": checks})
+        checks = {name: summaries[name] for name in LIVE_CHECK_NAMES}
+        dispatch = summaries[HISTORICAL_DISPATCH_JOB_NAME]
+        # Selected runs are push/schedule/dispatch executions on main; the
+        # historical-backfill path never produces a routine receipt, so the
+        # write-scoped dispatch job must have been skipped, never executed.
+        if dispatch.get("status") != "completed" or dispatch.get("conclusion") != "skipped":
+            raise VerificationError(
+                "historical-backfill dispatch job did not skip on the selected main execution"
+            )
+        auxiliary_jobs = {HISTORICAL_DISPATCH_JOB_NAME: str(dispatch.get("conclusion"))}
+        result.append(
+            {
+                "attempt": attempt,
+                "jobs_endpoint": endpoint,
+                "checks": checks,
+                "auxiliary_jobs": auxiliary_jobs,
+            }
+        )
     return result
 
 
@@ -584,7 +606,7 @@ def _snapshot(reader: ApiReader, *, repo: str, workflow_id: int) -> tuple[_Snaps
     source = reader.get_bytes(
         f"repos/{repo}/contents/{CANONICAL_WORKFLOW_PATH}?ref={run['head_sha']}"
     )
-    if _workflow_job_names(source) != set(LIVE_CHECK_NAMES):
+    if _workflow_job_names(source) != EXPECTED_WORKFLOW_JOB_NAMES:
         raise VerificationError("selected run workflow source does not expose exact live checks")
     return _Snapshot(main_sha=main_sha, run=run), endpoints
 

--- a/scripts/verify_contract_drift_workflow_state.py
+++ b/scripts/verify_contract_drift_workflow_state.py
@@ -355,7 +355,11 @@ def _run_key(run: Mapping[str, Any]) -> tuple[str, int, int]:
 
 
 def _selected_main_run(
-    runs: Iterable[dict[str, Any]], *, workflow_id: int, main_sha: str
+    runs: Iterable[dict[str, Any]],
+    *,
+    workflow_id: int,
+    main_sha: str,
+    is_historical_backfill: Callable[[dict[str, Any]], bool],
 ) -> dict[str, Any]:
     eligible = [
         run
@@ -365,6 +369,7 @@ def _selected_main_run(
         and run.get("head_branch") == "main"
         and run.get("head_sha") == main_sha
         and run.get("event") in {"push", "schedule", "workflow_dispatch"}
+        and not is_historical_backfill(run)
     ]
     if not eligible:
         raise VerificationError("no canonical main workflow execution matches current main")
@@ -599,10 +604,42 @@ class _Snapshot:
         }
 
 
+def _is_historical_backfill_dispatch(reader: ApiReader, *, repo: str, run: dict[str, Any]) -> bool:
+    # Run listings never expose dispatch inputs, so the historical-backfill
+    # input is recovered from the attempt topology: program-trajectory is the
+    # one job whose `if` is false exactly on a historical-backfill dispatch.
+    if run.get("event") != "workflow_dispatch":
+        return False
+    run_id = _require_int(run.get("id"), "run ID", minimum=1)
+    attempt = attempt_numbers(run)[-1]
+    endpoint = f"repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs"
+    jobs, _ = _paginate_collection(
+        reader,
+        endpoint,
+        collection_key="jobs",
+        identity=lambda job: job.get("id"),
+        label=f"attempt {attempt} jobs",
+    )
+    trajectory = [job for job in jobs if job.get("name") == "contract-drift-program-trajectory"]
+    if len(trajectory) != 1:
+        raise VerificationError("dispatch execution does not expose the program-trajectory job")
+    summary = _check_summary(
+        reader, repo=repo, endpoint=endpoint, job=trajectory[0], run=run, attempt=attempt
+    )
+    return summary.get("conclusion") == "skipped"
+
+
 def _snapshot(reader: ApiReader, *, repo: str, workflow_id: int) -> tuple[_Snapshot, list[str]]:
     main_sha = _main_sha(reader, repo)
     runs, endpoints = _workflow_runs(reader, repo=repo, workflow_id=workflow_id)
-    run = _selected_main_run(runs, workflow_id=workflow_id, main_sha=main_sha)
+    run = _selected_main_run(
+        runs,
+        workflow_id=workflow_id,
+        main_sha=main_sha,
+        is_historical_backfill=lambda candidate: _is_historical_backfill_dispatch(
+            reader, repo=repo, run=candidate
+        ),
+    )
     source = reader.get_bytes(
         f"repos/{repo}/contents/{CANONICAL_WORKFLOW_PATH}?ref={run['head_sha']}"
     )

--- a/tests/scripts/test_contract_drift_workflow.py
+++ b/tests/scripts/test_contract_drift_workflow.py
@@ -1,3 +1,4 @@
+import ast
 import io
 import json
 import os
@@ -12,6 +13,7 @@ from typing import Any
 import pytest
 import yaml
 
+import scripts.verify_contract_drift_workflow_state as workflow_state
 from scripts.verify_contract_drift_workflow_state import (
     CANONICAL_WORKFLOW_ID,
     CANONICAL_WORKFLOW_NAME,
@@ -41,6 +43,22 @@ LIVE_CHECK_NAMES = (
     "contract-drift-pr-delta",
     "contract-drift-main-receipt",
     "contract-drift-program-trajectory",
+)
+LIVE_JOB_IDS = ("pr-delta", "main-receipt", "program-trajectory")
+# The finalizer dispatch is the only step needing `actions: write`; it lives in
+# its own job so the routine receipt path never carries a write scope.
+DISPATCH_JOB_ID = "historical-backfill-dispatch"
+DISPATCH_JOB_NAME = "contract-drift-historical-backfill-dispatch"
+DISPATCH_JOB_IF = (
+    "success() && github.event_name == 'workflow_dispatch' && inputs.historical_backfill"
+)
+# (trigger event, inputs.historical_backfill, jobs whose `if` holds).
+EVENT_JOB_TABLE = (
+    ("pull_request", None, ("pr-delta",)),
+    ("push", None, ("main-receipt", "program-trajectory")),
+    ("schedule", None, ("main-receipt", "program-trajectory")),
+    ("workflow_dispatch", False, ("main-receipt", "program-trajectory")),
+    ("workflow_dispatch", True, ("main-receipt", DISPATCH_JOB_ID)),
 )
 SOURCE_SHA_EXPR = "${{ github.event_name == 'push' && github.event.after || github.sha }}"
 HISTORICAL_SOURCE_SHA_EXPR = "${{ github.event_name == 'workflow_dispatch' && inputs.historical_backfill && github.sha || github.event_name == 'push' && github.event.after || github.sha }}"
@@ -220,9 +238,10 @@ def _run_terminal(
 
 
 def test_workflow_has_exact_live_checks_and_events():
-    assert {job["name"] for job in JOBS.values()} == {f"contract-drift-{name}" for name in ("pr-delta", "main-receipt", "program-trajectory")}  # fmt: skip
+    assert {JOBS[job_id]["name"] for job_id in LIVE_JOB_IDS} == {f"contract-drift-{name}" for name in ("pr-delta", "main-receipt", "program-trajectory")}  # fmt: skip
+    assert set(JOBS) == {*LIVE_JOB_IDS, DISPATCH_JOB_ID}
     assert set(DOC["on"]) == {"pull_request", "push", "schedule", "workflow_dispatch"} and not {"paths", "paths-ignore"} & set(DOC["on"]["pull_request"])  # fmt: skip
-    assert all({"uses": "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065", "with": {"python-version": "3.11"}} in job["steps"] for job in JOBS.values())  # fmt: skip
+    assert all({"uses": "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065", "with": {"python-version": "3.11"}} in JOBS[job_id]["steps"] for job_id in LIVE_JOB_IDS)  # fmt: skip
 
 
 def test_pr_admission_is_event_bound_absolute_and_terminal():
@@ -338,10 +357,16 @@ def _run_record(
     return {"id": run_id, "workflow_id": CANONICAL_WORKFLOW_ID, "path": CANONICAL_WORKFLOW_PATH, "head_branch": "main", "head_sha": main_sha, "event": "push", "run_attempt": run_attempt, "run_started_at": started_at, "status": "completed", "conclusion": "failure"}  # fmt: skip
 
 
+FIXTURE_ATTEMPT_JOB_NAMES = (*LIVE_CHECK_NAMES, DISPATCH_JOB_NAME)
+FIXTURE_JOB_CONCLUSIONS = dict(
+    zip(FIXTURE_ATTEMPT_JOB_NAMES, ("skipped", "success", "failure", "skipped"), strict=True)
+)
+
+
 def _job_record(name: str, *, run_id: int, main_sha: str, attempt: int, job_id: int) -> tuple[dict[str, Any], str, dict[str, Any]]:  # fmt: skip
     check_id = job_id + 10_000
     check_url = f"https://api.github.com/repos/{FIXTURE_REPO}/check-runs/{check_id}"
-    conclusion = dict(zip(LIVE_CHECK_NAMES, ("skipped", "success", "failure"), strict=True))[name]
+    conclusion = FIXTURE_JOB_CONCLUSIONS[name]
     job = {"id": job_id, "name": name, "run_attempt": attempt, "check_run_url": check_url}
     check = {"id": check_id, "name": name, "head_sha": main_sha, "app": {"id": EXPECTED_PR_DELTA_APP_ID}, "status": "completed", "conclusion": conclusion, "details_url": f"https://github.com/{FIXTURE_REPO}/actions/runs/{run_id}/job/{job_id}"}  # fmt: skip
     return job, check_url, check
@@ -397,7 +422,7 @@ def _live_fixture(
 
     for attempt in range(1, selected_attempt + 1):
         jobs: list[dict[str, Any]] = []
-        for offset, name in enumerate(LIVE_CHECK_NAMES, start=1):
+        for offset, name in enumerate(FIXTURE_ATTEMPT_JOB_NAMES, start=1):
             job, check_url, check = _job_record(
                 name,
                 run_id=selected_id,
@@ -1025,11 +1050,7 @@ def test_historical_backfill_finalizes_only_after_the_receipt_job_completed():
     assert "build_contract_drift_historical_backfill.py" not in str(receipt)
     assert DOC["permissions"] == {"checks": "read", "contents": "read"}
     assert "permissions" not in JOBS["pr-delta"]
-    assert receipt["permissions"] == {
-        "actions": "write",
-        "checks": "read",
-        "contents": "read",
-    }
+    assert receipt["permissions"] == {"checks": "read", "contents": "read"}
 
     upload = _upload_step("main-receipt")
     assert upload["id"] == "receipt-upload"
@@ -1037,13 +1058,19 @@ def test_historical_backfill_finalizes_only_after_the_receipt_job_completed():
         "format('contract-drift-main-receipt-analyzer-{0}', github.sha)" in upload["with"]["name"]
     )
     assert "contract-drift-main-receipt-analyzer.json" in upload["with"]["path"]
-    dispatch = _named_run_step("main-receipt", "Finalize completed historical receipt")
-    assert dispatch["if"] == (
-        "github.event_name == 'workflow_dispatch' && inputs.historical_backfill"
-    )
-    assert dispatch["env"]["ANALYZER_ARTIFACT_ID"] == (
+    # The dispatch job depends on the completed receipt job and consumes the
+    # uploaded analyzer artifact through the job output, so it can only run
+    # after the producer job (and its upload) reached success.
+    assert receipt["outputs"]["analyzer_artifact_id"] == (
         "${{ steps.receipt-upload.outputs.artifact-id }}"
     )
+    dispatch_job = JOBS[DISPATCH_JOB_ID]
+    assert dispatch_job["needs"] == "main-receipt"
+    assert dispatch_job["if"] == DISPATCH_JOB_IF
+    assert dispatch_job["env"]["ANALYZER_ARTIFACT_ID"] == (
+        "${{ needs.main-receipt.outputs.analyzer_artifact_id }}"
+    )
+    dispatch = _named_run_step(DISPATCH_JOB_ID, "Finalize completed historical receipt")
     dispatch_run = dispatch["run"]
     assert "/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100&page=1" in dispatch_run
     assert 'select(.name == "contract-drift-main-receipt") | .id' in dispatch_run
@@ -1145,6 +1172,167 @@ def test_historical_backfill_finalizes_only_after_the_receipt_job_completed():
     analyzer = _analyzer_step_text(receipt)
     assert "tee contract-drift-main-receipt-analyzer.json" in analyzer
     assert "tee contract-drift-main-receipt.json" not in analyzer
+
+
+# --- least-privilege split: finalizer dispatch is its own gated job ----------
+
+
+def _job_permissions(job: dict) -> dict[str, str]:
+    permissions = job.get("permissions")
+    if permissions is None:
+        return dict(DOC["permissions"])
+    assert isinstance(permissions, dict), permissions
+    return dict(permissions)
+
+
+def _job_if_holds(job: dict, *, event: str, historical_backfill: bool | None) -> bool:
+    """Evaluate the job-level `if` for one trigger event with a tiny expression subset."""
+    expression = job.get("if")
+    if expression is None:
+        return True
+    text = str(expression)
+    replacements = {
+        "success()": "True",
+        "github.event_name": repr(event),
+        "!github.event.pull_request.draft": "True",
+        "inputs.historical_backfill": repr(bool(historical_backfill)),
+    }
+    for token, value in replacements.items():
+        text = text.replace(token, value)
+    text = text.replace("&&", " and ").replace("||", " or ")
+    text = re.sub(r"!(?!=)", " not ", text)
+
+    def evaluate(node: ast.AST) -> Any:
+        if isinstance(node, ast.Expression):
+            return evaluate(node.body)
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+            return not evaluate(node.operand)
+        if isinstance(node, ast.BoolOp):
+            values = [evaluate(value) for value in node.values]
+            return all(values) if isinstance(node.op, ast.And) else any(values)
+        if isinstance(node, ast.Compare) and len(node.ops) == 1:
+            left, right = evaluate(node.left), evaluate(node.comparators[0])
+            if isinstance(node.ops[0], ast.Eq):
+                return left == right
+            if isinstance(node.ops[0], ast.NotEq):
+                return left != right
+        raise AssertionError((ast.dump(node), expression))
+
+    return bool(evaluate(ast.parse(text, mode="eval")))
+
+
+def test_routine_main_receipt_is_read_only_and_finalizer_dispatch_is_its_own_gated_job():
+    # Job-level permissions cannot be conditioned per step, so the only way the
+    # routine receipt path can run read-only is for the dispatch to be a job.
+    receipt = JOBS["main-receipt"]
+    assert "actions" not in _job_permissions(receipt)
+    assert all(scope == "read" for scope in _job_permissions(receipt).values())
+    assert "actions/workflows/contract-drift-historical-backfill-finalizer.yml" not in str(receipt)
+    assert "gh api --method POST" not in str(receipt)
+    assert receipt["outputs"] == {
+        "analyzer_artifact_id": "${{ steps.receipt-upload.outputs.artifact-id }}"
+    }
+
+    assert set(JOBS) == {*LIVE_JOB_IDS, DISPATCH_JOB_ID}
+    dispatch_job = JOBS[DISPATCH_JOB_ID]
+    assert dispatch_job["name"] == DISPATCH_JOB_NAME
+    assert dispatch_job["name"] not in LIVE_CHECK_NAMES
+    assert dispatch_job["needs"] == "main-receipt"
+    assert dispatch_job["if"] == DISPATCH_JOB_IF
+    assert dispatch_job["permissions"] == {"actions": "write"}
+    assert dispatch_job["env"]["ANALYZER_ARTIFACT_ID"] == (
+        "${{ needs.main-receipt.outputs.analyzer_artifact_id }}"
+    )
+    assert dispatch_job["env"]["SOURCE_SHA"] == HISTORICAL_SOURCE_SHA_EXPR
+    assert "continue-on-error" not in str(dispatch_job)
+    assert all("uses" not in step for step in dispatch_job["steps"])
+    dispatch = _named_run_step(DISPATCH_JOB_ID, "Finalize completed historical receipt")
+    assert "if" not in dispatch
+    assert dispatch["env"] == {"GH_TOKEN": "${{ github.token }}"}
+    dispatch_run = dispatch["run"]
+    assert dispatch_run.startswith("set -euo pipefail\n")
+    assert '[[ "$ANALYZER_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]' in dispatch_run
+    assert "/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100&page=1" in dispatch_run
+    assert 'select(.name == "contract-drift-main-receipt") | .id' in dispatch_run
+    assert '--argjson artifact_id "$ANALYZER_ARTIFACT_ID"' in dispatch_run
+    assert '--arg source_sha "$SOURCE_SHA"' in dispatch_run
+    assert (
+        "actions/workflows/contract-drift-historical-backfill-finalizer.yml/dispatches"
+        in dispatch_run
+    )
+
+    # `actions: write` exists in exactly one job, and every other job is read-only.
+    writers = {job_id for job_id, job in JOBS.items() if "write" in _job_permissions(job).values()}
+    assert writers == {DISPATCH_JOB_ID}
+    assert TEXT.count("actions: write") == 1
+
+
+def test_event_permission_table_proves_non_historical_paths_never_reach_actions_write():
+    for event, historical_backfill, expected_jobs in EVENT_JOB_TABLE:
+        running = {
+            job_id
+            for job_id, job in JOBS.items()
+            if _job_if_holds(job, event=event, historical_backfill=historical_backfill)
+        }
+        assert running == set(expected_jobs), (event, historical_backfill)
+        effective = {job_id: _job_permissions(JOBS[job_id]) for job_id in running}
+        if event == "workflow_dispatch" and historical_backfill:
+            assert effective[DISPATCH_JOB_ID] == {"actions": "write"}
+            assert "actions" not in effective["main-receipt"]
+        else:
+            assert "write" not in {
+                scope for permissions in effective.values() for scope in permissions.values()
+            }, (event, historical_backfill)
+    # The gated job never runs on a routine event, so a skipped-job row is the
+    # only trace it leaves on push/schedule/non-backfill dispatch attempts.
+    assert JOBS[DISPATCH_JOB_ID]["needs"] == "main-receipt"
+    assert "program-trajectory" not in str(JOBS[DISPATCH_JOB_ID].get("needs"))
+
+
+def test_live_verifier_requires_the_skipped_dispatch_job_on_routine_main_runs():
+    assert workflow_state.HISTORICAL_DISPATCH_JOB_NAME == DISPATCH_JOB_NAME
+    assert DISPATCH_JOB_NAME not in workflow_state.LIVE_CHECK_NAMES
+    reader, expected = _live_fixture()
+    result = verify_workflow_state(reader)
+    selected = result["selection"]["selected_attempt"]
+    assert set(selected["checks"]) == set(LIVE_CHECK_NAMES)
+    assert selected["auxiliary_jobs"] == {DISPATCH_JOB_NAME: "skipped"}
+    endpoint = f"repos/synaptent/aragora/actions/runs/{expected['run_id']}/attempts/1/jobs?per_page=100&page=1"
+
+    # A missing dispatch job means the workflow source and the attempt disagree.
+    missing, _ = _live_fixture()
+    remaining = [
+        job
+        for job in missing.json_responses[endpoint][0]["jobs"]
+        if job["name"] != DISPATCH_JOB_NAME
+    ]
+    missing.json_responses[endpoint] = [_json_page(remaining, "jobs")]
+    with pytest.raises(VerificationError, match="exact three live checks"):
+        verify_workflow_state(missing)
+
+    # A routine push/schedule run that actually executed the dispatch job is hostile.
+    executed, _ = _live_fixture()
+    dispatch_job = next(
+        job
+        for job in executed.json_responses[endpoint][0]["jobs"]
+        if job["name"] == DISPATCH_JOB_NAME
+    )
+    executed.json_responses[dispatch_job["check_run_url"]][0]["conclusion"] = "success"
+    with pytest.raises(VerificationError, match="historical-backfill dispatch job did not skip"):
+        verify_workflow_state(executed)
+
+    # The dispatch job may never masquerade as a live check.
+    renamed, _ = _live_fixture()
+    dispatch_job = next(
+        job
+        for job in renamed.json_responses[endpoint][0]["jobs"]
+        if job["name"] == DISPATCH_JOB_NAME
+    )
+    dispatch_job["name"] = "contract-drift-main-receipt"
+    with pytest.raises(VerificationError, match="duplicate names"):
+        verify_workflow_state(renamed)
 
 
 def test_program_trajectory_preserves_real_red_exit(tmp_path):
@@ -1293,18 +1481,26 @@ def test_schedule_and_dispatch_resolve_main_once_for_both_main_jobs():
     assert program["env"]["SOURCE_SHA"] == SOURCE_SHA_EXPR
     assert program["steps"][0]["with"]["ref"] == SOURCE_SHA_EXPR
     assert TEXT.count(SOURCE_SHA_EXPR) == 2
-    assert TEXT.count(HISTORICAL_SOURCE_SHA_EXPR) == 2
+    # Receipt env + receipt checkout ref + the dispatch job's SOURCE_SHA, which
+    # must bind the identical resolved SHA into the finalizer payload.
+    assert TEXT.count(HISTORICAL_SOURCE_SHA_EXPR) == 3
+    assert JOBS[DISPATCH_JOB_ID]["env"]["SOURCE_SHA"] == HISTORICAL_SOURCE_SHA_EXPR
 
 
 def test_exact_three_live_check_names_are_separate():
-    assert len(set(JOBS)) == 3 and len(set(_job_names(DOC))) == 3
-    artifact_names = {job_id: _upload_step(job_id)["with"]["name"] for job_id in JOBS}
+    assert len(set(JOBS)) == 4 and len(set(_job_names(DOC))) == 4
+    assert set(_job_names(DOC)) & set(LIVE_CHECK_NAMES) == set(LIVE_CHECK_NAMES)
+    assert JOBS[DISPATCH_JOB_ID]["name"] not in LIVE_CHECK_NAMES
+    artifact_names = {job_id: _upload_step(job_id)["with"]["name"] for job_id in LIVE_JOB_IDS}
     assert len(set(artifact_names.values())) == 3
-    outputs = {job_id: _upload_step(job_id)["with"]["path"] for job_id in JOBS}
+    outputs = {job_id: _upload_step(job_id)["with"]["path"] for job_id in LIVE_JOB_IDS}
     assert len(set(outputs.values())) == 3
-    for job_id in JOBS:
+    for job_id in LIVE_JOB_IDS:
         assert f"contract-drift-{job_id}-" in artifact_names[job_id]
         assert f"contract-drift-{job_id}.json" in outputs[job_id]
+    # The dispatch job publishes nothing: no upload step, no live check name.
+    with pytest.raises(AssertionError, match="no upload step"):
+        _upload_step(DISPATCH_JOB_ID)
 
 
 def test_terminal_aggregator_fails_when_pr_delta_is_skipped(tmp_path):
@@ -1332,10 +1528,13 @@ def test_main_receipt_job_is_separate_from_intentionally_red_trajectory():
 
 def test_trajectory_failure_does_not_block_main_receipt(tmp_path):
     # No job anywhere in the workflow declares a dependency on the trajectory
-    # job, so its intentionally red exit cannot gate the receipt.
-    for job in JOBS.values():
+    # job, so its intentionally red exit cannot gate the receipt. The only
+    # `needs` edge is the gated dispatch job depending on the receipt itself.
+    for job_id, job in JOBS.items():
         needs = job.get("needs", [])
-        assert "program-trajectory" not in ([needs] if isinstance(needs, str) else needs)
+        needs = [needs] if isinstance(needs, str) else list(needs)
+        assert "program-trajectory" not in needs
+        assert needs == (["main-receipt"] if job_id == DISPATCH_JOB_ID else []), job_id
     env = {
         "EVENT_NAME": "push",
         "HISTORICAL_BACKFILL": "false",

--- a/tests/scripts/test_contract_drift_workflow.py
+++ b/tests/scripts/test_contract_drift_workflow.py
@@ -353,20 +353,27 @@ def _run_record(
     main_sha: str = FIXTURE_MAIN_SHA,
     run_attempt: int = 1,
     started_at: str = "2026-08-12T01:00:00Z",
+    event: str = "push",
+    conclusion: str = "failure",
 ) -> dict[str, Any]:
-    return {"id": run_id, "workflow_id": CANONICAL_WORKFLOW_ID, "path": CANONICAL_WORKFLOW_PATH, "head_branch": "main", "head_sha": main_sha, "event": "push", "run_attempt": run_attempt, "run_started_at": started_at, "status": "completed", "conclusion": "failure"}  # fmt: skip
+    return {"id": run_id, "workflow_id": CANONICAL_WORKFLOW_ID, "path": CANONICAL_WORKFLOW_PATH, "head_branch": "main", "head_sha": main_sha, "event": event, "run_attempt": run_attempt, "run_started_at": started_at, "status": "completed", "conclusion": conclusion}  # fmt: skip
 
 
 FIXTURE_ATTEMPT_JOB_NAMES = (*LIVE_CHECK_NAMES, DISPATCH_JOB_NAME)
 FIXTURE_JOB_CONCLUSIONS = dict(
     zip(FIXTURE_ATTEMPT_JOB_NAMES, ("skipped", "success", "failure", "skipped"), strict=True)
 )
+# Job conclusions of a (workflow_dispatch, historical_backfill=true) execution
+# per EVENT_JOB_TABLE: trajectory never runs, the write-scoped dispatch does.
+BACKFILL_DISPATCH_CONCLUSIONS = dict(
+    zip(FIXTURE_ATTEMPT_JOB_NAMES, ("skipped", "success", "skipped", "success"), strict=True)
+)
 
 
-def _job_record(name: str, *, run_id: int, main_sha: str, attempt: int, job_id: int) -> tuple[dict[str, Any], str, dict[str, Any]]:  # fmt: skip
+def _job_record(name: str, *, run_id: int, main_sha: str, attempt: int, job_id: int, conclusion: str | None = None) -> tuple[dict[str, Any], str, dict[str, Any]]:  # fmt: skip
     check_id = job_id + 10_000
     check_url = f"https://api.github.com/repos/{FIXTURE_REPO}/check-runs/{check_id}"
-    conclusion = FIXTURE_JOB_CONCLUSIONS[name]
+    conclusion = FIXTURE_JOB_CONCLUSIONS[name] if conclusion is None else conclusion
     job = {"id": job_id, "name": name, "run_attempt": attempt, "check_run_url": check_url}
     check = {"id": check_id, "name": name, "head_sha": main_sha, "app": {"id": EXPECTED_PR_DELTA_APP_ID}, "status": "completed", "conclusion": conclusion, "details_url": f"https://github.com/{FIXTURE_REPO}/actions/runs/{run_id}/job/{job_id}"}  # fmt: skip
     return job, check_url, check
@@ -1333,6 +1340,59 @@ def test_live_verifier_requires_the_skipped_dispatch_job_on_routine_main_runs():
     dispatch_job["name"] = "contract-drift-main-receipt"
     with pytest.raises(VerificationError, match="duplicate names"):
         verify_workflow_state(renamed)
+
+
+def _register_attempt_jobs(reader: FixtureApiReader, *, run: dict[str, Any], conclusions: dict[str, str]) -> None:  # fmt: skip
+    for attempt in range(1, run["run_attempt"] + 1):
+        jobs: list[dict[str, Any]] = []
+        for offset, name in enumerate(FIXTURE_ATTEMPT_JOB_NAMES, start=1):
+            job, check_url, check = _job_record(name, run_id=run["id"], main_sha=run["head_sha"], attempt=attempt, job_id=run["id"] * 1_000 + attempt * 100 + offset, conclusion=conclusions[name])  # fmt: skip
+            jobs.append(job)
+            reader.json_responses[check_url] = [check]
+        endpoint = f"repos/{FIXTURE_REPO}/actions/runs/{run['id']}/attempts/{attempt}/jobs?per_page=100&page=1"
+        reader.json_responses[endpoint] = [_json_page(jobs, "jobs")]
+
+
+def test_live_verifier_selects_the_newest_routine_run_past_historical_backfill_dispatches():
+    runs_endpoint = (
+        f"repos/{FIXTURE_REPO}/actions/workflows/{CANONICAL_WORKFLOW_ID}/runs?per_page=100&page=1"
+    )
+    routine = _run_record(run_id=7001, started_at="2026-08-12T01:00:00Z")
+    backfill = _run_record(run_id=7002, started_at="2026-08-12T02:00:00Z", event="workflow_dispatch", conclusion="success")  # fmt: skip
+    reader, _ = _live_fixture(runs=[routine])
+    reader.json_responses[runs_endpoint] = [_json_page([routine, backfill], "workflow_runs")] * 4
+    _register_attempt_jobs(reader, run=backfill, conclusions=BACKFILL_DISPATCH_CONCLUSIONS)
+    result = verify_workflow_state(reader)
+    assert result["selection"]["identity"] == {"run_started_at": routine["run_started_at"], "run_id": 7001, "run_attempt": 1}  # fmt: skip
+    assert result["selection"]["selected_attempt"]["auxiliary_jobs"] == {
+        DISPATCH_JOB_NAME: "skipped"
+    }
+    assert result["stable_requery"] is True
+
+    # A historical_backfill=false dispatch is a routine receipt and still wins as newest.
+    routine_dispatch = _run_record(run_id=7003, started_at="2026-08-12T03:00:00Z", event="workflow_dispatch")  # fmt: skip
+    reader, _ = _live_fixture(runs=[routine, routine_dispatch])
+    assert verify_workflow_state(reader)["selection"]["identity"]["run_id"] == 7003
+
+    # With only a backfill dispatch at main's tip there is no routine execution to verify.
+    only_backfill, _ = _live_fixture(runs=[backfill])
+    _register_attempt_jobs(only_backfill, run=backfill, conclusions=BACKFILL_DISPATCH_CONCLUSIONS)
+    with pytest.raises(VerificationError, match="matches current main"):
+        verify_workflow_state(only_backfill)
+
+    # A dispatch run whose attempt hides program-trajectory cannot be classified.
+    hidden, _ = _live_fixture(runs=[routine])
+    hidden.json_responses[runs_endpoint] = [_json_page([routine, backfill], "workflow_runs")] * 4
+    _register_attempt_jobs(hidden, run=backfill, conclusions=BACKFILL_DISPATCH_CONCLUSIONS)
+    jobs_endpoint = f"repos/{FIXTURE_REPO}/actions/runs/{backfill['id']}/attempts/1/jobs?per_page=100&page=1"  # fmt: skip
+    remaining = [
+        job
+        for job in hidden.json_responses[jobs_endpoint][0]["jobs"]
+        if job["name"] != "contract-drift-program-trajectory"
+    ]
+    hidden.json_responses[jobs_endpoint] = [_json_page(remaining, "jobs")]
+    with pytest.raises(VerificationError, match="does not expose the program-trajectory job"):
+        verify_workflow_state(hidden)
 
 
 def test_program_trajectory_preserves_real_red_exit(tmp_path):


### PR DESCRIPTION
## Summary

Least-privilege follow-up to claude's P3 on #9750 (head a98210bc11): the `main-receipt` job in `.github/workflows/contract-drift-governance.yml` carried `actions: write` on **every** non-PR trigger event, although only the historical-backfill path (`workflow_dispatch` with `historical_backfill=true`) dispatches the finalizer workflow. Job-level permissions cannot be conditioned per step, so this PR moves the finalizer dispatch into its own dependent job gated on `inputs.historical_backfill`. The routine receipt path now runs read-only.

**Tier 4 (workflow file). Parked draft, `operator-review-required`. Prepare-only: evidence collected UNPOSTED, no ready/settlement/merge.**

## Behavior

- `main-receipt`: permissions -> `{checks: read, contents: read}` (drops `actions: write`); exposes `outputs.analyzer_artifact_id` from the existing `receipt-upload` step; the "Finalize completed historical receipt" step is removed from this job. Every other step is byte-identical.
- New job `historical-backfill-dispatch` (`contract-drift-historical-backfill-dispatch`): `needs: main-receipt`, `if: success() && github.event_name == 'workflow_dispatch' && inputs.historical_backfill`, `timeout-minutes: 10`, `permissions: {actions: write}` (the only scope). It runs the identical finalize shell body with `GH_TOKEN: ${{ github.token }}`, reading `ANALYZER_ARTIFACT_ID` from the receipt job's output and `SOURCE_SHA` from the identical `HISTORICAL_SOURCE_SHA_EXPR`. One new leading guard: `[[ "$ANALYZER_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]` so a missing job output can never be dispatched silently. No checkout, no setup-python, no upload.
- Finalizer workflow (`contract-drift-historical-backfill-finalizer.yml`) is untouched: same inputs, same 30x10s poll of the source run (which covers the dispatch job's own runtime).
- `scripts/verify_contract_drift_workflow_state.py` (fail-closed extension): canonical-main source, selected-run-head source, and every attempt's job set must equal exactly the four job names (`LIVE_CHECK_NAMES` + `HISTORICAL_DISPATCH_JOB_NAME`); `checks` still exposes exactly the three live check names (VAL-CDG-015 wording holds); the dispatch job must be `completed/skipped` on every selected main execution, otherwise `VerificationError("historical-backfill dispatch job did not skip on the selected main execution")`; per-attempt `auxiliary_jobs` is emitted.

## Event / permission reasoning table (trigger event -> jobs run -> effective permissions)

Workflow-level `permissions: {checks: read, contents: read}`. `actions: write` appears exactly once in the file. Proven mechanically by `test_event_permission_table_proves_non_historical_paths_never_reach_actions_write`, which evaluates each job's `if` per event and asserts the effective permission map.

| trigger event | jobs that run | effective permissions | change vs main |
|---|---|---|---|
| `pull_request` (non-draft) | `pr-delta` | workflow-level read (`checks: read, contents: read`) | none |
| `push` (main) | `main-receipt`, `program-trajectory` | receipt: `checks: read, contents: read` (was `+ actions: write`); trajectory: inherited read | receipt token loses `actions: write`; steps identical |
| `schedule` | `main-receipt`, `program-trajectory` | same as push | same as push |
| `workflow_dispatch`, `historical_backfill=false`/absent | `main-receipt`, `program-trajectory` | same as push | same as push |
| `workflow_dispatch`, `historical_backfill=true` | `main-receipt`, `program-trajectory`, `historical-backfill-dispatch` | receipt read-only; dispatch job `actions: write` only | finalize dispatch moves from a receipt step to a dependent job that runs only after the receipt job (and its upload) succeeded |

On every non-historical path the dispatch job evaluates its `if` to false and is **skipped** (one skipped row per routine run; the verifier now requires exactly that). `program-trajectory` still has no `needs` edge, so its intentionally-red exit cannot gate the receipt; the test now asserts the only `needs` edge in the file is dispatch -> main-receipt.

## Round-2 fix: live main-run selection skips historical-backfill dispatches (commit 22ce963410)

openai's prepare-only r1 review found a genuine defect: `_selected_main_run()` treated every `workflow_dispatch` run at main's tip as eligible, while `_attempts()` requires the dispatch job to have skipped. A historical-backfill dispatch whose ref tip equals current main would become the newest selected run and fail the live verifier until a routine run superseded it. Run listings never expose dispatch inputs and the workflow has no `run-name`, so the verifier now classifies `workflow_dispatch` candidates by attempt topology: `program-trajectory` is the one job whose `if` is false exactly on a historical-backfill dispatch, so a dispatch run whose newest attempt has `program-trajectory` = `skipped` is excluded from selection; the newest routine execution is selected instead. A dispatch attempt that does not expose `program-trajectory` fails closed (`dispatch execution does not expose the program-trajectory job`). Existing error strings and pins are unchanged.

Red-first: `test_live_verifier_selects_the_newest_routine_run_past_historical_backfill_dispatches` failed on the pre-fix code with `VerificationError: historical-backfill dispatch job did not skip on the selected main execution` (RED_RC=1), then passed after the fix. It also covers: a `historical_backfill=false` dispatch still wins as newest; a backfill-only history at main's tip raises the existing `no canonical main workflow execution matches current main`; the hidden-trajectory hostile case.

## Validation (all in the isolated worktree at this head)

- Red-first (`set -o pipefail`): the three new tests failed for the intended reasons before the workflow/verifier edits (`'actions' in {...'write'...}`; job-set mismatch at `('push', None)`; `AttributeError: HISTORICAL_DISPATCH_JOB_NAME`).
- `python3 -m pytest tests/scripts/test_contract_drift_workflow.py -q -p no:randomly` -> `52 passed, 1 skipped` at 22ce963410 (skip = pre-existing env-gated live test)
- VAL-CDG-015 23-name selector -> `23 passed, 29 deselected`
- CDG battery (`test_generate_contract_drift_inventory.py test_contract_drift_workflow.py test_build_contract_drift_historical_backfill.py test_contract_drift_sequence.py`) -> `512 passed, 1 skipped` at 22ce963410 (`test_check_contract_drift_ratchet.py` replaces the inventory file in this run)
- Workflow-policy tests (`test_contract_drift_boundary_workflow.py test_contract_drift_trusted_bootstrap.py test_check_workflow_checkout_integrity_policy.py test_check_required_check_priority_policy.py test_precommit_baseline_policy.py`) -> `83 passed`
- Inventory closure `-k "successor_backfill or workflow_dispatch or workflow_structure or authority_closure"` -> `2 passed` (the `local_workflow_dispatch` closure edge survives the job move); ratchet `-k "governance or workflow or guard_v2 or pin"` -> `10 passed`
- `actionlint` on both workflow files -> rc=0 (v1.7.11); `check_workflow_checkout_integrity_policy.py` pass; `check_workflow_pip_install_policy.py` pass
- `make lint` + `ruff format --check` clean; `make test-smoke` pass; smoke tier + `preflight_mypy.sh --diff-base origin/main` + `automation_pr_preflight.sh` results recorded in the settlement packet
- No new `noqa` / `type: ignore` markers.

## Measured LOC

`git diff --numstat origin/main...HEAD` at 22ce963410: `.github/workflows/contract-drift-governance.yml` +16/-3; `scripts/verify_contract_drift_workflow_state.py` +66/-7; `tests/scripts/test_contract_drift_workflow.py` +283/-24. Total +365/-34 = 399 changed lines (cap 800).

## Risks / disclosures

- Routine main runs now show a fourth, skipped job row (`contract-drift-historical-backfill-dispatch`); the live verifier requires it to be skipped and fails closed if it ran or is missing.
- The verifier's job-set requirement changes from "exactly the three live names" to "exactly the three live names plus the dispatch job" at the source and attempt level; `checks` output shape is unchanged. Any run recorded against a pre-split head will fail the verifier's source check by design (the selected run must be on this workflow shape).
- `HISTORICAL_SOURCE_SHA_EXPR` count pin moves 2 -> 3 (dispatch job env repeats the identical expression).
- The dispatch job's `GH_TOKEN` now carries only `actions: write`; the `dispatches` POST and the attempt-jobs GET both work under that scope.
- The finalizer's 30x10s source-run poll must also cover the dispatch job; the job has `timeout-minutes: 10` and a single short step.
- Selection now issues one extra attempt-jobs page (plus one check-run read) per `workflow_dispatch` candidate at main's tip; push/schedule candidates are classified without extra reads.

## Ownership

Source: claude P3 on PR #9750. Standard structex prepare-only Tier-4 flow: one draft PR, evidence unposted, settlement packet in the mission library, park.

