### PR TITLE
refactor(gauntlet): break the odr_export<->odr_signing import cycle [Tier 2]

### DIFF
--- a/aragora/gauntlet/odr_export.py
+++ b/aragora/gauntlet/odr_export.py
@@ -14,13 +14,10 @@ Two guarantees drive every line of this module:
    emitted as explicit absent markers (``{"status": "absent", "reason": ...}``)
    rather than fabricated values.
 
-Canonicalization follows RFC 8785 (JSON Canonicalization Scheme, JCS):
-UTF-8 output, no insignificant whitespace, object members sorted by UTF-16
-code units, and numbers serialized using the ECMAScript
-``Number::toString`` shortest-round-trip algorithm. No external dependency is
-required; :func:`jcs_canonicalize` implements the subset of JCS needed for
-I-JSON-safe payloads (which all ODR payloads are) and is covered by
-byte-stability tests against the RFC 8785 examples.
+Canonicalization follows RFC 8785 (JSON Canonicalization Scheme, JCS) and is
+implemented in the dependency-free leaf :mod:`aragora.gauntlet.odr_jcs`;
+:func:`jcs_canonicalize` and :func:`odr_content_digest` are re-exported here
+so this module remains the reference emitter surface.
 
 The profile is designed to ride standard envelopes (SCITT / COSE detached
 signatures) rather than inventing one: ``signatures[]`` is emitted empty and
@@ -29,12 +26,12 @@ reserved for the Ed25519 detached-signature work tracked in issue #8225.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
-import math
 from importlib import resources
 from typing import TYPE_CHECKING, Any, Callable
+
+from aragora.gauntlet.odr_jcs import jcs_canonicalize, odr_content_digest
 
 if TYPE_CHECKING:
     from aragora.gauntlet.receipt_models import DecisionReceipt
@@ -55,134 +52,6 @@ __all__ = [
     "odr_content_digest",
     "sign_odr_if_configured",
 ]
-
-
-# ---------------------------------------------------------------------------
-# RFC 8785 (JCS) canonicalization
-# ---------------------------------------------------------------------------
-
-
-def _es_number_to_string(value: float) -> str:
-    """Serialize a float per ECMAScript ``Number::toString`` (RFC 8785 3.2.2.3).
-
-    Raises:
-        ValueError: for NaN or +/-Infinity, which JCS forbids.
-    """
-    if math.isnan(value) or math.isinf(value):
-        raise ValueError("NaN and Infinity cannot be canonicalized per RFC 8785")
-    if value == 0:
-        # Covers -0.0 as well: JCS serializes negative zero as "0".
-        return "0"
-
-    sign = "-" if value < 0 else ""
-    # Python's repr() yields the shortest digit string that round-trips the
-    # IEEE-754 double, which is the same digit selection ECMAScript uses.
-    # Only the *formatting* rules differ; they are applied below.
-    text = repr(abs(value))
-    if "e" in text or "E" in text:
-        mantissa, _, exp_text = text.lower().partition("e")
-        exponent = int(exp_text)
-    else:
-        mantissa, exponent = text, 0
-
-    if "." in mantissa:
-        int_part, frac_part = mantissa.split(".", 1)
-    else:
-        int_part, frac_part = mantissa, ""
-
-    digits = int_part + frac_part
-    # Position of the decimal point measured in digits from the left of
-    # ``digits``: value == 0.<digits> * 10**point.
-    point = len(int_part) + exponent
-
-    stripped = digits.lstrip("0")
-    point -= len(digits) - len(stripped)
-    digits = stripped.rstrip("0")
-
-    k = len(digits)
-    n = point
-    if k <= n <= 21:
-        out = digits + "0" * (n - k)
-    elif 0 < n <= 21:
-        out = digits[:n] + "." + digits[n:]
-    elif -6 < n <= 0:
-        out = "0." + "0" * (-n) + digits
-    else:
-        e = n - 1
-        head = digits[0] + ("." + digits[1:] if k > 1 else "")
-        out = f"{head}e{'+' if e >= 0 else '-'}{abs(e)}"
-    return sign + out
-
-
-_ES_INT_LIMIT = 10**21  # ECMAScript switches to exponent notation at 1e21.
-
-
-def _jcs_serialize(value: Any, out: list[str]) -> None:
-    """Append the JCS serialization of ``value`` to ``out``."""
-    if value is None:
-        out.append("null")
-    elif value is True:
-        out.append("true")
-    elif value is False:
-        out.append("false")
-    elif isinstance(value, str):
-        # json.dumps applies exactly the JCS string rules: minimal escaping,
-        # two-character escapes for the common controls, lowercase \u00xx for
-        # the rest, and raw UTF-8 for everything else (ensure_ascii=False).
-        out.append(json.dumps(value, ensure_ascii=False))
-    elif isinstance(value, int):
-        if abs(value) < _ES_INT_LIMIT:
-            out.append(str(value))
-        else:
-            out.append(_es_number_to_string(float(value)))
-    elif isinstance(value, float):
-        out.append(_es_number_to_string(value))
-    elif isinstance(value, (list, tuple)):
-        out.append("[")
-        for i, item in enumerate(value):
-            if i:
-                out.append(",")
-            _jcs_serialize(item, out)
-        out.append("]")
-    elif isinstance(value, dict):
-        out.append("{")
-        # RFC 8785 sorts member names by UTF-16 code units; comparing the
-        # UTF-16BE encodings byte-wise is equivalent.
-        keys = sorted(value.keys(), key=lambda k: str(k).encode("utf-16-be"))
-        for i, key in enumerate(keys):
-            if i:
-                out.append(",")
-            if not isinstance(key, str):
-                raise TypeError(f"JCS object member names must be strings, got {type(key)!r}")
-            out.append(json.dumps(key, ensure_ascii=False))
-            out.append(":")
-            _jcs_serialize(value[key], out)
-        out.append("}")
-    else:
-        raise TypeError(f"Type {type(value)!r} is not JCS-serializable")
-
-
-def jcs_canonicalize(value: Any) -> bytes:
-    """Canonicalize ``value`` to RFC 8785 (JCS) UTF-8 bytes.
-
-    The output is byte-stable: equal inputs (regardless of dict insertion
-    order) always produce identical bytes, which is the hashing basis for the
-    ODR profile.
-    """
-    out: list[str] = []
-    _jcs_serialize(value, out)
-    return "".join(out).encode("utf-8")
-
-
-def odr_content_digest(odr: dict[str, Any]) -> str:
-    """SHA-256 hex digest over the JCS bytes of the ODR payload.
-
-    The ``signatures`` array is excluded so that attaching detached
-    signatures (SCITT/COSE, Ed25519 per #8225) never changes the digest the
-    signatures cover.
-    """
-    payload = {k: v for k, v in odr.items() if k != "signatures"}
-    return hashlib.sha256(jcs_canonicalize(payload)).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/aragora/gauntlet/odr_jcs.py
+++ b/aragora/gauntlet/odr_jcs.py
@@ -11,7 +11,7 @@ byte-stability tests against the RFC 8785 examples.
 This is a dependency-free leaf shared by the emitter
 (:mod:`aragora.gauntlet.odr_export`) and the signer
 (:mod:`aragora.gauntlet.odr_signing`); ``aragora_verify.jcs`` mirrors it
-byte-for-byte so producer and verifier always agree on the digest.
+functionally so producer and verifier always agree on the digest.
 """
 
 from __future__ import annotations

--- a/aragora/gauntlet/odr_jcs.py
+++ b/aragora/gauntlet/odr_jcs.py
@@ -1,0 +1,152 @@
+"""RFC 8785 (JCS) canonicalization and the ODR content digest.
+
+Canonicalization follows RFC 8785 (JSON Canonicalization Scheme, JCS):
+UTF-8 output, no insignificant whitespace, object members sorted by UTF-16
+code units, and numbers serialized using the ECMAScript
+``Number::toString`` shortest-round-trip algorithm. No external dependency is
+required; :func:`jcs_canonicalize` implements the subset of JCS needed for
+I-JSON-safe payloads (which all ODR payloads are) and is covered by
+byte-stability tests against the RFC 8785 examples.
+
+This is a dependency-free leaf shared by the emitter
+(:mod:`aragora.gauntlet.odr_export`) and the signer
+(:mod:`aragora.gauntlet.odr_signing`); ``aragora_verify.jcs`` mirrors it
+byte-for-byte so producer and verifier always agree on the digest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+__all__ = ["jcs_canonicalize", "odr_content_digest"]
+
+
+# ---------------------------------------------------------------------------
+# RFC 8785 (JCS) canonicalization
+# ---------------------------------------------------------------------------
+
+
+def _es_number_to_string(value: float) -> str:
+    """Serialize a float per ECMAScript ``Number::toString`` (RFC 8785 3.2.2.3).
+
+    Raises:
+        ValueError: for NaN or +/-Infinity, which JCS forbids.
+    """
+    if math.isnan(value) or math.isinf(value):
+        raise ValueError("NaN and Infinity cannot be canonicalized per RFC 8785")
+    if value == 0:
+        # Covers -0.0 as well: JCS serializes negative zero as "0".
+        return "0"
+
+    sign = "-" if value < 0 else ""
+    # Python's repr() yields the shortest digit string that round-trips the
+    # IEEE-754 double, which is the same digit selection ECMAScript uses.
+    # Only the *formatting* rules differ; they are applied below.
+    text = repr(abs(value))
+    if "e" in text or "E" in text:
+        mantissa, _, exp_text = text.lower().partition("e")
+        exponent = int(exp_text)
+    else:
+        mantissa, exponent = text, 0
+
+    if "." in mantissa:
+        int_part, frac_part = mantissa.split(".", 1)
+    else:
+        int_part, frac_part = mantissa, ""
+
+    digits = int_part + frac_part
+    # Position of the decimal point measured in digits from the left of
+    # ``digits``: value == 0.<digits> * 10**point.
+    point = len(int_part) + exponent
+
+    stripped = digits.lstrip("0")
+    point -= len(digits) - len(stripped)
+    digits = stripped.rstrip("0")
+
+    k = len(digits)
+    n = point
+    if k <= n <= 21:
+        out = digits + "0" * (n - k)
+    elif 0 < n <= 21:
+        out = digits[:n] + "." + digits[n:]
+    elif -6 < n <= 0:
+        out = "0." + "0" * (-n) + digits
+    else:
+        e = n - 1
+        head = digits[0] + ("." + digits[1:] if k > 1 else "")
+        out = f"{head}e{'+' if e >= 0 else '-'}{abs(e)}"
+    return sign + out
+
+
+_ES_INT_LIMIT = 10**21  # ECMAScript switches to exponent notation at 1e21.
+
+
+def _jcs_serialize(value: Any, out: list[str]) -> None:
+    """Append the JCS serialization of ``value`` to ``out``."""
+    if value is None:
+        out.append("null")
+    elif value is True:
+        out.append("true")
+    elif value is False:
+        out.append("false")
+    elif isinstance(value, str):
+        # json.dumps applies exactly the JCS string rules: minimal escaping,
+        # two-character escapes for the common controls, lowercase \u00xx for
+        # the rest, and raw UTF-8 for everything else (ensure_ascii=False).
+        out.append(json.dumps(value, ensure_ascii=False))
+    elif isinstance(value, int):
+        if abs(value) < _ES_INT_LIMIT:
+            out.append(str(value))
+        else:
+            out.append(_es_number_to_string(float(value)))
+    elif isinstance(value, float):
+        out.append(_es_number_to_string(value))
+    elif isinstance(value, (list, tuple)):
+        out.append("[")
+        for i, item in enumerate(value):
+            if i:
+                out.append(",")
+            _jcs_serialize(item, out)
+        out.append("]")
+    elif isinstance(value, dict):
+        out.append("{")
+        # RFC 8785 sorts member names by UTF-16 code units; comparing the
+        # UTF-16BE encodings byte-wise is equivalent.
+        keys = sorted(value.keys(), key=lambda k: str(k).encode("utf-16-be"))
+        for i, key in enumerate(keys):
+            if i:
+                out.append(",")
+            if not isinstance(key, str):
+                raise TypeError(f"JCS object member names must be strings, got {type(key)!r}")
+            out.append(json.dumps(key, ensure_ascii=False))
+            out.append(":")
+            _jcs_serialize(value[key], out)
+        out.append("}")
+    else:
+        raise TypeError(f"Type {type(value)!r} is not JCS-serializable")
+
+
+def jcs_canonicalize(value: Any) -> bytes:
+    """Canonicalize ``value`` to RFC 8785 (JCS) UTF-8 bytes.
+
+    The output is byte-stable: equal inputs (regardless of dict insertion
+    order) always produce identical bytes, which is the hashing basis for the
+    ODR profile.
+    """
+    out: list[str] = []
+    _jcs_serialize(value, out)
+    return "".join(out).encode("utf-8")
+
+
+def odr_content_digest(odr: dict[str, Any]) -> str:
+    """SHA-256 hex digest over the JCS bytes of the ODR payload.
+
+    The ``signatures`` array is excluded so that attaching detached
+    signatures (SCITT/COSE, Ed25519 per #8225) never changes the digest the
+    signatures cover.
+    """
+    payload = {k: v for k, v in odr.items() if k != "signatures"}
+    return hashlib.sha256(jcs_canonicalize(payload)).hexdigest()

--- a/aragora/gauntlet/odr_signing.py
+++ b/aragora/gauntlet/odr_signing.py
@@ -15,8 +15,9 @@ consumer are guaranteed compatible:
     key_id     = "ed25519-" + SHA-256(raw_public_key).hexdigest()[:16]
     entry      = {"alg": "Ed25519", "key_id": key_id, "signature": base64(signature)}
 
-The digest is computed with :func:`aragora.gauntlet.odr_export.odr_content_digest`,
-which the verifier's own docstring states it "mirrors exactly". Excluding the
+The digest is computed with :func:`aragora.gauntlet.odr_jcs.odr_content_digest`
+(re-exported by :mod:`aragora.gauntlet.odr_export`), which the verifier's own
+docstring states it "mirrors exactly". Excluding the
 ``signatures`` array from the digest is what makes the signatures *detached*:
 attaching one never changes the bytes it covers.
 
@@ -38,7 +39,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-from aragora.gauntlet.odr_export import odr_content_digest
+from aragora.gauntlet.odr_jcs import odr_content_digest
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (

--- a/scripts/ci/boundary_maps/receipts_verifier.json
+++ b/scripts/ci/boundary_maps/receipts_verifier.json
@@ -8,6 +8,7 @@
     "aragora/gauntlet/receipt_models.py",
     "aragora/gauntlet/receipt.py",
     "aragora/receipts",
+    "aragora/gauntlet/odr_jcs.py",
     "aragora/gauntlet/odr_export.py",
     "aragora/gauntlet/odr_signing.py",
     "aragora/gauntlet/odr_verify.py",
@@ -30,6 +31,7 @@
     "aragora.gauntlet.receipt_models",
     "aragora.gauntlet.receipt",
     "aragora.receipts",
+    "aragora.gauntlet.odr_jcs",
     "aragora.gauntlet.odr_export",
     "aragora.gauntlet.odr_signing",
     "aragora.gauntlet.odr_verify"

--- a/tests/gauntlet/test_odr_jcs.py
+++ b/tests/gauntlet/test_odr_jcs.py
@@ -8,22 +8,31 @@ importing the emitter, and lets the emitter keep re-exporting the public names.
 from __future__ import annotations
 
 import ast
+import subprocess
+import sys
 from pathlib import Path
 
 from aragora.gauntlet import odr_export, odr_jcs, odr_signing
 
 _GAUNTLET_DIR = Path(odr_signing.__file__).resolve().parent
+_PACKAGE = "aragora.gauntlet"
 
 
 def _imported_modules(path: Path) -> set[str]:
+    """Absolute dotted names imported by ``path``, with relative imports resolved."""
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             names.update(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            names.add(node.module)
-            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                base = ".".join(_PACKAGE.split(".")[: len(_PACKAGE.split(".")) - node.level + 1])
+                module = f"{base}.{node.module}" if node.module else base
+            else:
+                module = node.module or ""
+            names.add(module)
+            names.update(f"{module}.{alias.name}" for alias in node.names)
     return names
 
 
@@ -45,18 +54,30 @@ def test_leaf_module_imports_nothing_from_aragora():
     assert not any(name.startswith("aragora") for name in imports), imports
 
 
-def test_signer_and_exporter_import_in_either_order():
-    import importlib
-    import sys
+def test_relative_import_resolver_sees_package_siblings(tmp_path):
+    probe = tmp_path / "probe.py"
+    probe.write_text("from . import odr_export\nfrom .odr_signing import x\n", encoding="utf-8")
+    names = _imported_modules(probe)
+    assert "aragora.gauntlet.odr_export" in names
+    assert "aragora.gauntlet.odr_signing.x" in names
 
+
+def test_signer_and_exporter_import_in_either_order():
+    # A fresh interpreter per order keeps this process's module objects intact,
+    # so lazily-imported exception classes elsewhere keep matching their tests.
     for first, second in (
         ("aragora.gauntlet.odr_signing", "aragora.gauntlet.odr_export"),
         ("aragora.gauntlet.odr_export", "aragora.gauntlet.odr_signing"),
     ):
-        for name in ("aragora.gauntlet.odr_signing", "aragora.gauntlet.odr_export"):
-            sys.modules.pop(name, None)
-        importlib.import_module(first)
-        importlib.import_module(second)
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {first}, {second}; print('ok')"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "ok"
 
 
 def test_leaf_digest_matches_shipped_verifier():

--- a/tests/gauntlet/test_odr_jcs.py
+++ b/tests/gauntlet/test_odr_jcs.py
@@ -1,0 +1,72 @@
+"""The JCS canonicalization leaf shared by the ODR emitter and signer.
+
+``odr_export`` (emitter) and ``odr_signing`` (signer) both need the RFC 8785
+digest; hosting it in a leaf module lets the signer depend on it without
+importing the emitter, and lets the emitter keep re-exporting the public names.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from aragora.gauntlet import odr_export, odr_jcs, odr_signing
+
+_GAUNTLET_DIR = Path(odr_signing.__file__).resolve().parent
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return names
+
+
+def test_exporter_reexports_the_leaf_implementation():
+    assert odr_export.jcs_canonicalize is odr_jcs.jcs_canonicalize
+    assert odr_export.odr_content_digest is odr_jcs.odr_content_digest
+    assert "jcs_canonicalize" in odr_export.__all__
+    assert "odr_content_digest" in odr_export.__all__
+
+
+def test_signer_does_not_import_the_exporter():
+    imports = _imported_modules(_GAUNTLET_DIR / "odr_signing.py")
+    assert not any(name.startswith("aragora.gauntlet.odr_export") for name in imports), imports
+    assert "aragora.gauntlet.odr_jcs.odr_content_digest" in imports
+
+
+def test_leaf_module_imports_nothing_from_aragora():
+    imports = _imported_modules(_GAUNTLET_DIR / "odr_jcs.py")
+    assert not any(name.startswith("aragora") for name in imports), imports
+
+
+def test_signer_and_exporter_import_in_either_order():
+    import importlib
+    import sys
+
+    for first, second in (
+        ("aragora.gauntlet.odr_signing", "aragora.gauntlet.odr_export"),
+        ("aragora.gauntlet.odr_export", "aragora.gauntlet.odr_signing"),
+    ):
+        for name in ("aragora.gauntlet.odr_signing", "aragora.gauntlet.odr_export"):
+            sys.modules.pop(name, None)
+        importlib.import_module(first)
+        importlib.import_module(second)
+
+
+def test_leaf_digest_matches_shipped_verifier():
+    from aragora_verify import odr_content_digest as verifier_digest
+
+    doc = {
+        "odr_version": "0.1",
+        "receipt_id": "rcpt-1",
+        "claim": {"verdict": "PASS", "score": 0.5},
+        "signatures": [{"alg": "Ed25519", "key_id": "k", "signature": "c2ln"}],
+    }
+    assert odr_jcs.odr_content_digest(doc) == verifier_digest(doc)
+    assert odr_jcs.jcs_canonicalize({"b": 1, "a": [1.0, 1e21]}) == b'{"a":[1,1e+21],"b":1}'


### PR DESCRIPTION
## Summary

Repairs the `aragora.gauntlet.odr_export <-> aragora.gauntlet.odr_signing` mutual import cycle (#9240, the receipt-path pair). RFC 8785 canonicalization and the ODR content digest move verbatim into a dependency-free leaf, `aragora/gauntlet/odr_jcs.py`; `odr_signing` imports `odr_content_digest` from the leaf, and `odr_export` re-exports `jcs_canonicalize` / `odr_content_digest` so every existing import path (`from aragora.gauntlet.odr_export import odr_content_digest`, scripts, tests, monkeypatch targets, `aragora_verify` parity) is unchanged. The Boundary 2 receipts+verifier map lists the new leaf; no new edges (11 baseline edges, unchanged).

Receipt-First mission M0 (`m0-import-cycle-repair`, epic #9966); repair PR 1 of the six eligible pairs. Cycle count 144 → 143 on this branch (`--list-cycles` diff vs `origin/main`: removed `[odr_export, odr_signing]`, added none).

## Exit metric moved

None (guardrail: import cycles 144 → 143, ceiling 140).

## Test commands

- `python3 -m pytest tests/gauntlet/test_odr_jcs.py -q` → red (module missing) then 5 passed
- `python3 -m pytest tests/gauntlet aragora-verify/tests tests/ci/test_check_boundary_edges.py tests/cli/test_review.py -q -n 8 --timeout=120` → 2152 passed
- `python3 -c "import aragora.gauntlet.odr_signing, aragora.gauntlet.odr_export; print('ok')"` → `ok`
- `aragora demo rate-limiter --offline --receipt r.json && aragora receipt export r.json --format odr --output r.odr.json && python3 -m aragora_verify r.odr.json` → `Open Decision Receipt — VERIFIED`, exit 0; fail-closed export with an unusable key → exit 1, no output file
- `python3 scripts/ci/check_boundary_edges.py` → passed (11 baseline edges)
- `bash $MISSION_DIR/bin/gate.sh lint|typecheck|contracts|guardrails|test` → all `GATE PASSED` (test: 3859 passed, 3 skipped)

## Reviewed design tradeoffs

- A leaf module was chosen over a function-local import in `odr_signing.sign_odr_receipt`: the signer computes the digest on the hot path, and a lazy import would hide the dependency rather than remove it. The leaf has no `aragora` imports at all, so it can never re-enter a cycle.
- `odr_export` keeps re-exporting both names (`__all__` unchanged) so `docs/specs/OPEN_DECISION_RECEIPT.md`'s reference path and the `aragora_verify.jcs` "mirrors `odr_export.odr_content_digest`" contract stay true; the test asserts identity (`odr_export.odr_content_digest is odr_jcs.odr_content_digest`).
- The moved code is byte-identical (cut and paste), so digests, signatures and the cross-verifier parity tests are unaffected.

## Risks

Low: pure module split, no behaviour change; the receipt export/sign/verify path was exercised end to end. The Boundary 2 map gains one source entry for the new leaf (no baseline edge changes).
