### PR TITLE
feat(ci): add --list-cycles to measure_import_graph.py

### DIFF
--- a/scripts/ci/measure_import_graph.py
+++ b/scripts/ci/measure_import_graph.py
@@ -37,6 +37,7 @@ Usage
     python3 scripts/ci/measure_import_graph.py            # JSON: the 3 metrics
     python3 scripts/ci/measure_import_graph.py --json     # (same; explicit)
     python3 scripts/ci/measure_import_graph.py --check    # cycles ratchet
+    python3 scripts/ci/measure_import_graph.py --list-cycles  # JSON: the mutual pairs
     python3 scripts/ci/measure_import_graph.py --freeze --adopt   # write baseline
     python3 scripts/ci/measure_import_graph.py --freeze   # shrink-only re-freeze
 
@@ -105,15 +106,21 @@ def build_aragora_graph(exclude_type_checking: bool = True):
 # --- Pure metric functions --------------------------------------------------
 
 
-def count_mutual_cycles(graph) -> int:
-    """Unordered pairs of modules that directly import each other."""
+def list_mutual_cycles(graph) -> list[list[str]]:
+    """Sorted unordered pairs ``[a, b]`` (``a < b``) of modules that directly
+    import each other."""
     edges: set[tuple[str, str]] = set()
     for module in graph.modules:
         for imported in graph.find_modules_directly_imported_by(module):
             if module != imported:
                 edges.add((module, imported))
     pairs = {tuple(sorted((a, b))) for (a, b) in edges if (b, a) in edges}
-    return len(pairs)
+    return [list(pair) for pair in sorted(pairs)]
+
+
+def count_mutual_cycles(graph) -> int:
+    """Unordered pairs of modules that directly import each other."""
+    return len(list_mutual_cycles(graph))
 
 
 def count_server_imported_by(graph, server_package: str = SERVER_PACKAGE) -> int:
@@ -210,6 +217,7 @@ def _git_head() -> str:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
+        usage="%(prog)s [options]",
         description=(
             "Measure the aragora import graph (mutual cycles, server imported-by, "
             "handlers flat-root) with TYPE_CHECKING imports excluded, and ratchet "
@@ -251,7 +259,21 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit a machine-readable JSON summary (the default output is already JSON).",
     )
+    parser.add_argument(
+        "--list-cycles",
+        action="store_true",
+        help=(
+            "Print the mutual import cycles themselves as JSON "
+            "({'cycles': [[a, b], ...]}, sorted pairs) instead of the counts."
+        ),
+    )
     return parser
+
+
+def _run_list_cycles() -> int:
+    cycles = list_mutual_cycles(build_aragora_graph())
+    print(json.dumps({"cycles": cycles, "exclude_type_checking_imports": True}, indent=2))
+    return 0
 
 
 def _run_check(args: argparse.Namespace) -> int:
@@ -303,6 +325,8 @@ def main(argv: list[str] | None = None) -> int:
             return _run_freeze(args)
         if args.check:
             return _run_check(args)
+        if args.list_cycles:
+            return _run_list_cycles()
         print(json.dumps(measure_all(), indent=2))
     except MeasureError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/tests/ci/test_measure_import_graph.py
+++ b/tests/ci/test_measure_import_graph.py
@@ -124,6 +124,45 @@ def test_freeze_adopt_writes_current_value(tmp_path, monkeypatch):
     assert written["exclude_type_checking_imports"] is True
 
 
+def test_list_cycles_returns_sorted_pairs():
+    pairs = mig.list_mutual_cycles(_synthetic_graph())
+    assert pairs == [["aragora.a", "aragora.b"]]
+    assert len(pairs) == mig.count_mutual_cycles(_synthetic_graph())
+
+
+def test_list_cycles_pairs_are_ordered_and_unique():
+    graph = grimp.ImportGraph()
+    for module in ("aragora", "aragora.z", "aragora.y", "aragora.m", "aragora.n"):
+        graph.add_module(module)
+    graph.add_import(importer="aragora.z", imported="aragora.y")
+    graph.add_import(importer="aragora.y", imported="aragora.z")
+    graph.add_import(importer="aragora.n", imported="aragora.m")
+    graph.add_import(importer="aragora.m", imported="aragora.n")
+    graph.add_import(importer="aragora.z", imported="aragora.m")  # one-way: not a cycle
+    pairs = mig.list_mutual_cycles(graph)
+    assert pairs == [["aragora.m", "aragora.n"], ["aragora.y", "aragora.z"]]
+    assert all(a < b for a, b in pairs)
+    assert pairs == sorted(pairs)
+
+
+def test_list_cycles_cli_prints_json_matching_count(monkeypatch, capsys):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    assert mig.main(["--list-cycles"]) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["cycles"] == [["aragora.a", "aragora.b"]]
+    assert out["exclude_type_checking_imports"] is True
+    assert len(out["cycles"]) == mig.count_mutual_cycles(_synthetic_graph())
+
+
+def test_list_cycles_flag_is_documented_alongside_existing_flags(capsys):
+    with pytest.raises(SystemExit) as exc:
+        mig.main(["--help"])
+    assert exc.value.code == 0
+    text = capsys.readouterr().out
+    for flag in ("--list-cycles", "--check", "--freeze", "--adopt", "--baseline", "--json"):
+        assert flag in text
+
+
 def test_default_output_has_three_integer_metrics(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
     monkeypatch.setattr(mig, "count_handlers_flat_root", lambda *a, **k: 187)


### PR DESCRIPTION
## Summary

Adds `--list-cycles` to `scripts/ci/measure_import_graph.py`. It prints the mutual import pairs themselves as JSON (`{"cycles": [[a, b], ...], "exclude_type_checking_imports": true}`, each pair sorted with `a < b`, list sorted) so the M0 cycle-repair PRs can be diffed against `origin/main` (removed>0, added=0) rather than only counted. `count_mutual_cycles` now delegates to the new `list_mutual_cycles`, so the two can never disagree. `--check`, `--freeze`, `--adopt`, `--baseline`, `--json` are untouched.

Receipt-First mission M0 (`m0-import-cycle-repair`, epic #9966); first of the cycle-repair PRs for #9240.

## Exit metric moved

None (guardrail tooling). Enables the import-cycle guardrail (144 on main, ceiling 140) to be repaired and verified pair by pair.

## Test commands

- `timeout 300 python3 -m pytest tests/ci/test_measure_import_graph.py -q -p no:cacheprovider` → red first (4 failed, 11 passed), then 15 passed
- `python3 scripts/ci/measure_import_graph.py --list-cycles | python3 -c "..."` → `144 True`, equal to `--json` `.mutual_import_cycles` (144) on the same tree
- `bash $MISSION_DIR/bin/gate.sh lint|typecheck|contracts|guardrails|test` → all `GATE PASSED` (test: 3854 passed, 3 skipped)

## Reviewed design tradeoffs

- Emit pairs from the same edge set that `count_mutual_cycles` uses (one function, one source of truth) rather than a second traversal.
- Plain JSON with sorted, deterministic ordering so validators can `diff` two trees byte-wise.
- Argparse `usage="%(prog)s [options]"` keeps each flag mentioned exactly once in `--help`, which the mission validators grep with `grep -c`.

## Risks

Low: additive flag; no behaviour change to existing modes; no runtime code touched.
