### PR TITLE
docs(metrics): refresh two drifted canonical counts so --check is green on main

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -17,7 +17,7 @@
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5551` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
 | Test functions (class + module level) | `226053` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `1044` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `1064` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2912` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3205` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1110` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1119` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `97` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 


### PR DESCRIPTION
## Summary

Docs-only, Tier 0. Makes `docs/METRICS.md` truthful so `python3 scripts/regenerate_metrics.py --check` exits 0 on clean `main` (mission feature `p4m-metrics-doc-truthfulness`, operator ruling 2026-09-03; absorbs the cancelled `misc-metrics-ambient-docfiles-drift-regen`).

Baseline on clean `origin/main` at `30105dc7a8062b7d53b1c36e38e934b9ed51607b` (disposable detached worktree, `python3 scripts/regenerate_metrics.py --check`, exit 1):

```
DRIFT: @pytest.mark.parametrize decorators 1044 -> 1064 (1.9%)
DRIFT: Markdown files under docs/ 1110 -> 1119 (0.8%)
```

## Change

Regenerates exactly the two rows that exceed the 0.5% tolerance (`+2/-2` on `docs/METRICS.md`, values produced by `scripts/regenerate_metrics.py`):

| Row | Before | After |
|---|---|---|
| `@pytest.mark.parametrize decorators` | 1044 | 1064 |
| `Markdown files under docs/` | 1110 | 1119 |

The four other rows that moved on main (Python files 4310 -> 4325, Python LOC 1994979 -> 2001014, test files 5551 -> 5573, test functions 226053 -> 226324) are all below tolerance (0.12% to 0.40%) and are deliberately held at their committed values. `scripts/doc_stats.py` consumes those rows and the docs-build sync gate (`doc_stats.py --write` + `git diff --quiet`) would ripple a refresh into `README.md` (path-frozen for mission PRs) and five stat-block docs (`docs/CANONICAL_GOALS.md`, `docs/EXTENDED_README.md`, `docs/STATUS.md`, `docs/architecture/ARCHITECTURE.md`, `docs/status/FEATURE_DISCOVERY.md`), which are outside this docs-only change. Verified: on this head `python3 scripts/doc_stats.py --write` reports `Updated 0 documentation files` and leaves the tree clean.

Metric moved (R4): VAL-P4M-001 `regenerate_metrics.py --check` exit code 1 -> 0 (`No drift beyond 0.5% threshold.`).

Pointer alignment (VAL-P4M-002): `CLAUDE.md` (lines 194, 226, 235, 442, 510) and `README.md` (lines 248, 259, 339) point at `docs/METRICS.md` for generated counts; the only exact numbers README states (3,205 operations / 2,912 paths / 41 adapter specs / 46 files) match this doc. No edit to `CLAUDE.md` (protected) or `README.md` (path-frozen) is needed.

## Validation

- `python3 scripts/regenerate_metrics.py --check` (on this head): `No drift beyond 0.5% threshold.` exit 0
- `python3 scripts/doc_stats.py --write`: `Updated 0 documentation files`, `git status --porcelain` empty
- `make lint`: All checks passed! (exit 0)
- `ruff format --check aragora/ tests/ scripts/`: 10880 files already formatted (exit 0)
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (post-commit, fresh `MYPY_CACHE_DIR`): no python changes; mypy preflight skipped (exit 0)
- `python3 -m pytest tests/scripts/test_regenerate_metrics.py tests/scripts/test_doc_stats.py -q`: 44 passed (exit 0)
- `make test-smoke`: Smoke tests passed! (exit 0)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: docs-only diff detected, preflight: ok (exit 0)

## Census disclosure (Standing Policy 2026-08-19, tolerated stale-regen class)

Twelve open foreign PRs carry a stale regenerated hunk on `docs/METRICS.md` (all pure table-row regen, no other edit to this file; none touched by this PR): #8823 `99203f0b0b80`, #8939 `4028b9e3f7ab`, #9028 `f4835c2f14b3`, #9057 `bc314c79b138`, #9074 `4cab27921618`, #9677 `13fc88507009`, #9682 `325859130fc9`, #9846 `ebb0d489d122`, #9880 `fb7faed07cef`, #9882 `781c8c36c846`, #9929 `f61b8f265ed8`, #9932 `66eef0e2b80a`.

No workflow, policy, release, attestation, `CLAUDE.md`, or `README.md` edits (R1/R3, protected-file guard).
