### PR TITLE
refactor(debate): break the security_debate<->security_response import cycle [Tier 1]

### DIFF
--- a/aragora/debate/security_debate.py
+++ b/aragora/debate/security_debate.py
@@ -84,7 +84,7 @@ async def run_security_debate(
     from aragora.core_types import DebateResult, Environment
     from aragora.debate.orchestrator import Arena
     from aragora.debate.protocol import DebateProtocol
-    from aragora.debate.security_response import build_security_debate_question
+    from aragora.debate.security_question import build_security_debate_question
 
     # Build the debate question from security findings
     question = build_security_debate_question(event)

--- a/aragora/debate/security_question.py
+++ b/aragora/debate/security_question.py
@@ -1,0 +1,88 @@
+"""
+Security debate question builder.
+
+Turns a SecurityEvent into the remediation prompt that the security debate
+runner feeds to Arena. It depends only on the domain-free events module so
+that both the runner (aragora.debate.security_debate) and the events-side
+trigger (aragora.debate.security_response) can share it without importing
+each other.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aragora.events.security_events import (
+    SecurityEvent,
+    is_secret_finding,
+    safe_secret_type,
+)
+
+__all__ = ["build_security_debate_question"]
+
+
+def build_security_debate_question(event: SecurityEvent) -> str:
+    """
+    Build a debate question from security findings.
+
+    Args:
+        event: Security event with findings
+
+    Returns:
+        Formatted debate question
+    """
+    findings = event.findings[:5]  # Limit to top 5 findings
+
+    if not findings:
+        return f"Analyze and recommend remediation for security findings in {event.repository or 'the codebase'}."
+
+    event_metadata = getattr(event, "metadata", None)
+    if not isinstance(event_metadata, dict) or len(findings) != 1:
+        event_metadata = None
+
+    def _is_secret(finding: Any) -> bool:
+        return is_secret_finding(finding, event_metadata=event_metadata)
+
+    # Group secret-like findings first so aliases or mislabeled scanner output
+    # never reach the unredacted vulnerability summary.
+    secrets = [f for f in findings if _is_secret(f)]
+    vulns = [f for f in findings if not _is_secret(f) and f.finding_type == "vulnerability"]
+
+    question_parts = []
+
+    if vulns:
+        vuln_summary = ", ".join(f"{v.cve_id or v.title} in {v.package_name}" for v in vulns[:3])
+        question_parts.append(f"vulnerabilities ({vuln_summary})")
+
+    if secrets:
+        secret_types = set(safe_secret_type(s.metadata.get("secret_type")) for s in secrets)
+        question_parts.append(f"exposed secrets ({', '.join(secret_types)})")
+
+    findings_str = " and ".join(question_parts)
+
+    def _prompt_safe_title(finding: Any) -> str:
+        if _is_secret(finding):
+            return "Secret finding"
+        return str(getattr(finding, "title", ""))
+
+    def _prompt_safe_description(finding: Any) -> str:
+        if _is_secret(finding):
+            return "[redacted secret finding description]"
+        return str(getattr(finding, "description", ""))[:200]
+
+    return (
+        f"Analyze the following critical security findings and provide remediation recommendations:\n\n"
+        f"Repository: {event.repository or 'Unknown'}\n"
+        f"Findings: {findings_str}\n\n"
+        f"Details:\n"
+        + "\n".join(
+            f"- {f.severity.value.upper()}: {_prompt_safe_title(f)} - {_prompt_safe_description(f)}"
+            for f in findings
+        )
+        + "\n\n"
+        "What is the recommended prioritized remediation plan, considering:\n"
+        "1. Immediate mitigations (quick wins)\n"
+        "2. Root cause fixes\n"
+        "3. Preventive measures for future\n"
+        "4. Impact on existing functionality"
+    )

--- a/aragora/debate/security_response.py
+++ b/aragora/debate/security_response.py
@@ -7,6 +7,9 @@ because it is the domain-coupled half of that module: it imports
 aragora.debate.orchestrator.Arena, aragora.debate.protocol, and
 aragora.agents.api_agents.{anthropic,openai}.
 
+The question builder lives in aragora.debate.security_question (a leaf shared
+with the runner in aragora.debate.security_debate) and is re-exported here.
+
 Self-registers trigger_security_debate as the callback that
 aragora.events.security_events.SecurityEventEmitter invokes for its
 auto-debate path (see register_security_debate_runner), so the domain-free
@@ -35,83 +38,15 @@ import logging
 import uuid
 from typing import Any
 
+from aragora.debate.security_question import build_security_debate_question
 from aragora.events.security_events import (
     SecurityDebateRunner,
     SecurityEvent,
     _register_default_security_debate_runner,
     _store_security_debate_result,
-    is_secret_finding,
-    safe_secret_type,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def build_security_debate_question(event: SecurityEvent) -> str:
-    """
-    Build a debate question from security findings.
-
-    Args:
-        event: Security event with findings
-
-    Returns:
-        Formatted debate question
-    """
-    findings = event.findings[:5]  # Limit to top 5 findings
-
-    if not findings:
-        return f"Analyze and recommend remediation for security findings in {event.repository or 'the codebase'}."
-
-    event_metadata = getattr(event, "metadata", None)
-    if not isinstance(event_metadata, dict) or len(findings) != 1:
-        event_metadata = None
-
-    def _is_secret(finding: Any) -> bool:
-        return is_secret_finding(finding, event_metadata=event_metadata)
-
-    # Group secret-like findings first so aliases or mislabeled scanner output
-    # never reach the unredacted vulnerability summary.
-    secrets = [f for f in findings if _is_secret(f)]
-    vulns = [f for f in findings if not _is_secret(f) and f.finding_type == "vulnerability"]
-
-    question_parts = []
-
-    if vulns:
-        vuln_summary = ", ".join(f"{v.cve_id or v.title} in {v.package_name}" for v in vulns[:3])
-        question_parts.append(f"vulnerabilities ({vuln_summary})")
-
-    if secrets:
-        secret_types = set(safe_secret_type(s.metadata.get("secret_type")) for s in secrets)
-        question_parts.append(f"exposed secrets ({', '.join(secret_types)})")
-
-    findings_str = " and ".join(question_parts)
-
-    def _prompt_safe_title(finding: Any) -> str:
-        if _is_secret(finding):
-            return "Secret finding"
-        return str(getattr(finding, "title", ""))
-
-    def _prompt_safe_description(finding: Any) -> str:
-        if _is_secret(finding):
-            return "[redacted secret finding description]"
-        return str(getattr(finding, "description", ""))[:200]
-
-    return (
-        f"Analyze the following critical security findings and provide remediation recommendations:\n\n"
-        f"Repository: {event.repository or 'Unknown'}\n"
-        f"Findings: {findings_str}\n\n"
-        f"Details:\n"
-        + "\n".join(
-            f"- {f.severity.value.upper()}: {_prompt_safe_title(f)} - {_prompt_safe_description(f)}"
-            for f in findings
-        )
-        + "\n\n"
-        "What is the recommended prioritized remediation plan, considering:\n"
-        "1. Immediate mitigations (quick wins)\n"
-        "2. Root cause fixes\n"
-        "3. Preventive measures for future\n"
-        "4. Impact on existing functionality"
-    )
 
 
 async def trigger_security_debate(

--- a/tests/debate/test_security_debate.py
+++ b/tests/debate/test_security_debate.py
@@ -121,7 +121,7 @@ class TestRunSecurityDebate:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="What remediation steps should we take?",
             ),
             patch(
@@ -145,7 +145,7 @@ class TestRunSecurityDebate:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="What remediation steps should we take?",
             ),
             patch(
@@ -177,7 +177,7 @@ class TestRunSecurityDebate:
         # Just test the empty agents case is handled
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="What remediation?",
             ),
             patch(
@@ -278,7 +278,7 @@ class TestSecurityDebateIntegration:
         # Mock get_security_debate_agents to return empty list
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="What remediation steps?",
             ),
             patch(
@@ -304,7 +304,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Remediation question",
             ),
             patch(
@@ -327,7 +327,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(
@@ -366,7 +366,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(
@@ -419,7 +419,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(
@@ -472,7 +472,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(
@@ -525,7 +525,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(
@@ -578,7 +578,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(
@@ -635,7 +635,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(
@@ -662,7 +662,7 @@ class TestSecurityDebateIntegration:
 
         with (
             patch(
-                "aragora.debate.security_response.build_security_debate_question",
+                "aragora.debate.security_question.build_security_debate_question",
                 return_value="Q",
             ),
             patch(

--- a/tests/debate/test_security_question.py
+++ b/tests/debate/test_security_question.py
@@ -1,0 +1,85 @@
+"""The security debate question builder leaf.
+
+``security_debate`` (runner) needs the question builder and ``security_response``
+(the events-side trigger) needs the runner; hosting the builder in a leaf lets
+the runner stop importing the trigger while the trigger keeps re-exporting the
+builder for its existing callers.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from aragora.debate import security_debate, security_question, security_response
+
+_DEBATE_DIR = Path(security_debate.__file__).resolve().parent
+_PACKAGE = "aragora.debate"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Absolute dotted names imported by ``path``, with relative imports resolved."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                parts = _PACKAGE.split(".")
+                base = ".".join(parts[: len(parts) - node.level + 1])
+                module = f"{base}.{node.module}" if node.module else base
+            else:
+                module = node.module or ""
+            names.add(module)
+            names.update(f"{module}.{alias.name}" for alias in node.names)
+    return names
+
+
+def test_response_module_reexports_the_leaf_builder():
+    assert (
+        security_response.build_security_debate_question
+        is security_question.build_security_debate_question
+    )
+    assert "build_security_debate_question" in security_response.__all__
+
+
+def test_runner_does_not_import_the_response_module():
+    imports = _imported_modules(_DEBATE_DIR / "security_debate.py")
+    assert not any(name.startswith("aragora.debate.security_response") for name in imports), imports
+    assert "aragora.debate.security_question.build_security_debate_question" in imports
+
+
+def test_leaf_imports_nothing_from_debate_package():
+    imports = _imported_modules(_DEBATE_DIR / "security_question.py")
+    assert not any(name.startswith("aragora.debate") for name in imports), imports
+
+
+def test_leaf_builds_the_same_question_as_before():
+    from aragora.events.security_events import (
+        SecurityEvent,
+        SecurityEventType,
+        SecurityFinding,
+        SecuritySeverity,
+    )
+
+    event = SecurityEvent(
+        event_type=SecurityEventType.CRITICAL_CVE,
+        severity=SecuritySeverity.CRITICAL,
+        repository="acme/widgets",
+        findings=[
+            SecurityFinding(
+                id="finding-1",
+                finding_type="vulnerability",
+                severity=SecuritySeverity.CRITICAL,
+                title="RCE in parser",
+                description="Remote code execution via crafted input",
+                cve_id="CVE-2026-0001",
+                package_name="widget-parser",
+            )
+        ],
+    )
+    question = security_question.build_security_debate_question(event)
+    assert "Repository: acme/widgets" in question
+    assert "CVE-2026-0001 in widget-parser" in question
+    assert question == security_response.build_security_debate_question(event)


### PR DESCRIPTION
## Summary

Repairs the `aragora.debate.security_debate <-> aragora.debate.security_response` mutual import cycle (#9240, pair 2 of the six eligible pairs). `build_security_debate_question` moves verbatim into a leaf module, `aragora/debate/security_question.py`, that depends only on the domain-free `aragora.events.security_events`. The runner (`security_debate.run_security_debate`) imports the builder from the leaf; the events-side trigger (`security_response`) re-exports it, so `from aragora.debate.security_response import build_security_debate_question` and `__all__` are unchanged. The 13 `patch("aragora.debate.security_response.build_security_debate_question")` sites in `tests/debate/test_security_debate.py` now patch the leaf, which is the name the runner actually resolves.

Receipt-First mission M0 (`m0-import-cycle-repair`, epic #9966); repair PR 2. Cycle count 143 → 142 on this branch (`--list-cycles` diff vs `origin/main`: removed `[security_debate, security_response]`, added none).

## Exit metric moved

None (guardrail: import cycles 143 → 142, ceiling 140).

## Test commands

- `python3 -m pytest tests/debate/test_security_question.py -q` → red (module missing) then 4 passed
- `python3 -m pytest tests/debate tests/events tests/handlers/test_security_debate.py -q -n 8 --timeout=120` → 19561 passed, 10 skipped
- `python3 -c "import aragora.debate.security_debate, aragora.debate.security_response; print('ok')"` → `ok`
- `python3 scripts/ci/measure_import_graph.py --list-cycles` diff vs origin/main → before 143 / after 142, removed 1, added 0
- `bash $MISSION_DIR/bin/gate.sh lint|typecheck|contracts|guardrails|test` → all `GATE PASSED` (test: 3860 passed, 3 skipped)

## Reviewed design tradeoffs

- The builder was the only thing the runner needed from the trigger, and it is pure (event → string) with no `aragora.debate` dependencies, so it is the natural leaf. Both the runner's and the trigger's edges into `security_debate`/`security_response` were function-local already; grimp counts those, so only a structural move removes the cycle.
- `security_response` keeps the module-level self-registration side effect and its three composition-root imports untouched; only its import list and docstring change.
- Runner tests patch `aragora.debate.security_question.build_security_debate_question` now. Patching the old re-export name would no longer affect the runner, so the repoint is required for the tests to keep meaning what they meant.

## Risks

Low: pure module split, no behaviour change; the leaf test asserts identity of the re-export and byte-equal question output through both entry points.
