### PR TITLE
refactor(observability): extract trace_state leaf shared by tracing and the OTel bridge [Tier 2]

### DIFF
--- a/aragora/observability/middleware/otel_bridge.py
+++ b/aragora/observability/middleware/otel_bridge.py
@@ -50,6 +50,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from aragora.observability.middleware.trace_state import set_span_exporter
+
 logger = logging.getLogger(__name__)
 
 # OpenTelemetry imports - optional
@@ -299,6 +301,7 @@ def init_otel_bridge(config: OTelBridgeConfig | None = None) -> bool:
         if is_initialized():
             _tracer = otel_get_tracer("aragora.middleware", config.service_version)
             _otel_available = True
+            set_span_exporter(export_span_to_otel)
             logger.info(
                 "OpenTelemetry bridge initialized via unified setup: service=%s, sampler=%s",
                 config.service_name,
@@ -379,6 +382,7 @@ def init_otel_bridge(config: OTelBridgeConfig | None = None) -> bool:
         # Get tracer
         _tracer = trace.get_tracer("aragora.middleware", config.service_version)
         _otel_available = True
+        set_span_exporter(export_span_to_otel)
 
         logger.info(
             "OpenTelemetry bridge initialized (direct): endpoint=%s, service=%s, sampler=%s",
@@ -405,7 +409,7 @@ def export_span_to_otel(span: Any) -> None:
     Converts the middleware Span object to an OpenTelemetry span and exports it.
 
     Args:
-        span: Internal Span object from aragora.observability.middleware.tracing
+        span: Internal Span object from aragora.observability.middleware.trace_state
     """
     if not _otel_available or _tracer is None:
         return
@@ -460,7 +464,7 @@ def inject_trace_context(headers: dict[str, str]) -> dict[str, str]:
     if not _otel_available or _propagator is None:
         # Fall back to internal trace context
         try:
-            from aragora.observability.middleware.tracing import get_span_id, get_trace_id
+            from aragora.observability.middleware.trace_state import get_span_id, get_trace_id
 
             trace_id = get_trace_id()
             span_id = get_span_id()
@@ -515,7 +519,7 @@ def get_current_trace_id() -> str | None:
     """
     if not _otel_available:
         try:
-            from aragora.observability.middleware.tracing import get_trace_id
+            from aragora.observability.middleware.trace_state import get_trace_id
 
             return get_trace_id()
         except ImportError:
@@ -541,7 +545,7 @@ def get_current_span_id() -> str | None:
     """
     if not _otel_available:
         try:
-            from aragora.observability.middleware.tracing import get_span_id
+            from aragora.observability.middleware.trace_state import get_span_id
 
             return get_span_id()
         except ImportError:
@@ -575,7 +579,7 @@ def create_span_context(
     if not _otel_available or _tracer is None:
         # Fall back to internal tracing
         try:
-            from aragora.observability.middleware.tracing import trace_context
+            from aragora.observability.middleware.trace_state import trace_context
 
             return trace_context(operation)
         except ImportError:
@@ -619,6 +623,7 @@ def shutdown_otel_bridge() -> None:
     finally:
         _otel_available = False
         _tracer = None
+        set_span_exporter(None)
 
 
 def is_otel_available() -> bool:

--- a/aragora/observability/middleware/trace_state.py
+++ b/aragora/observability/middleware/trace_state.py
@@ -1,0 +1,281 @@
+"""Trace context state shared by the tracing middleware and the OpenTelemetry bridge.
+
+Holds the context variables, ID generators, ``Span`` and ``trace_context`` so
+that both the HTTP tracing middleware and the OpenTelemetry bridge can consume
+them without depending on each other. Export of finished spans is delegated to
+whichever exporter the bridge registers via ``set_span_exporter``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# Context variables for trace propagation
+_trace_id: ContextVar[str | None] = ContextVar("trace_id", default=None)
+_span_id: ContextVar[str | None] = ContextVar("span_id", default=None)
+_parent_span_id: ContextVar[str | None] = ContextVar("parent_span_id", default=None)
+_span_stack: ContextVar[list[Span]] = ContextVar("span_stack", default=[])
+
+
+def generate_trace_id() -> str:
+    """Generate a unique trace ID.
+
+    Uses UUID4 with hex encoding for 32-character trace IDs,
+    compatible with most tracing systems.
+
+    Returns:
+        32-character hex trace ID
+    """
+    return uuid.uuid4().hex
+
+
+def generate_span_id() -> str:
+    """Generate a unique span ID.
+
+    Uses UUID4 truncated to 16 characters for span IDs,
+    following OpenTelemetry conventions.
+
+    Returns:
+        16-character hex span ID
+    """
+    return uuid.uuid4().hex[:16]
+
+
+def get_trace_id() -> str | None:
+    """Get the current trace ID.
+
+    Returns:
+        Current trace ID or None if not in trace context
+    """
+    return _trace_id.get()
+
+
+def get_span_id() -> str | None:
+    """Get the current span ID.
+
+    Returns:
+        Current span ID or None if not in trace context
+    """
+    return _span_id.get()
+
+
+def get_parent_span_id() -> str | None:
+    """Get the parent span ID.
+
+    Returns:
+        Parent span ID or None if no parent
+    """
+    return _parent_span_id.get()
+
+
+def set_trace_id(trace_id: str) -> None:
+    """Set the current trace ID.
+
+    Args:
+        trace_id: The trace ID to set
+    """
+    _trace_id.set(trace_id)
+
+
+def set_span_id(span_id: str) -> None:
+    """Set the current span ID.
+
+    Args:
+        span_id: The span ID to set
+    """
+    _span_id.set(span_id)
+
+
+@dataclass
+class Span:
+    """Represents a single operation within a trace.
+
+    Tracks timing, tags, and events for observability.
+    """
+
+    trace_id: str
+    span_id: str
+    operation: str
+    parent_span_id: str | None = None
+    start_time: float = field(default_factory=time.time)
+    end_time: float | None = None
+    tags: dict[str, Any] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    status: str = "ok"
+    error: str | None = None
+
+    def set_tag(self, key: str, value: Any) -> None:
+        """Set a tag on the span.
+
+        Args:
+            key: Tag name
+            value: Tag value
+        """
+        self.tags[key] = value
+
+    def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> None:
+        """Add an event to the span.
+
+        Args:
+            name: Event name
+            attributes: Optional event attributes
+        """
+        self.events.append(
+            {
+                "name": name,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "attributes": attributes or {},
+            }
+        )
+
+    def set_error(self, error: Exception) -> None:
+        """Mark the span as errored.
+
+        Args:
+            error: The exception that occurred
+        """
+        self.status = "error"
+        self.error = f"{type(error).__name__}: {str(error)}"
+        self.add_event(
+            "exception",
+            {
+                "type": type(error).__name__,
+                "message": str(error),
+            },
+        )
+
+    def finish(self) -> None:
+        """Mark the span as finished and hand it to the registered exporter, if any."""
+        self.end_time = time.time()
+        exporter = _span_exporter
+        if exporter is not None:
+            exporter(self)
+
+    @property
+    def duration_ms(self) -> float:
+        """Get span duration in milliseconds."""
+        end = self.end_time or time.time()
+        return (end - self.start_time) * 1000
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert span to dictionary for logging/export."""
+        return {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "operation": self.operation,
+            "start_time": datetime.fromtimestamp(self.start_time, tz=timezone.utc).isoformat(),
+            "end_time": (
+                datetime.fromtimestamp(self.end_time, tz=timezone.utc).isoformat()
+                if self.end_time
+                else None
+            ),
+            "duration_ms": round(self.duration_ms, 2),
+            "status": self.status,
+            "error": self.error,
+            "tags": self.tags,
+            "events": self.events,
+        }
+
+
+@contextmanager
+def trace_context(
+    operation: str,
+    trace_id: str | None = None,
+    parent_span_id: str | None = None,
+) -> Generator[Span, None, None]:
+    """Context manager for creating a traced operation.
+
+    Creates a new span for the operation and propagates trace context.
+
+    Args:
+        operation: Name of the operation being traced
+        trace_id: Optional trace ID (uses current or generates new if not set)
+        parent_span_id: Optional parent span ID for nested spans
+
+    Yields:
+        Span object for the current operation
+
+    Example:
+        with trace_context("debate.create") as span:
+            span.set_tag("agents", ["claude", "gpt4"])
+            debate = await create_debate(...)
+            span.set_tag("debate_id", debate.id)
+    """
+    # Get or generate trace ID
+    current_trace_id = trace_id or get_trace_id() or generate_trace_id()
+
+    # Get parent span ID (current span becomes parent for this new span)
+    current_span_id = get_span_id()
+    actual_parent = parent_span_id or current_span_id
+
+    # Generate new span ID
+    new_span_id = generate_span_id()
+
+    # Create span
+    span = Span(
+        trace_id=current_trace_id,
+        span_id=new_span_id,
+        operation=operation,
+        parent_span_id=actual_parent,
+    )
+
+    # Push span to stack
+    stack = _span_stack.get().copy()
+    stack.append(span)
+
+    # Set context
+    old_trace = _trace_id.set(current_trace_id)
+    old_span = _span_id.set(new_span_id)
+    old_parent = _parent_span_id.set(actual_parent)
+    old_stack = _span_stack.set(stack)
+
+    try:
+        yield span
+    except BaseException as e:
+        if isinstance(e, Exception):
+            span.set_error(e)
+        raise
+    finally:
+        span.finish()
+
+        # Pop span from stack
+        stack = _span_stack.get().copy()
+        if stack:
+            stack.pop()
+
+        # Restore context
+        _trace_id.reset(old_trace)
+        _span_id.reset(old_span)
+        _parent_span_id.reset(old_parent)
+        _span_stack.reset(old_stack)
+
+
+_span_exporter: Callable[[Span], None] | None = None
+
+
+def set_span_exporter(exporter: Callable[[Span], None] | None) -> None:
+    """Register the callable that receives every finished span (``None`` clears it)."""
+    global _span_exporter
+    _span_exporter = exporter
+
+
+__all__ = [
+    "Span",
+    "generate_span_id",
+    "generate_trace_id",
+    "get_parent_span_id",
+    "get_span_id",
+    "get_trace_id",
+    "set_span_exporter",
+    "set_span_id",
+    "set_trace_id",
+    "trace_context",
+]

--- a/aragora/observability/middleware/tracing.py
+++ b/aragora/observability/middleware/tracing.py
@@ -31,15 +31,30 @@ OpenTelemetry Integration:
 
 from __future__ import annotations
 
-import time
-import uuid
-from contextlib import contextmanager
-from contextvars import ContextVar
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from functools import wraps
 from typing import Any
-from collections.abc import Callable, Generator
+from collections.abc import Callable
+
+from aragora.observability.middleware.trace_state import (
+    Span,
+    generate_span_id,
+    generate_trace_id,
+    get_parent_span_id,
+    get_span_id,
+    get_trace_id,
+    set_span_id,
+    set_trace_id,
+    trace_context,
+)
+
+# Context variables live in ``trace_state``; re-exported here because callers
+# and tests reset them through this module.
+from aragora.observability.middleware.trace_state import (  # noqa: F401
+    _parent_span_id,
+    _span_id,
+    _span_stack,
+    _trace_id,
+)
 
 # Trace ID header names (W3C Trace Context compatible)
 TRACE_ID_HEADER = "X-Trace-ID"
@@ -48,254 +63,6 @@ PARENT_SPAN_HEADER = "X-Parent-Span-ID"
 
 # W3C Trace Context header (if using OpenTelemetry format)
 TRACEPARENT_HEADER = "traceparent"
-
-# Context variables for trace propagation
-_trace_id: ContextVar[str | None] = ContextVar("trace_id", default=None)
-_span_id: ContextVar[str | None] = ContextVar("span_id", default=None)
-_parent_span_id: ContextVar[str | None] = ContextVar("parent_span_id", default=None)
-_span_stack: ContextVar[list[Span]] = ContextVar("span_stack", default=[])
-
-
-def generate_trace_id() -> str:
-    """Generate a unique trace ID.
-
-    Uses UUID4 with hex encoding for 32-character trace IDs,
-    compatible with most tracing systems.
-
-    Returns:
-        32-character hex trace ID
-    """
-    return uuid.uuid4().hex
-
-
-def generate_span_id() -> str:
-    """Generate a unique span ID.
-
-    Uses UUID4 truncated to 16 characters for span IDs,
-    following OpenTelemetry conventions.
-
-    Returns:
-        16-character hex span ID
-    """
-    return uuid.uuid4().hex[:16]
-
-
-def get_trace_id() -> str | None:
-    """Get the current trace ID.
-
-    Returns:
-        Current trace ID or None if not in trace context
-    """
-    return _trace_id.get()
-
-
-def get_span_id() -> str | None:
-    """Get the current span ID.
-
-    Returns:
-        Current span ID or None if not in trace context
-    """
-    return _span_id.get()
-
-
-def get_parent_span_id() -> str | None:
-    """Get the parent span ID.
-
-    Returns:
-        Parent span ID or None if no parent
-    """
-    return _parent_span_id.get()
-
-
-def set_trace_id(trace_id: str) -> None:
-    """Set the current trace ID.
-
-    Args:
-        trace_id: The trace ID to set
-    """
-    _trace_id.set(trace_id)
-
-
-def set_span_id(span_id: str) -> None:
-    """Set the current span ID.
-
-    Args:
-        span_id: The span ID to set
-    """
-    _span_id.set(span_id)
-
-
-@dataclass
-class Span:
-    """Represents a single operation within a trace.
-
-    Tracks timing, tags, and events for observability.
-    """
-
-    trace_id: str
-    span_id: str
-    operation: str
-    parent_span_id: str | None = None
-    start_time: float = field(default_factory=time.time)
-    end_time: float | None = None
-    tags: dict[str, Any] = field(default_factory=dict)
-    events: list[dict[str, Any]] = field(default_factory=list)
-    status: str = "ok"
-    error: str | None = None
-
-    def set_tag(self, key: str, value: Any) -> None:
-        """Set a tag on the span.
-
-        Args:
-            key: Tag name
-            value: Tag value
-        """
-        self.tags[key] = value
-
-    def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> None:
-        """Add an event to the span.
-
-        Args:
-            name: Event name
-            attributes: Optional event attributes
-        """
-        self.events.append(
-            {
-                "name": name,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "attributes": attributes or {},
-            }
-        )
-
-    def set_error(self, error: Exception) -> None:
-        """Mark the span as errored.
-
-        Args:
-            error: The exception that occurred
-        """
-        self.status = "error"
-        self.error = f"{type(error).__name__}: {str(error)}"
-        self.add_event(
-            "exception",
-            {
-                "type": type(error).__name__,
-                "message": str(error),
-            },
-        )
-
-    def finish(self) -> None:
-        """Mark the span as finished and export to OpenTelemetry if available."""
-        self.end_time = time.time()
-        # Export to OpenTelemetry if bridge is available
-        try:
-            from aragora.observability.middleware.otel_bridge import (
-                export_span_to_otel,
-                is_otel_available,
-            )
-
-            if is_otel_available():
-                export_span_to_otel(self)
-        except ImportError:
-            pass
-
-    @property
-    def duration_ms(self) -> float:
-        """Get span duration in milliseconds."""
-        end = self.end_time or time.time()
-        return (end - self.start_time) * 1000
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert span to dictionary for logging/export."""
-        return {
-            "trace_id": self.trace_id,
-            "span_id": self.span_id,
-            "parent_span_id": self.parent_span_id,
-            "operation": self.operation,
-            "start_time": datetime.fromtimestamp(self.start_time, tz=timezone.utc).isoformat(),
-            "end_time": (
-                datetime.fromtimestamp(self.end_time, tz=timezone.utc).isoformat()
-                if self.end_time
-                else None
-            ),
-            "duration_ms": round(self.duration_ms, 2),
-            "status": self.status,
-            "error": self.error,
-            "tags": self.tags,
-            "events": self.events,
-        }
-
-
-@contextmanager
-def trace_context(
-    operation: str,
-    trace_id: str | None = None,
-    parent_span_id: str | None = None,
-) -> Generator[Span, None, None]:
-    """Context manager for creating a traced operation.
-
-    Creates a new span for the operation and propagates trace context.
-
-    Args:
-        operation: Name of the operation being traced
-        trace_id: Optional trace ID (uses current or generates new if not set)
-        parent_span_id: Optional parent span ID for nested spans
-
-    Yields:
-        Span object for the current operation
-
-    Example:
-        with trace_context("debate.create") as span:
-            span.set_tag("agents", ["claude", "gpt4"])
-            debate = await create_debate(...)
-            span.set_tag("debate_id", debate.id)
-    """
-    # Get or generate trace ID
-    current_trace_id = trace_id or get_trace_id() or generate_trace_id()
-
-    # Get parent span ID (current span becomes parent for this new span)
-    current_span_id = get_span_id()
-    actual_parent = parent_span_id or current_span_id
-
-    # Generate new span ID
-    new_span_id = generate_span_id()
-
-    # Create span
-    span = Span(
-        trace_id=current_trace_id,
-        span_id=new_span_id,
-        operation=operation,
-        parent_span_id=actual_parent,
-    )
-
-    # Push span to stack
-    stack = _span_stack.get().copy()
-    stack.append(span)
-
-    # Set context
-    old_trace = _trace_id.set(current_trace_id)
-    old_span = _span_id.set(new_span_id)
-    old_parent = _parent_span_id.set(actual_parent)
-    old_stack = _span_stack.set(stack)
-
-    try:
-        yield span
-    except BaseException as e:
-        if isinstance(e, Exception):
-            span.set_error(e)
-        raise
-    finally:
-        span.finish()
-
-        # Pop span from stack
-        stack = _span_stack.get().copy()
-        if stack:
-            stack.pop()
-
-        # Restore context
-        _trace_id.reset(old_trace)
-        _span_id.reset(old_span)
-        _parent_span_id.reset(old_parent)
-        _span_stack.reset(old_stack)
 
 
 def traced(operation: str | None = None) -> Callable:

--- a/tests/observability/test_trace_state.py
+++ b/tests/observability/test_trace_state.py
@@ -1,0 +1,169 @@
+"""``trace_state`` is the dependency-free leaf shared by ``tracing`` and ``otel_bridge``.
+
+The OpenTelemetry bridge falls back to the internal trace context when no
+collector is configured, and internal spans export to the bridge when one is.
+Both sides consume the leaf instead of each other; the bridge publishes its
+exporter through the leaf's hook so span export is unchanged.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.observability.middleware import otel_bridge, trace_state, tracing
+
+_MIDDLEWARE_DIR = Path(trace_state.__file__).resolve().parent
+_PACKAGE = "aragora.observability.middleware"
+_LEAF = f"{_PACKAGE}.trace_state"
+_TRACING = f"{_PACKAGE}.tracing"
+_BRIDGE = f"{_PACKAGE}.otel_bridge"
+
+
+def _runtime_imports(path: Path) -> set[str]:
+    """Absolute dotted names imported at runtime (``TYPE_CHECKING`` blocks excluded)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+
+    def visit(nodes: list[ast.stmt]) -> None:
+        for node in nodes:
+            if isinstance(node, ast.If) and getattr(node.test, "id", None) == "TYPE_CHECKING":
+                visit(node.orelse)
+                continue
+            if isinstance(node, ast.Import):
+                names.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    parts = _PACKAGE.split(".")
+                    base = ".".join(parts[: len(parts) - node.level + 1])
+                    module = f"{base}.{node.module}" if node.module else base
+                else:
+                    module = node.module or ""
+                names.add(module)
+                names.update(f"{module}.{alias.name}" for alias in node.names)
+            for field in ("body", "orelse", "finalbody", "handlers"):
+                children = getattr(node, field, None)
+                if isinstance(children, list):
+                    visit([c for c in children if isinstance(c, ast.stmt)])
+                    for handler in [c for c in children if isinstance(c, ast.ExceptHandler)]:
+                        visit(handler.body)
+
+    visit(tree.body)
+    return names
+
+
+@pytest.fixture(autouse=True)
+def _bridge_disabled():
+    otel_bridge._otel_available = False
+    otel_bridge._tracer = None
+    trace_state.set_span_exporter(None)
+    yield
+    otel_bridge._otel_available = False
+    otel_bridge._tracer = None
+    trace_state.set_span_exporter(None)
+
+
+def test_leaf_imports_nothing_from_aragora():
+    imports = _runtime_imports(_MIDDLEWARE_DIR / "trace_state.py")
+    assert not any(name.startswith("aragora") for name in imports), imports
+
+
+def test_bridge_has_no_runtime_edge_into_tracing():
+    imports = _runtime_imports(_MIDDLEWARE_DIR / "otel_bridge.py")
+    assert not any(name.startswith(_TRACING) for name in imports), imports
+    assert any(name.startswith(_LEAF) for name in imports)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Span",
+        "trace_context",
+        "generate_trace_id",
+        "generate_span_id",
+        "get_trace_id",
+        "get_span_id",
+        "get_parent_span_id",
+        "set_trace_id",
+        "set_span_id",
+        "_trace_id",
+        "_span_id",
+        "_parent_span_id",
+        "_span_stack",
+    ],
+)
+def test_tracing_re_exports_the_leaf_object(name: str):
+    assert getattr(tracing, name) is getattr(trace_state, name)
+
+
+def test_span_finish_exports_through_the_registered_bridge_exporter():
+    tracer = MagicMock()
+    otel_bridge._otel_available = True
+    otel_bridge._tracer = tracer
+    trace_state.set_span_exporter(otel_bridge.export_span_to_otel)
+
+    with patch.dict(
+        "sys.modules", {"opentelemetry": MagicMock(), "opentelemetry.trace": MagicMock()}
+    ):
+        with tracing.trace_context("leaf.export") as span:
+            span.set_tag("k", "v")
+
+    tracer.start_as_current_span.assert_called_once()
+    assert tracer.start_as_current_span.call_args.args[0] == "leaf.export"
+
+
+def test_span_finish_is_silent_without_an_exporter():
+    tracer = MagicMock()
+    otel_bridge._otel_available = True
+    otel_bridge._tracer = tracer
+
+    with tracing.trace_context("leaf.noexport"):
+        pass
+
+    tracer.start_as_current_span.assert_not_called()
+
+
+def test_shutdown_unregisters_the_exporter():
+    otel_bridge._otel_available = True
+    otel_bridge._tracer = MagicMock()
+    trace_state.set_span_exporter(otel_bridge.export_span_to_otel)
+
+    with patch.dict(
+        "sys.modules", {"opentelemetry": MagicMock(), "opentelemetry.trace": MagicMock()}
+    ):
+        otel_bridge.shutdown_otel_bridge()
+
+    assert trace_state._span_exporter is None
+    assert otel_bridge.is_otel_available() is False
+
+
+def test_bridge_fallbacks_read_the_internal_context():
+    with tracing.trace_context("bridge.fallback") as span:
+        assert otel_bridge.get_current_trace_id() == span.trace_id
+        assert otel_bridge.get_current_span_id() == span.span_id
+        headers = otel_bridge.inject_trace_context({})
+        assert headers["X-Trace-ID"] == span.trace_id
+        with otel_bridge.create_span_context("bridge.child") as child:
+            assert isinstance(child, trace_state.Span)
+            assert child.parent_span_id == span.span_id
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [(_BRIDGE, _TRACING), (_TRACING, _BRIDGE), (_LEAF, _BRIDGE)],
+)
+def test_modules_import_in_either_order(first: str, second: str):
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {first}, {second}; print('ok')"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/tests/server/middleware/test_otel_bridge.py
+++ b/tests/server/middleware/test_otel_bridge.py
@@ -417,7 +417,7 @@ class TestInjectTraceContext:
         original_import = builtins.__import__
 
         def custom_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 return mock_tracing
             return original_import(name, *args, **kwargs)
 
@@ -439,7 +439,7 @@ class TestInjectTraceContext:
         original_import = builtins.__import__
 
         def custom_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 return mock_tracing
             return original_import(name, *args, **kwargs)
 
@@ -531,7 +531,7 @@ class TestGetCurrentIds:
         original_import = builtins.__import__
 
         def custom_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 return mock_tracing
             return original_import(name, *args, **kwargs)
 
@@ -551,7 +551,7 @@ class TestGetCurrentIds:
         original_import = builtins.__import__
 
         def custom_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 return mock_tracing
             return original_import(name, *args, **kwargs)
 
@@ -569,7 +569,7 @@ class TestGetCurrentIds:
         original_import = builtins.__import__
 
         def fail_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 raise ImportError("not available")
             return original_import(name, *args, **kwargs)
 
@@ -586,7 +586,7 @@ class TestGetCurrentIds:
         original_import = builtins.__import__
 
         def fail_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 raise ImportError("not available")
             return original_import(name, *args, **kwargs)
 
@@ -614,7 +614,7 @@ class TestCreateSpanContext:
         original_import = builtins.__import__
 
         def custom_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 return mock_tracing
             return original_import(name, *args, **kwargs)
 
@@ -631,7 +631,7 @@ class TestCreateSpanContext:
         original_import = builtins.__import__
 
         def fail_import(name, *args, **kwargs):
-            if name == "aragora.observability.middleware.tracing":
+            if name == "aragora.observability.middleware.trace_state":
                 raise ImportError("nope")
             return original_import(name, *args, **kwargs)
 


### PR DESCRIPTION
## Summary

Repairs the sixth and last eligible #9240 pair: `aragora.observability.middleware.otel_bridge <-> aragora.observability.middleware.tracing`. The bridge fell back to the internal trace context (`get_trace_id`, `get_span_id`, `trace_context`) with function-local imports of `tracing`, and `Span.finish` imported the bridge to export finished spans; grimp counts both directions.

The shared state (context variables, ID generators, `Span`, `trace_context`) moves verbatim into a new dependency-free leaf `aragora/observability/middleware/trace_state.py`. `tracing` imports and re-exports every name (including the private context variables that tests reset), so `from aragora.observability.middleware.tracing import ...` and the deprecated `aragora.server.middleware.tracing` shim resolve to the same objects. The bridge consumes the leaf, and instead of `Span.finish` reaching back into the bridge, the bridge registers `export_span_to_otel` through `trace_state.set_span_exporter` on both init success paths and clears it on shutdown. `export_span_to_otel` keeps its own `_otel_available`/`_tracer` guard, so the export behaviour is unchanged: nothing exports until `init_otel_bridge` succeeds, nothing exports after `shutdown_otel_bridge`.

Eight `builtins.__import__` interceptors in `tests/server/middleware/test_otel_bridge.py` that targeted the `tracing` module name are repointed to `trace_state` (the module the bridge now resolves).

Receipt-First mission M0 (`m0-import-cycle-repair`, epic #9966); repair PR 5 (pair 6 of 6). Cycle count 139 → 138 (`--list-cycles` diff vs `origin/main`: removed the `otel_bridge/tracing` pair, added none).

## Exit metric moved

None (guardrail: import cycles 139 → 138, ceiling 140).

## Test commands

- `python3 -m pytest tests/observability/test_trace_state.py -q` → red on origin/main (`ModuleNotFoundError: trace_state`) then 22 passed (leaf imports nothing from `aragora`, bridge has no runtime edge into `tracing`, 13 re-exported names are identical objects, exporter registration/unregistration, bridge fallbacks read the internal context, three import orders in fresh interpreters)
- All 10 test files referencing the middleware pair plus `tests/observability` and `tests/events`: 2574 passed, 1 failed (`tests/events/test_culture_integration.py::…::test_apply_culture_hints_with_consensus`, an xdist order-dependent flake: passes in isolation on this branch and on pristine `origin/main` `cfc64b9d38`; the file never touches tracing)
- `tests/observability/test_trace_state.py tests/server/middleware/test_otel_bridge.py tests/server/middleware/test_tracing_middleware.py tests/middleware/test_tracing.py` three consecutive runs → 213 passed each
- `python3 -c "import aragora.observability.middleware.otel_bridge, aragora.observability.middleware.tracing; print('ok')"` → `ok`
- `python3 scripts/ci/measure_import_graph.py --check` → `OK: mutual import cycles 138 <= baseline 140.`
- `mypy aragora/ --ignore-missing-imports | tail -1` → `Found 1744 errors in 468 files` (unchanged)
- `bash $MISSION_DIR/bin/gate.sh lint|typecheck|contracts|guardrails|test` → all `GATE PASSED` (guardrails: `mutual_import_cycles: 138 (limit 140) ok`; test: 3860 passed, 3 skipped)

## Reviewed design tradeoffs

- A `TYPE_CHECKING`-only rewrite was not possible: both directions are genuine runtime calls (fallback IDs, span export).
- Making the bridge the leaf (bridge imports nothing, tracing imports bridge) would leave `Span.finish` needing the bridge, so the state had to move out of `tracing`; the exporter hook is the smallest inversion that keeps `Span.finish` free of the bridge.
- The hook is registered only where `_otel_available` flips true and cleared in `shutdown_otel_bridge`'s `finally`, mirroring the existing state transitions; the exporter's own guard makes a stale registration a no-op.

## Risks

Low: code moved verbatim, one indirection added on span export. Identity of every re-exported name and both import orders are asserted; the existing 51 bridge tests and 160+ tracing tests pass unchanged apart from the module-name repoint.
