### PR TITLE
feat(scripts): add receipt-first scoreboard

### DIFF
--- a/scripts/receipt_first_scoreboard.py
+++ b/scripts/receipt_first_scoreboard.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Receipt-First mission scoreboard: ten exit metrics and six guardrails as baseline/now/delta.
+
+Network rows (1, 4, 5, 7, 8, 9) are cached so offline runs still render. Every network call goes
+through ``curl`` or ``gh`` so the proxy environment applies uniformly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, NamedTuple
+
+Row = dict[str, Any]
+REPO = "synaptent/aragora"
+BASELINE_REF = "23909906e8"
+BASELINE_DATE = "2026-09-02"
+STATUSES = ("ok", "fail", "unavailable", "pending-operator")
+NETWORK_ROWS = (1, 4, 5, 7, 8, 9)
+DEFAULT_CACHE = Path.home() / ".aragora" / "receipt-first-scoreboard-cache.json"
+ATLAS_DIR = Path.home() / ".aragora" / "receipt-first-atlas"
+API_PROBE = "https://api.aragora.ai/readyz"
+CANARY_PROBE = "https://api-canary.aragora.ai/readyz"
+CODE_SEARCH_QUERY = "synaptent/aragora@ -repo:synaptent/aragora"
+VECTORS = "tests/verify/test_odr_vectors.py"
+PIN_RE = re.compile(r"synaptent/aragora@([0-9a-f]{7,40})")
+README_PIN_RE = re.compile(r"uses: synaptent/aragora@([0-9a-f]{7,40})")
+STATUS_LINE_RE = re.compile(r"^\*\*Status:\*\* (\w+) (v[0-9.]+)")
+LEDGER_RE = re.compile(r"^- \[metric (\d+)\] .*#(\d+) head ([0-9a-f]{40}|n/a)\s*$")
+METRIC_ROW_RE = re.compile(r"^\| *(10|[1-9]) *\|")
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+PARITY_GAP_KEYS = "missing_from_python_sdk missing_from_typescript_sdk missing_from_both_sdks"
+PARITY_GAP_KEYS += " stale_python_sdk_paths stale_typescript_sdk_paths"
+MYPY_ERROR_LIMIT, MYPY_BASELINE_LIMIT = 1744, 3115
+
+# (id, name, baseline value, baseline cell as printed); frozen for the whole mission.
+METRICS: list[tuple[int, str, Any, str]] = [
+    (1, "PyPI `aragora` newest release age", 58, "58 d (2.9.0, 2026-07-06)"),
+    (2, "README Action pin age", 57, "57 d (8b600a3a, 2026-07-07)"),
+    (3, "ODR spec status", "Draft v0.1", "Draft v0.1, no vectors"),
+    (4, "`aragora-verify` on PyPI", "0.1.1", "0.1.1 (2026-07-04)"),
+    (5, "Disagreement Atlas", 1659, "1659 records, #9951 draft, no atlas-v1 release"),
+    (6, "Dissent visibility", 53, "53 CHANGES-REQUESTED / 1659 records"),
+    (7, "Hosted API", "000", "000 (canary 200)"),
+    (8, "Verifiable published receipts", 0, "0"),
+    (9, "External repos using the Action", 0, "0 (demo repo absent)"),
+    (10, "Contract-drift units", 398, "398 (target 84, fail)"),
+]
+MEASUREMENTS = {
+    1: "curl https://pypi.org/pypi/aragora/json → max(upload_time_iso_8601 over releases)",
+    2: "uses: synaptent/aragora@<sha> in README.md; git log -1 --format=%cI <sha>",
+    3: "sed -n 3p docs/specs/OPEN_DECISION_RECEIPT.md; test -f tests/verify/test_odr_vectors.py",
+    4: "curl https://pypi.org/pypi/aragora-verify/json; ^version in aragora-verify/pyproject.toml",
+    5: "docs/atlas/manifest.json .dataset.record_count; gh release view atlas-v1; gh pr view 9951",
+    6: "Atlas JSONL: verdict==changes_requested, posted_to_thread, distinct (pr, head_sha) rounds",
+    7: f"curl -s -o /dev/null -w %{{http_code}} --max-time 15 {API_PROBE} (one probe per run)",
+    8: "gh release list --limit 100 → receipts-* tags → *.odr.json assets; first-hour run",
+    9: "gh api search/code (paths under .github/workflows/); gh repo view aragora-receipt-demo",
+    10: "check_contract_drift_ratchet.py --mode program --ref <40-hex> --json .current.total_items",
+}
+GUARDRAILS: list[tuple[str, str, int, int]] = [
+    ("import_cycles", "Mutual import cycles", 140, 144),
+    ("handlers_flat_root", "Handlers flat-root files", 187, 187),
+    ("ci_workflows", "Workflows", 97, 97),
+    ("doc_files", "Docs pages", 1119, 1119),
+    ("top_level_modules", "Top-level packages", 145, 145),
+    ("openapi_operations", "OpenAPI operations", 3205, 3205),
+]
+
+
+class NetworkUnavailable(Exception):
+    """A network-backed measurement could not be completed; fall back to the cache."""
+
+
+class Cmd(NamedTuple):
+    rc: int
+    out: str
+    err: str
+
+    ok = property(lambda self: self.rc == 0)
+
+
+def run_cmd(argv: list[str], *, timeout: float = 60, cwd: Any = None, env: Any = None) -> Cmd:
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, cwd=cwd, env=env)
+    except subprocess.TimeoutExpired:
+        return Cmd(124, "", f"timeout after {timeout}s: {' '.join(argv)}")
+    except OSError as exc:
+        return Cmd(127, "", str(exc))
+    return Cmd(p.returncode, p.stdout, p.stderr)
+
+
+def json_cmd(argv: list[str], *, timeout: float = 60, cwd: Path | None = None) -> Any:
+    c = run_cmd(argv, timeout=timeout, cwd=cwd)
+    if not c.ok or not c.out.strip():
+        raise NetworkUnavailable(c.err.strip() or f"empty output from {argv[0]}")
+    return json.loads(c.out)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def utc_date(value: str) -> date:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc).date()
+
+
+def age_days(value: str) -> int:
+    return (datetime.now(timezone.utc).date() - utc_date(value)).days
+
+
+def read_text(p: Path) -> str:
+    return p.read_text(errors="replace") if p.is_file() else ""
+
+
+def is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def compute_delta(baseline: Any, now: Any) -> Any:
+    if is_number(baseline) and is_number(now):
+        return now - baseline
+    return f"{'null' if baseline is None else baseline} → {'null' if now is None else now}"
+
+
+def semver(text: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in re.findall(r"\d+", text)[:3])
+
+
+def curl_code(url: str, max_time: int) -> str:
+    argv = ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", str(max_time), url]
+    return run_cmd(argv, timeout=max_time + 5).out.strip() or "000"
+
+
+def pypi_newest(package: str) -> tuple[str, str]:
+    argv = ["curl", "-s", "--max-time", "30", f"https://pypi.org/pypi/{package}/json"]
+    d = json_cmd(argv, timeout=35)
+    newest = max(f["upload_time_iso_8601"] for files in d["releases"].values() for f in files)
+    return d["info"]["version"], newest
+
+
+def releases() -> list[Row]:
+    return json_cmd(f"gh release list -R {REPO} --limit 100 --json tagName,publishedAt".split())
+
+
+def release_assets(tag: str) -> list[str]:
+    c = run_cmd(["gh", "release", "view", tag, "-R", REPO, "--json", "assets"])
+    if c.ok:
+        return [a["name"] for a in json.loads(c.out).get("assets", [])]
+    if "not found" in c.err.lower():
+        return []
+    raise NetworkUnavailable(c.err.strip())
+
+
+@dataclass
+class Ctx:
+    root: Path
+    offline: bool
+    ref: str
+    quorum_runs: int | None
+    run_vectors: bool
+    network_ok: bool = True
+    atlas_v1_assets: list[str] | None = None
+
+
+def metric_1(ctx: Ctx) -> Row:
+    version, uploaded = pypi_newest("aragora")
+    age = age_days(uploaded)
+    r: Row = {"now": age, "version": version, "upload_date": utc_date(uploaded).isoformat()}
+    return r | {"status": "ok" if age <= 14 else "fail"}
+
+
+def metric_2(ctx: Ctx) -> Row:
+    m = README_PIN_RE.search(read_text(ctx.root / "README.md"))
+    sha = m.group(1) if m else None
+    scope = ["README.md", "docs", "docs-site", "examples", ".github", "action.yml"]
+    tracked = run_cmd(["git", "ls-files", *scope], cwd=ctx.root).out.split()
+    pins = [p for rel in tracked for p in PIN_RE.findall(read_text(ctx.root / rel))]
+    distinct = sorted(set(pins))
+    r: Row = {"sha": sha, "pin_count": len(pins), "distinct_shas": distinct, "now": None}
+    r.update(commit_date=None, status="fail")
+    if len(distinct) > 1:
+        r["warning"] = f"{len(distinct)} distinct pinned SHAs: {[s[:10] for s in distinct]}"
+    if not sha:
+        return r | {"note": "no README pin"}
+    argv = ["git", "log", "-1", "--format=%cI", sha]
+    if not run_cmd(argv, cwd=ctx.root).ok and not ctx.offline:
+        run_cmd(["git", "fetch", "origin", sha, "--quiet"], cwd=ctx.root, timeout=120)
+    log = run_cmd(argv, cwd=ctx.root)
+    if not (log.ok and log.out.strip()):
+        return r | {"note": "pinned sha not in local history"}
+    age = age_days(log.out.strip())
+    date_ = utc_date(log.out.strip()).isoformat()
+    return r | {"now": age, "commit_date": date_, "status": "ok" if age <= 14 else "fail"}
+
+
+def metric_3(ctx: Ctx) -> Row:
+    lines = read_text(ctx.root / "docs/specs/OPEN_DECISION_RECEIPT.md").splitlines()
+    m = STATUS_LINE_RE.match(lines[2]) if len(lines) >= 3 else None
+    status, version = (m.group(1), m.group(2)) if m else (None, None)
+    vectors = (ctx.root / VECTORS).is_file()
+    vpass: bool | None = None
+    if ctx.run_vectors and vectors:
+        argv = [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", VECTORS]
+        vpass = run_cmd(argv, cwd=ctx.root, timeout=600).ok
+    ok = bool(version) and semver(version or "") >= (0, 2) and vectors and vpass is not False
+    r: Row = {"now": f"{status} {version}" if m else None, "spec_status": status}
+    r.update(version=version, vectors_present=vectors, vectors_pass=vpass)
+    return r | {"status": "ok" if ok else "fail"}
+
+
+def metric_4(ctx: Ctx) -> Row:
+    version, uploaded = pypi_newest("aragora-verify")
+    ok = semver(version) >= (0, 2)
+    date_ = utc_date(uploaded).isoformat()
+    return {"now": version, "upload_date": date_, "status": "ok" if ok else "fail"}
+
+
+def metric_5(ctx: Ctx) -> Row:
+    tags = [x["tagName"] for x in releases()]
+    assets = release_assets("atlas-v1") if "atlas-v1" in tags else []
+    ctx.atlas_v1_assets = assets
+    pr = json_cmd(["gh", "pr", "view", "9951", "-R", REPO, "--json", "state"])
+    merged = pr.get("state") == "MERGED"
+    manifest = read_text(ctx.root / "docs/atlas/manifest.json")
+    if not manifest:
+        argv = "git show rf/pr9951-inspect:docs/atlas/manifest.json".split()
+        manifest = run_cmd(argv, cwd=ctx.root).out
+    try:
+        count: int | None = int(json.loads(manifest)["dataset"]["record_count"])
+    except (ValueError, KeyError, TypeError):
+        count = None
+    r: Row = {"now": count, "record_count": count, "pr_9951_merged": merged}
+    r.update(atlas_v1_assets=assets, atlas_release_count=sum(t.startswith("atlas-") for t in tags))
+    return r | {"status": "ok" if merged and assets else "fail"}
+
+
+def metric_6(ctx: Ctx) -> Row:
+    r: Row = {"now": None, "posted": None, "rounds": None, "records": None, "upper_bound": True}
+    r.update(quorum_runs=ctx.quorum_runs, status="unavailable")
+    if not ctx.offline and ctx.atlas_v1_assets and not list(ATLAS_DIR.glob("*.jsonl")):
+        ATLAS_DIR.mkdir(parents=True, exist_ok=True)
+        argv = f"gh release download atlas-v1 -R {REPO} -p *.jsonl --clobber".split()
+        run_cmd(argv + ["-D", str(ATLAS_DIR)], timeout=120)
+    candidates = [ctx.root / "docs/atlas/atlas-v1.jsonl", *sorted(ATLAS_DIR.glob("*.jsonl"))]
+    jsonl = next((p for p in candidates if p.is_file()), None)
+    if jsonl is None:
+        return r | {"reason": "no Atlas JSONL (docs/atlas/atlas-v1.jsonl or atlas-v1 asset)"}
+    recs = [json.loads(line) for line in jsonl.read_text().splitlines() if line.strip()]
+    cr = sum(x.get("verdict") == "changes_requested" for x in recs)
+    posted = sum(bool(x.get("posted_to_thread")) for x in recs)
+    rounds = len({(x.get("pr"), x.get("head_sha")) for x in recs})
+    r.update(now=cr, posted=posted, rounds=rounds, records=len(recs), source=str(jsonl))
+    return r | {"ratio": round(posted / rounds, 3) if rounds else None, "status": "fail"}
+
+
+def metric_7(ctx: Ctx) -> Row:
+    code, canary = curl_code(API_PROBE, 15), curl_code(CANARY_PROBE, 15)
+    r: Row = {"now": code, "canary_code": canary, "probe": API_PROBE}
+    return r | {"status": "ok" if code == "200" else "fail"}
+
+
+def first_hour_run_ok(after: str) -> bool:
+    argv = f"gh run list -R {REPO} --workflow metrics-drift.yml --status success".split()
+    c = run_cmd(argv + ["--limit", "10", "--json", "databaseId,createdAt"])
+    runs = json.loads(c.out) if c.ok and c.out.strip() else []
+    jq = '[.jobs[]|select(.name=="receipt-first-hour" and .conclusion=="success")]|length'
+    for run in [x for x in runs if x.get("createdAt", "") >= after][:3]:
+        url = f"repos/{REPO}/actions/runs/{run['databaseId']}/jobs"
+        j = run_cmd(["gh", "api", url, "--jq", jq])
+        if j.ok and j.out.strip().isdigit() and int(j.out) > 0:
+            return True
+    return False
+
+
+def metric_8(ctx: Ctx) -> Row:
+    rel = [x for x in releases() if x["tagName"].startswith("receipts-")]
+    tags = [x["tagName"] for x in rel]
+    per_tag = {t: sum(n.endswith(".odr.json") for n in release_assets(t)) for t in tags}
+    total = sum(per_tag.values())
+    run_ok = total >= 3 and first_hour_run_ok(max(x.get("publishedAt", "") for x in rel))
+    r: Row = {"now": total, "receipts_releases": per_tag, "first_hour_run_ok": run_ok}
+    return r | {"status": "ok" if total >= 3 and run_ok else "fail"}
+
+
+def metric_9(ctx: Ctx) -> Row:
+    search = json_cmd(["gh", "api", "search/code?q=synaptent/aragora@+-repo:synaptent/aragora"])
+    items = search.get("items", [])
+    count = sum(str(i.get("path", "")).startswith(".github/workflows/") for i in items)
+    repo = run_cmd(["gh", "repo", "view", "synaptent/aragora-receipt-demo", "--json", "name"])
+    if not repo.ok and "could not resolve" not in repo.err.lower():
+        raise NetworkUnavailable(repo.err.strip())
+    r: Row = {"now": count, "code_search_count": count, "demo_repo_exists": repo.ok}
+    return r | {"query": CODE_SEARCH_QUERY, "status": "ok" if count >= 1 or repo.ok else "fail"}
+
+
+def metric_10(ctx: Ctx) -> Row:
+    argv = [sys.executable, "scripts/check_contract_drift_ratchet.py", "--mode", "program"]
+    out = run_cmd(argv + ["--ref", ctx.ref, "--json"], cwd=ctx.root, timeout=300).out
+    d = json.loads(out) if out.strip() else {}
+    total = d.get("current", {}).get("total_items")
+    argv = [sys.executable, "scripts/check_sdk_parity.py", "--json"]
+    parity = run_cmd(argv, cwd=ctx.root, timeout=300).out
+    g = json.loads(parity).get("gaps", {}) if parity.strip() else None
+    gaps = sum(len(g.get(k, [])) for k in PARITY_GAP_KEYS.split()) if g is not None else None
+    inv = read_text(ctx.root / "scripts/baselines/contract_drift_inventory.json")
+    items = json.loads(inv).get("items", []) if inv else []
+    r: Row = {"now": total, "total_items": total, "ref": ctx.ref, "sdk_parity_gaps": gaps}
+    r.update(target=d.get("target", {}).get("max_open_items"), ratchet_status=d.get("status"))
+    r["inventory_open"] = sum(i.get("status") == "open" for i in items) if inv else None
+    r["informational"] = ["inventory_open", "sdk_parity_gaps"]
+    ok = d.get("status") == "pass" and is_number(total) and total <= 398
+    return r | {"status": "ok" if ok else "fail"}
+
+
+def local_verify_version(ctx: Ctx, row: Row) -> None:
+    text = read_text(ctx.root / "aragora-verify/pyproject.toml")
+    m = re.search(r'^version = "([^"]+)"', text, re.M)
+    local, now = (m.group(1) if m else None), row.get("now")
+    row["local_version"] = local
+    row["local_ahead_of_pypi"] = bool(local and now and semver(local) > semver(str(now)))
+
+
+def load_cache(path: Path) -> Row:
+    try:
+        d = json.loads(path.read_text())
+        return d if isinstance(d, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def measure_guardrails(root: Path) -> Row:
+    graph = [sys.executable, "scripts/ci/measure_import_graph.py", "--json"]
+    regen = [sys.executable, "scripts/regenerate_metrics.py", "--json"]
+    g, m = json_cmd(graph, cwd=root, timeout=180), json_cmd(regen, cwd=root, timeout=180)
+    vals = {x["key"]: x["value"] for x in m["metrics"]} if "metrics" in m else m
+    r: Row = {"import_cycles": g.get("mutual_import_cycles")}
+    r["handlers_flat_root"] = g.get("handlers_flat_root")
+    return r | {gid: vals.get(gid) for gid, _, _, _ in GUARDRAILS[2:]}
+
+
+def guardrail_rows(values: Row) -> list[Row]:
+    rows = []
+    for gid, name, ceiling, baseline in GUARDRAILS:
+        now = values.get(gid)
+        status = "ok" if is_number(now) and now <= ceiling else "over"
+        row = {"id": gid, "name": name, "ceiling": ceiling, "baseline": baseline}
+        rows.append(row | {"now": now, "status": status})
+    return rows
+
+
+def read_parked(path: Path | None) -> tuple[dict[int, str], str]:
+    """Return {metric: '#N'} from the settlement ledger and the verbatim ``## Parked`` block."""
+    pending: dict[int, str] = {}
+    parked: list[str] = []
+    section = None
+    for line in read_text(path).splitlines() if path else []:
+        if line.startswith("## "):
+            section = line[3:].strip()
+        elif section == "Awaiting operator settlement" and (m := LEDGER_RE.match(line)):
+            pending.setdefault(int(m.group(1)), f"#{m.group(2)}")
+        elif section == "Parked":
+            parked.append(line)
+    return pending, "\n".join(parked).strip("\n")
+
+
+def origin_main_cycles(root: Path) -> int | None:
+    tmp = tempfile.mkdtemp(prefix="rf-scoreboard-main-")
+    try:
+        unpack = ["sh", "-c", f"git archive origin/main | tar -x -C '{tmp}'"]
+        if not run_cmd(unpack, cwd=root, timeout=300).ok:
+            return None
+        argv = [sys.executable, "scripts/ci/measure_import_graph.py", "--json"]
+        g = run_cmd(argv, cwd=tmp, timeout=180, env={**os.environ, "PYTHONPATH": tmp})
+        return json.loads(g.out).get("mutual_import_cycles") if g.ok and g.out.strip() else None
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def check_guardrails(root: Path, offline: bool) -> int:
+    if not offline:
+        run_cmd(["git", "fetch", "origin", "main", "--quiet"], cwd=root, timeout=120)
+    sha = run_cmd(["git", "rev-parse", "origin/main"], cwd=root).out.strip()
+    main_cycles = origin_main_cycles(root)
+    shown = "unknown" if main_cycles is None else main_cycles
+    print(f"origin/main mutual_import_cycles: {shown} ({sha[:10]})")
+    values = measure_guardrails(root)
+    mypy = ["sh", "-c", "mypy aragora/ --ignore-missing-imports | tail -1"]
+    tail = run_cmd(mypy, cwd=root, timeout=540).out.strip()
+    m = re.search(r"Found (\d+) errors?", tail)
+    wc = run_cmd(["sh", "-c", "wc -l < .mypy-baseline"], cwd=root).out.strip()
+    print(f"mypy: {tail or 'no output'}")
+    limit = max(140, main_cycles) if is_number(main_cycles) else 140
+    checks = [("mutual_import_cycles", values["import_cycles"], limit)]
+    checks += [(gid, values[gid], ceiling) for gid, _, ceiling, _ in GUARDRAILS[1:]]
+    checks += [("mypy_errors", int(m.group(1)) if m else 0, MYPY_ERROR_LIMIT)]
+    checks += [("mypy_baseline_lines", int(wc) if wc.isdigit() else None, MYPY_BASELINE_LIMIT)]
+    bad = []
+    for name, value, cap in checks:
+        ok = is_number(value) and value <= cap
+        print(f"{name}: {value} (limit {cap}) {'ok' if ok else 'OVER'}")
+        bad += [] if ok else [name]
+    print(f"FAIL: guardrail regression: {', '.join(bad)}" if bad else "guardrails ok")
+    return 1 if bad else 0
+
+
+def build_rows(ctx: Ctx, cache: Row, pending: dict[int, str]) -> tuple[list[Row], Row]:
+    cached = cache.get("metrics", {})
+    measured: dict[int, Row] = {}
+    failed: dict[int, str] = {}
+
+    def attempt(i: int) -> None:
+        if i in NETWORK_ROWS and (ctx.offline or not ctx.network_ok):
+            failed[i] = "offline" if ctx.offline else "pypi.org pre-probe failed"
+            return
+        try:
+            measured[i] = globals()[f"metric_{i}"](ctx)
+        except NetworkUnavailable as exc:
+            failed[i] = str(exc)
+        except (ValueError, KeyError, TypeError, OSError) as exc:
+            failed[i] = f"{type(exc).__name__}: {exc}"
+
+    attempt(1)  # doubles as the reachability pre-probe for the other network rows
+    ctx.network_ok = 1 in measured
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        list(pool.map(attempt, (4, 5, 7, 8, 9)))
+    for i in (2, 3, 6, 10):
+        attempt(i)
+    rows, new_cache = [], dict(cached)
+    for mid, name, baseline, cell in METRICS:
+        row: Row = {"id": mid, "name": name, "baseline": baseline, "baseline_cell": cell}
+        old = cached.get(str(mid)) if mid in NETWORK_ROWS else None
+        if mid in measured:
+            row.update(measured[mid])
+            if mid in NETWORK_ROWS:
+                new_cache[str(mid)] = {k: v for k, v in measured[mid].items() if k != "status"}
+        else:
+            reason = failed.get(mid, "not measured")
+            row.update(old or {"now": None}, status="unavailable", reason=reason)
+            row.update({"cached_at": cache.get("cached_at")} if old else {})
+        if mid == 4:
+            local_verify_version(ctx, row)
+        row.update(measurement=MEASUREMENTS[mid], delta=compute_delta(baseline, row.get("now")))
+        if row["status"] == "fail" and mid in pending:
+            row.update(status="pending-operator", pending_ref=pending[mid])
+        rows.append(row)
+    if not any(i in measured for i in NETWORK_ROWS):
+        return rows, {}
+    return rows, {"cached_at": utc_stamp(), "metrics": new_cache}
+
+
+def now_cell(r: Row) -> str:
+    now = r.get("now")
+    if now is None:
+        return "null"
+    extra = {
+        1: f"d ({r.get('version')}, {r.get('upload_date')})",
+        2: f"d ({str(r.get('sha'))[:8]}, {r.get('commit_date')})",
+        4: f"({r.get('upload_date')}; local {r.get('local_version')})",
+        5: f"records, #9951 {'merged' if r.get('pr_9951_merged') else 'open'}",
+        6: f"CHANGES-REQUESTED / {r.get('records')} records",
+        7: f"(canary {r.get('canary_code')})",
+        9: f"(demo repo {'present' if r.get('demo_repo_exists') else 'absent'})",
+        10: f"(target {r.get('target')}, {r.get('ratchet_status')})",
+    }
+    return f"{now} {extra[r['id']]}" if r["id"] in extra else str(now)
+
+
+def render_markdown(doc: Row, parked_given: bool) -> str:
+    out = ["# Receipt-First scoreboard", ""]
+    out.append(f"baseline_ref: {doc['baseline_ref']} ({doc['baseline_date']})")
+    out.append(f"measured ref: {doc['ref']}")
+    out += [f"generated_at: {doc['generated_at']}{' (offline)' if doc['offline'] else ''}", ""]
+    out += ["| # | Metric | Baseline | Now | Delta | Status |", "|---|---|---|---|---|---|"]
+    for r in doc["metrics"]:
+        status = r["status"] + (f" {r['pending_ref']}" if r.get("pending_ref") else "")
+        if r["status"] == "unavailable" and r.get("cached_at"):
+            status += f" (cached {r['cached_at']})"
+        cells = (r["id"], r["name"], r["baseline_cell"], now_cell(r), r["delta"], status)
+        out.append("| " + " | ".join(str(c) for c in cells) + " |")
+    out += ["", "## Guardrails", "", "| Guardrail | Ceiling | Baseline | Now | Status |"]
+    out.append("|---|---|---|---|---|")
+    for g in doc["guardrails"]:
+        cells = (g["name"], g["ceiling"], g["baseline"], g["now"], g["status"])
+        out.append("| " + " | ".join(str(c) for c in cells) + " |")
+    if parked_given:
+        out += ["", "## Parked", doc["parked"] or "(none yet)"]
+    return "\n".join(out) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Receipt-First scoreboard (10 metrics, 6 guardrails)")
+    add = p.add_argument
+    add("--json", action="store_true", help="print one JSON object")
+    add("--markdown", action="store_true", help="print Markdown tables (default)")
+    add("--cache", type=Path, default=DEFAULT_CACHE, help="cache file for the network rows")
+    add("--offline", action="store_true", help="no network; network rows come from the cache")
+    add("--post", action="store_true", help="post the Markdown as one NEW comment on --epic")
+    add("--epic", type=int, help="tracking epic issue number (required by --post)")
+    add("--parked-file", type=Path, help="ledger file: sole source of pending-operator rows")
+    add("--ref", help="40-hex ref for row 10 (default: HEAD)")
+    add("--quorum-runs", type=int, help="row 6 denominator (informational)")
+    add("--run-vectors", action="store_true", help=f"run pytest {VECTORS} for row 3")
+    add("--check-guardrails", action="store_true", help="compare guardrails; exit 1 on regression")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.post and args.epic is None:
+        parser.error("--post requires --epic N (nothing posted)")
+    if args.post and args.epic <= 0:
+        parser.error(f"--epic must be a positive issue number, got epic {args.epic}")
+    root = repo_root()
+    if args.check_guardrails:
+        return check_guardrails(root, args.offline)
+    ref = args.ref if args.ref and HEX40.match(args.ref) else None
+    ref = ref or run_cmd(["git", "rev-parse", args.ref or "HEAD"], cwd=root).out.strip()
+    if not HEX40.match(ref):
+        raise SystemExit(f"error: could not resolve --ref {args.ref or 'HEAD'!r} to a 40-hex SHA")
+    pending, parked_text = read_parked(args.parked_file)
+    cache = load_cache(args.cache)
+    ctx = Ctx(root, args.offline, ref, args.quorum_runs, args.run_vectors)
+    rows, new_cache = build_rows(ctx, cache, pending)
+    if new_cache:
+        try:
+            args.cache.parent.mkdir(parents=True, exist_ok=True)
+            args.cache.write_text(json.dumps(new_cache, indent=2, sort_keys=True) + "\n")
+        except OSError as exc:
+            print(f"warning: could not write cache {args.cache}: {exc}", file=sys.stderr)
+    try:
+        guardrails = guardrail_rows(measure_guardrails(root))
+    except (NetworkUnavailable, ValueError, KeyError) as exc:
+        print(f"warning: guardrail measurement failed: {exc}", file=sys.stderr)
+        guardrails = guardrail_rows({})
+    doc: Row = {"baseline_ref": BASELINE_REF, "baseline_date": BASELINE_DATE}
+    doc.update(generated_at=utc_stamp(), ref=ref, offline=args.offline)
+    doc.update(network_ok=ctx.network_ok, cache_path=str(args.cache))
+    doc.update(cached_at=(new_cache or cache).get("cached_at"), metrics=rows)
+    doc.update(guardrails=guardrails, parked=parked_text)
+    if args.post:
+        body = Path(tempfile.mkdtemp(prefix="rf-scoreboard-")) / "scoreboard.md"
+        body.write_text(render_markdown(doc, args.parked_file is not None))
+        argv = ["gh", "issue", "comment", str(args.epic), "-R", REPO, "--body-file", str(body)]
+        c = run_cmd(argv, timeout=120)
+        if not c.ok:
+            print(f"error: posting to epic #{args.epic} failed: {c.err.strip()}", file=sys.stderr)
+            return 1
+        print(c.out.strip())
+    elif args.json:
+        print(json.dumps(doc, indent=2, ensure_ascii=False))
+    else:
+        print(render_markdown(doc, args.parked_file is not None), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/receipt_first_scoreboard.py
+++ b/scripts/receipt_first_scoreboard.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""Receipt-First mission scoreboard: ten exit metrics and six guardrails as baseline/now/delta.
-
-Network rows (1, 4, 5, 7, 8, 9) are cached so offline runs still render. Every network call goes
-through ``curl`` or ``gh`` so the proxy environment applies uniformly.
-"""
+"""Receipt-First scoreboard: 10 exit metrics + 6 guardrails; network rows cached for --offline."""
 
 from __future__ import annotations
 
@@ -11,13 +7,11 @@ import argparse
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -33,15 +27,12 @@ API_PROBE = "https://api.aragora.ai/readyz"
 CANARY_PROBE = "https://api-canary.aragora.ai/readyz"
 CODE_SEARCH_QUERY = "synaptent/aragora@ -repo:synaptent/aragora"
 VECTORS = "tests/verify/test_odr_vectors.py"
+MANIFEST = "docs/atlas/manifest.json"
 PIN_RE = re.compile(r"synaptent/aragora@([0-9a-f]{7,40})")
-README_PIN_RE = re.compile(r"uses: synaptent/aragora@([0-9a-f]{7,40})")
 STATUS_LINE_RE = re.compile(r"^\*\*Status:\*\* (\w+) (v[0-9.]+)")
 LEDGER_RE = re.compile(r"^- \[metric (\d+)\] .*#(\d+) head ([0-9a-f]{40}|n/a)\s*$")
 METRIC_ROW_RE = re.compile(r"^\| *(10|[1-9]) *\|")
 HEX40 = re.compile(r"^[0-9a-f]{40}$")
-PARITY_GAP_KEYS = "missing_from_python_sdk missing_from_typescript_sdk missing_from_both_sdks"
-PARITY_GAP_KEYS += " stale_python_sdk_paths stale_typescript_sdk_paths"
-MYPY_ERROR_LIMIT, MYPY_BASELINE_LIMIT = 1744, 3115
 
 # (id, name, baseline value, baseline cell as printed); frozen for the whole mission.
 METRICS: list[tuple[int, str, Any, str]] = [
@@ -64,7 +55,7 @@ MEASUREMENTS = {
     5: "docs/atlas/manifest.json .dataset.record_count; gh release view atlas-v1; gh pr view 9951",
     6: "Atlas JSONL: verdict==changes_requested, posted_to_thread, distinct (pr, head_sha) rounds",
     7: f"curl -s -o /dev/null -w %{{http_code}} --max-time 15 {API_PROBE} (one probe per run)",
-    8: "gh release list --limit 100 → receipts-* tags → *.odr.json assets; first-hour run",
+    8: "receipts-* releases → *.odr.json assets; receipt-first-hour job (metrics-drift.yml, M4)",
     9: "gh api search/code (paths under .github/workflows/); gh repo view aragora-receipt-demo",
     10: "check_contract_drift_ratchet.py --mode program --ref <40-hex> --json .current.total_items",
 }
@@ -78,57 +69,41 @@ GUARDRAILS: list[tuple[str, str, int, int]] = [
 ]
 
 
-class NetworkUnavailable(Exception):
-    """A network-backed measurement could not be completed; fall back to the cache."""
-
-
 class Cmd(NamedTuple):
     rc: int
     out: str
     err: str
 
-    ok = property(lambda self: self.rc == 0)
+    @property
+    def ok(self) -> bool:
+        return self.rc == 0
 
 
 def run_cmd(argv: list[str], *, timeout: float = 60, cwd: Any = None, env: Any = None) -> Cmd:
     try:
         p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, cwd=cwd, env=env)
-    except subprocess.TimeoutExpired:
-        return Cmd(124, "", f"timeout after {timeout}s: {' '.join(argv)}")
-    except OSError as exc:
-        return Cmd(127, "", str(exc))
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return Cmd(124 if isinstance(exc, subprocess.TimeoutExpired) else 127, "", str(exc))
     return Cmd(p.returncode, p.stdout, p.stderr)
 
 
 def json_cmd(argv: list[str], *, timeout: float = 60, cwd: Path | None = None) -> Any:
     c = run_cmd(argv, timeout=timeout, cwd=cwd)
     if not c.ok or not c.out.strip():
-        raise NetworkUnavailable(c.err.strip() or f"empty output from {argv[0]}")
+        raise RuntimeError(c.err.strip() or f"empty output from {argv[0]}")
     return json.loads(c.out)
 
 
-def repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent
-
-
-def utc_stamp() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def utc_date(value: str) -> date:
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc).date()
-
-
-def age_days(value: str) -> int:
-    return (datetime.now(timezone.utc).date() - utc_date(value)).days
-
-
-def read_text(p: Path) -> str:
-    return p.read_text(errors="replace") if p.is_file() else ""
-
-
-def is_number(value: Any) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+repo_root = lambda: Path(__file__).resolve().parent.parent
+utc_stamp = lambda: datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+utc_dt = lambda s: datetime.fromisoformat(s.replace("Z", "+00:00")).astimezone(timezone.utc)
+utc_date = lambda s: utc_dt(s).date().isoformat()
+age_days = lambda s: (datetime.now(timezone.utc).date() - utc_dt(s).date()).days
+read_text = lambda p: p.read_text(errors="replace") if p.is_file() else ""
+is_number = lambda v: isinstance(v, (int, float)) and not isinstance(v, bool)
+semver = lambda text: tuple(int(x) for x in re.findall(r"\d+", text)[:3])
+RELEASE_LIST = f"gh release list -R {REPO} --limit 100 --json tagName,publishedAt".split()
+releases = lambda: json_cmd(RELEASE_LIST)
 
 
 def compute_delta(baseline: Any, now: Any) -> Any:
@@ -137,125 +112,102 @@ def compute_delta(baseline: Any, now: Any) -> Any:
     return f"{'null' if baseline is None else baseline} → {'null' if now is None else now}"
 
 
-def semver(text: str) -> tuple[int, ...]:
-    return tuple(int(x) for x in re.findall(r"\d+", text)[:3])
-
-
 def curl_code(url: str, max_time: int) -> str:
     argv = ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", str(max_time), url]
     return run_cmd(argv, timeout=max_time + 5).out.strip() or "000"
 
 
 def pypi_newest(package: str) -> tuple[str, str]:
-    argv = ["curl", "-s", "--max-time", "30", f"https://pypi.org/pypi/{package}/json"]
-    d = json_cmd(argv, timeout=35)
+    d = json_cmd(["curl", "-s", "--max-time", "30", f"https://pypi.org/pypi/{package}/json"])
     newest = max(f["upload_time_iso_8601"] for files in d["releases"].values() for f in files)
     return d["info"]["version"], newest
 
 
-def releases() -> list[Row]:
-    return json_cmd(f"gh release list -R {REPO} --limit 100 --json tagName,publishedAt".split())
-
-
 def release_assets(tag: str) -> list[str]:
     c = run_cmd(["gh", "release", "view", tag, "-R", REPO, "--json", "assets"])
-    if c.ok:
-        return [a["name"] for a in json.loads(c.out).get("assets", [])]
-    if "not found" in c.err.lower():
-        return []
-    raise NetworkUnavailable(c.err.strip())
+    if not c.ok and "not found" not in c.err.lower():
+        raise RuntimeError(c.err.strip())
+    return [a["name"] for a in json.loads(c.out or "{}").get("assets", [])]
 
 
-@dataclass
-class Ctx:
-    root: Path
-    offline: bool
-    ref: str
-    quorum_runs: int | None
-    run_vectors: bool
-    network_ok: bool = True
-    atlas_v1_assets: list[str] | None = None
-
-
-def metric_1(ctx: Ctx) -> Row:
+def metric_1(ctx: Any) -> Row:
     version, uploaded = pypi_newest("aragora")
-    age = age_days(uploaded)
-    r: Row = {"now": age, "version": version, "upload_date": utc_date(uploaded).isoformat()}
-    return r | {"status": "ok" if age <= 14 else "fail"}
+    r: Row = {"now": age_days(uploaded), "version": version, "upload_date": utc_date(uploaded)}
+    return r | {"status": "ok" if r["now"] <= 14 else "fail"}
 
 
-def metric_2(ctx: Ctx) -> Row:
-    m = README_PIN_RE.search(read_text(ctx.root / "README.md"))
+def metric_2(ctx: Any) -> Row:
+    m = re.search("uses: " + PIN_RE.pattern, read_text(ctx.root / "README.md"))
     sha = m.group(1) if m else None
     scope = ["README.md", "docs", "docs-site", "examples", ".github", "action.yml"]
     tracked = run_cmd(["git", "ls-files", *scope], cwd=ctx.root).out.split()
     pins = [p for rel in tracked for p in PIN_RE.findall(read_text(ctx.root / rel))]
     distinct = sorted(set(pins))
-    r: Row = {"sha": sha, "pin_count": len(pins), "distinct_shas": distinct, "now": None}
-    r.update(commit_date=None, status="fail")
+    r: Row = {"now": None, "sha": sha, "pin_count": len(pins), "distinct_shas": distinct}
+    r["status"] = "fail"
     if len(distinct) > 1:
         r["warning"] = f"{len(distinct)} distinct pinned SHAs: {[s[:10] for s in distinct]}"
-    if not sha:
-        return r | {"note": "no README pin"}
-    argv = ["git", "log", "-1", "--format=%cI", sha]
-    if not run_cmd(argv, cwd=ctx.root).ok and not ctx.offline:
+    argv = ["git", "log", "-1", "--format=%cI", sha or "HEAD"]
+    log = run_cmd(argv, cwd=ctx.root) if sha else Cmd(1, "", "no README pin")
+    if sha and not log.ok and not ctx.offline:
         run_cmd(["git", "fetch", "origin", sha, "--quiet"], cwd=ctx.root, timeout=120)
-    log = run_cmd(argv, cwd=ctx.root)
+        log = run_cmd(argv, cwd=ctx.root)
     if not (log.ok and log.out.strip()):
-        return r | {"note": "pinned sha not in local history"}
-    age = age_days(log.out.strip())
-    date_ = utc_date(log.out.strip()).isoformat()
-    return r | {"now": age, "commit_date": date_, "status": "ok" if age <= 14 else "fail"}
+        return r | {"note": "pinned sha not in local history" if sha else "no README pin"}
+    age, cd = age_days(log.out.strip()), utc_date(log.out.strip())
+    return r | {"now": age, "commit_date": cd, "status": "ok" if age <= 14 else "fail"}
 
 
-def metric_3(ctx: Ctx) -> Row:
+def metric_3(ctx: Any) -> Row:
     lines = read_text(ctx.root / "docs/specs/OPEN_DECISION_RECEIPT.md").splitlines()
     m = STATUS_LINE_RE.match(lines[2]) if len(lines) >= 3 else None
     status, version = (m.group(1), m.group(2)) if m else (None, None)
     vectors = (ctx.root / VECTORS).is_file()
-    vpass: bool | None = None
-    if ctx.run_vectors and vectors:
-        argv = [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", VECTORS]
-        vpass = run_cmd(argv, cwd=ctx.root, timeout=600).ok
+    argv = [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", VECTORS]
+    vpass = run_cmd(argv, cwd=ctx.root, timeout=600).ok if ctx.run_vectors and vectors else None
     ok = bool(version) and semver(version or "") >= (0, 2) and vectors and vpass is not False
-    r: Row = {"now": f"{status} {version}" if m else None, "spec_status": status}
-    r.update(version=version, vectors_present=vectors, vectors_pass=vpass)
-    return r | {"status": "ok" if ok else "fail"}
+    r: Row = {
+        "now": f"{status} {version}" if m else None,
+        "spec_status": status,
+        "version": version,
+    }
+    return r | {"vectors_present": vectors, "vectors_pass": vpass, "status": "ok" if ok else "fail"}
 
 
-def metric_4(ctx: Ctx) -> Row:
+def metric_4(ctx: Any) -> Row:
     version, uploaded = pypi_newest("aragora-verify")
-    ok = semver(version) >= (0, 2)
-    date_ = utc_date(uploaded).isoformat()
-    return {"now": version, "upload_date": date_, "status": "ok" if ok else "fail"}
+    status = "ok" if semver(version) >= (0, 2) else "fail"
+    return {"now": version, "upload_date": utc_date(uploaded), "status": status}
 
 
-def metric_5(ctx: Ctx) -> Row:
+def metric_5(ctx: Any) -> Row:
     tags = [x["tagName"] for x in releases()]
     assets = release_assets("atlas-v1") if "atlas-v1" in tags else []
     ctx.atlas_v1_assets = assets
     pr = json_cmd(["gh", "pr", "view", "9951", "-R", REPO, "--json", "state"])
+    local, count, source = read_text(ctx.root / MANIFEST), None, None
+    for source in ("worktree", "origin/main", "rf/pr9951-inspect"):
+        argv = ["git", "show", f"{source}:{MANIFEST}"]
+        text = local if source == "worktree" else run_cmd(argv, cwd=ctx.root).out
+        try:
+            count = int(json.loads(text)["dataset"]["record_count"])
+            break
+        except (ValueError, KeyError, TypeError):
+            source = None
     merged = pr.get("state") == "MERGED"
-    manifest = read_text(ctx.root / "docs/atlas/manifest.json")
-    if not manifest:
-        argv = "git show rf/pr9951-inspect:docs/atlas/manifest.json".split()
-        manifest = run_cmd(argv, cwd=ctx.root).out
-    try:
-        count: int | None = int(json.loads(manifest)["dataset"]["record_count"])
-    except (ValueError, KeyError, TypeError):
-        count = None
-    r: Row = {"now": count, "record_count": count, "pr_9951_merged": merged}
-    r.update(atlas_v1_assets=assets, atlas_release_count=sum(t.startswith("atlas-") for t in tags))
+    r: Row = {"now": count, "record_count": count, "record_count_source": source}
+    r.update(pr_9951_merged=merged, atlas_v1_assets=assets)
+    r["atlas_release_count"] = sum(t.startswith("atlas-") for t in tags)
     return r | {"status": "ok" if merged and assets else "fail"}
 
 
-def metric_6(ctx: Ctx) -> Row:
-    r: Row = {"now": None, "posted": None, "rounds": None, "records": None, "upper_bound": True}
-    r.update(quorum_runs=ctx.quorum_runs, status="unavailable")
+def metric_6(ctx: Any) -> Row:
+    r: Row = {"now": None, "upper_bound": True, "quorum_runs": ctx.quorum_runs}
+    r["note"] = "upper bound from the Atlas JSONL; ok needs the post-M2 advisory-summary count"
+    r["status"] = "unavailable"
     if not ctx.offline and ctx.atlas_v1_assets and not list(ATLAS_DIR.glob("*.jsonl")):
         ATLAS_DIR.mkdir(parents=True, exist_ok=True)
-        argv = f"gh release download atlas-v1 -R {REPO} -p *.jsonl --clobber".split()
-        run_cmd(argv + ["-D", str(ATLAS_DIR)], timeout=120)
+        run_cmd(f"gh release download atlas-v1 -R {REPO} -p *.jsonl".split(), cwd=ATLAS_DIR)
     candidates = [ctx.root / "docs/atlas/atlas-v1.jsonl", *sorted(ATLAS_DIR.glob("*.jsonl"))]
     jsonl = next((p for p in candidates if p.is_file()), None)
     if jsonl is None:
@@ -268,47 +220,41 @@ def metric_6(ctx: Ctx) -> Row:
     return r | {"ratio": round(posted / rounds, 3) if rounds else None, "status": "fail"}
 
 
-def metric_7(ctx: Ctx) -> Row:
+def metric_7(ctx: Any) -> Row:
     code, canary = curl_code(API_PROBE, 15), curl_code(CANARY_PROBE, 15)
-    r: Row = {"now": code, "canary_code": canary, "probe": API_PROBE}
-    return r | {"status": "ok" if code == "200" else "fail"}
+    return {"now": code, "canary_code": canary, "status": "ok" if code == "200" else "fail"}
 
 
-def first_hour_run_ok(after: str) -> bool:
-    argv = f"gh run list -R {REPO} --workflow metrics-drift.yml --status success".split()
-    c = run_cmd(argv + ["--limit", "10", "--json", "databaseId,createdAt"])
-    runs = json.loads(c.out) if c.ok and c.out.strip() else []
-    jq = '[.jobs[]|select(.name=="receipt-first-hour" and .conclusion=="success")]|length'
-    for run in [x for x in runs if x.get("createdAt", "") >= after][:3]:
-        url = f"repos/{REPO}/actions/runs/{run['databaseId']}/jobs"
-        j = run_cmd(["gh", "api", url, "--jq", jq])
-        if j.ok and j.out.strip().isdigit() and int(j.out) > 0:
-            return True
-    return False
-
-
-def metric_8(ctx: Ctx) -> Row:
+def metric_8(ctx: Any) -> Row:
     rel = [x for x in releases() if x["tagName"].startswith("receipts-")]
     tags = [x["tagName"] for x in rel]
     per_tag = {t: sum(n.endswith(".odr.json") for n in release_assets(t)) for t in tags}
-    total = sum(per_tag.values())
-    run_ok = total >= 3 and first_hour_run_ok(max(x.get("publishedAt", "") for x in rel))
+    total, run_ok = sum(per_tag.values()), False
+    newest = max((x.get("publishedAt", "") for x in rel), default="")
+    argv = f"gh run list -R {REPO} --workflow metrics-drift.yml --status success".split()
+    c = run_cmd(argv + ["--limit", "10", "--json", "databaseId,createdAt"]) if total >= 3 else None
+    runs = [x for x in json.loads(c.out or "[]") if x.get("createdAt", "") >= newest] if c else []
+    jq = '[.jobs[]|select(.name=="receipt-first-hour" and .conclusion=="success")]|length'
+    for run in runs[:3]:
+        url = f"repos/{REPO}/actions/runs/{run['databaseId']}/jobs"
+        j = run_cmd(["gh", "api", url, "--jq", jq])
+        run_ok = run_ok or (j.ok and j.out.strip().isdigit() and int(j.out) > 0)
     r: Row = {"now": total, "receipts_releases": per_tag, "first_hour_run_ok": run_ok}
     return r | {"status": "ok" if total >= 3 and run_ok else "fail"}
 
 
-def metric_9(ctx: Ctx) -> Row:
-    search = json_cmd(["gh", "api", "search/code?q=synaptent/aragora@+-repo:synaptent/aragora"])
-    items = search.get("items", [])
+def metric_9(ctx: Any) -> Row:
+    q = f"search/code?q={CODE_SEARCH_QUERY.replace(' ', '+')}&per_page=100"
+    items = json_cmd(["gh", "api", q]).get("items", [])
     count = sum(str(i.get("path", "")).startswith(".github/workflows/") for i in items)
     repo = run_cmd(["gh", "repo", "view", "synaptent/aragora-receipt-demo", "--json", "name"])
     if not repo.ok and "could not resolve" not in repo.err.lower():
-        raise NetworkUnavailable(repo.err.strip())
+        raise RuntimeError(repo.err.strip())
     r: Row = {"now": count, "code_search_count": count, "demo_repo_exists": repo.ok}
     return r | {"query": CODE_SEARCH_QUERY, "status": "ok" if count >= 1 or repo.ok else "fail"}
 
 
-def metric_10(ctx: Ctx) -> Row:
+def metric_10(ctx: Any) -> Row:
     argv = [sys.executable, "scripts/check_contract_drift_ratchet.py", "--mode", "program"]
     out = run_cmd(argv + ["--ref", ctx.ref, "--json"], cwd=ctx.root, timeout=300).out
     d = json.loads(out) if out.strip() else {}
@@ -316,31 +262,16 @@ def metric_10(ctx: Ctx) -> Row:
     argv = [sys.executable, "scripts/check_sdk_parity.py", "--json"]
     parity = run_cmd(argv, cwd=ctx.root, timeout=300).out
     g = json.loads(parity).get("gaps", {}) if parity.strip() else None
-    gaps = sum(len(g.get(k, [])) for k in PARITY_GAP_KEYS.split()) if g is not None else None
-    inv = read_text(ctx.root / "scripts/baselines/contract_drift_inventory.json")
-    items = json.loads(inv).get("items", []) if inv else []
+    gaps = sum(len(v) for v in g.values() if isinstance(v, list)) if g is not None else None
+    inv = json.loads(
+        read_text(ctx.root / "scripts/baselines/contract_drift_inventory.json") or "{}"
+    )
     r: Row = {"now": total, "total_items": total, "ref": ctx.ref, "sdk_parity_gaps": gaps}
     r.update(target=d.get("target", {}).get("max_open_items"), ratchet_status=d.get("status"))
-    r["inventory_open"] = sum(i.get("status") == "open" for i in items) if inv else None
+    r["inventory_open"] = sum(i.get("status") == "open" for i in inv["items"]) if inv else None
     r["informational"] = ["inventory_open", "sdk_parity_gaps"]
     ok = d.get("status") == "pass" and is_number(total) and total <= 398
     return r | {"status": "ok" if ok else "fail"}
-
-
-def local_verify_version(ctx: Ctx, row: Row) -> None:
-    text = read_text(ctx.root / "aragora-verify/pyproject.toml")
-    m = re.search(r'^version = "([^"]+)"', text, re.M)
-    local, now = (m.group(1) if m else None), row.get("now")
-    row["local_version"] = local
-    row["local_ahead_of_pypi"] = bool(local and now and semver(local) > semver(str(now)))
-
-
-def load_cache(path: Path) -> Row:
-    try:
-        d = json.loads(path.read_text())
-        return d if isinstance(d, dict) else {}
-    except (OSError, ValueError):
-        return {}
 
 
 def measure_guardrails(root: Path) -> Row:
@@ -354,20 +285,17 @@ def measure_guardrails(root: Path) -> Row:
 
 
 def guardrail_rows(values: Row) -> list[Row]:
-    rows = []
-    for gid, name, ceiling, baseline in GUARDRAILS:
-        now = values.get(gid)
-        status = "ok" if is_number(now) and now <= ceiling else "over"
-        row = {"id": gid, "name": name, "ceiling": ceiling, "baseline": baseline}
-        rows.append(row | {"now": now, "status": status})
+    keys = ("id", "name", "ceiling", "baseline")
+    rows: list[Row] = [dict(zip(keys, g), now=values.get(g[0])) for g in GUARDRAILS]
+    for r in rows:
+        r["status"] = "ok" if is_number(r["now"]) and r["now"] <= r["ceiling"] else "over"
     return rows
 
 
 def read_parked(path: Path | None) -> tuple[dict[int, str], str]:
     """Return {metric: '#N'} from the settlement ledger and the verbatim ``## Parked`` block."""
     pending: dict[int, str] = {}
-    parked: list[str] = []
-    section = None
+    parked, section = [], None
     for line in read_text(path).splitlines() if path else []:
         if line.startswith("## "):
             section = line[3:].strip()
@@ -378,50 +306,38 @@ def read_parked(path: Path | None) -> tuple[dict[int, str], str]:
     return pending, "\n".join(parked).strip("\n")
 
 
-def origin_main_cycles(root: Path) -> int | None:
-    tmp = tempfile.mkdtemp(prefix="rf-scoreboard-main-")
-    try:
-        unpack = ["sh", "-c", f"git archive origin/main | tar -x -C '{tmp}'"]
-        if not run_cmd(unpack, cwd=root, timeout=300).ok:
-            return None
-        argv = [sys.executable, "scripts/ci/measure_import_graph.py", "--json"]
-        g = run_cmd(argv, cwd=tmp, timeout=180, env={**os.environ, "PYTHONPATH": tmp})
-        return json.loads(g.out).get("mutual_import_cycles") if g.ok and g.out.strip() else None
-    finally:
-        shutil.rmtree(tmp, ignore_errors=True)
-
-
 def check_guardrails(root: Path, offline: bool) -> int:
     if not offline:
         run_cmd(["git", "fetch", "origin", "main", "--quiet"], cwd=root, timeout=120)
     sha = run_cmd(["git", "rev-parse", "origin/main"], cwd=root).out.strip()
-    main_cycles = origin_main_cycles(root)
-    shown = "unknown" if main_cycles is None else main_cycles
-    print(f"origin/main mutual_import_cycles: {shown} ({sha[:10]})")
+    with tempfile.TemporaryDirectory(prefix="rf-scoreboard-main-") as tmp:
+        unpack = ["sh", "-c", f"git archive origin/main | tar -x -C '{tmp}'"]
+        argv = [sys.executable, "scripts/ci/measure_import_graph.py", "--json"]
+        env = {**os.environ, "PYTHONPATH": tmp}
+        g = run_cmd(argv, cwd=tmp, timeout=180, env=env) if run_cmd(unpack, cwd=root).ok else None
+    main_cycles = json.loads(g.out).get("mutual_import_cycles") if g and g.ok and g.out else None
+    print(f"origin/main mutual_import_cycles: {main_cycles or 'unknown'} ({sha[:10]})")
     values = measure_guardrails(root)
     mypy = ["sh", "-c", "mypy aragora/ --ignore-missing-imports | tail -1"]
     tail = run_cmd(mypy, cwd=root, timeout=540).out.strip()
     m = re.search(r"Found (\d+) errors?", tail)
-    wc = run_cmd(["sh", "-c", "wc -l < .mypy-baseline"], cwd=root).out.strip()
+    errors = int(m.group(1)) if m else (0 if tail.startswith("Success") else None)
+    wc = int(run_cmd(["sh", "-c", "wc -l < .mypy-baseline"], cwd=root).out.strip() or -1)
     print(f"mypy: {tail or 'no output'}")
-    limit = max(140, main_cycles) if is_number(main_cycles) else 140
+    limit = max(140, main_cycles) if isinstance(main_cycles, int) else 140
     checks = [("mutual_import_cycles", values["import_cycles"], limit)]
     checks += [(gid, values[gid], ceiling) for gid, _, ceiling, _ in GUARDRAILS[1:]]
-    checks += [("mypy_errors", int(m.group(1)) if m else 0, MYPY_ERROR_LIMIT)]
-    checks += [("mypy_baseline_lines", int(wc) if wc.isdigit() else None, MYPY_BASELINE_LIMIT)]
-    bad = []
+    checks += [("mypy_errors", errors, 1744), ("mypy_baseline_lines", wc, 3115)]
+    bad = [name for name, value, cap in checks if not (is_number(value) and 0 <= value <= cap)]
     for name, value, cap in checks:
-        ok = is_number(value) and value <= cap
-        print(f"{name}: {value} (limit {cap}) {'ok' if ok else 'OVER'}")
-        bad += [] if ok else [name]
+        print(f"{name}: {value} (limit {cap}) {'OVER' if name in bad else 'ok'}")
     print(f"FAIL: guardrail regression: {', '.join(bad)}" if bad else "guardrails ok")
     return 1 if bad else 0
 
 
-def build_rows(ctx: Ctx, cache: Row, pending: dict[int, str]) -> tuple[list[Row], Row]:
-    cached = cache.get("metrics", {})
-    measured: dict[int, Row] = {}
-    failed: dict[int, str] = {}
+def build_rows(ctx: Any, cache: Row, pending: dict[int, str]) -> tuple[list[Row], Row]:
+    cached, stamp = cache.get("metrics", {}), ctx.generated_at
+    measured, failed = {}, {}
 
     def attempt(i: int) -> None:
         if i in NETWORK_ROWS and (ctx.offline or not ctx.network_ok):
@@ -429,17 +345,14 @@ def build_rows(ctx: Ctx, cache: Row, pending: dict[int, str]) -> tuple[list[Row]
             return
         try:
             measured[i] = globals()[f"metric_{i}"](ctx)
-        except NetworkUnavailable as exc:
-            failed[i] = str(exc)
-        except (ValueError, KeyError, TypeError, OSError) as exc:
+        except Exception as exc:
             failed[i] = f"{type(exc).__name__}: {exc}"
 
     attempt(1)  # doubles as the reachability pre-probe for the other network rows
     ctx.network_ok = 1 in measured
     with ThreadPoolExecutor(max_workers=6) as pool:
         list(pool.map(attempt, (4, 5, 7, 8, 9)))
-    for i in (2, 3, 6, 10):
-        attempt(i)
+    list(map(attempt, (2, 3, 6, 10)))
     rows, new_cache = [], dict(cached)
     for mid, name, baseline, cell in METRICS:
         row: Row = {"id": mid, "name": name, "baseline": baseline, "baseline_cell": cell}
@@ -447,120 +360,96 @@ def build_rows(ctx: Ctx, cache: Row, pending: dict[int, str]) -> tuple[list[Row]
         if mid in measured:
             row.update(measured[mid])
             if mid in NETWORK_ROWS:
-                new_cache[str(mid)] = {k: v for k, v in measured[mid].items() if k != "status"}
+                new_cache[str(mid)] = measured[mid] | {"cached_at": stamp}
         else:
-            reason = failed.get(mid, "not measured")
-            row.update(old or {"now": None}, status="unavailable", reason=reason)
-            row.update({"cached_at": cache.get("cached_at")} if old else {})
+            row.update(old or {"now": None}, status="unavailable", reason=failed[mid])
+            row["cached_at"] = old.get("cached_at", cache.get("cached_at")) if old else None
         if mid == 4:
-            local_verify_version(ctx, row)
+            toml = read_text(ctx.root / "aragora-verify/pyproject.toml")
+            m = re.search(r'^version = "([^"]+)"', toml, re.M)
+            local, now = (m.group(1) if m else None), row.get("now")
+            row["local_version"] = local
+            row["local_ahead_of_pypi"] = bool(local and now and semver(local) > semver(str(now)))
         row.update(measurement=MEASUREMENTS[mid], delta=compute_delta(baseline, row.get("now")))
         if row["status"] == "fail" and mid in pending:
             row.update(status="pending-operator", pending_ref=pending[mid])
         rows.append(row)
-    if not any(i in measured for i in NETWORK_ROWS):
-        return rows, {}
-    return rows, {"cached_at": utc_stamp(), "metrics": new_cache}
-
-
-def now_cell(r: Row) -> str:
-    now = r.get("now")
-    if now is None:
-        return "null"
-    extra = {
-        1: f"d ({r.get('version')}, {r.get('upload_date')})",
-        2: f"d ({str(r.get('sha'))[:8]}, {r.get('commit_date')})",
-        4: f"({r.get('upload_date')}; local {r.get('local_version')})",
-        5: f"records, #9951 {'merged' if r.get('pr_9951_merged') else 'open'}",
-        6: f"CHANGES-REQUESTED / {r.get('records')} records",
-        7: f"(canary {r.get('canary_code')})",
-        9: f"(demo repo {'present' if r.get('demo_repo_exists') else 'absent'})",
-        10: f"(target {r.get('target')}, {r.get('ratchet_status')})",
-    }
-    return f"{now} {extra[r['id']]}" if r["id"] in extra else str(now)
+    fresh = any(i in measured for i in NETWORK_ROWS)
+    return rows, {"cached_at": stamp, "metrics": new_cache} if fresh else {}
 
 
 def render_markdown(doc: Row, parked_given: bool) -> str:
-    out = ["# Receipt-First scoreboard", ""]
-    out.append(f"baseline_ref: {doc['baseline_ref']} ({doc['baseline_date']})")
-    out.append(f"measured ref: {doc['ref']}")
-    out += [f"generated_at: {doc['generated_at']}{' (offline)' if doc['offline'] else ''}", ""]
-    out += ["| # | Metric | Baseline | Now | Delta | Status |", "|---|---|---|---|---|---|"]
+    line = lambda cells: "| " + " | ".join(str(c) for c in cells) + " |"
+    out = ["# Receipt-First scoreboard", "", f"baseline_ref: {BASELINE_REF} ({BASELINE_DATE})"]
+    out += [f"measured ref: {doc['ref']}", f"generated_at: {doc['generated_at']}", ""]
+    out += [line(("#", "Metric", "Baseline", "Now", "Delta", "Status")), "|---" * 6 + "|"]
     for r in doc["metrics"]:
-        status = r["status"] + (f" {r['pending_ref']}" if r.get("pending_ref") else "")
-        if r["status"] == "unavailable" and r.get("cached_at"):
-            status += f" (cached {r['cached_at']})"
-        cells = (r["id"], r["name"], r["baseline_cell"], now_cell(r), r["delta"], status)
-        out.append("| " + " | ".join(str(c) for c in cells) + " |")
-    out += ["", "## Guardrails", "", "| Guardrail | Ceiling | Baseline | Now | Status |"]
-    out.append("|---|---|---|---|---|")
-    for g in doc["guardrails"]:
-        cells = (g["name"], g["ceiling"], g["baseline"], g["now"], g["status"])
-        out.append("| " + " | ".join(str(c) for c in cells) + " |")
+        cached = r["status"] == "unavailable" and r.get("cached_at")
+        parts = (r["status"], r.get("pending_ref"), cached and f"(cached {cached})")
+        unit = {1: " d", 2: " d", 7: f" (canary {r.get('canary_code')})"}.get(r["id"], "")
+        now = "null" if r.get("now") is None else f"{r['now']}{unit}"
+        status = " ".join(filter(None, parts))
+        out.append(line((r["id"], r["name"], r["baseline_cell"], now, r["delta"], status)))
+    keys = ("name", "ceiling", "baseline", "now", "status")
+    out += ["", "## Guardrails", "", line(("Guardrail", "Ceiling", "Baseline", "Now", "Status"))]
+    out += ["|---" * 5 + "|"] + [line([g[k] for k in keys]) for g in doc["guardrails"]]
     if parked_given:
         out += ["", "## Parked", doc["parked"] or "(none yet)"]
     return "\n".join(out) + "\n"
 
 
-def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description="Receipt-First scoreboard (10 metrics, 6 guardrails)")
-    add = p.add_argument
-    add("--json", action="store_true", help="print one JSON object")
-    add("--markdown", action="store_true", help="print Markdown tables (default)")
-    add("--cache", type=Path, default=DEFAULT_CACHE, help="cache file for the network rows")
-    add("--offline", action="store_true", help="no network; network rows come from the cache")
-    add("--post", action="store_true", help="post the Markdown as one NEW comment on --epic")
-    add("--epic", type=int, help="tracking epic issue number (required by --post)")
-    add("--parked-file", type=Path, help="ledger file: sole source of pending-operator rows")
-    add("--ref", help="40-hex ref for row 10 (default: HEAD)")
-    add("--quorum-runs", type=int, help="row 6 denominator (informational)")
-    add("--run-vectors", action="store_true", help=f"run pytest {VECTORS} for row 3")
-    add("--check-guardrails", action="store_true", help="compare guardrails; exit 1 on regression")
-    return p
-
-
 def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-    if args.post and args.epic is None:
-        parser.error("--post requires --epic N (nothing posted)")
-    if args.post and args.epic <= 0:
-        parser.error(f"--epic must be a positive issue number, got epic {args.epic}")
-    root = repo_root()
+    p = argparse.ArgumentParser(description="Receipt-First scoreboard (10 metrics, 6 guardrails)")
+    p.add_argument("--json", action="store_true", help="print one JSON object")
+    p.add_argument("--markdown", action="store_true", help="print Markdown tables (default)")
+    p.add_argument("--cache", type=Path, default=DEFAULT_CACHE, help="cache for the network rows")
+    p.add_argument("--offline", action="store_true", help="no network; network rows from the cache")
+    p.add_argument("--post", action="store_true", help="post Markdown as one NEW comment on --epic")
+    p.add_argument("--epic", type=int, help="tracking epic issue number (required by --post)")
+    p.add_argument("--parked-file", type=Path, help="ledger: sole source of pending-operator rows")
+    p.add_argument("--ref", help="40-hex ref for row 10 (default: HEAD)")
+    p.add_argument("--quorum-runs", type=int, help="row 6 denominator (informational)")
+    p.add_argument("--run-vectors", action="store_true", help=f"run pytest {VECTORS} for row 3")
+    p.add_argument("--check-guardrails", action="store_true", help="exit 1 on guardrail regression")
+    args = p.parse_args(argv)
+    if args.post and not (args.epic or 0) > 0:
+        p.error(f"--post requires --epic N (positive issue number), got epic {args.epic}")
+    args.root = root = repo_root()
     if args.check_guardrails:
-        return check_guardrails(root, args.offline)
-    ref = args.ref if args.ref and HEX40.match(args.ref) else None
-    ref = ref or run_cmd(["git", "rev-parse", args.ref or "HEAD"], cwd=root).out.strip()
-    if not HEX40.match(ref):
-        raise SystemExit(f"error: could not resolve --ref {args.ref or 'HEAD'!r} to a 40-hex SHA")
-    pending, parked_text = read_parked(args.parked_file)
-    cache = load_cache(args.cache)
-    ctx = Ctx(root, args.offline, ref, args.quorum_runs, args.run_vectors)
-    rows, new_cache = build_rows(ctx, cache, pending)
-    if new_cache:
         try:
-            args.cache.parent.mkdir(parents=True, exist_ok=True)
-            args.cache.write_text(json.dumps(new_cache, indent=2, sort_keys=True) + "\n")
-        except OSError as exc:
-            print(f"warning: could not write cache {args.cache}: {exc}", file=sys.stderr)
+            return check_guardrails(root, args.offline)
+        except Exception as exc:
+            print(f"FAIL: guardrail measurement failed: {exc}", file=sys.stderr)
+            return 1
+    args.ref = run_cmd(["git", "rev-parse", args.ref or "HEAD"], cwd=root).out.strip()
+    if not HEX40.match(args.ref):
+        raise SystemExit("error: could not resolve --ref to a 40-hex SHA")
+    pending, parked_text = read_parked(args.parked_file)
+    try:
+        cache = json.loads(args.cache.read_text())
+        cache = cache if isinstance(cache, dict) else {}
+    except (OSError, ValueError):
+        cache = {}
+    args.network_ok, args.atlas_v1_assets, args.generated_at = True, None, utc_stamp()
+    rows, new_cache = build_rows(args, cache, pending)
+    if new_cache:
+        args.cache.parent.mkdir(parents=True, exist_ok=True)
+        args.cache.write_text(json.dumps(new_cache, indent=2, sort_keys=True) + "\n")
     try:
         guardrails = guardrail_rows(measure_guardrails(root))
-    except (NetworkUnavailable, ValueError, KeyError) as exc:
+    except Exception as exc:
         print(f"warning: guardrail measurement failed: {exc}", file=sys.stderr)
         guardrails = guardrail_rows({})
-    doc: Row = {"baseline_ref": BASELINE_REF, "baseline_date": BASELINE_DATE}
-    doc.update(generated_at=utc_stamp(), ref=ref, offline=args.offline)
-    doc.update(network_ok=ctx.network_ok, cache_path=str(args.cache))
-    doc.update(cached_at=(new_cache or cache).get("cached_at"), metrics=rows)
-    doc.update(guardrails=guardrails, parked=parked_text)
+    doc: Row = {"baseline_ref": BASELINE_REF, "baseline_date": BASELINE_DATE, "ref": args.ref}
+    doc.update(generated_at=args.generated_at, network_ok=args.network_ok, parked=parked_text)
+    doc.update(cached_at=(new_cache or cache).get("cached_at"), metrics=rows, guardrails=guardrails)
     if args.post:
         body = Path(tempfile.mkdtemp(prefix="rf-scoreboard-")) / "scoreboard.md"
         body.write_text(render_markdown(doc, args.parked_file is not None))
         argv = ["gh", "issue", "comment", str(args.epic), "-R", REPO, "--body-file", str(body)]
         c = run_cmd(argv, timeout=120)
         if not c.ok:
-            print(f"error: posting to epic #{args.epic} failed: {c.err.strip()}", file=sys.stderr)
-            return 1
+            sys.exit(f"error: posting to epic #{args.epic} failed: {c.err.strip()}")
         print(c.out.strip())
     elif args.json:
         print(json.dumps(doc, indent=2, ensure_ascii=False))

--- a/tests/scripts/test_receipt_first_scoreboard.py
+++ b/tests/scripts/test_receipt_first_scoreboard.py
@@ -3,35 +3,29 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 import scripts.receipt_first_scoreboard as sb
 
 HEAD = "a" * 40
 PIN = "8b600a3a8dbf076f4027ae27f3dcbbf48e75409f"
-NET = (1, 4, 5, 7, 8, 9)
 FLAGS = "--json --markdown --cache --offline --post --epic --parked-file --ref --quorum-runs"
 FLAGS += " --run-vectors --check-guardrails"
 UP = "upload_time_iso_8601"
-PYPI = {"info": {"version": "2.9.0"}, "releases": {"2.9.0": [{UP: "2026-07-06T15:15:14Z"}]}}
-PYPI["releases"]["2.8.0"] = [{UP: "2026-06-01T00:00:00Z"}]
+REL = {"2.9.0": [{UP: "2026-07-06T15:15:14Z"}], "2.8.0": [{UP: "2026-06-01T00:00:00Z"}]}
+PYPI = {"info": {"version": "2.9.0"}, "releases": REL}
 VERIFY = {"info": {"version": "0.1.1"}, "releases": {"0.1.1": [{UP: "2026-07-04T03:28:01Z"}]}}
 RATCHET = {"current": {"total_items": 398}, "target": {"max_open_items": 84}, "status": "fail"}
-PARITY = {"gaps": {"missing_from_python_sdk": [1], "stale_python_sdk_paths": [1] * 31}}
-PARITY["gaps"]["stale_typescript_sdk_paths"] = [1] * 61
+PARITY = {"gaps": {"missing_from_python_sdk": [1], "stale_python_sdk_paths": [1] * 92}}
 GRAPH = {"mutual_import_cycles": 144, "handlers_flat_root": 187}
-KEYS = [("ci_workflows", 97), ("doc_files", 1119), ("top_level_modules", 145)]
-REGEN = {"metrics": [{"key": k, "value": v} for k, v in KEYS + [("openapi_operations", 3205)]]}
+KEYS = {"ci_workflows": 97, "doc_files": 1119, "top_level_modules": 145, "openapi_operations": 3205}
+REGEN = {"metrics": [{"key": k, "value": v} for k, v in KEYS.items()]}
 LEDGER = "EPIC=#1\n## Awaiting operator settlement\n- [metric 10] batch 1 packet — PR #77 head "
 LEDGER += "b" * 40 + "\n- [metric 8] receipts packet #78 head n/a\n- metric 7 foo #2\n"
 LEDGER += "- [metric 2] bump #79 head n/a\n\n## Parked\n(none yet)\n"
+GUARD = ["--check-guardrails", "--offline"]
 
 
 class FakeCmds:
@@ -75,6 +69,7 @@ def fake(monkeypatch: pytest.MonkeyPatch, root: Path, tmp_path: Path) -> FakeCmd
     f.on("git log -1", out="2026-07-06T19:05:18-05:00\n")
     f.on("git ls-files", out="README.md\n")
     f.on("git show", rc=1, err="fatal: path does not exist")
+    f.on("git archive origin/main", out="")
     f.on("curl", "pypi.org/pypi/aragora/json", out=json.dumps(PYPI))
     f.on("curl", "pypi.org/pypi/aragora-verify/json", out=json.dumps(VERIFY))
     f.on("curl", "api.aragora.ai/readyz", out="000")
@@ -89,21 +84,23 @@ def fake(monkeypatch: pytest.MonkeyPatch, root: Path, tmp_path: Path) -> FakeCmd
     f.on("measure_import_graph.py", out=json.dumps(GRAPH))
     f.on("regenerate_metrics.py", out=json.dumps(REGEN))
     f.on("gh issue comment", out="https://github.com/synaptent/aragora/issues/9966#issuecomment-1")
+    f.on("mypy aragora/", out="Found 1744 errors in 468 files (checked 4000 source files)\n")
+    f.on("wc -l < .mypy-baseline", out="3115\n")
     monkeypatch.setattr(sb, "run_cmd", f)
     monkeypatch.setattr(sb, "repo_root", lambda: root)
     monkeypatch.setattr(sb, "ATLAS_DIR", tmp_path / "atlas-cache")
+    monkeypatch.setattr(sb, "DEFAULT_CACHE", tmp_path / "c.json")
     return f
 
 
-def run(capsys, *argv: str, cache: Path) -> tuple[int, str, str]:
-    rc = sb.main([*argv, "--cache", str(cache)])
-    out, err = capsys.readouterr()
-    return rc, out, err
+def run(capsys, *argv: str) -> tuple[int, str, str]:
+    rc = sb.main(list(argv))
+    return (rc, *capsys.readouterr())
 
 
-def rows(capsys, *argv: str, cache: Path) -> tuple[dict, dict[int, dict]]:
-    rc, out, _ = run(capsys, "--json", *argv, cache=cache)
-    assert rc == 0
+def rows(capsys, *argv: str) -> tuple[dict, dict[int, dict]]:
+    rc, out, err = run(capsys, "--json", *argv)
+    assert rc == 0 and "Traceback" not in err
     doc = json.loads(out)
     return doc, {int(m["id"]): m for m in doc["metrics"]}
 
@@ -115,22 +112,18 @@ def test_help_lists_every_flag(capsys):
     assert exc.value.code == 0 and all(flag in text for flag in FLAGS.split())
 
 
-def test_post_without_epic_is_usage_error(fake, capsys, tmp_path):
+def test_post_without_epic_or_epic_zero_posts_nothing(fake, capsys):
     with pytest.raises(SystemExit) as exc:
-        sb.main(["--post", "--offline", "--cache", str(tmp_path / "c.json")])
+        sb.main(["--post", "--offline"])
     assert exc.value.code == 2 and "--epic" in capsys.readouterr().err
-    assert fake.matching("gh issue comment") == []
-
-
-def test_post_epic_zero_exits_nonzero_naming_epic(fake, capsys, tmp_path):
     with pytest.raises(SystemExit) as exc:
-        sb.main(["--post", "--epic", "0", "--offline", "--cache", str(tmp_path / "c.json")])
-    assert exc.value.code != 0 and "0" in capsys.readouterr().err
+        sb.main(["--post", "--epic", "0", "--offline"])
+    assert exc.value.code != 0 and "epic 0" in capsys.readouterr().err
     assert fake.matching("gh issue comment") == []
 
 
-def test_json_shape_and_baseline_constants(fake, capsys, tmp_path):
-    doc, r = rows(capsys, cache=tmp_path / "c.json")
+def test_json_shape_and_baseline_constants(fake, capsys):
+    doc, r = rows(capsys)
     assert doc["baseline_ref"] == "23909906e8" and doc["baseline_date"] == "2026-09-02"
     assert doc["generated_at"].endswith("Z") and "parked" in doc and sorted(r) == list(range(1, 11))
     for m in doc["metrics"]:
@@ -142,8 +135,8 @@ def test_json_shape_and_baseline_constants(fake, capsys, tmp_path):
     assert doc["guardrails"][0]["now"] == 144 and doc["guardrails"][0]["status"] != "ok"
 
 
-def test_row_details_match_definitions(fake, capsys, tmp_path):
-    _, r = rows(capsys, "--ref", HEAD, cache=tmp_path / "c.json")
+def test_row_details_match_definitions(fake, capsys):
+    _, r = rows(capsys, "--ref", HEAD)
     assert r[1]["version"] == "2.9.0" and r[1]["upload_date"] == "2026-07-06"
     assert isinstance(r[1]["now"], int) and isinstance(r[1]["delta"], int)
     assert r[2]["sha"] == PIN and r[2]["commit_date"] == "2026-07-07" and r[2]["pin_count"] == 1
@@ -155,7 +148,7 @@ def test_row_details_match_definitions(fake, capsys, tmp_path):
     assert r[5]["atlas_v1_assets"] == [] and r[5]["pr_9951_merged"] is False
     assert r[5]["atlas_release_count"] == 0 and r[5]["status"] == "fail" and "record_count" in r[5]
     assert r[7]["now"] == "000" and r[7]["canary_code"] == "200" and r[7]["status"] == "fail"
-    assert r[8]["now"] == 0 and r[8]["status"] == "fail"
+    assert r[8]["now"] == 0 and r[8]["status"] == "fail" and r[8]["receipts_releases"] == {}
     assert r[9]["code_search_count"] == 0 and r[9]["demo_repo_exists"] is False
     assert "synaptent/aragora@" in r[9]["query"] and "-repo:synaptent/aragora" in r[9]["query"]
     assert r[10]["total_items"] == 398 and r[10]["target"] == 84
@@ -164,88 +157,94 @@ def test_row_details_match_definitions(fake, capsys, tmp_path):
     assert r[10]["delta"] == 0 and r[10]["status"] == "fail"
 
 
-def test_delta_typing(fake, capsys, tmp_path):
-    _, r = rows(capsys, cache=tmp_path / "c.json")
-    assert r[8]["delta"] == 0 and r[10]["delta"] == 0
+def test_delta_numeric_when_both_numeric_else_arrow_string(fake, capsys):
+    _, r = rows(capsys)
+    assert r[8]["delta"] == 0 and r[10]["delta"] == 0 and isinstance(r[1]["delta"], int)
     assert r[3]["delta"] == "Draft v0.1 → Draft v0.1" and r[7]["delta"] == "000 → 000"
     assert sb.compute_delta(58, 60) == 2 and sb.compute_delta("a", None) == "a → null"
 
 
-def test_hosted_probe_is_single_readyz(fake, capsys, tmp_path):
-    rows(capsys, cache=tmp_path / "c.json")
+def test_hosted_probe_is_single_readyz_and_no_pytest(fake, capsys):
+    rows(capsys)
+    run(capsys, "--markdown")
     probes = fake.matching("api.aragora.ai")
-    assert len(probes) == 1 and probes[0][-1] == "https://api.aragora.ai/readyz"
+    assert len(probes) == 2 and probes[0][-1] == "https://api.aragora.ai/readyz"
     assert probes[0][probes[0].index("--max-time") + 1] == "15"
     assert not any("/health" in " ".join(c) for c in fake.calls)
-
-
-def test_plain_run_never_invokes_pytest(fake, capsys, tmp_path):
-    rows(capsys, cache=tmp_path / "c.json")
-    run(capsys, "--markdown", cache=tmp_path / "c.json")
     assert fake.matching("pytest") == []
 
 
-def test_run_vectors_sets_vectors_pass(fake, capsys, tmp_path, root):
+def test_run_vectors_sets_vectors_pass(fake, capsys, root):
     (root / "tests/verify").mkdir(parents=True)
     (root / "tests/verify/test_odr_vectors.py").write_text("")
     fake.on("pytest", "test_odr_vectors.py", out="1 passed")
-    _, r = rows(capsys, "--run-vectors", "--offline", cache=tmp_path / "c.json")
+    _, r = rows(capsys, "--run-vectors", "--offline")
     assert r[3]["vectors_present"] is True and r[3]["vectors_pass"] is True
 
 
 def test_cache_written_then_offline_marks_unavailable(fake, capsys, tmp_path):
-    cache = tmp_path / "c.json"
-    online, on = rows(capsys, cache=cache)
+    cache = tmp_path / "other.json"
+    online, on = rows(capsys, "--cache", str(cache))
     data = json.loads(cache.read_text())
     assert "cached_at" in data and {"1", "4", "5", "7", "8", "9"} <= set(data["metrics"])
     fake.calls.clear()
-    off_doc, off = rows(capsys, "--offline", cache=cache)
-    for i in NET:
+    off_doc, off = rows(capsys, "--offline", "--cache", str(cache))
+    for i in (1, 4, 5, 7, 8, 9):
         assert off[i]["status"] == "unavailable" and off[i]["now"] == on[i]["now"]
         assert off[i]["delta"] == on[i]["delta"]
     for i in (2, 3, 10):
         assert off[i]["status"] == on[i]["status"] and off[i]["now"] == on[i]["now"]
     assert off_doc["guardrails"] == online["guardrails"]
     assert fake.matching("curl") == [] and fake.matching("gh ") == []
+    _, r = rows(capsys, "--offline", "--cache", str(tmp_path / "missing" / "c.json"))
+    assert (r[1]["now"], r[1]["status"], r[1]["delta"]) == (None, "unavailable", "58 → null")
 
 
-def test_missing_cache_offline_yields_null_and_exit_0(fake, capsys, tmp_path):
-    rc, out, err = run(capsys, "--json", "--offline", cache=tmp_path / "missing" / "c.json")
-    r = {int(m["id"]): m for m in json.loads(out)["metrics"]}
-    assert rc == 0 and "Traceback" not in err
-    assert r[1]["now"] is None and r[1]["status"] == "unavailable"
-    assert r[1]["delta"] == "58 → null"
-
-
-def test_network_failure_falls_back_to_cache_without_traceback(fake, capsys, tmp_path):
-    cache = tmp_path / "c.json"
-    rows(capsys, cache=cache)
+def test_network_failure_falls_back_to_cache_without_traceback(fake, capsys):
+    rows(capsys)
     for needle in ("curl", "gh release", "gh pr view", "gh api", "gh repo view"):
         fake.on(needle, rc=7, err="Failed to connect to 127.0.0.1 port 9")
-    rc, out, err = run(capsys, "--json", cache=cache)
-    r = {int(m["id"]): m for m in json.loads(out)["metrics"]}
-    assert rc == 0 and "Traceback" not in err
+    _, r = rows(capsys)
     assert r[1]["status"] == "unavailable" and r[1]["now"] == 58 + r[1]["delta"]
     assert r[7]["status"] == "unavailable" and r[7]["now"] == "000"
-    assert len(fake.matching("api.aragora.ai")) == 1
+    assert len(fake.matching("api.aragora.ai")) == 1  # pre-probe failed: no second probe
+
+
+def test_unexpected_row_error_marks_only_that_row_unavailable(fake, capsys):
+    fake.on("gh api search/code", out="[]")
+    _, r = rows(capsys)
+    assert r[9]["status"] == "unavailable" and "AttributeError" in r[9]["reason"]
+    assert r[1]["status"] == "fail" and r[7]["status"] == "fail"
+
+
+def test_cache_entries_carry_per_row_stamp(fake, capsys, tmp_path, monkeypatch):
+    stamps = iter(["2026-09-03T10:00:00Z", "2026-09-03T10:00:01Z"])
+    monkeypatch.setattr(sb, "utc_stamp", lambda: next(stamps))
+    rows(capsys)
+    first = json.loads((tmp_path / "c.json").read_text())["metrics"]["9"]["cached_at"]
+    fake.on("gh api search/code", rc=7, err="Failed to connect")
+    _, r = rows(capsys)
+    data = json.loads((tmp_path / "c.json").read_text())
+    assert data["metrics"]["9"]["cached_at"] == first == r[9]["cached_at"]
+    assert data["metrics"]["1"]["cached_at"] != first and data["cached_at"] != first
 
 
 def test_parked_file_pending_operator_grammar(fake, capsys, tmp_path):
     parked = tmp_path / "parked.md"
     parked.write_text(LEDGER)
-    doc, r = rows(capsys, "--offline", "--parked-file", str(parked), cache=tmp_path / "c.json")
+    doc, r = rows(capsys, "--offline", "--parked-file", str(parked))
     assert r[10]["status"] == "pending-operator" and r[10]["pending_ref"] == "#77"
     assert r[8]["status"] == "unavailable" and "pending_ref" not in r[8]
     assert r[7]["status"] == "unavailable" and "pending_ref" not in r[7]
     assert r[2]["status"] in ("fail", "pending-operator") and doc["parked"] == "(none yet)"
-    doc2, _ = rows(capsys, "--offline", cache=tmp_path / "c.json")
+    doc2, _ = rows(capsys, "--offline")
     assert not any("pending_ref" in m for m in doc2["metrics"])
 
 
 def test_markdown_tables_and_parked_block(fake, capsys, tmp_path):
     parked = tmp_path / "parked.md"
     parked.write_text(LEDGER.replace("(none yet)", "- park A: next action `cmd`\n\n## Other\nx"))
-    rc, md, _ = run(capsys, "--markdown", "--offline", "--parked-file", str(parked), cache=parked)
+    rc, md, _ = run(capsys, "--markdown", "--offline", "--parked-file", str(parked))
     header = next(line for line in md.splitlines() if "Metric" in line and "|" in line)
     assert rc == 0 and all(c in header for c in ("Metric", "Baseline", "Now", "Delta", "Status"))
     data_rows = [line for line in md.splitlines() if sb.METRIC_ROW_RE.match(line)]
@@ -255,49 +254,47 @@ def test_markdown_tables_and_parked_block(fake, capsys, tmp_path):
     assert "## Other" not in md
     guard = [line for line in md.splitlines() if line.startswith(("| Mutual import", "| OpenAPI"))]
     assert len(guard) == 2
-    _, md2, _ = run(capsys, "--markdown", "--offline", cache=tmp_path / "c.json")
+    _, md2, _ = run(capsys, "--markdown", "--offline")
     assert "## Parked" not in md2 and "pending-operator" not in md2
 
 
-def test_markdown_deterministic_except_generated_at(fake, capsys, tmp_path, monkeypatch):
+def test_markdown_deterministic_except_generated_at(fake, capsys, monkeypatch):
     stamps = iter(["2026-09-03T10:00:00Z", "2026-09-03T10:00:01Z"])
     monkeypatch.setattr(sb, "utc_stamp", lambda: next(stamps))
-    _, a, _ = run(capsys, "--markdown", "--offline", cache=tmp_path / "c.json")
-    _, b, _ = run(capsys, "--markdown", "--offline", cache=tmp_path / "c.json")
+    _, a, _ = run(capsys, "--markdown", "--offline")
+    _, b, _ = run(capsys, "--markdown", "--offline")
     diff = [(x, y) for x, y in zip(a.splitlines(), b.splitlines(), strict=True) if x != y]
     assert len(diff) == 1 and "generated_at" in diff[0][0]
 
 
-def test_row2_warns_on_multiple_distinct_pins(fake, capsys, tmp_path, root):
+def test_row2_warns_on_multiple_distinct_pins(fake, capsys, root):
     (root / "docs/GITHUB_ACTION_SETUP.md").write_text("uses: synaptent/aragora@" + "c" * 40 + "\n")
     fake.on("git ls-files", out="README.md\ndocs/GITHUB_ACTION_SETUP.md\n")
-    _, r = rows(capsys, "--offline", cache=tmp_path / "c.json")
+    _, r = rows(capsys, "--offline")
     assert r[2]["pin_count"] == 2 and "2" in r[2]["warning"] and len(r[2]["distinct_shas"]) == 2
 
 
-def test_row5_ok_after_merge_and_release(fake, capsys, tmp_path):
+def test_row5_ok_after_merge_and_release(fake, capsys):
     fake.on("gh pr view 9951", out='{"state": "MERGED"}')
     fake.on("gh release list", out='[{"tagName": "atlas-v1"}, {"tagName": "atlas-2026-09-10"}]')
     fake.on("gh release view atlas-v1", out='{"assets": [{"name": "atlas-v1.jsonl"}]}')
-    _, r = rows(capsys, cache=tmp_path / "c.json")
+    _, r = rows(capsys)
     assert r[5]["atlas_v1_assets"] == ["atlas-v1.jsonl"] and r[5]["atlas_release_count"] == 2
     assert r[5]["pr_9951_merged"] is True and r[5]["status"] == "ok"
 
 
-def test_row8_counts_odr_assets_on_receipts_releases(fake, capsys, tmp_path):
+def test_row8_counts_odr_assets_on_receipts_releases(fake, capsys):
     tag = "receipts-2026-10-01"
-    fake.on(
-        "gh release list", out=f'[{{"tagName": "{tag}", "publishedAt": "2026-10-01T00:00:00Z"}}]'
-    )
+    fake.on("gh release list", out=json.dumps([{"tagName": tag, "publishedAt": "2026-10-01"}]))
     assets = [{"name": f"pr{i}.odr.json"} for i in range(3)] + [{"name": "k.pem"}]
     fake.on(f"gh release view {tag}", out=json.dumps({"assets": assets}))
     fake.on("gh run list", out="[]")
-    _, r = rows(capsys, cache=tmp_path / "c.json")
+    _, r = rows(capsys)
     assert r[8]["now"] == 3 and r[8]["delta"] == 3 and r[8]["receipts_releases"] == {tag: 3}
     assert r[8]["first_hour_run_ok"] is False and r[8]["status"] == "fail"
 
 
-def test_row6_counts_atlas_jsonl(fake, capsys, tmp_path, root):
+def test_row6_counts_atlas_jsonl(fake, capsys, root):
     (root / "docs/atlas").mkdir()
     recs = [
         {"pr": 1, "head_sha": "x", "verdict": "changes_requested", "posted_to_thread": True},
@@ -305,29 +302,36 @@ def test_row6_counts_atlas_jsonl(fake, capsys, tmp_path, root):
         {"pr": 2, "head_sha": "y", "verdict": "pass", "posted_to_thread": True},
     ]
     (root / "docs/atlas/atlas-v1.jsonl").write_text("".join(json.dumps(x) + "\n" for x in recs))
-    _, r = rows(capsys, "--offline", "--quorum-runs", "4", cache=tmp_path / "c.json")
+    _, r = rows(capsys, "--offline", "--quorum-runs", "4")
     assert (r[6]["now"], r[6]["posted"], r[6]["rounds"], r[6]["records"]) == (1, 2, 2, 3)
     assert r[6]["quorum_runs"] == 4 and r[6]["upper_bound"] is True and r[6]["delta"] == 1 - 53
 
 
-def test_post_creates_new_comment_with_refs(fake, capsys, tmp_path):
-    rc, out, _ = run(capsys, "--post", "--epic", "9966", "--offline", cache=tmp_path / "c.json")
+def test_post_creates_new_comment_with_refs(fake, capsys):
+    rc, out, _ = run(capsys, "--post", "--epic", "9966", "--offline")
     posts = fake.matching("gh issue comment")
     assert rc == 0 and "issuecomment-1" in out and len(posts) == 1 and posts[0][3] == "9966"
     body = Path(posts[0][posts[0].index("--body-file") + 1]).read_text()
     assert "23909906e8" in body and HEAD in body and "| Metric" in body
 
 
-def test_check_guardrails_exit_codes(fake, capsys, tmp_path, monkeypatch):
-    monkeypatch.setattr(sb.tempfile, "mkdtemp", lambda prefix: str(tmp_path / "main"))
-    (tmp_path / "main").mkdir()
-    fake.on("git archive origin/main", out="")
-    fake.on("mypy aragora/", out="Found 1744 errors in 468 files (checked 4000 source files)\n")
-    fake.on("wc -l < .mypy-baseline", out="3115\n")
-    assert sb.main(["--check-guardrails", "--offline"]) == 0
+def test_check_guardrails_exit_codes(fake, capsys):
+    assert sb.main(GUARD) == 0
     out = capsys.readouterr().out
     assert "origin/main mutual_import_cycles: 144 (aaaaaaa" in out and "(limit 144) ok" in out
     assert fake.matching("git fetch") == []
     fake.on("mypy aragora/", out="Found 1745 errors in 468 files\n")
-    assert sb.main(["--check-guardrails", "--offline"]) == 1
+    assert sb.main(GUARD) == 1
     assert "mypy_errors" in capsys.readouterr().out
+
+
+def test_check_guardrails_mypy_fails_closed(fake, capsys):
+    fake.on("mypy aragora/", out="", rc=124, err="timeout")
+    assert sb.main(GUARD) == 1
+    assert "mypy_errors: None (limit 1744) OVER" in capsys.readouterr().out
+    fake.on("mypy aragora/", out="Success: no issues found in 4000 source files\n")
+    assert sb.main(GUARD) == 0
+    assert "mypy_errors: 0 (limit 1744) ok" in capsys.readouterr().out
+    fake.on("measure_import_graph.py", out="", rc=1, err="boom")
+    assert sb.main(GUARD) == 1
+    assert "guardrail measurement failed" in capsys.readouterr().err

--- a/tests/scripts/test_receipt_first_scoreboard.py
+++ b/tests/scripts/test_receipt_first_scoreboard.py
@@ -1,0 +1,333 @@
+"""Tests for scripts/receipt_first_scoreboard.py (hermetic: every subprocess is faked)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import scripts.receipt_first_scoreboard as sb
+
+HEAD = "a" * 40
+PIN = "8b600a3a8dbf076f4027ae27f3dcbbf48e75409f"
+NET = (1, 4, 5, 7, 8, 9)
+FLAGS = "--json --markdown --cache --offline --post --epic --parked-file --ref --quorum-runs"
+FLAGS += " --run-vectors --check-guardrails"
+UP = "upload_time_iso_8601"
+PYPI = {"info": {"version": "2.9.0"}, "releases": {"2.9.0": [{UP: "2026-07-06T15:15:14Z"}]}}
+PYPI["releases"]["2.8.0"] = [{UP: "2026-06-01T00:00:00Z"}]
+VERIFY = {"info": {"version": "0.1.1"}, "releases": {"0.1.1": [{UP: "2026-07-04T03:28:01Z"}]}}
+RATCHET = {"current": {"total_items": 398}, "target": {"max_open_items": 84}, "status": "fail"}
+PARITY = {"gaps": {"missing_from_python_sdk": [1], "stale_python_sdk_paths": [1] * 31}}
+PARITY["gaps"]["stale_typescript_sdk_paths"] = [1] * 61
+GRAPH = {"mutual_import_cycles": 144, "handlers_flat_root": 187}
+KEYS = [("ci_workflows", 97), ("doc_files", 1119), ("top_level_modules", 145)]
+REGEN = {"metrics": [{"key": k, "value": v} for k, v in KEYS + [("openapi_operations", 3205)]]}
+LEDGER = "EPIC=#1\n## Awaiting operator settlement\n- [metric 10] batch 1 packet — PR #77 head "
+LEDGER += "b" * 40 + "\n- [metric 8] receipts packet #78 head n/a\n- metric 7 foo #2\n"
+LEDGER += "- [metric 2] bump #79 head n/a\n\n## Parked\n(none yet)\n"
+
+
+class FakeCmds:
+    """Routes run_cmd argv to canned results; records every call."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.routes: list[tuple[tuple[str, ...], sb.Cmd]] = []
+
+    def on(self, *needles: str, out: str = "", rc: int = 0, err: str = "") -> None:
+        self.routes.insert(0, (needles, sb.Cmd(rc, out, err)))
+
+    def __call__(self, argv, **kwargs) -> sb.Cmd:
+        self.calls.append(list(argv))
+        joined = " ".join(argv)
+        hit = next((r for n, r in self.routes if all(x in joined for x in n)), None)
+        return hit or sb.Cmd(1, "", f"unhandled: {joined}")
+
+    def matching(self, *needles: str) -> list[list[str]]:
+        return [c for c in self.calls if all(n in " ".join(c) for n in needles)]
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    files = {
+        "README.md": f"uses: synaptent/aragora@{PIN}\n",
+        "docs/specs/OPEN_DECISION_RECEIPT.md": "# ODR\n\n**Status:** Draft v0.1 — Tier 2\n",
+        "aragora-verify/pyproject.toml": '[project]\nversion = "0.1.2"\n',
+        "scripts/baselines/contract_drift_inventory.json": '{"items": [{"status": "open"}]}',
+    }
+    for rel, text in files.items():
+        (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / rel).write_text(text)
+    return tmp_path
+
+
+@pytest.fixture
+def fake(monkeypatch: pytest.MonkeyPatch, root: Path, tmp_path: Path) -> FakeCmds:
+    f = FakeCmds()
+    f.on("git rev-parse", out=HEAD + "\n")
+    f.on("git log -1", out="2026-07-06T19:05:18-05:00\n")
+    f.on("git ls-files", out="README.md\n")
+    f.on("git show", rc=1, err="fatal: path does not exist")
+    f.on("curl", "pypi.org/pypi/aragora/json", out=json.dumps(PYPI))
+    f.on("curl", "pypi.org/pypi/aragora-verify/json", out=json.dumps(VERIFY))
+    f.on("curl", "api.aragora.ai/readyz", out="000")
+    f.on("curl", "api-canary.aragora.ai/readyz", out="200")
+    f.on("gh release list", out='[{"tagName": "v2.9.0", "publishedAt": "2026-07-06T00:00:00Z"}]')
+    f.on("gh release view atlas-v1", rc=1, err="release not found")
+    f.on("gh pr view 9951", out='{"state": "OPEN"}')
+    f.on("gh api search/code", out='{"total_count": 0, "items": []}')
+    f.on("gh repo view synaptent/aragora-receipt-demo", rc=1, err="Could not resolve")
+    f.on("check_contract_drift_ratchet.py", out=json.dumps(RATCHET), rc=1)
+    f.on("check_sdk_parity.py", out=json.dumps(PARITY))
+    f.on("measure_import_graph.py", out=json.dumps(GRAPH))
+    f.on("regenerate_metrics.py", out=json.dumps(REGEN))
+    f.on("gh issue comment", out="https://github.com/synaptent/aragora/issues/9966#issuecomment-1")
+    monkeypatch.setattr(sb, "run_cmd", f)
+    monkeypatch.setattr(sb, "repo_root", lambda: root)
+    monkeypatch.setattr(sb, "ATLAS_DIR", tmp_path / "atlas-cache")
+    return f
+
+
+def run(capsys, *argv: str, cache: Path) -> tuple[int, str, str]:
+    rc = sb.main([*argv, "--cache", str(cache)])
+    out, err = capsys.readouterr()
+    return rc, out, err
+
+
+def rows(capsys, *argv: str, cache: Path) -> tuple[dict, dict[int, dict]]:
+    rc, out, _ = run(capsys, "--json", *argv, cache=cache)
+    assert rc == 0
+    doc = json.loads(out)
+    return doc, {int(m["id"]): m for m in doc["metrics"]}
+
+
+def test_help_lists_every_flag(capsys):
+    with pytest.raises(SystemExit) as exc:
+        sb.main(["--help"])
+    text = capsys.readouterr().out
+    assert exc.value.code == 0 and all(flag in text for flag in FLAGS.split())
+
+
+def test_post_without_epic_is_usage_error(fake, capsys, tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        sb.main(["--post", "--offline", "--cache", str(tmp_path / "c.json")])
+    assert exc.value.code == 2 and "--epic" in capsys.readouterr().err
+    assert fake.matching("gh issue comment") == []
+
+
+def test_post_epic_zero_exits_nonzero_naming_epic(fake, capsys, tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        sb.main(["--post", "--epic", "0", "--offline", "--cache", str(tmp_path / "c.json")])
+    assert exc.value.code != 0 and "0" in capsys.readouterr().err
+    assert fake.matching("gh issue comment") == []
+
+
+def test_json_shape_and_baseline_constants(fake, capsys, tmp_path):
+    doc, r = rows(capsys, cache=tmp_path / "c.json")
+    assert doc["baseline_ref"] == "23909906e8" and doc["baseline_date"] == "2026-09-02"
+    assert doc["generated_at"].endswith("Z") and "parked" in doc and sorted(r) == list(range(1, 11))
+    for m in doc["metrics"]:
+        assert {"id", "name", "baseline", "now", "delta", "status", "measurement"} <= set(m)
+        assert m["status"] in sb.STATUSES and m["delta"] is not None
+    assert [g["ceiling"] for g in doc["guardrails"]] == [140, 187, 97, 1119, 145, 3205]
+    for g in doc["guardrails"]:
+        assert {"id", "name", "ceiling", "baseline", "now", "status"} <= set(g)
+    assert doc["guardrails"][0]["now"] == 144 and doc["guardrails"][0]["status"] != "ok"
+
+
+def test_row_details_match_definitions(fake, capsys, tmp_path):
+    _, r = rows(capsys, "--ref", HEAD, cache=tmp_path / "c.json")
+    assert r[1]["version"] == "2.9.0" and r[1]["upload_date"] == "2026-07-06"
+    assert isinstance(r[1]["now"], int) and isinstance(r[1]["delta"], int)
+    assert r[2]["sha"] == PIN and r[2]["commit_date"] == "2026-07-07" and r[2]["pin_count"] == 1
+    assert "warning" not in r[2]
+    assert r[3]["now"] == "Draft v0.1" and r[3]["vectors_present"] is False
+    assert r[3]["vectors_pass"] is None
+    assert r[4]["now"] == "0.1.1" and r[4]["local_version"] == "0.1.2"
+    assert r[4]["local_ahead_of_pypi"] is True
+    assert r[5]["atlas_v1_assets"] == [] and r[5]["pr_9951_merged"] is False
+    assert r[5]["atlas_release_count"] == 0 and r[5]["status"] == "fail" and "record_count" in r[5]
+    assert r[7]["now"] == "000" and r[7]["canary_code"] == "200" and r[7]["status"] == "fail"
+    assert r[8]["now"] == 0 and r[8]["status"] == "fail"
+    assert r[9]["code_search_count"] == 0 and r[9]["demo_repo_exists"] is False
+    assert "synaptent/aragora@" in r[9]["query"] and "-repo:synaptent/aragora" in r[9]["query"]
+    assert r[10]["total_items"] == 398 and r[10]["target"] == 84
+    assert r[10]["ratchet_status"] == "fail" and r[10]["ref"] == HEAD
+    assert r[10]["inventory_open"] == 1 and r[10]["sdk_parity_gaps"] == 93
+    assert r[10]["delta"] == 0 and r[10]["status"] == "fail"
+
+
+def test_delta_typing(fake, capsys, tmp_path):
+    _, r = rows(capsys, cache=tmp_path / "c.json")
+    assert r[8]["delta"] == 0 and r[10]["delta"] == 0
+    assert r[3]["delta"] == "Draft v0.1 → Draft v0.1" and r[7]["delta"] == "000 → 000"
+    assert sb.compute_delta(58, 60) == 2 and sb.compute_delta("a", None) == "a → null"
+
+
+def test_hosted_probe_is_single_readyz(fake, capsys, tmp_path):
+    rows(capsys, cache=tmp_path / "c.json")
+    probes = fake.matching("api.aragora.ai")
+    assert len(probes) == 1 and probes[0][-1] == "https://api.aragora.ai/readyz"
+    assert probes[0][probes[0].index("--max-time") + 1] == "15"
+    assert not any("/health" in " ".join(c) for c in fake.calls)
+
+
+def test_plain_run_never_invokes_pytest(fake, capsys, tmp_path):
+    rows(capsys, cache=tmp_path / "c.json")
+    run(capsys, "--markdown", cache=tmp_path / "c.json")
+    assert fake.matching("pytest") == []
+
+
+def test_run_vectors_sets_vectors_pass(fake, capsys, tmp_path, root):
+    (root / "tests/verify").mkdir(parents=True)
+    (root / "tests/verify/test_odr_vectors.py").write_text("")
+    fake.on("pytest", "test_odr_vectors.py", out="1 passed")
+    _, r = rows(capsys, "--run-vectors", "--offline", cache=tmp_path / "c.json")
+    assert r[3]["vectors_present"] is True and r[3]["vectors_pass"] is True
+
+
+def test_cache_written_then_offline_marks_unavailable(fake, capsys, tmp_path):
+    cache = tmp_path / "c.json"
+    online, on = rows(capsys, cache=cache)
+    data = json.loads(cache.read_text())
+    assert "cached_at" in data and {"1", "4", "5", "7", "8", "9"} <= set(data["metrics"])
+    fake.calls.clear()
+    off_doc, off = rows(capsys, "--offline", cache=cache)
+    for i in NET:
+        assert off[i]["status"] == "unavailable" and off[i]["now"] == on[i]["now"]
+        assert off[i]["delta"] == on[i]["delta"]
+    for i in (2, 3, 10):
+        assert off[i]["status"] == on[i]["status"] and off[i]["now"] == on[i]["now"]
+    assert off_doc["guardrails"] == online["guardrails"]
+    assert fake.matching("curl") == [] and fake.matching("gh ") == []
+
+
+def test_missing_cache_offline_yields_null_and_exit_0(fake, capsys, tmp_path):
+    rc, out, err = run(capsys, "--json", "--offline", cache=tmp_path / "missing" / "c.json")
+    r = {int(m["id"]): m for m in json.loads(out)["metrics"]}
+    assert rc == 0 and "Traceback" not in err
+    assert r[1]["now"] is None and r[1]["status"] == "unavailable"
+    assert r[1]["delta"] == "58 → null"
+
+
+def test_network_failure_falls_back_to_cache_without_traceback(fake, capsys, tmp_path):
+    cache = tmp_path / "c.json"
+    rows(capsys, cache=cache)
+    for needle in ("curl", "gh release", "gh pr view", "gh api", "gh repo view"):
+        fake.on(needle, rc=7, err="Failed to connect to 127.0.0.1 port 9")
+    rc, out, err = run(capsys, "--json", cache=cache)
+    r = {int(m["id"]): m for m in json.loads(out)["metrics"]}
+    assert rc == 0 and "Traceback" not in err
+    assert r[1]["status"] == "unavailable" and r[1]["now"] == 58 + r[1]["delta"]
+    assert r[7]["status"] == "unavailable" and r[7]["now"] == "000"
+    assert len(fake.matching("api.aragora.ai")) == 1
+
+
+def test_parked_file_pending_operator_grammar(fake, capsys, tmp_path):
+    parked = tmp_path / "parked.md"
+    parked.write_text(LEDGER)
+    doc, r = rows(capsys, "--offline", "--parked-file", str(parked), cache=tmp_path / "c.json")
+    assert r[10]["status"] == "pending-operator" and r[10]["pending_ref"] == "#77"
+    assert r[8]["status"] == "unavailable" and "pending_ref" not in r[8]
+    assert r[7]["status"] == "unavailable" and "pending_ref" not in r[7]
+    assert r[2]["status"] in ("fail", "pending-operator") and doc["parked"] == "(none yet)"
+    doc2, _ = rows(capsys, "--offline", cache=tmp_path / "c.json")
+    assert not any("pending_ref" in m for m in doc2["metrics"])
+
+
+def test_markdown_tables_and_parked_block(fake, capsys, tmp_path):
+    parked = tmp_path / "parked.md"
+    parked.write_text(LEDGER.replace("(none yet)", "- park A: next action `cmd`\n\n## Other\nx"))
+    rc, md, _ = run(capsys, "--markdown", "--offline", "--parked-file", str(parked), cache=parked)
+    header = next(line for line in md.splitlines() if "Metric" in line and "|" in line)
+    assert rc == 0 and all(c in header for c in ("Metric", "Baseline", "Now", "Delta", "Status"))
+    data_rows = [line for line in md.splitlines() if sb.METRIC_ROW_RE.match(line)]
+    assert len(data_rows) == 10 and "23909906e8" in md and HEAD in md
+    assert "pending-operator #77" in data_rows[9]
+    assert md.split("## Parked\n", 1)[1].strip() == "- park A: next action `cmd`"
+    assert "## Other" not in md
+    guard = [line for line in md.splitlines() if line.startswith(("| Mutual import", "| OpenAPI"))]
+    assert len(guard) == 2
+    _, md2, _ = run(capsys, "--markdown", "--offline", cache=tmp_path / "c.json")
+    assert "## Parked" not in md2 and "pending-operator" not in md2
+
+
+def test_markdown_deterministic_except_generated_at(fake, capsys, tmp_path, monkeypatch):
+    stamps = iter(["2026-09-03T10:00:00Z", "2026-09-03T10:00:01Z"])
+    monkeypatch.setattr(sb, "utc_stamp", lambda: next(stamps))
+    _, a, _ = run(capsys, "--markdown", "--offline", cache=tmp_path / "c.json")
+    _, b, _ = run(capsys, "--markdown", "--offline", cache=tmp_path / "c.json")
+    diff = [(x, y) for x, y in zip(a.splitlines(), b.splitlines(), strict=True) if x != y]
+    assert len(diff) == 1 and "generated_at" in diff[0][0]
+
+
+def test_row2_warns_on_multiple_distinct_pins(fake, capsys, tmp_path, root):
+    (root / "docs/GITHUB_ACTION_SETUP.md").write_text("uses: synaptent/aragora@" + "c" * 40 + "\n")
+    fake.on("git ls-files", out="README.md\ndocs/GITHUB_ACTION_SETUP.md\n")
+    _, r = rows(capsys, "--offline", cache=tmp_path / "c.json")
+    assert r[2]["pin_count"] == 2 and "2" in r[2]["warning"] and len(r[2]["distinct_shas"]) == 2
+
+
+def test_row5_ok_after_merge_and_release(fake, capsys, tmp_path):
+    fake.on("gh pr view 9951", out='{"state": "MERGED"}')
+    fake.on("gh release list", out='[{"tagName": "atlas-v1"}, {"tagName": "atlas-2026-09-10"}]')
+    fake.on("gh release view atlas-v1", out='{"assets": [{"name": "atlas-v1.jsonl"}]}')
+    _, r = rows(capsys, cache=tmp_path / "c.json")
+    assert r[5]["atlas_v1_assets"] == ["atlas-v1.jsonl"] and r[5]["atlas_release_count"] == 2
+    assert r[5]["pr_9951_merged"] is True and r[5]["status"] == "ok"
+
+
+def test_row8_counts_odr_assets_on_receipts_releases(fake, capsys, tmp_path):
+    tag = "receipts-2026-10-01"
+    fake.on(
+        "gh release list", out=f'[{{"tagName": "{tag}", "publishedAt": "2026-10-01T00:00:00Z"}}]'
+    )
+    assets = [{"name": f"pr{i}.odr.json"} for i in range(3)] + [{"name": "k.pem"}]
+    fake.on(f"gh release view {tag}", out=json.dumps({"assets": assets}))
+    fake.on("gh run list", out="[]")
+    _, r = rows(capsys, cache=tmp_path / "c.json")
+    assert r[8]["now"] == 3 and r[8]["delta"] == 3 and r[8]["receipts_releases"] == {tag: 3}
+    assert r[8]["first_hour_run_ok"] is False and r[8]["status"] == "fail"
+
+
+def test_row6_counts_atlas_jsonl(fake, capsys, tmp_path, root):
+    (root / "docs/atlas").mkdir()
+    recs = [
+        {"pr": 1, "head_sha": "x", "verdict": "changes_requested", "posted_to_thread": True},
+        {"pr": 1, "head_sha": "x", "verdict": "pass", "posted_to_thread": False},
+        {"pr": 2, "head_sha": "y", "verdict": "pass", "posted_to_thread": True},
+    ]
+    (root / "docs/atlas/atlas-v1.jsonl").write_text("".join(json.dumps(x) + "\n" for x in recs))
+    _, r = rows(capsys, "--offline", "--quorum-runs", "4", cache=tmp_path / "c.json")
+    assert (r[6]["now"], r[6]["posted"], r[6]["rounds"], r[6]["records"]) == (1, 2, 2, 3)
+    assert r[6]["quorum_runs"] == 4 and r[6]["upper_bound"] is True and r[6]["delta"] == 1 - 53
+
+
+def test_post_creates_new_comment_with_refs(fake, capsys, tmp_path):
+    rc, out, _ = run(capsys, "--post", "--epic", "9966", "--offline", cache=tmp_path / "c.json")
+    posts = fake.matching("gh issue comment")
+    assert rc == 0 and "issuecomment-1" in out and len(posts) == 1 and posts[0][3] == "9966"
+    body = Path(posts[0][posts[0].index("--body-file") + 1]).read_text()
+    assert "23909906e8" in body and HEAD in body and "| Metric" in body
+
+
+def test_check_guardrails_exit_codes(fake, capsys, tmp_path, monkeypatch):
+    monkeypatch.setattr(sb.tempfile, "mkdtemp", lambda prefix: str(tmp_path / "main"))
+    (tmp_path / "main").mkdir()
+    fake.on("git archive origin/main", out="")
+    fake.on("mypy aragora/", out="Found 1744 errors in 468 files (checked 4000 source files)\n")
+    fake.on("wc -l < .mypy-baseline", out="3115\n")
+    assert sb.main(["--check-guardrails", "--offline"]) == 0
+    out = capsys.readouterr().out
+    assert "origin/main mutual_import_cycles: 144 (aaaaaaa" in out and "(limit 144) ok" in out
+    assert fake.matching("git fetch") == []
+    fake.on("mypy aragora/", out="Found 1745 errors in 468 files\n")
+    assert sb.main(["--check-guardrails", "--offline"]) == 1
+    assert "mypy_errors" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
Adds `scripts/receipt_first_scoreboard.py`, the executable form of the Receipt-First mission's metric definitions: ten exit-metric rows and six guardrails rendered as baseline / now / delta / status against baseline `23909906e8` (2026-09-02). Tracking epic: #9966.

- `--json` / `--markdown` (metric objects carry `name`, `measurement`, `delta`; guardrail objects carry `id`, `name`, `ceiling`, `baseline`, `now`, `status`).
- Network rows (1, 4, 5, 7, 8, 9) cache to `~/.aragora/receipt-first-scoreboard-cache.json` (`cached_at`); `--cache PATH`, `--offline`, a dead proxy or a missing cache all exit 0 with `unavailable` rows and no traceback. Every network call goes through `curl`/`gh` so proxy env applies uniformly.
- `--parked-file` is the only source of `pending-operator` rows (`- [metric <n>] … #<N> head <sha|n/a>` grammar under `## Awaiting operator settlement`) and of the verbatim `## Parked` block in Markdown.
- `--post --epic N` posts one new comment per invocation; `--post` without `--epic` is an argparse error (exit 2); `--epic 0` exits 2 naming the epic.
- `--ref <40-hex>` for row 10, `--quorum-runs N` for row 6, `--run-vectors` for row 3 (plain runs never invoke pytest), `--check-guardrails` (origin/main cycles via `git archive` into a temp tree, mypy tail, `.mypy-baseline` line count; exit 1 only on a regression).
- Row 7 makes exactly one `api.aragora.ai/readyz --max-time 15` probe per invocation plus the canary probe; `/health` is never used.

## Exit metric moved: none (hygiene)
This PR is the measuring instrument; it moves no row.

## Test commands
- `python3 -m pytest tests/scripts/test_receipt_first_scoreboard.py -q -p no:cacheprovider` → 21 passed (red first: collection error before the script existed).
- `bash $MISSION_DIR/bin/gate.sh lint|typecheck|contracts|guardrails|test` → all `GATE PASSED` (test: 3854 passed, 3 skipped).
- `time timeout 120 python3 scripts/receipt_first_scoreboard.py --json --parked-file …` → exit 0, real 21 s; `--json --offline` → exit 0, 5.9 s; `--check-guardrails --offline` → exit 0, 9 s (mypy tail `Found 1744 errors`, cycles 144 limit 144).
- `HTTPS_PROXY=http://127.0.0.1:9 … --json` → exit 0 in 5 s, all network rows `unavailable` from cache.

## Reviewed design tradeoffs
- One `run_cmd` subprocess wrapper for git, curl, gh and the repo's own measurement scripts, so tests fake every process with one router and proxy env reaches every network call; rejected `urllib` because it would need separate proxy handling from `gh`.
- Row 1 doubles as the PyPI reachability pre-probe: if it fails, the other network rows are skipped and served from cache instead of each timing out (keeps the dead-proxy path ≤10 s).
- Row 6 reads the Atlas JSONL (local `docs/atlas/atlas-v1.jsonl` or a downloaded `atlas-v1` asset) and reports `unavailable` when neither exists rather than parsing `summary.md`, so the number is always the dataset count the contract names.
- Cycles limit is `max(140, origin/main count)` like `bin/gate.sh`; all other ceilings fixed.

## Risks
- Low: new script + tests only; nothing imports it. Cache file lives under `~/.aragora/`; a corrupt cache is treated as empty.
- Row 2 pin age depends on the pinned SHA being fetchable; if not in local history it reports `now: null` with a note instead of failing.
