### PR TITLE
chore(sdk): remove 9 phantom webhooks endpoint pairs from both SDKs (paydown batch 02)

### DIFF
--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -31,7 +31,7 @@ integration depended on them.
 | `debates.get_agent_statistics(debate_id)` | `GET /api/v1/debates/{id}/agent-statistics` | `debates.get_agent_stats()` (aggregate per-agent statistics) |
 | `debates.get_debate_health(debate_id)` | `GET /api/v1/debates/{id}/health` | `debates.get_health()` for system health, `debates.get(debate_id)` for a debate's status |
 
-Removed 9 `webhooks` methods (sync `WebhooksAPI` and async `AsyncWebhooksAPI`)
+Removed 10 `webhooks` methods (sync `WebhooksAPI` and async `AsyncWebhooksAPI`)
 that targeted per-webhook sub-routes no server handler dispatches. The
 webhook handler only routes `/api/v1/webhooks/{id}` and
 `/api/v1/webhooks/{id}/test` below a webhook id, so every one of these calls
@@ -42,6 +42,7 @@ returned 404 and no working integration depended on them.
 | `webhooks.list_deliveries(webhook_id, status, limit, offset)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.list_dead_letter()` for failed deliveries; successful deliveries are not listed |
 | `webhooks.get_delivery(webhook_id, delivery_id)` | `GET /api/v1/webhooks/{id}/deliveries/{delivery_id}` | `webhooks.get_dead_letter(dead_letter_id)` for a failed delivery; successful deliveries are not exposed individually |
 | `webhooks.retry_delivery(webhook_id, delivery_id)` | `POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry` | `webhooks.retry_dead_letter(dead_letter_id)` |
+| `webhooks.get_delivery_stats(webhook_id, days)` | `GET /api/v1/webhooks/{id}/stats` | No replacement; per-webhook delivery statistics are not served (`GET /api/v1/webhooks/queue/stats` reports the shared delivery queue, not a single webhook) |
 | `webhooks.subscribe_events(webhook_id, events)` | `POST /api/v1/webhooks/{id}/events` | `webhooks.update(webhook_id, events=[...])` with the full event list |
 | `webhooks.unsubscribe_events(webhook_id, events)` | `DELETE /api/v1/webhooks/{id}/events` | `webhooks.update(webhook_id, events=[...])` with the remaining events |
 | `webhooks.get_retry_policy(webhook_id)` | `GET /api/v1/webhooks/{id}/retry-policy` | No replacement; the retry policy is server-configured, not per webhook |

--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -39,7 +39,7 @@ returned 404 and no working integration depended on them.
 
 | Removed Method | Route | Migration |
 |----------------|-------|-----------|
-| `webhooks.list_deliveries(webhook_id, status, limit, offset)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.get_delivery_stats(webhook_id)` for per-webhook counts; `webhooks.list_dead_letter()` for failed deliveries |
+| `webhooks.list_deliveries(webhook_id, status, limit, offset)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.list_dead_letter()` for failed deliveries; successful deliveries are not listed |
 | `webhooks.get_delivery(webhook_id, delivery_id)` | `GET /api/v1/webhooks/{id}/deliveries/{delivery_id}` | `webhooks.get_dead_letter(dead_letter_id)` for a failed delivery; successful deliveries are not exposed individually |
 | `webhooks.retry_delivery(webhook_id, delivery_id)` | `POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry` | `webhooks.retry_dead_letter(dead_letter_id)` |
 | `webhooks.subscribe_events(webhook_id, events)` | `POST /api/v1/webhooks/{id}/events` | `webhooks.update(webhook_id, events=[...])` with the full event list |

--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -20,7 +20,7 @@ integration depended on them.
 |----------------|-------|-----------|
 | `debates.restore(debate_id)` | `POST /api/v1/debates/{id}/restore` | `debates.update(debate_id, status="active")` |
 | `debates.make_permanent(debate_id)` | `POST /api/v1/debates/{id}/make-permanent` | None needed; completed debates persist automatically |
-| `debates.find_similar(debate_id, limit)` | `GET /api/v1/debates/{id}/similar` | `debates.search(query)` with the debate task text |
+| `debates.find_similar(debate_id, limit)` | `GET /api/v1/debates/{id}/similar` | `consensus.get_similar_debates(topic, limit)` (`GET /api/v1/consensus/similar`) with the debate task text as `topic` |
 | `debates.get_quality(debate_id)` | `GET /api/v1/debates/{id}/quality` | `debates.get_verification_report(debate_id)` |
 | `debates.get_notes(debate_id)` | `GET /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
 | `debates.add_note(debate_id, content)` | `POST /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
@@ -30,6 +30,24 @@ integration depended on them.
 | `debates.retry_batch(batch_id)` | `POST /api/v1/debates/batch/{id}/retry` | Re-submit failed jobs with `debates.submit_batch(...)` |
 | `debates.get_agent_statistics(debate_id)` | `GET /api/v1/debates/{id}/agent-statistics` | `debates.get_agent_stats()` (aggregate per-agent statistics) |
 | `debates.get_debate_health(debate_id)` | `GET /api/v1/debates/{id}/health` | `debates.get_health()` for system health, `debates.get(debate_id)` for a debate's status |
+
+Removed 9 `webhooks` methods (sync `WebhooksAPI` and async `AsyncWebhooksAPI`)
+that targeted per-webhook sub-routes no server handler dispatches. The
+webhook handler only routes `/api/v1/webhooks/{id}` and
+`/api/v1/webhooks/{id}/test` below a webhook id, so every one of these calls
+returned 404 and no working integration depended on them.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `webhooks.list_deliveries(webhook_id, status, limit, offset)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.get_delivery_stats(webhook_id)` for per-webhook counts; `webhooks.list_dead_letter()` for failed deliveries |
+| `webhooks.get_delivery(webhook_id, delivery_id)` | `GET /api/v1/webhooks/{id}/deliveries/{delivery_id}` | `webhooks.get_dead_letter(dead_letter_id)` for a failed delivery; successful deliveries are not exposed individually |
+| `webhooks.retry_delivery(webhook_id, delivery_id)` | `POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry` | `webhooks.retry_dead_letter(dead_letter_id)` |
+| `webhooks.subscribe_events(webhook_id, events)` | `POST /api/v1/webhooks/{id}/events` | `webhooks.update(webhook_id, events=[...])` with the full event list |
+| `webhooks.unsubscribe_events(webhook_id, events)` | `DELETE /api/v1/webhooks/{id}/events` | `webhooks.update(webhook_id, events=[...])` with the remaining events |
+| `webhooks.get_retry_policy(webhook_id)` | `GET /api/v1/webhooks/{id}/retry-policy` | No replacement; the retry policy is server-configured, not per webhook |
+| `webhooks.update_retry_policy(webhook_id, **policy)` | `PUT /api/v1/webhooks/{id}/retry-policy` | No replacement; the retry policy is server-configured, not per webhook |
+| `webhooks.rotate_secret(webhook_id)` | `POST /api/v1/webhooks/{id}/rotate-secret` | `webhooks.delete(webhook_id)` then `webhooks.create(...)`; the secret is returned once on creation |
+| `webhooks.get_signing_info(webhook_id)` | `GET /api/v1/webhooks/{id}/signing` | Deliveries are signed with HMAC-SHA256 as `sha256=<hex>`; see `docs/api/WEBHOOKS.md` |
 
 ---
 
@@ -133,7 +151,7 @@ No breaking changes currently scheduled.
 
 ## Migration Guides
 
-- [API v1 to v2 Migration](../../docs/MIGRATION_V1_TO_V2.md) - Complete guide for API migration
+- [API v1 to v2 Migration](../../docs/api/V1_TO_V2_MIGRATION.md) - Complete guide for API migration
 - [SDK Guide](../../docs/SDK_GUIDE.md) - Full SDK documentation
 
 ---

--- a/sdk/python/aragora_sdk/namespaces/webhooks.py
+++ b/sdk/python/aragora_sdk/namespaces/webhooks.py
@@ -165,65 +165,12 @@ class WebhooksAPI:
     # Delivery Management
     # =========================================================================
 
-    def list_deliveries(
-        self, webhook_id: str, status: str | None = None, limit: int = 20, offset: int = 0
-    ) -> dict[str, Any]:
-        """List webhook deliveries."""
-        params: dict[str, Any] = {"limit": limit, "offset": offset}
-        if status:
-            params["status"] = status
-        return self._client.request(
-            "GET", f"/api/v1/webhooks/{webhook_id}/deliveries", params=params
-        )
-
-    def get_delivery(self, webhook_id: str, delivery_id: str) -> dict[str, Any]:
-        """Get delivery details."""
-        return self._client.request(
-            "GET", f"/api/v1/webhooks/{webhook_id}/deliveries/{delivery_id}"
-        )
-
-    def retry_delivery(self, webhook_id: str, delivery_id: str) -> dict[str, Any]:
-        """Retry a failed delivery."""
-        return self._client.request(
-            "POST", f"/api/v1/webhooks/{webhook_id}/deliveries/{delivery_id}/retry"
-        )
-
     def get_delivery_stats(self, webhook_id: str, days: int | None = None) -> dict[str, Any]:
         """Get delivery stats for a webhook."""
         params: dict[str, Any] = {}
         if days is not None:
             params["days"] = days
         return self._client.request("GET", f"/api/v1/webhooks/{webhook_id}/stats", params=params)
-
-    def subscribe_events(self, webhook_id: str, events: _List[str]) -> dict[str, Any]:
-        """Subscribe to events for a webhook."""
-        return self._client.request(
-            "POST", f"/api/v1/webhooks/{webhook_id}/events", json={"events": events}
-        )
-
-    def unsubscribe_events(self, webhook_id: str, events: _List[str]) -> dict[str, Any]:
-        """Unsubscribe from events for a webhook."""
-        return self._client.request(
-            "DELETE", f"/api/v1/webhooks/{webhook_id}/events", json={"events": events}
-        )
-
-    def get_retry_policy(self, webhook_id: str) -> dict[str, Any]:
-        """Get webhook retry policy."""
-        return self._client.request("GET", f"/api/v1/webhooks/{webhook_id}/retry-policy")
-
-    def update_retry_policy(self, webhook_id: str, **policy: Any) -> dict[str, Any]:
-        """Update webhook retry policy."""
-        return self._client.request(
-            "PUT", f"/api/v1/webhooks/{webhook_id}/retry-policy", json=policy
-        )
-
-    def rotate_secret(self, webhook_id: str) -> dict[str, Any]:
-        """Rotate webhook secret."""
-        return self._client.request("POST", f"/api/v1/webhooks/{webhook_id}/rotate-secret")
-
-    def get_signing_info(self, webhook_id: str) -> dict[str, Any]:
-        """Get signing key info."""
-        return self._client.request("GET", f"/api/v1/webhooks/{webhook_id}/signing")
 
     def list_dead_letter(self, limit: int | None = None) -> dict[str, Any]:
         """List deliveries in the dead-letter queue."""
@@ -350,29 +297,6 @@ class AsyncWebhooksAPI:
     # Delivery Management
     # =========================================================================
 
-    async def list_deliveries(
-        self, webhook_id: str, status: str | None = None, limit: int = 20, offset: int = 0
-    ) -> dict[str, Any]:
-        """List webhook deliveries."""
-        params: dict[str, Any] = {"limit": limit, "offset": offset}
-        if status:
-            params["status"] = status
-        return await self._client.request(
-            "GET", f"/api/v1/webhooks/{webhook_id}/deliveries", params=params
-        )
-
-    async def get_delivery(self, webhook_id: str, delivery_id: str) -> dict[str, Any]:
-        """Get delivery details."""
-        return await self._client.request(
-            "GET", f"/api/v1/webhooks/{webhook_id}/deliveries/{delivery_id}"
-        )
-
-    async def retry_delivery(self, webhook_id: str, delivery_id: str) -> dict[str, Any]:
-        """Retry a failed delivery."""
-        return await self._client.request(
-            "POST", f"/api/v1/webhooks/{webhook_id}/deliveries/{delivery_id}/retry"
-        )
-
     async def get_delivery_stats(self, webhook_id: str, days: int | None = None) -> dict[str, Any]:
         """Get delivery stats for a webhook."""
         params: dict[str, Any] = {}
@@ -381,36 +305,6 @@ class AsyncWebhooksAPI:
         return await self._client.request(
             "GET", f"/api/v1/webhooks/{webhook_id}/stats", params=params
         )
-
-    async def subscribe_events(self, webhook_id: str, events: _List[str]) -> dict[str, Any]:
-        """Subscribe to events for a webhook."""
-        return await self._client.request(
-            "POST", f"/api/v1/webhooks/{webhook_id}/events", json={"events": events}
-        )
-
-    async def unsubscribe_events(self, webhook_id: str, events: _List[str]) -> dict[str, Any]:
-        """Unsubscribe from events for a webhook."""
-        return await self._client.request(
-            "DELETE", f"/api/v1/webhooks/{webhook_id}/events", json={"events": events}
-        )
-
-    async def get_retry_policy(self, webhook_id: str) -> dict[str, Any]:
-        """Get webhook retry policy."""
-        return await self._client.request("GET", f"/api/v1/webhooks/{webhook_id}/retry-policy")
-
-    async def update_retry_policy(self, webhook_id: str, **policy: Any) -> dict[str, Any]:
-        """Update webhook retry policy."""
-        return await self._client.request(
-            "PUT", f"/api/v1/webhooks/{webhook_id}/retry-policy", json=policy
-        )
-
-    async def rotate_secret(self, webhook_id: str) -> dict[str, Any]:
-        """Rotate webhook secret."""
-        return await self._client.request("POST", f"/api/v1/webhooks/{webhook_id}/rotate-secret")
-
-    async def get_signing_info(self, webhook_id: str) -> dict[str, Any]:
-        """Get signing key info."""
-        return await self._client.request("GET", f"/api/v1/webhooks/{webhook_id}/signing")
 
     async def list_dead_letter(self, limit: int | None = None) -> dict[str, Any]:
         """List deliveries in the dead-letter queue."""

--- a/sdk/python/aragora_sdk/namespaces/webhooks.py
+++ b/sdk/python/aragora_sdk/namespaces/webhooks.py
@@ -165,13 +165,6 @@ class WebhooksAPI:
     # Delivery Management
     # =========================================================================
 
-    def get_delivery_stats(self, webhook_id: str, days: int | None = None) -> dict[str, Any]:
-        """Get delivery stats for a webhook."""
-        params: dict[str, Any] = {}
-        if days is not None:
-            params["days"] = days
-        return self._client.request("GET", f"/api/v1/webhooks/{webhook_id}/stats", params=params)
-
     def list_dead_letter(self, limit: int | None = None) -> dict[str, Any]:
         """List deliveries in the dead-letter queue."""
         params: dict[str, Any] = {}
@@ -296,15 +289,6 @@ class AsyncWebhooksAPI:
     # =========================================================================
     # Delivery Management
     # =========================================================================
-
-    async def get_delivery_stats(self, webhook_id: str, days: int | None = None) -> dict[str, Any]:
-        """Get delivery stats for a webhook."""
-        params: dict[str, Any] = {}
-        if days is not None:
-            params["days"] = days
-        return await self._client.request(
-            "GET", f"/api/v1/webhooks/{webhook_id}/stats", params=params
-        )
 
     async def list_dead_letter(self, limit: int | None = None) -> dict[str, Any]:
         """List deliveries in the dead-letter queue."""

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -41,7 +41,7 @@ on them. The interfaces used only by those methods (`WebhookDeliveryAttempt`,
 
 | Removed Method | Route | Migration |
 |----------------|-------|-----------|
-| `webhooks.listDeliveries(webhookId, options)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.getDeliveryStats(webhookId)` for per-webhook counts; `webhooks.listDeadLetter()` for failed deliveries |
+| `webhooks.listDeliveries(webhookId, options)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.listDeadLetter()` for failed deliveries; successful deliveries are not listed |
 | `webhooks.getDelivery(webhookId, deliveryId)` | `GET /api/v1/webhooks/{id}/deliveries/{deliveryId}` | `webhooks.getDeadLetter(id)` for a failed delivery; successful deliveries are not exposed individually |
 | `webhooks.retryDelivery(webhookId, deliveryId)` | `POST /api/v1/webhooks/{id}/deliveries/{deliveryId}/retry` | `webhooks.retryDeadLetter(id)` |
 | `webhooks.subscribeEvents(webhookId, events)` | `POST /api/v1/webhooks/{id}/events` | `webhooks.update(webhookId, { events })` with the full event list |

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -21,7 +21,7 @@ methods (`DebateHealthDetail`, `BatchResults`, `ArgumentQualityAnalysis`,
 |----------------|-------|-----------|
 | `debates.restore(debateId)` | `POST /api/v1/debates/{id}/restore` | `debates.update(debateId, { status: 'active' })` |
 | `debates.makePermanent(debateId)` | `POST /api/v1/debates/{id}/make-permanent` | None needed; completed debates persist automatically |
-| `debates.findSimilar(debateId, limit)` | `GET /api/v1/debates/{id}/similar` | `debates.search(query)` or `debates.compare(debateIds)` |
+| `debates.findSimilar(debateId, limit)` | `GET /api/v1/debates/{id}/similar` | `consensus.findSimilar({ topic, limit })` (`GET /api/v1/consensus/similar`) with the debate task text as `topic` |
 | `debates.analyzeArgumentQuality(debateId)` | `GET /api/v1/debates/{id}/quality` | `debates.getSummary(debateId)` |
 | `debates.getNotes(debateId)` | `GET /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
 | `debates.addNote(debateId, note)` | `POST /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
@@ -31,6 +31,25 @@ methods (`DebateHealthDetail`, `BatchResults`, `ArgumentQualityAnalysis`,
 | `debates.retryBatch(batchId, options)` | `POST /api/v1/debates/batch/{id}/retry` | Re-submit failed debates with `debates.submitBatch(...)` |
 | `debates.getDebateAgentStatistics(debateId)` | `GET /api/v1/debates/{id}/agent-statistics` | `debates.getStatsAgents()` (aggregate per-agent statistics) |
 | `debates.getHealth(debateId)` | `GET /api/v1/debates/{id}/health` | `debates.listHealth()` for system-wide debate health |
+
+Removed 9 `webhooks` methods from `WebhooksAPI` that targeted per-webhook
+sub-routes no server handler dispatches. The webhook handler only routes
+`/api/v1/webhooks/{id}` and `/api/v1/webhooks/{id}/test` below a webhook id,
+so every one of these calls returned 404 and no working integration depended
+on them. The interfaces used only by those methods (`WebhookDeliveryAttempt`,
+`WebhookRetryPolicy`) were removed with them.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `webhooks.listDeliveries(webhookId, options)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.getDeliveryStats(webhookId)` for per-webhook counts; `webhooks.listDeadLetter()` for failed deliveries |
+| `webhooks.getDelivery(webhookId, deliveryId)` | `GET /api/v1/webhooks/{id}/deliveries/{deliveryId}` | `webhooks.getDeadLetter(id)` for a failed delivery; successful deliveries are not exposed individually |
+| `webhooks.retryDelivery(webhookId, deliveryId)` | `POST /api/v1/webhooks/{id}/deliveries/{deliveryId}/retry` | `webhooks.retryDeadLetter(id)` |
+| `webhooks.subscribeEvents(webhookId, events)` | `POST /api/v1/webhooks/{id}/events` | `webhooks.update(webhookId, { events })` with the full event list |
+| `webhooks.unsubscribeEvents(webhookId, events)` | `DELETE /api/v1/webhooks/{id}/events` | `webhooks.update(webhookId, { events })` with the remaining events |
+| `webhooks.getRetryPolicy(webhookId)` | `GET /api/v1/webhooks/{id}/retry-policy` | No replacement; the retry policy is server-configured, not per webhook |
+| `webhooks.updateRetryPolicy(webhookId, policy)` | `PUT /api/v1/webhooks/{id}/retry-policy` | No replacement; the retry policy is server-configured, not per webhook |
+| `webhooks.rotateSecret(webhookId)` | `POST /api/v1/webhooks/{id}/rotate-secret` | `webhooks.delete(webhookId)` then `webhooks.create(...)`; the secret is returned once on creation |
+| `webhooks.getSigningInfo(webhookId)` | `GET /api/v1/webhooks/{id}/signing` | Deliveries are signed with HMAC-SHA256 as `sha256=<hex>`; see `docs/api/WEBHOOKS.md` |
 
 ---
 

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -21,7 +21,7 @@ methods (`DebateHealthDetail`, `BatchResults`, `ArgumentQualityAnalysis`,
 |----------------|-------|-----------|
 | `debates.restore(debateId)` | `POST /api/v1/debates/{id}/restore` | `debates.update(debateId, { status: 'active' })` |
 | `debates.makePermanent(debateId)` | `POST /api/v1/debates/{id}/make-permanent` | None needed; completed debates persist automatically |
-| `debates.findSimilar(debateId, limit)` | `GET /api/v1/debates/{id}/similar` | `consensus.findSimilar({ topic, limit })` (`GET /api/v1/consensus/similar`) with the debate task text as `topic` |
+| `debates.findSimilar(debateId, limit)` | `GET /api/v1/debates/{id}/similar` | `consensus.findSimilar({ topic, limit })` (`GET /api/consensus/similar`) with the debate task text as `topic` |
 | `debates.analyzeArgumentQuality(debateId)` | `GET /api/v1/debates/{id}/quality` | `debates.getSummary(debateId)` |
 | `debates.getNotes(debateId)` | `GET /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
 | `debates.addNote(debateId, note)` | `POST /api/v1/debates/{id}/notes` | No replacement (server has no notes feature) |
@@ -32,7 +32,7 @@ methods (`DebateHealthDetail`, `BatchResults`, `ArgumentQualityAnalysis`,
 | `debates.getDebateAgentStatistics(debateId)` | `GET /api/v1/debates/{id}/agent-statistics` | `debates.getStatsAgents()` (aggregate per-agent statistics) |
 | `debates.getHealth(debateId)` | `GET /api/v1/debates/{id}/health` | `debates.listHealth()` for system-wide debate health |
 
-Removed 9 `webhooks` methods from `WebhooksAPI` that targeted per-webhook
+Removed 10 `webhooks` methods from `WebhooksAPI` that targeted per-webhook
 sub-routes no server handler dispatches. The webhook handler only routes
 `/api/v1/webhooks/{id}` and `/api/v1/webhooks/{id}/test` below a webhook id,
 so every one of these calls returned 404 and no working integration depended
@@ -44,6 +44,7 @@ on them. The interfaces used only by those methods (`WebhookDeliveryAttempt`,
 | `webhooks.listDeliveries(webhookId, options)` | `GET /api/v1/webhooks/{id}/deliveries` | `webhooks.listDeadLetter()` for failed deliveries; successful deliveries are not listed |
 | `webhooks.getDelivery(webhookId, deliveryId)` | `GET /api/v1/webhooks/{id}/deliveries/{deliveryId}` | `webhooks.getDeadLetter(id)` for a failed delivery; successful deliveries are not exposed individually |
 | `webhooks.retryDelivery(webhookId, deliveryId)` | `POST /api/v1/webhooks/{id}/deliveries/{deliveryId}/retry` | `webhooks.retryDeadLetter(id)` |
+| `webhooks.getDeliveryStats(webhookId, options)` | `GET /api/v1/webhooks/{id}/stats` | No replacement; per-webhook delivery statistics are not served (`webhooks.getQueueStats()` reports the shared delivery queue, not a single webhook) |
 | `webhooks.subscribeEvents(webhookId, events)` | `POST /api/v1/webhooks/{id}/events` | `webhooks.update(webhookId, { events })` with the full event list |
 | `webhooks.unsubscribeEvents(webhookId, events)` | `DELETE /api/v1/webhooks/{id}/events` | `webhooks.update(webhookId, { events })` with the remaining events |
 | `webhooks.getRetryPolicy(webhookId)` | `GET /api/v1/webhooks/{id}/retry-policy` | No replacement; the retry policy is server-configured, not per webhook |

--- a/sdk/typescript/src/namespaces/webhooks.ts
+++ b/sdk/typescript/src/namespaces/webhooks.ts
@@ -83,27 +83,6 @@ export interface UpdateWebhookRequest {
 }
 
 /**
- * Webhook delivery attempt
- */
-export interface WebhookDeliveryAttempt {
-  attempt_number: number;
-  timestamp: string;
-  response_code?: number;
-  response_time_ms: number;
-  error?: string;
-}
-
-/**
- * Webhook retry policy
- */
-export interface WebhookRetryPolicy {
-  max_retries: number;
-  initial_delay_ms: number;
-  max_delay_ms: number;
-  backoff_multiplier: number;
-}
-
-/**
  * Interface for the internal client used by WebhooksAPI.
  */
 interface WebhooksClientInterface {
@@ -243,49 +222,10 @@ export class WebhooksAPI {
   // ===========================================================================
 
   /**
-   * List webhook deliveries.
-   */
-  async listDeliveries(webhookId: string, options?: { status?: string; limit?: number; offset?: number }): Promise<{ deliveries: WebhookDelivery[]; total: number }> {
-    return this.client.request('GET', `/api/v1/webhooks/${webhookId}/deliveries`, { params: options });
-  }
-
-  /**
-   * Get delivery details.
-   */
-  async getDelivery(webhookId: string, deliveryId: string): Promise<WebhookDelivery & { attempts: WebhookDeliveryAttempt[] }> {
-    return this.client.request('GET', `/api/v1/webhooks/${webhookId}/deliveries/${deliveryId}`);
-  }
-
-  /**
-   * Retry a failed delivery.
-   */
-  async retryDelivery(webhookId: string, deliveryId: string): Promise<{ retried: boolean; new_delivery_id: string }> {
-    return this.client.request('POST', `/api/v1/webhooks/${webhookId}/deliveries/${deliveryId}/retry`);
-  }
-
-  /**
    * Get delivery stats for a webhook.
    */
   async getDeliveryStats(webhookId: string, options?: { days?: number }): Promise<{ success_rate: number; avg_latency_ms: number; total_deliveries: number; failed_deliveries: number }> {
     return this.client.request('GET', `/api/v1/webhooks/${webhookId}/stats`, { params: options });
-  }
-
-  // ===========================================================================
-  // Retry Policy
-  // ===========================================================================
-
-  /**
-   * Get webhook retry policy.
-   */
-  async getRetryPolicy(webhookId: string): Promise<WebhookRetryPolicy> {
-    return this.client.request('GET', `/api/v1/webhooks/${webhookId}/retry-policy`);
-  }
-
-  /**
-   * Update webhook retry policy.
-   */
-  async updateRetryPolicy(webhookId: string, policy: Partial<WebhookRetryPolicy>): Promise<WebhookRetryPolicy> {
-    return this.client.request('PUT', `/api/v1/webhooks/${webhookId}/retry-policy`, { json: policy });
   }
 
   // ===========================================================================
@@ -297,38 +237,6 @@ export class WebhooksAPI {
    */
   async getEventCategories(): Promise<{ categories: { name: string; description: string; events: string[] }[] }> {
     return this.client.request('GET', '/api/v1/webhooks/events/categories');
-  }
-
-  /**
-   * Subscribe to events for a webhook.
-   */
-  async subscribeEvents(webhookId: string, events: string[]): Promise<{ subscribed: string[] }> {
-    return this.client.request('POST', `/api/v1/webhooks/${webhookId}/events`, { json: { events } });
-  }
-
-  /**
-   * Unsubscribe from events for a webhook.
-   */
-  async unsubscribeEvents(webhookId: string, events: string[]): Promise<{ unsubscribed: string[] }> {
-    return this.client.request('DELETE', `/api/v1/webhooks/${webhookId}/events`, { json: { events } });
-  }
-
-  // ===========================================================================
-  // Signing and Verification
-  // ===========================================================================
-
-  /**
-   * Rotate webhook secret.
-   */
-  async rotateSecret(webhookId: string): Promise<{ new_secret: string; old_secret_valid_until: string }> {
-    return this.client.request('POST', `/api/v1/webhooks/${webhookId}/rotate-secret`);
-  }
-
-  /**
-   * Get signing key info.
-   */
-  async getSigningInfo(webhookId: string): Promise<{ algorithm: string; header_name: string; format: string }> {
-    return this.client.request('GET', `/api/v1/webhooks/${webhookId}/signing`);
   }
 
   // ===========================================================================

--- a/sdk/typescript/src/namespaces/webhooks.ts
+++ b/sdk/typescript/src/namespaces/webhooks.ts
@@ -218,17 +218,6 @@ export class WebhooksAPI {
   }
 
   // ===========================================================================
-  // Delivery Management
-  // ===========================================================================
-
-  /**
-   * Get delivery stats for a webhook.
-   */
-  async getDeliveryStats(webhookId: string, options?: { days?: number }): Promise<{ success_rate: number; avg_latency_ms: number; total_deliveries: number; failed_deliveries: number }> {
-    return this.client.request('GET', `/api/v1/webhooks/${webhookId}/stats`, { params: options });
-  }
-
-  // ===========================================================================
   // Event Filtering
   // ===========================================================================
 


### PR DESCRIPTION
## Summary

SDK drift paydown batch 02 of 6 (tranche 1; operator Decision "SDK PAYDOWN TRANCHE 1", `library/decision-ledger.md` L999 == `library/operator-approvals.md` L852, plus "SDK PAYDOWN TRANCHE 1 - AMENDMENT 1", `library/decision-ledger.md` L1002 == `library/operator-approvals.md` L858). Follows PR #9967 (batch 01).

Deletes the matched Python + TypeScript `webhooks` methods whose `VERB /path` is absent from both `docs/api/openapi.json` and `docs/api/openapi_generated.json` AND from every handler under `aragora/server` (`aragora/server/handlers/webhook_management.py` only dispatches `/api/v1/webhooks/{id}` and `/api/v1/webhooks/{id}/test` below a webhook id; the only served `stats` literal is `/api/v1/webhooks/queue/stats`). Each removed pair is re-verified individually; no spec entries added, no baselines edited.

### Removed (10 matched pairs, both SDKs, sync + async on the Python side)

| Route | Python (`WebhooksAPI` / `AsyncWebhooksAPI`) | TypeScript (`WebhooksAPI`) |
|---|---|---|
| `GET /api/v1/webhooks/{id}/deliveries` | `list_deliveries` | `listDeliveries` |
| `GET /api/v1/webhooks/{id}/deliveries/{delivery_id}` | `get_delivery` | `getDelivery` |
| `POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry` | `retry_delivery` | `retryDelivery` |
| `GET /api/v1/webhooks/{id}/stats` | `get_delivery_stats` | `getDeliveryStats` |
| `POST /api/v1/webhooks/{id}/events` | `subscribe_events` | `subscribeEvents` |
| `DELETE /api/v1/webhooks/{id}/events` | `unsubscribe_events` | `unsubscribeEvents` |
| `GET /api/v1/webhooks/{id}/retry-policy` | `get_retry_policy` | `getRetryPolicy` |
| `PUT /api/v1/webhooks/{id}/retry-policy` | `update_retry_policy` | `updateRetryPolicy` |
| `POST /api/v1/webhooks/{id}/rotate-secret` | `rotate_secret` | `rotateSecret` |
| `GET /api/v1/webhooks/{id}/signing` | `get_signing_info` | `getSigningInfo` |

Also removed: the TS interfaces `WebhookDeliveryAttempt` and `WebhookRetryPolicy` (used only by the deleted methods; neither was re-exported from `namespaces/index.ts`). `getDeliveryStats` used an inline return type, so nothing else is orphaned. No SDK test referenced any removed method (`sdk/python/tests/test_webhooks.py` uses only `create`/`get_events`/`list`; no TS test file covers `webhooks`), so no test deletions.

### Docs

- `sdk/python/BREAKING_CHANGES.md` and `sdk/typescript/BREAKING_CHANGES.md`: 10 new rows with migrations under "Unreleased (2026-09-03)". The `{id}/stats` row has no replacement: `GET /api/v1/webhooks/queue/stats` (`get_queue_stats` / `getQueueStats`) reports the shared delivery queue, not a single webhook.
- Batch-01 review follow-ups: the `find_similar` / `findSimilar` migration rows now point at `consensus.get_similar_debates(topic, limit)` / `consensus.findSimilar({ topic, limit })` instead of `debates.search(query)`; the TS row is annotated with the path `consensus.ts` actually requests (`GET /api/consensus/similar`), the Python row with `GET /api/v1/consensus/similar`; the Python file's migration-guide link now targets the real `docs/api/V1_TO_V2_MIGRATION.md` (same relative form the TS file uses).

### Skipped (served-but-undocumented, per the Decision; noted in the mission tech-debt ledger)

- `GET /api/v1/webhooks/events/categories` (`webhook_management.py` ROUTES) - kept `get_event_categories` / `getEventCategories`.
- `modes: GET /api/modes/{id}` and `spectate: GET /api/spectate/{id}/stream` (advisory list) are NOT in this PR: open draft PR #9112 (`codex/9086-sdk-parity-option-a-repair-20260710`, head `cac520938ef8`) already deletes exactly those methods and their tests, and their tests live outside `sdk/` (`tests/sdk/`, `aragora/live/tests/sdk/`), which this tranche's `sdk/`-only scope cannot touch.

## Measurements

`python3 scripts/verify_sdk_contracts.py --strict --baseline scripts/baselines/verify_sdk_contracts.json`

| | origin/main `0be6be4330` (PR base) | `ea98e273a2` | this head `aa1ab8c53d` |
|---|---|---|---|
| Python SDK drift (endpoints not in spec) | 452 | 443 | **442** |
| TypeScript SDK drift (endpoints not in spec) | 308 | 299 | **298** |
| Baseline regressions | py=0 ts=0 stable=0 | py=0 ts=0 stable=0 | py=0 ts=0 stable=0 |

- `git diff --numstat 0be6be4330...HEAD`: +42 / -228 = **270 LOC** across 4 files, all under `sdk/`.
- `scripts/baselines/` byte-identical to origin/main (all 18 files).

## Local gates (all on the committed head `aa1ab8c53d`)

- `python3 scripts/check_sdk_parity.py --strict --baseline … --budget …` PASS (stale_python 31/36, missing_from_both 0)
- `python3 scripts/check_sdk_namespace_parity.py --strict --baseline …` Regressions: 0
- `python3 scripts/check_cross_sdk_parity.py --strict --baseline …` PASS (python_only=0 typescript_only=0)
- `python3 scripts/verify_sdk_contracts.py --strict --baseline …` PASS (442 / 298, regressions 0)
- `sdk/python`: `ruff check` + `ruff format --check` clean; `python3 -m pytest tests` → `1395 passed in 9.49s`
- `sdk/typescript`: `npm ci` (184 packages) + `npx tsc --noEmit` exit 0; `npm test` → `Tests 1 failed | 1720 passed (1721)` (the pre-existing `parity-compat-routes.test.ts › maps debate stats compatibility routes` failure present on origin/main, see `library/environment.md` 2026-09-03 R2 note)
- `make lint`, `ruff format --check aragora/ tests/ scripts/` (10880 files), `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh cache): clean
- AWS-neutralized `make test-smoke`: "Smoke tests passed!"
- `python3 scripts/ci/check_docs_links.py`: OK
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok

## Review history

- **Round 1 (head `3a4b5c9a15`)**: claude P2 (counted): the `list_deliveries` / `listDeliveries` migration rows pointed at `get_delivery_stats` / `getDeliveryStats`, whose `GET /api/v1/webhooks/{id}/stats` route the handler does not dispatch. Fixed in `ea98e273a2` (2-line doc change; both rows point only at `list_dead_letter` / `listDeadLetter`).
- **Round 2 (head `ea98e273a2`)**: claude PASS; openai P2 (counted): the new BREAKING_CHANGES prose says only `/{id}` and `/{id}/test` are dispatched below a webhook id, yet both SDKs still exposed `get_delivery_stats` / `getDeliveryStats` against `{id}/stats`. That pair had been kept only because the batch assignment listed the route as served-but-undocumented; the PR was parked for a ruling.
- **Amendment 1 (`library/decision-ledger.md` L1002)**: confirms `GET /api/v1/webhooks/{id}/stats` is phantom and authorizes exactly one resolving head plus one fresh two-family round. `aa1ab8c53d` is that head: it deletes the pair (sync + async Python, TS, no orphaned types), adds the tenth BREAKING_CHANGES row per SDK, and folds in the round-2 claude P3 doc nit on the `consensus.findSimilar` path annotation.

## Settlement

Tier 3 (`sdk/` prefix). Settles in-session under the recorded tranche Decision + Amendment 1: record-settlement while draft -> prepared reviewer bodies posted byte-exact -> ready -> model quorum -> merge-packet satisfied -> non-admin `--match-head-commit` squash merge.
