### PR TITLE
refactor(nomic): route dev_leases and dev_receipts through the dev_coordination facade [Tier 1]

### DIFF
--- a/aragora/nomic/dev_leases.py
+++ b/aragora/nomic/dev_leases.py
@@ -6,12 +6,17 @@ import sqlite3
 import uuid
 from datetime import timedelta
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from . import dev_coordination as _dev
-from .dev_coordination.core import _claims_overlap
+if TYPE_CHECKING:
+    from .dev_coordination import core as _dev
+else:
+    # Runtime access goes through the package facade (PEP 562 fall-through to
+    # ``core``) because ``core`` delegates lease operations back to this module.
+    from . import dev_coordination as _dev
 from .dev_coordination.models import LeaseConflictError, LeaseStatus, WorkLease
 
+_claims_overlap = _dev._claims_overlap
 _json_dump = _dev._json_dump
 _json_loads = _dev._json_loads
 _normalize_claim = _dev._normalize_claim

--- a/aragora/nomic/dev_receipts.py
+++ b/aragora/nomic/dev_receipts.py
@@ -8,10 +8,17 @@ import time
 import uuid
 from datetime import timedelta
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .dev_coordination import _get_lane_telemetry
-from .dev_coordination import core as _dev
+
+if TYPE_CHECKING:
+    from .dev_coordination import core as _dev
+else:
+    # At runtime the package facade is the consumer surface (PEP 562 fall-through
+    # to ``core``); ``core`` itself delegates back here with function-local
+    # imports, so a direct module edge would make the two mutually dependent.
+    from . import dev_coordination as _dev
 from .dev_coordination.models import (
     CompletionReceipt,
     FileScopeViolationError,

--- a/tests/nomic/test_dev_coordination_facade_edges.py
+++ b/tests/nomic/test_dev_coordination_facade_edges.py
@@ -1,0 +1,101 @@
+"""``dev_leases`` / ``dev_receipts`` consume ``core`` through the package facade.
+
+``core`` delegates lease and receipt operations to those two modules with
+function-local imports, and they in turn need ``core``'s helpers. The package
+``__init__`` is the designated consumer surface (PEP 562 fall-through to
+``core``), so routing the runtime dependency through it leaves ``core`` as the
+only module with a concrete edge into the pair.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import aragora.nomic.dev_coordination as facade
+from aragora.nomic import dev_leases, dev_receipts
+from aragora.nomic.dev_coordination import core
+
+_NOMIC_DIR = Path(dev_leases.__file__).resolve().parent
+_PACKAGE = "aragora.nomic"
+
+
+def _runtime_imports(path: Path) -> set[str]:
+    """Absolute dotted names imported at runtime (``TYPE_CHECKING`` blocks excluded)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+
+    def visit(nodes: list[ast.stmt]) -> None:
+        for node in nodes:
+            if isinstance(node, ast.If) and getattr(node.test, "id", None) == "TYPE_CHECKING":
+                visit(node.orelse)
+                continue
+            if isinstance(node, ast.Import):
+                names.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    parts = _PACKAGE.split(".")
+                    base = ".".join(parts[: len(parts) - node.level + 1])
+                    module = f"{base}.{node.module}" if node.module else base
+                else:
+                    module = node.module or ""
+                names.add(module)
+                names.update(f"{module}.{alias.name}" for alias in node.names)
+            for field in ("body", "orelse", "finalbody", "handlers"):
+                children = getattr(node, field, None)
+                if isinstance(children, list):
+                    visit([c for c in children if isinstance(c, ast.stmt)])
+                    for handler in [c for c in children if isinstance(c, ast.ExceptHandler)]:
+                        visit(handler.body)
+
+    visit(tree.body)
+    return names
+
+
+@pytest.mark.parametrize("module_name", ["dev_leases", "dev_receipts"])
+def test_module_has_no_runtime_edge_into_core(module_name: str):
+    imports = _runtime_imports(_NOMIC_DIR / f"{module_name}.py")
+    assert not any(name.startswith("aragora.nomic.dev_coordination.core") for name in imports), (
+        imports
+    )
+    assert "aragora.nomic.dev_coordination" in imports
+
+
+@pytest.mark.parametrize("module", [dev_leases, dev_receipts])
+def test_facade_resolves_every_consumed_name_to_the_core_object(module):
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    names = sorted(set(re.findall(r"\b_dev\.([A-Za-z_][A-Za-z0-9_]*)", source)))
+    assert names, "expected the module to consume helpers through `_dev`"
+    mismatches = [n for n in names if getattr(facade, n) is not getattr(core, n)]
+    assert mismatches == []
+    assert module._dev is facade
+
+
+def test_leases_claims_overlap_is_the_core_implementation():
+    assert dev_leases._claims_overlap is core._claims_overlap
+    assert dev_receipts._path_matches_glob is core._path_matches_glob
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        ("aragora.nomic.dev_leases", "aragora.nomic.dev_coordination.core"),
+        ("aragora.nomic.dev_receipts", "aragora.nomic.dev_coordination.core"),
+        ("aragora.nomic.dev_coordination.core", "aragora.nomic.dev_receipts"),
+    ],
+)
+def test_modules_import_in_either_order(first: str, second: str):
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {first}, {second}; print('ok')"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"


### PR DESCRIPTION
## Summary

Repairs both `aragora.nomic.dev_coordination.core` mutual import cycles from #9240 in one PR (the two pairs the feature allows to share a PR): `core <-> aragora.nomic.dev_leases` and `core <-> aragora.nomic.dev_receipts`. `core` delegates every lease/receipt operation to those two modules with function-local imports (which grimp counts), and they in turn bound `core` directly. The package `__init__` is already the designated consumer surface (PEP 562 `__getattr__` fall-through to `core`, documented for exactly `dev_receipts`'s bulk attribute access), so both modules now take `_dev` from the facade at runtime; a `TYPE_CHECKING` branch keeps `_dev` typed as `core` so mypy still resolves the 95 consumed helpers (whole-tree error count stays at the 1744 baseline). `dev_leases` gets `_claims_overlap` the same way it already gets `_path_matches_glob`. Every name is the identical object (`facade.X is core.X`, asserted for all 88 + 7 consumed names).

Receipt-First mission M0 (`m0-import-cycle-repair`, epic #9966); repair PR 4 (pairs 4 and 5). Cycle count 141 → 139 on this branch (`--list-cycles` diff vs `origin/main`: removed the two `dev_coordination.core` pairs, added none). `python3 scripts/ci/measure_import_graph.py --check` now prints `OK: mutual import cycles 139 <= baseline 140.` on this branch.

## Exit metric moved

None (guardrail: import cycles 141 → 139, ceiling 140 now satisfied).

## Test commands

- `python3 -m pytest tests/nomic/test_dev_coordination_facade_edges.py -q` → red (3 failed / 5 passed: runtime edge into `core` present, `dev_receipts._dev` was `core`) then 8 passed
- `python3 -m pytest tests/nomic -k "dev_coordination or dev_leases or dev_receipts or dev_salvage or facade" -q -n 8 --timeout=120` → 144 passed
- All 30 test files referencing `dev_coordination|dev_leases|dev_receipts` (`tests/nomic`, `tests/swarm`, `tests/cli`, `tests/server`): 935 passed, 7 failed; the 7 failures (`tests/swarm/test_worker_no_deliverable.py`, `test_timeout_cleanup.py`, `test_session_artifact_prevention.py`) fail identically on pristine `origin/main` `eb85ba766b` with the change stashed (worker-prompt text and auto-push assertions, unrelated to this diff)
- `python3 -c "import aragora.nomic.dev_leases, aragora.nomic.dev_receipts, aragora.nomic.dev_coordination.core; print('ok')"` → `ok`
- `python3 scripts/ci/measure_import_graph.py --check` → `OK: mutual import cycles 139 <= baseline 140.` (exit 0)
- `mypy aragora/ --ignore-missing-imports | tail -1` → `Found 1744 errors in 468 files` (same as origin/main; a facade-only binding without the `TYPE_CHECKING` branch grew it to 1960)
- `bash $MISSION_DIR/bin/gate.sh lint|typecheck|contracts|guardrails|test` → all `GATE PASSED` (test: 3860 passed, 3 skipped)

## Reviewed design tradeoffs

- Extracting the 95 consumed helpers (~1,550 LOC of `core`) into a leaf was rejected: it would exceed the 800 LOC budget and re-home code that `core` itself uses everywhere. Routing through the existing facade is the change the package layout was designed for.
- The facade binds `_LANE_TELEMETRY` and imports `core` at module scope, so `dev_receipts` importing the facade first is the same import order as before (the facade already imported `core` before `dev_receipts` could run).
- `TYPE_CHECKING` re-binding is the documented grimp exclusion (`exclude_type_checking_imports=True`); it changes nothing at runtime and keeps the mypy surface identical.

## Risks

Low: two import rewrites, no behaviour change. Identity of every consumed helper is asserted by the new test, and both import orders are exercised in fresh interpreters.
