### PR TITLE
refactor(sdk): remove 12 phantom debates method pairs (paydown batch 01)

### DIFF
--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -6,6 +6,33 @@ This document tracks breaking changes specific to the Aragora Python SDK. For co
 
 ## Version 2.x
 
+### Unreleased (2026-09-03)
+
+#### Breaking Changes
+
+Removed 12 `debates` methods (sync `DebatesAPI` and async `AsyncDebatesAPI`)
+that targeted routes no server handler dispatches. Every one of them was
+already marked DEPRECATED and emitted a `DeprecationWarning`; each call
+fell through to the debate slug lookup and returned 404, so no working
+integration depended on them.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `debates.restore(debate_id)` | `POST /api/v1/debates/{id}/restore` | `debates.update(debate_id, status="active")` |
+| `debates.make_permanent(debate_id)` | `POST /api/v1/debates/{id}/make-permanent` | None needed; completed debates persist automatically |
+| `debates.find_similar(debate_id, limit)` | `GET /api/v1/debates/{id}/similar` | `debates.search(query)` with the debate task text |
+| `debates.get_quality(debate_id)` | `GET /api/v1/debates/{id}/quality` | `debates.get_verification_report(debate_id)` |
+| `debates.get_notes(debate_id)` | `GET /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
+| `debates.add_note(debate_id, content)` | `POST /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
+| `debates.delete_note(debate_id, note_id)` | `DELETE /api/v1/debates/{id}/notes/{note_id}` | No replacement (server has no notes feature) |
+| `debates.get_batch_results(batch_id)` | `GET /api/v1/debates/batch/{id}/results` | `debates.get_batch_status(batch_id)` (includes per-job results) |
+| `debates.cancel_batch(batch_id)` | `POST /api/v1/debates/batch/{id}/cancel` | Cancel individual debates with `debates.cancel(debate_id)` |
+| `debates.retry_batch(batch_id)` | `POST /api/v1/debates/batch/{id}/retry` | Re-submit failed jobs with `debates.submit_batch(...)` |
+| `debates.get_agent_statistics(debate_id)` | `GET /api/v1/debates/{id}/agent-statistics` | `debates.get_agent_stats()` (aggregate per-agent statistics) |
+| `debates.get_debate_health(debate_id)` | `GET /api/v1/debates/{id}/health` | `debates.get_health()` for system health, `debates.get(debate_id)` for a debate's status |
+
+---
+
 ### v2.4.0 (2026-01-25)
 
 **No breaking changes.** Added new namespace resources.

--- a/sdk/python/aragora_sdk/namespaces/debates.py
+++ b/sdk/python/aragora_sdk/namespaces/debates.py
@@ -4,8 +4,7 @@ Debates Namespace API
 Provides methods for creating, managing, and analyzing debates.
 
 Note: A number of methods below (get_rounds, get_agents, get_votes,
-get_notes, get_metadata, get_timeline, get_tags, find_similar, the
-per-debate analytics/batch extras, ...) target routes that no server
+get_metadata, get_timeline, get_tags, ...) target routes that no server
 handler dispatches. Because ``DebatesHandler.can_handle`` claims all of
 ``/api/debates/*``, such requests do not 404 cleanly at the router: the
 dispatcher matches DebatesHandler, finds no route branch, and falls
@@ -918,33 +917,6 @@ class DebatesAPI:
         """Resume a paused debate."""
         return self._client.request("POST", f"/api/v1/debates/{debate_id}/resume")
 
-    def restore(self, debate_id: str) -> dict[str, Any]:
-        """Restore an archived debate.
-
-        DEPRECATED: POST /api/v1/debates/{id}/restore is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use update(debate_id, status="active") instead.
-        """
-        _warn_deprecated(
-            "debates.restore() targets an unserved route (404 via slug "
-            "fallback); use update(debate_id, status='active')."
-        )
-        return self._client.request("POST", f"/api/v1/debates/{debate_id}/restore")
-
-    def make_permanent(self, debate_id: str) -> dict[str, Any]:
-        """Make a debate permanent.
-
-        DEPRECATED: POST /api/v1/debates/{id}/make-permanent is not
-        dispatched by any server handler; the request falls into the debate
-        slug lookup and returns 404. Completed debates are persisted
-        automatically; there is no server-side equivalent.
-        """
-        _warn_deprecated(
-            "debates.make_permanent() targets an unserved route (404 via "
-            "slug fallback); debates are persisted automatically."
-        )
-        return self._client.request("POST", f"/api/v1/debates/{debate_id}/make-permanent")
-
     def clone(self, debate_id: str, **options: Any) -> dict[str, Any]:
         """Clone a debate with fresh state."""
         return self._client.request("POST", f"/api/v1/debates/{debate_id}/clone", json=options)
@@ -1041,21 +1013,6 @@ class DebatesAPI:
         )
         return self._client.request("GET", f"/api/v1/debates/{debate_id}/tags")
 
-    def find_similar(self, debate_id: str, limit: int = 5) -> dict[str, Any]:
-        """Find debates similar to this one.
-
-        DEPRECATED: GET /api/v1/debates/{id}/similar is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use search() with the debate task text instead.
-        """
-        _warn_deprecated(
-            "debates.find_similar() targets an unserved route (404 via "
-            "slug fallback); use search()."
-        )
-        return self._client.request(
-            "GET", f"/api/v1/debates/{debate_id}/similar", params={"limit": limit}
-        )
-
     # ========== Graph & Matrix ==========
 
     def get_graph(self, debate_id: str) -> dict[str, Any]:
@@ -1118,20 +1075,6 @@ class DebatesAPI:
         """Get meta-level critique of the debate."""
         return self._client.request("GET", f"/api/v1/debate/{debate_id}/meta-critique")
 
-    def get_quality(self, debate_id: str) -> dict[str, Any]:
-        """Get argument quality analysis.
-
-        DEPRECATED: GET /api/v1/debates/{id}/quality is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use get_verification_report() or
-        get_explainability() instead.
-        """
-        _warn_deprecated(
-            "debates.get_quality() targets an unserved route (404 via slug "
-            "fallback); use get_verification_report()."
-        )
-        return self._client.request("GET", f"/api/v1/debates/{debate_id}/quality")
-
     def verify_claim(
         self, debate_id: str, claim_id: str, evidence: str | None = None
     ) -> dict[str, Any]:
@@ -1140,124 +1083,6 @@ class DebatesAPI:
         if evidence is not None:
             data["evidence"] = evidence
         return self._client.request("POST", f"/api/v1/debates/{debate_id}/verify", json=data)
-
-    # ========== Notes ==========
-
-    def get_notes(self, debate_id: str) -> dict[str, Any]:
-        """Get notes attached to a debate.
-
-        DEPRECATED: the server has no debate-notes feature; GET
-        /api/v1/debates/{id}/notes is not dispatched by any handler and
-        returns 404 via the debate slug lookup. There is no replacement.
-        """
-        _warn_deprecated(
-            "debates.get_notes() targets an unserved route (404 via slug "
-            "fallback); the server has no debate-notes feature."
-        )
-        return self._client.request("GET", f"/api/v1/debates/{debate_id}/notes")
-
-    def add_note(self, debate_id: str, content: str) -> dict[str, Any]:
-        """Add a note to a debate.
-
-        DEPRECATED: the server has no debate-notes feature; POST
-        /api/v1/debates/{id}/notes is not dispatched by any handler and
-        returns 404 via the debate slug lookup. There is no replacement.
-        """
-        _warn_deprecated(
-            "debates.add_note() targets an unserved route (404 via slug "
-            "fallback); the server has no debate-notes feature."
-        )
-        return self._client.request(
-            "POST", f"/api/v1/debates/{debate_id}/notes", json={"content": content}
-        )
-
-    def delete_note(self, debate_id: str, note_id: str) -> dict[str, Any]:
-        """Delete a note from a debate.
-
-        DEPRECATED: the server has no debate-notes feature; DELETE
-        /api/v1/debates/{id}/notes/{note_id} is not dispatched by any
-        handler and returns 404 via the debate slug lookup. There is no
-        replacement.
-        """
-        _warn_deprecated(
-            "debates.delete_note() targets an unserved route (404 via slug "
-            "fallback); the server has no debate-notes feature."
-        )
-        return self._client.request("DELETE", f"/api/v1/debates/{debate_id}/notes/{note_id}")
-
-    # ========== Batch Results ==========
-
-    def get_batch_results(self, batch_id: str) -> dict[str, Any]:
-        """Get results of a batch job.
-
-        DEPRECATED: GET /api/v1/debates/batch/{id}/results is not
-        dispatched by any server handler; the request falls into the
-        debate slug lookup and returns 404. Use get_batch_status() --
-        its response includes per-job results.
-        """
-        _warn_deprecated(
-            "debates.get_batch_results() targets an unserved route (404 "
-            "via slug fallback); use get_batch_status()."
-        )
-        return self._client.request("GET", f"/api/v1/debates/batch/{batch_id}/results")
-
-    def cancel_batch(self, batch_id: str) -> dict[str, Any]:
-        """Cancel a batch job.
-
-        DEPRECATED: the server has no batch-cancel endpoint. This POST is
-        mis-dispatched into the single-debate cancel branch with the
-        literal id "batch" and always fails with 404. There is no
-        replacement.
-        """
-        _warn_deprecated(
-            "debates.cancel_batch() targets an unserved route (mis-"
-            "dispatched, always 404); the server has no batch cancel."
-        )
-        return self._client.request("POST", f"/api/v1/debates/batch/{batch_id}/cancel")
-
-    def retry_batch(self, batch_id: str) -> dict[str, Any]:
-        """Retry failed jobs in a batch.
-
-        DEPRECATED: POST /api/v1/debates/batch/{id}/retry is not
-        dispatched by any server handler; the request falls into the
-        debate slug lookup and returns 404. Re-submit failed jobs with
-        submit_batch() instead.
-        """
-        _warn_deprecated(
-            "debates.retry_batch() targets an unserved route (404 via slug "
-            "fallback); re-submit failed jobs with submit_batch()."
-        )
-        return self._client.request("POST", f"/api/v1/debates/batch/{batch_id}/retry")
-
-    # ========== Agent & Debate Health ==========
-
-    def get_agent_statistics(self, debate_id: str) -> dict[str, Any]:
-        """Get per-agent statistics for a debate.
-
-        DEPRECATED: GET /api/v1/debates/{id}/agent-statistics is not
-        dispatched by any server handler; the request falls into the
-        debate slug lookup and returns 404. Use get_agent_stats() for
-        global per-agent statistics.
-        """
-        _warn_deprecated(
-            "debates.get_agent_statistics() targets an unserved route (404 "
-            "via slug fallback); use get_agent_stats()."
-        )
-        return self._client.request("GET", f"/api/v1/debates/{debate_id}/agent-statistics")
-
-    def get_debate_health(self, debate_id: str) -> dict[str, Any]:
-        """Get health status for a specific debate.
-
-        DEPRECATED: GET /api/v1/debates/{id}/health is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use get_health() for system health or get() for
-        a debate's status.
-        """
-        _warn_deprecated(
-            "debates.get_debate_health() targets an unserved route (404 "
-            "via slug fallback); use get_health() or get()."
-        )
-        return self._client.request("GET", f"/api/v1/debates/{debate_id}/health")
 
     # ========== Intervention ==========
 
@@ -2109,33 +1934,6 @@ class AsyncDebatesAPI:
         """Resume a paused debate."""
         return await self._client.request("POST", f"/api/v1/debates/{debate_id}/resume")
 
-    async def restore(self, debate_id: str) -> dict[str, Any]:
-        """Restore an archived debate.
-
-        DEPRECATED: POST /api/v1/debates/{id}/restore is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use update(debate_id, status="active") instead.
-        """
-        _warn_deprecated(
-            "debates.restore() targets an unserved route (404 via slug "
-            "fallback); use update(debate_id, status='active')."
-        )
-        return await self._client.request("POST", f"/api/v1/debates/{debate_id}/restore")
-
-    async def make_permanent(self, debate_id: str) -> dict[str, Any]:
-        """Make a debate permanent.
-
-        DEPRECATED: POST /api/v1/debates/{id}/make-permanent is not
-        dispatched by any server handler; the request falls into the debate
-        slug lookup and returns 404. Completed debates are persisted
-        automatically; there is no server-side equivalent.
-        """
-        _warn_deprecated(
-            "debates.make_permanent() targets an unserved route (404 via "
-            "slug fallback); debates are persisted automatically."
-        )
-        return await self._client.request("POST", f"/api/v1/debates/{debate_id}/make-permanent")
-
     async def clone(self, debate_id: str, **options: Any) -> dict[str, Any]:
         """Clone a debate with fresh state."""
         return await self._client.request(
@@ -2234,21 +2032,6 @@ class AsyncDebatesAPI:
         )
         return await self._client.request("GET", f"/api/v1/debates/{debate_id}/tags")
 
-    async def find_similar(self, debate_id: str, limit: int = 5) -> dict[str, Any]:
-        """Find debates similar to this one.
-
-        DEPRECATED: GET /api/v1/debates/{id}/similar is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use search() with the debate task text instead.
-        """
-        _warn_deprecated(
-            "debates.find_similar() targets an unserved route (404 via "
-            "slug fallback); use search()."
-        )
-        return await self._client.request(
-            "GET", f"/api/v1/debates/{debate_id}/similar", params={"limit": limit}
-        )
-
     # ========== Graph & Matrix ==========
 
     async def get_graph(self, debate_id: str) -> dict[str, Any]:
@@ -2319,20 +2102,6 @@ class AsyncDebatesAPI:
         """Get meta-level critique of the debate."""
         return await self._client.request("GET", f"/api/v1/debate/{debate_id}/meta-critique")
 
-    async def get_quality(self, debate_id: str) -> dict[str, Any]:
-        """Get argument quality analysis.
-
-        DEPRECATED: GET /api/v1/debates/{id}/quality is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use get_verification_report() or
-        get_explainability() instead.
-        """
-        _warn_deprecated(
-            "debates.get_quality() targets an unserved route (404 via slug "
-            "fallback); use get_verification_report()."
-        )
-        return await self._client.request("GET", f"/api/v1/debates/{debate_id}/quality")
-
     async def verify_claim(
         self, debate_id: str, claim_id: str, evidence: str | None = None
     ) -> dict[str, Any]:
@@ -2341,124 +2110,6 @@ class AsyncDebatesAPI:
         if evidence is not None:
             data["evidence"] = evidence
         return await self._client.request("POST", f"/api/v1/debates/{debate_id}/verify", json=data)
-
-    # ========== Notes ==========
-
-    async def get_notes(self, debate_id: str) -> dict[str, Any]:
-        """Get notes attached to a debate.
-
-        DEPRECATED: the server has no debate-notes feature; GET
-        /api/v1/debates/{id}/notes is not dispatched by any handler and
-        returns 404 via the debate slug lookup. There is no replacement.
-        """
-        _warn_deprecated(
-            "debates.get_notes() targets an unserved route (404 via slug "
-            "fallback); the server has no debate-notes feature."
-        )
-        return await self._client.request("GET", f"/api/v1/debates/{debate_id}/notes")
-
-    async def add_note(self, debate_id: str, content: str) -> dict[str, Any]:
-        """Add a note to a debate.
-
-        DEPRECATED: the server has no debate-notes feature; POST
-        /api/v1/debates/{id}/notes is not dispatched by any handler and
-        returns 404 via the debate slug lookup. There is no replacement.
-        """
-        _warn_deprecated(
-            "debates.add_note() targets an unserved route (404 via slug "
-            "fallback); the server has no debate-notes feature."
-        )
-        return await self._client.request(
-            "POST", f"/api/v1/debates/{debate_id}/notes", json={"content": content}
-        )
-
-    async def delete_note(self, debate_id: str, note_id: str) -> dict[str, Any]:
-        """Delete a note from a debate.
-
-        DEPRECATED: the server has no debate-notes feature; DELETE
-        /api/v1/debates/{id}/notes/{note_id} is not dispatched by any
-        handler and returns 404 via the debate slug lookup. There is no
-        replacement.
-        """
-        _warn_deprecated(
-            "debates.delete_note() targets an unserved route (404 via slug "
-            "fallback); the server has no debate-notes feature."
-        )
-        return await self._client.request("DELETE", f"/api/v1/debates/{debate_id}/notes/{note_id}")
-
-    # ========== Batch Results ==========
-
-    async def get_batch_results(self, batch_id: str) -> dict[str, Any]:
-        """Get results of a batch job.
-
-        DEPRECATED: GET /api/v1/debates/batch/{id}/results is not
-        dispatched by any server handler; the request falls into the
-        debate slug lookup and returns 404. Use get_batch_status() --
-        its response includes per-job results.
-        """
-        _warn_deprecated(
-            "debates.get_batch_results() targets an unserved route (404 "
-            "via slug fallback); use get_batch_status()."
-        )
-        return await self._client.request("GET", f"/api/v1/debates/batch/{batch_id}/results")
-
-    async def cancel_batch(self, batch_id: str) -> dict[str, Any]:
-        """Cancel a batch job.
-
-        DEPRECATED: the server has no batch-cancel endpoint. This POST is
-        mis-dispatched into the single-debate cancel branch with the
-        literal id "batch" and always fails with 404. There is no
-        replacement.
-        """
-        _warn_deprecated(
-            "debates.cancel_batch() targets an unserved route (mis-"
-            "dispatched, always 404); the server has no batch cancel."
-        )
-        return await self._client.request("POST", f"/api/v1/debates/batch/{batch_id}/cancel")
-
-    async def retry_batch(self, batch_id: str) -> dict[str, Any]:
-        """Retry failed jobs in a batch.
-
-        DEPRECATED: POST /api/v1/debates/batch/{id}/retry is not
-        dispatched by any server handler; the request falls into the
-        debate slug lookup and returns 404. Re-submit failed jobs with
-        submit_batch() instead.
-        """
-        _warn_deprecated(
-            "debates.retry_batch() targets an unserved route (404 via slug "
-            "fallback); re-submit failed jobs with submit_batch()."
-        )
-        return await self._client.request("POST", f"/api/v1/debates/batch/{batch_id}/retry")
-
-    # ========== Agent & Debate Health ==========
-
-    async def get_agent_statistics(self, debate_id: str) -> dict[str, Any]:
-        """Get per-agent statistics for a debate.
-
-        DEPRECATED: GET /api/v1/debates/{id}/agent-statistics is not
-        dispatched by any server handler; the request falls into the
-        debate slug lookup and returns 404. Use get_agent_stats() for
-        global per-agent statistics.
-        """
-        _warn_deprecated(
-            "debates.get_agent_statistics() targets an unserved route (404 "
-            "via slug fallback); use get_agent_stats()."
-        )
-        return await self._client.request("GET", f"/api/v1/debates/{debate_id}/agent-statistics")
-
-    async def get_debate_health(self, debate_id: str) -> dict[str, Any]:
-        """Get health status for a specific debate.
-
-        DEPRECATED: GET /api/v1/debates/{id}/health is not dispatched by
-        any server handler; the request falls into the debate slug lookup
-        and returns 404. Use get_health() for system health or get() for
-        a debate's status.
-        """
-        _warn_deprecated(
-            "debates.get_debate_health() targets an unserved route (404 "
-            "via slug fallback); use get_health() or get()."
-        )
-        return await self._client.request("GET", f"/api/v1/debates/{debate_id}/health")
 
     # ========== Intervention ==========
 

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -1,0 +1,42 @@
+# TypeScript SDK Breaking Changes
+
+This document tracks breaking changes specific to the Aragora TypeScript SDK. For core API breaking changes, see the main [BREAKING_CHANGES.md](../../docs/BREAKING_CHANGES.md).
+
+---
+
+## Version 2.x
+
+### Unreleased (2026-09-03)
+
+#### Breaking Changes
+
+Removed 12 `debates` methods from `DebatesAPI` that targeted routes no server
+handler dispatches. Every one of them was already marked `@deprecated`; each
+call fell through to the debate slug lookup and returned 404, so no working
+integration depended on them. The response interfaces used only by those
+methods (`DebateHealthDetail`, `BatchResults`, `ArgumentQualityAnalysis`,
+`DebateNote`) were removed with them.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `debates.restore(debateId)` | `POST /api/v1/debates/{id}/restore` | `debates.update(debateId, { status: 'active' })` |
+| `debates.makePermanent(debateId)` | `POST /api/v1/debates/{id}/make-permanent` | None needed; completed debates persist automatically |
+| `debates.findSimilar(debateId, limit)` | `GET /api/v1/debates/{id}/similar` | `debates.search(query)` or `debates.compare(debateIds)` |
+| `debates.analyzeArgumentQuality(debateId)` | `GET /api/v1/debates/{id}/quality` | `debates.getSummary(debateId)` |
+| `debates.getNotes(debateId)` | `GET /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
+| `debates.addNote(debateId, note)` | `POST /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
+| `debates.deleteNote(debateId, noteId)` | `DELETE /api/v1/debates/{id}/notes/{noteId}` | No replacement (server has no notes feature) |
+| `debates.getBatchResults(batchId)` | `GET /api/v1/debates/batch/{id}/results` | `debates.getBatchStatus(batchId)` (includes per-job state) |
+| `debates.cancelBatch(batchId)` | `POST /api/v1/debates/batch/{id}/cancel` | Cancel individual debates with `debates.cancel(debateId)` |
+| `debates.retryBatch(batchId, options)` | `POST /api/v1/debates/batch/{id}/retry` | Re-submit failed debates with `debates.submitBatch(...)` |
+| `debates.getDebateAgentStatistics(debateId)` | `GET /api/v1/debates/{id}/agent-statistics` | `debates.getStatsAgents()` (aggregate per-agent statistics) |
+| `debates.getHealth(debateId)` | `GET /api/v1/debates/{id}/health` | `debates.listHealth()` for system-wide debate health |
+
+---
+
+## Migration Guides
+
+- [API v1 to v2 Migration](../../docs/api/V1_TO_V2_MIGRATION.md) - Complete guide for API migration
+- [SDK Guide](../../docs/SDK_GUIDE.md) - Full SDK documentation
+
+---

--- a/sdk/typescript/src/namespaces/debates.ts
+++ b/sdk/typescript/src/namespaces/debates.ts
@@ -90,19 +90,6 @@ export interface DebateHealthStatus {
 }
 
 /**
- * Health detail for a specific debate
- */
-export interface DebateHealthDetail {
-  debate_id: string;
-  status: 'healthy' | 'stuck' | 'stalled' | 'completed';
-  stuck_since_round: number | null;
-  current_round: number;
-  last_activity: string;
-  agents_active: string[];
-  recommendations: string[];
-}
-
-/**
  * Debate filter options
  */
 export interface DebateFilters {
@@ -207,22 +194,6 @@ export interface BatchExportResult {
 }
 
 /**
- * Batch operation results
- */
-export interface BatchResults {
-  batch_id: string;
-  status: 'pending' | 'running' | 'completed' | 'failed';
-  total_jobs: number;
-  completed_jobs: number;
-  failed_jobs: number;
-  debates: Array<{
-    debate_id: string;
-    status: 'success' | 'failed' | 'pending';
-    error?: string;
-  }>;
-}
-
-/**
  * Debate comparison result
  */
 export interface DebateComparison {
@@ -234,34 +205,6 @@ export interface DebateComparison {
     positions: Record<string, string>;
   }>;
   consensus_alignment: number;
-}
-
-/**
- * Argument quality analysis
- */
-export interface ArgumentQualityAnalysis {
-  debate_id: string;
-  overall_score: number;
-  by_agent: Array<{
-    name: string;
-    quality_score: number;
-    evidence_usage: number;
-    logical_consistency: number;
-    engagement_quality: number;
-  }>;
-  recommendations: string[];
-}
-
-/**
- * Debate note
- */
-export interface DebateNote {
-  note_id: string;
-  debate_id: string;
-  content: string;
-  author: string;
-  created_at: string;
-  updated_at: string;
 }
 
 /**
@@ -1911,20 +1854,6 @@ export class DebatesAPI {
     return this.client.request('GET', '/api/v1/debates/health');
   }
 
-  /**
-   * Get health status for a specific debate.
-   *
-   * @deprecated The server has no per-debate health endpoint: no handler
-   * dispatches GET /api/v1/debates/{id}/health, so the request falls through
-   * to DebatesHandler's slug lookup and returns 404. Use {@link listHealth}
-   * (GET /api/v1/debates/health) for system-wide debate health instead.
-   *
-   * @param debateId - The debate ID
-   */
-  async getHealth(debateId: string): Promise<DebateHealthDetail> {
-    return this.client.request('GET', `/api/v1/debates/${debateId}/health`);
-  }
-
   // ===========================================================================
   // Advanced Query & Filtering
   // ===========================================================================
@@ -2222,60 +2151,6 @@ export class DebatesAPI {
   }
 
   // ===========================================================================
-  // Batch Operations (Extended)
-  // ===========================================================================
-
-  /**
-   * Cancel a batch job.
-   *
-   * @deprecated The server has no batch-cancel endpoint. Worse than a 404:
-   * DebatesHandler.handle_post matches the `/cancel` suffix and treats the
-   * literal path segment "batch" as a debate ID, so this attempts to cancel a
-   * debate named "batch" and fails. Cancel individual debates with
-   * {@link cancel} instead.
-   *
-   * @param batchId - The batch ID to cancel
-   */
-  async cancelBatch(batchId: string): Promise<{ success: boolean; cancelled_jobs: number }> {
-    return this.client.request('POST', `/api/v1/debates/batch/${batchId}/cancel`);
-  }
-
-  /**
-   * Retry failed jobs in a batch.
-   *
-   * @deprecated Not served: no handler dispatches
-   * POST /api/v1/debates/batch/{id}/retry — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. Re-submit failed debates
-   * with {@link submitBatch} instead.
-   *
-   * @param batchId - The batch ID
-   * @param options - Retry options
-   */
-  async retryBatch(
-    batchId: string,
-    options?: { onlyFailed?: boolean }
-  ): Promise<{ success: boolean; retried_count: number }> {
-    return this.client.request('POST', `/api/v1/debates/batch/${batchId}/retry`, {
-      body: options,
-    });
-  }
-
-  /**
-   * Get detailed results from a completed batch.
-   *
-   * @deprecated Not served: no handler dispatches
-   * GET /api/v1/debates/batch/{id}/results — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. Use {@link getBatchStatus}
-   * (documented GET /api/v1/debates/batch/{id}/status, which includes per-job
-   * state) instead.
-   *
-   * @param batchId - The batch ID
-   */
-  async getBatchResults(batchId: string): Promise<BatchResults> {
-    return this.client.request('GET', `/api/v1/debates/batch/${batchId}/results`);
-  }
-
-  // ===========================================================================
   // Comparison & Analysis
   // ===========================================================================
 
@@ -2296,41 +2171,6 @@ export class DebatesAPI {
     return this.client.request('POST', '/api/v1/debates/compare', {
       body: { debate_ids: debateIds },
     });
-  }
-
-  /**
-   * Get similar debates to a given debate.
-   *
-   * @deprecated Not served: no handler dispatches
-   * GET /api/v1/debates/{id}/similar — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. Use cross-debate search
-   * ({@link search}) or {@link compare} instead.
-   *
-   * @param debateId - The debate ID to find similar debates for
-   * @param limit - Maximum number of similar debates to return
-   */
-  async findSimilar(
-    debateId: string,
-    limit: number = 10
-  ): Promise<{ debates: Array<{ debate_id: string; similarity_score: number; task: string }> }> {
-    return this.client.request('GET', `/api/v1/debates/${debateId}/similar`, {
-      params: { limit },
-    });
-  }
-
-  /**
-   * Analyze argument quality in a debate.
-   *
-   * @deprecated Not served: no handler dispatches
-   * GET /api/v1/debates/{id}/quality — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. There is no server
-   * equivalent; the closest documented endpoint is
-   * GET /api/v1/debates/{id}/summary ({@link getSummary}).
-   *
-   * @param debateId - The debate ID
-   */
-  async analyzeArgumentQuality(debateId: string): Promise<ArgumentQualityAnalysis> {
-    return this.client.request('GET', `/api/v1/debates/${debateId}/quality`);
   }
 
   // ===========================================================================
@@ -2371,20 +2211,6 @@ export class DebatesAPI {
     return this.client.request('GET', '/api/v1/debates/archived', {
       params: options as Record<string, unknown>,
     });
-  }
-
-  /**
-   * Restore an archived debate.
-   *
-   * @deprecated Not served: no handler dispatches
-   * POST /api/v1/debates/{id}/restore — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. There is no un-archive
-   * endpoint on the server (archiving via {@link archive} is one-way today).
-   *
-   * @param debateId - The debate ID to restore
-   */
-  async restore(debateId: string): Promise<{ success: boolean }> {
-    return this.client.request('POST', `/api/v1/debates/${debateId}/restore`);
   }
 
   /**
@@ -2482,62 +2308,6 @@ export class DebatesAPI {
     return this.client.request('PATCH', `/api/v1/debates/${debateId}/metadata`, {
       body: { metadata },
     });
-  }
-
-  // ===========================================================================
-  // Notes & Comments
-  // ===========================================================================
-
-  /**
-   * Add a note to a debate.
-   *
-   * @deprecated Not served: the server has no debate-notes feature. No handler
-   * dispatches POST /api/v1/debates/{id}/notes — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. Store annotations via
-   * {@link update} (PATCH /api/v1/debates/{id} with a `metadata` field)
-   * instead.
-   *
-   * @param debateId - The debate ID
-   * @param note - The note content
-   */
-  async addNote(
-    debateId: string,
-    note: string
-  ): Promise<{ note_id: string; success: boolean }> {
-    return this.client.request('POST', `/api/v1/debates/${debateId}/notes`, {
-      body: { note },
-    });
-  }
-
-  /**
-   * Get notes for a debate.
-   *
-   * @deprecated Not served: the server has no debate-notes feature. No handler
-   * dispatches GET /api/v1/debates/{id}/notes — the request falls through to
-   * DebatesHandler's slug lookup and returns 404.
-   *
-   * @param debateId - The debate ID
-   */
-  async getNotes(debateId: string): Promise<DebateNote[]> {
-    const response = await this.client.request<{ notes: DebateNote[] }>(
-      'GET',
-      `/api/v1/debates/${debateId}/notes`
-    );
-    return response.notes;
-  }
-
-  /**
-   * Delete a note from a debate.
-   *
-   * @deprecated Not served: the server has no debate-notes feature. No handler
-   * dispatches DELETE /api/v1/debates/{id}/notes/{noteId} — the request falls
-   * through to DebatesHandler's slug lookup and returns 404.
-   *
-   * @param debateId - The debate ID
-   * @param noteId - The note ID to delete
-   */
-  async deleteNote(debateId: string, noteId: string): Promise<{ success: boolean }> {
-    return this.client.request('DELETE', `/api/v1/debates/${debateId}/notes/${noteId}`);
   }
 
   // ===========================================================================
@@ -3282,43 +3052,5 @@ export class DebatesAPI {
     };
   }> {
     return this.client.request('GET', `/api/v1/debates/${encodeURIComponent(debateId)}/reasoning`);
-  }
-  /**
-   * Get per-agent performance statistics for a specific debate.
-   *
-   * @deprecated Not served: no handler dispatches
-   * GET /api/v1/debates/{id}/agent-statistics — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. Use {@link getStatsAgents}
-   * (documented GET /api/debates/stats/agents, aggregate across debates)
-   * instead.
-   *
-   * @param debateId - The debate to retrieve agent statistics for
-   * @returns Per-agent statistics keyed by agent name
-   */
-  async getDebateAgentStatistics(debateId: string): Promise<{
-    debate_id: string;
-    agents: Record<string, {
-      contribution_score?: number;
-      argument_count?: number;
-      consensus_alignment?: number;
-      win_rate?: number;
-      avg_confidence?: number;
-    }>;
-  }> {
-    return this.client.request('GET', `/api/v1/debates/${encodeURIComponent(debateId)}/agent-statistics`);
-  }
-
-  /**
-   * Make a debate permanent (prevent automatic cleanup or archiving).
-   *
-   * @deprecated Not served: no handler dispatches
-   * POST /api/v1/debates/{id}/make-permanent — the request falls through to
-   * DebatesHandler's slug lookup and returns 404. There is no server
-   * equivalent for pinning a debate.
-   *
-   * @param debateId - The debate to mark as permanent
-   */
-  async makePermanent(debateId: string): Promise<{ success: boolean; is_permanent: boolean; debate_id: string }> {
-    return this.client.request('POST', `/api/v1/debates/${encodeURIComponent(debateId)}/make-permanent`);
   }
 }


### PR DESCRIPTION
## Summary

SDK drift paydown batch 01 of 6 (tranche 1, namespaces `debates` + `payments`). Deletes 12 matched Python+TypeScript SDK method pairs in the `debates` namespace whose `VERB /path` is absent from the OpenAPI union (`docs/api/openapi.json` + `docs/api/openapi_generated.json`) **and** has no server-side handler (`rg aragora/server` returns zero hits for each path). Every removed method was already marked deprecated and returned 404 via the debate slug fallback.

`payments` has zero drift entries on both sides, so nothing was removed there.

## Governed metric (verify_sdk_contracts --strict, live printed counts)

| | before (origin/main `ec2f6abac9`) | after (this head) |
|---|---|---|
| Python SDK drift | 464 | **452** |
| TypeScript SDK drift | 319 | **308** |
| Baseline regressions | py=0 ts=0 stable=0 | py=0 ts=0 stable=0 |

## Removed pairs (route -> Python / TypeScript)

| Route | Python (`DebatesAPI` + `AsyncDebatesAPI`) | TypeScript (`DebatesAPI`) |
|---|---|---|
| `POST /debates/{id}/restore` | `restore` | `restore` |
| `POST /debates/{id}/make-permanent` | `make_permanent` | `makePermanent` |
| `GET /debates/{id}/similar` | `find_similar` | `findSimilar` |
| `GET /debates/{id}/quality` | `get_quality` | `analyzeArgumentQuality` |
| `GET /debates/{id}/notes` | `get_notes` | `getNotes` |
| `POST /debates/{id}/notes` | `add_note` | `addNote` |
| `DELETE /debates/{id}/notes/{note_id}` | `delete_note` | `deleteNote` |
| `GET /debates/batch/{id}/results` | `get_batch_results` | `getBatchResults` |
| `POST /debates/batch/{id}/cancel` | `cancel_batch` | `cancelBatch` |
| `POST /debates/batch/{id}/retry` | `retry_batch` | `retryBatch` |
| `GET /debates/{id}/agent-statistics` | `get_agent_statistics` | `getDebateAgentStatistics` |
| `GET /debates/{id}/health` | `get_debate_health` | `getHealth` |

Also removed: TypeScript interfaces `DebateHealthDetail`, `BatchResults`, `ArgumentQualityAnalysis`, `DebateNote` (used only by the deleted methods; not re-exported from `namespaces/index.ts`). No SDK test referenced any deleted method, so no test deletions were needed. `GET /debates/{id}/notes` is Python-only in the checker's count (the TS `getNotes` used a generic `request<...>(` the regex misses) but was deleted on both sides to keep cross-SDK path parity.

Skipped (served but undocumented, noted in the mission tech-debt ledger, not deleted): `GET /debates/analytics/consensus`, `GET /debates/analytics/trends`, `GET /debates/archived`, `GET /debates/{id}/reasoning`, `GET /debates/{id}/spectate/public`.

## Invariants

- All 18 files under `scripts/baselines/` byte-identical to origin/main (`git diff --stat origin/main...HEAD -- scripts/baselines/` is empty).
- Diff confined to `sdk/python/**` and `sdk/typescript/**`; no `scripts/`, `.github/`, `aragora/`, or `docs/api/` changes.
- `git diff --numstat origin/main...HEAD`: +70 / -618 = 688 LOC.
- Breaking changes recorded in `sdk/python/BREAKING_CHANGES.md` (appended) and `sdk/typescript/BREAKING_CHANGES.md` (new, same format).

## Local gates (all on the committed head)

- `python3 scripts/verify_sdk_contracts.py --strict --baseline scripts/baselines/verify_sdk_contracts.json` -> exit 0, py 452 / ts 308, regressions 0/0/0
- `python3 scripts/check_cross_sdk_parity.py --strict --baseline scripts/baselines/cross_sdk_parity.json` -> PASS, python_only=0 typescript_only=0
- `python3 scripts/check_sdk_namespace_parity.py --strict --baseline scripts/baselines/check_sdk_namespace_parity.json` -> Regressions: 0
- `python3 scripts/check_sdk_parity.py --strict --baseline ... --budget ...` -> PASS, missing_from_both 0/0, stale_python 31/36
- `cd sdk/python && python3 -m pytest tests/ -q` -> 1395 passed; `ruff check aragora_sdk/ tests/` -> All checks passed
- `cd sdk/typescript && npm ci && npx tsc --noEmit` -> exit 0; `npm test` -> 1720 passed, 1 failed (`parity-compat-routes.test.ts > maps debate stats compatibility routes`; pre-existing on origin/main `ec2f6abac9`, reproduced in a detached worktree; `getStatsAgents` is untouched by this diff)
- `PYTHONPATH=sdk/python:. python3 -m pytest tests/sdk -q` -> 403 passed
- `make lint` -> All checks passed; `ruff format --check aragora/ tests/ scripts/` -> already formatted
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh cache, post-commit) -> Success: no issues found in 1 source file
- AWS-neutralized `make test-smoke` -> Smoke tests passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

## Governance

Tier 3 (computed via the `sdk/` TIER_3_PREFIXES entry). Settled in-session under the recorded phase Decision "SDK PAYDOWN TRANCHE 1" (mission `library/decision-ledger.md` L999 == `library/operator-approvals.md` L852, sha256-no-nl `76c560976c67d212...`), feature `sdk-paydown-01`.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
