### PR TITLE
refactor(missions): break the orchestrator<->swarm import cycle [Tier 1]

### DIFF
--- a/aragora/missions/dispatch.py
+++ b/aragora/missions/dispatch.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
-from .orchestrator import Handoff
+from .handoff import Handoff
 from .reconcile import write_operator_receipt
 from .state import PARK_KIND_MATERIALIZATION, PARK_KIND_MISSING_BRANCH, Feature
 

--- a/aragora/missions/handoff.py
+++ b/aragora/missions/handoff.py
@@ -1,0 +1,56 @@
+"""The worker contract: what a dispatch receives and what it hands back.
+
+Kept in a leaf that depends only on :mod:`aragora.missions.state` so both the
+orchestrator (which consumes handoffs) and the swarm (which produces them from
+fenced workers) can share the types without importing each other.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from .state import Feature
+
+__all__ = ["Dispatch", "Handoff"]
+
+
+@dataclass
+class Handoff:
+    """What a worker returns. The orchestrator must dispose of every field.
+
+    ``success`` advances the feature; ``follow_ups`` are worker-proposed queue
+    extensions; ``blocked_reason`` records why it failed. Proposed follow-ups are
+    advisory by default. A dispatch must set ``accept_follow_ups=True`` to make them
+    executable, so a buggy worker cannot silently widen mission scope. ``terminal``
+    distinguishes a block that **cannot self-heal by retrying** (operator-gated,
+    Tier-3, a contaminated branch needing re-derive) from a transient one — a
+    structured flag instead of sniffing the reason string, so the orchestrator and
+    swarm agree. ``awaiting_claim`` is a third disposition (#8758): the feature is
+    real work this dispatch cannot drive at all — it needs a *worker* to claim it
+    (``Status.AWAITING_CLAIM``, claimable by ``ledger.select_for``) — so triage
+    parks it claimable with **no retry accounting** instead of failing it toward
+    BLOCKED. ``parked`` is the fourth disposition (#8758 design decision,
+    2026-07-02): "not ready yet", never "dead" — triage moves the feature to the
+    retryable, reconciler-owned ``Status.PARKED`` (recording
+    ``parked_reason``/``parked_at``) instead of blocking it; ``parked_kind``
+    says why (``PARK_KIND_MISSING_BRANCH`` waits for a live ``metadata.branch``,
+    ``PARK_KIND_DECOMPOSITION`` is retry-bounded by ``retry_count`` → TERMINAL
+    after ``max_retries`` attempts).
+    """
+
+    success: bool = False
+    terminal: bool = False  # True = do not retry; park/block immediately
+    awaiting_claim: bool = False  # True = park claimable (AWAITING_CLAIM), no retry burn
+    parked: bool = False  # True = park retryably (PARKED); reconciler-owned exit
+    parked_kind: str | None = None  # PARK_KIND_* — what the reconciler re-verifies
+    blocked_reason: str | None = None
+    follow_ups: list[Feature] = field(default_factory=list)
+    accept_follow_ups: bool = False
+    discovered: list[str] = field(default_factory=list)  # tracked into notes/library
+    session_id: str | None = None
+
+
+# A dispatch takes the feature to work and returns a Handoff. It must be
+# idempotent: a feature retried after a crash must converge to the same result.
+Dispatch = Callable[[Feature], Handoff]

--- a/aragora/missions/intake.py
+++ b/aragora/missions/intake.py
@@ -56,7 +56,7 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from .orchestrator import Dispatch, Handoff
+from .handoff import Dispatch, Handoff
 from .state import PARK_KIND_DECOMPOSITION, Feature, Status
 
 if TYPE_CHECKING:

--- a/aragora/missions/orchestrator.py
+++ b/aragora/missions/orchestrator.py
@@ -8,17 +8,18 @@ lost or double-done work.
 
 Dispatch is pluggable. Phase A ships a stub; the real engine wires
 ``swarm/boss_loop.py``'s tick + ``quorum_evidence``/``review_queue`` merge-gate in
-as the ``dispatch`` callable (see the spec, Phase A2).
+as the ``dispatch`` callable (see the spec, Phase A2). The ``Handoff`` /
+``Dispatch`` contract itself lives in :mod:`aragora.missions.handoff` and is
+re-exported here.
 """
 
 from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
-from dataclasses import dataclass, field
 from pathlib import Path
 
+from .handoff import Dispatch, Handoff
 from .ledger import LedgerCorruptError
 from .state import (
     PARK_KIND_DECOMPOSITION,
@@ -32,46 +33,7 @@ from .state import (
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass
-class Handoff:
-    """What a worker returns. The orchestrator must dispose of every field.
-
-    ``success`` advances the feature; ``follow_ups`` are worker-proposed queue
-    extensions; ``blocked_reason`` records why it failed. Proposed follow-ups are
-    advisory by default. A dispatch must set ``accept_follow_ups=True`` to make them
-    executable, so a buggy worker cannot silently widen mission scope. ``terminal``
-    distinguishes a block that **cannot self-heal by retrying** (operator-gated,
-    Tier-3, a contaminated branch needing re-derive) from a transient one — a
-    structured flag instead of sniffing the reason string, so the orchestrator and
-    swarm agree. ``awaiting_claim`` is a third disposition (#8758): the feature is
-    real work this dispatch cannot drive at all — it needs a *worker* to claim it
-    (``Status.AWAITING_CLAIM``, claimable by ``ledger.select_for``) — so triage
-    parks it claimable with **no retry accounting** instead of failing it toward
-    BLOCKED. ``parked`` is the fourth disposition (#8758 design decision,
-    2026-07-02): "not ready yet", never "dead" — triage moves the feature to the
-    retryable, reconciler-owned ``Status.PARKED`` (recording
-    ``parked_reason``/``parked_at``) instead of blocking it; ``parked_kind``
-    says why (``PARK_KIND_MISSING_BRANCH`` waits for a live ``metadata.branch``,
-    ``PARK_KIND_DECOMPOSITION`` is retry-bounded by ``retry_count`` → TERMINAL
-    after ``max_retries`` attempts).
-    """
-
-    success: bool = False
-    terminal: bool = False  # True = do not retry; park/block immediately
-    awaiting_claim: bool = False  # True = park claimable (AWAITING_CLAIM), no retry burn
-    parked: bool = False  # True = park retryably (PARKED); reconciler-owned exit
-    parked_kind: str | None = None  # PARK_KIND_* — what the reconciler re-verifies
-    blocked_reason: str | None = None
-    follow_ups: list[Feature] = field(default_factory=list)
-    accept_follow_ups: bool = False
-    discovered: list[str] = field(default_factory=list)  # tracked into notes/library
-    session_id: str | None = None
-
-
-# A dispatch takes the feature to work and returns a Handoff. It must be
-# idempotent: a feature retried after a crash must converge to the same result.
-Dispatch = Callable[[Feature], Handoff]
+__all__ = ["Dispatch", "Handoff", "MissionOrchestrator"]
 
 
 class MissionOrchestrator:
@@ -486,8 +448,9 @@ class MissionOrchestrator:
     def _reconcile_ledger(self) -> None:
         """Fold ledger results into state before driving (swarm→orchestrator switch).
 
-        Imported lazily to avoid a circular import (swarm imports from this module).
-        Called while the exclusive fence is already held, so it does not re-acquire.
+        Imported lazily so importing the orchestrator does not load the swarm's
+        git/subprocess machinery. Called while the exclusive fence is already held,
+        so it does not re-acquire.
         """
         from .swarm import _reconcile_locked
 

--- a/aragora/missions/swarm.py
+++ b/aragora/missions/swarm.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from .intake import is_intake_feature
 from .ledger import DEFAULT_LEASE_TTL, Ledger, LedgerCorruptError, select_for
-from .orchestrator import Dispatch, Handoff
+from .handoff import Dispatch, Handoff
 from .state import (
     PARK_KIND_MATERIALIZATION,
     PARK_KIND_MISSING_BRANCH,

--- a/tests/missions/test_handoff.py
+++ b/tests/missions/test_handoff.py
@@ -1,0 +1,75 @@
+"""The Handoff/Dispatch contract leaf shared by the orchestrator and the swarm.
+
+``swarm`` needs the worker contract types and ``orchestrator`` needs the swarm's
+ledger reconcile; hosting the contract in a leaf lets the swarm stop importing
+the orchestrator while the orchestrator keeps re-exporting the public names.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from aragora.missions import handoff, orchestrator, swarm
+
+_MISSIONS_DIR = Path(orchestrator.__file__).resolve().parent
+_PACKAGE = "aragora.missions"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Absolute dotted names imported by ``path``, with relative imports resolved."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                parts = _PACKAGE.split(".")
+                base = ".".join(parts[: len(parts) - node.level + 1])
+                module = f"{base}.{node.module}" if node.module else base
+            else:
+                module = node.module or ""
+            names.add(module)
+            names.update(f"{module}.{alias.name}" for alias in node.names)
+    return names
+
+
+def test_orchestrator_reexports_the_leaf_contract():
+    assert orchestrator.Handoff is handoff.Handoff
+    assert orchestrator.Dispatch is handoff.Dispatch
+
+
+def test_package_surface_still_exposes_handoff():
+    from aragora.missions import Handoff
+
+    assert Handoff is handoff.Handoff
+    assert swarm.Handoff is handoff.Handoff
+
+
+def test_swarm_does_not_import_the_orchestrator():
+    imports = _imported_modules(_MISSIONS_DIR / "swarm.py")
+    assert not any(name.startswith("aragora.missions.orchestrator") for name in imports), imports
+    assert "aragora.missions.handoff.Handoff" in imports
+
+
+def test_leaf_depends_only_on_state():
+    imports = _imported_modules(_MISSIONS_DIR / "handoff.py")
+    internal = {name for name in imports if name.startswith("aragora.missions")}
+    assert internal <= {"aragora.missions.state", "aragora.missions.state.Feature"}, internal
+
+
+def test_handoff_defaults_are_unchanged():
+    h = handoff.Handoff()
+    assert (h.success, h.terminal, h.awaiting_claim, h.parked, h.parked_kind) == (
+        False,
+        False,
+        False,
+        False,
+        None,
+    )
+    assert h.blocked_reason is None
+    assert h.follow_ups == []
+    assert h.accept_follow_ups is False
+    assert h.discovered == []
+    assert h.session_id is None


### PR DESCRIPTION
## Summary

Repairs the `aragora.missions.orchestrator <-> aragora.missions.swarm` mutual import cycle (#9240, pair 3 of the six eligible pairs). The worker contract (`Handoff` dataclass and the `Dispatch` callable alias) moves verbatim into a leaf module, `aragora/missions/handoff.py`, that depends only on `aragora.missions.state`. `swarm`, `intake` and `dispatch` import the contract from the leaf; `orchestrator` re-exports both names (and gains an explicit `__all__`), so `from aragora.missions.orchestrator import Handoff` and the package surface `from aragora.missions import Handoff` are unchanged. The orchestrator's function-local `from .swarm import _reconcile_locked` stays as is (now a one-way edge).

Receipt-First mission M0 (`m0-import-cycle-repair`, epic #9966); repair PR 3. Cycle count 142 → 141 on this branch (`--list-cycles` diff vs `origin/main`: removed `[missions.orchestrator, missions.swarm]`, added none).

## Exit metric moved

None (guardrail: import cycles 142 → 141, ceiling 140).

## Test commands

- `python3 -m pytest tests/missions/test_handoff.py -q` → red (module missing) then 5 passed
- `python3 -m pytest tests/missions tests/cli/test_mission_cli.py -q -n 8 --timeout=120` → 229 passed
- `python3 -c "import aragora.missions.swarm, aragora.missions.orchestrator; print('ok')"` → `ok`
- `python3 scripts/ci/measure_import_graph.py --list-cycles` diff vs origin/main → before 142 / after 141, removed 1, added 0
- `bash $MISSION_DIR/bin/gate.sh lint|typecheck|contracts|guardrails|test` → all `GATE PASSED` (test: 3860 passed, 3 skipped)

## Reviewed design tradeoffs

- `Handoff`/`Dispatch` were the only things the swarm needed from the orchestrator, and they depend on nothing but `Feature`, so they are the natural leaf. The swarm's edge was module-level and the orchestrator's was function-local; grimp counts both, so only a structural move removes the cycle.
- `intake.py` and `dispatch.py` also imported the contract from `orchestrator`; they now import from the leaf so the contract has a single home. Their public names are unchanged.
- The orchestrator keeps its lazy `_reconcile_locked` import (importing the orchestrator should not load the swarm's git/subprocess machinery); the docstring no longer claims a cycle as the reason.

## Risks

Low: pure module split, no behaviour change; the leaf test asserts identity of the re-exports through `orchestrator`, `swarm` and the package `__init__`, and that `Handoff` defaults are unchanged.
