### PR TITLE
chore(sdk): remove 10 phantom admin endpoint pairs from both SDKs (paydown batch 03)

### DIFF
--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -60,7 +60,7 @@ returned 405 from that handler, so no working integration depended on them.
 | Removed Method | Route | Migration |
 |----------------|-------|-----------|
 | `admin.get_organization(org_id)` | `GET /api/v1/admin/organizations/{id}` | `organizations.get(org_id)` (`GET /api/v1/org/{id}`) |
-| `admin.update_organization(org_id, **fields)` | `PUT /api/v1/admin/organizations/{id}` | No replacement; no in-spec route updates an organization by id |
+| `admin.update_organization(org_id, **fields)` | `PUT /api/v1/admin/organizations/{id}` | `organizations.update(org_id, name=..., settings=...)` (`PUT /api/v1/org/{id}`, served but not yet in the spec; org-admin scoped and accepts only `name` and `settings`) |
 | `admin.get_user(user_id)` | `GET /api/v1/admin/users/{id}` | `admin.list_users(...)` and filter by id |
 | `admin.suspend_user(user_id, reason)` | `POST /api/v1/admin/users/{id}/suspend` | `admin.deactivate_user(user_id)` |
 | `admin.impersonate_user(user_id)` | `POST /api/v1/admin/users/{id}/impersonate` | `client.request("POST", f"/api/v1/admin/impersonate/{user_id}")` |
@@ -68,7 +68,7 @@ returned 405 from that handler, so no working integration depended on them.
 | `admin.adjust_credits(org_id, amount, reason)` | `POST /api/v1/admin/organizations/{id}/credits` | `client.request("POST", f"/api/v1/admin/credits/{org_id}/adjust", json={...})` |
 | `admin.get_credit_account(org_id)` | `GET /api/v1/admin/organizations/{id}/credits` | `client.request("GET", f"/api/v1/admin/credits/{org_id}")` |
 | `admin.list_credit_transactions(org_id, **params)` | `GET /api/v1/admin/organizations/{id}/credits/transactions` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/transactions", params={...})` |
-| `admin.get_expiring_credits(org_id)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/expiring")` |
+| `admin.get_expiring_credits(org_id)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/expiring", params={"within_days": 30})` (`within_days` 1-365, default 30) |
 
 ---
 

--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -50,6 +50,26 @@ returned 404 and no working integration depended on them.
 | `webhooks.rotate_secret(webhook_id)` | `POST /api/v1/webhooks/{id}/rotate-secret` | `webhooks.delete(webhook_id)` then `webhooks.create(...)`; the secret is returned once on creation |
 | `webhooks.get_signing_info(webhook_id)` | `GET /api/v1/webhooks/{id}/signing` | Deliveries are signed with HMAC-SHA256 as `sha256=<hex>`; see `docs/api/WEBHOOKS.md` |
 
+Removed 10 `admin` methods (sync `AdminAPI` and async `AsyncAdminAPI`) that
+targeted routes no server handler dispatches. Below an organization or user id
+the admin handler only serves the `/activate`, `/deactivate` and `/unlock`
+user actions; impersonation is served as `POST /api/v1/admin/impersonate/{user_id}`
+and credits under `/api/v1/admin/credits/{org_id}/...`. Every call below
+returned 405 from that handler, so no working integration depended on them.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `admin.get_organization(org_id)` | `GET /api/v1/admin/organizations/{id}` | `organizations.get(org_id)` (`GET /api/v1/org/{id}`) |
+| `admin.update_organization(org_id, **fields)` | `PUT /api/v1/admin/organizations/{id}` | No replacement; no in-spec route updates an organization by id |
+| `admin.get_user(user_id)` | `GET /api/v1/admin/users/{id}` | `admin.list_users(...)` and filter by id |
+| `admin.suspend_user(user_id, reason)` | `POST /api/v1/admin/users/{id}/suspend` | `admin.deactivate_user(user_id)` |
+| `admin.impersonate_user(user_id)` | `POST /api/v1/admin/users/{id}/impersonate` | `client.request("POST", f"/api/v1/admin/impersonate/{user_id}")` |
+| `admin.issue_credits(org_id, amount, reason, expires_at=None)` | `POST /api/v1/admin/organizations/{id}/credits` | `client.request("POST", f"/api/v1/admin/credits/{org_id}/issue", json={...})` |
+| `admin.adjust_credits(org_id, amount, reason)` | `POST /api/v1/admin/organizations/{id}/credits` | `client.request("POST", f"/api/v1/admin/credits/{org_id}/adjust", json={...})` |
+| `admin.get_credit_account(org_id)` | `GET /api/v1/admin/organizations/{id}/credits` | `client.request("GET", f"/api/v1/admin/credits/{org_id}")` |
+| `admin.list_credit_transactions(org_id, **params)` | `GET /api/v1/admin/organizations/{id}/credits/transactions` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/transactions", params={...})` |
+| `admin.get_expiring_credits(org_id)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/expiring")` |
+
 ---
 
 ### v2.4.0 (2026-01-25)

--- a/sdk/python/aragora_sdk/namespaces/admin.py
+++ b/sdk/python/aragora_sdk/namespaces/admin.py
@@ -326,30 +326,8 @@ class AdminAPI:
         )
 
     # ===========================================================================
-    # Organization Management
-    # ===========================================================================
-
-    def get_organization(self, org_id: str) -> dict[str, Any]:
-        """Get an organization by ID."""
-        return self._client.request("GET", f"/api/v1/admin/organizations/{org_id}")
-
-    def update_organization(self, org_id: str, **kwargs: Any) -> dict[str, Any]:
-        """Update an organization."""
-        return self._client.request("PUT", f"/api/v1/admin/organizations/{org_id}", json=kwargs)
-
-    # ===========================================================================
     # User Management
     # ===========================================================================
-
-    def get_user(self, user_id: str) -> dict[str, Any]:
-        """Get a user by ID."""
-        return self._client.request("GET", f"/api/v1/admin/users/{user_id}")
-
-    def suspend_user(self, user_id: str, reason: str) -> dict[str, Any]:
-        """Suspend a user."""
-        return self._client.request(
-            "POST", f"/api/v1/admin/users/{user_id}/suspend", json={"reason": reason}
-        )
 
     def activate_user(self, user_id: str) -> dict[str, Any]:
         """Activate a user."""
@@ -358,10 +336,6 @@ class AdminAPI:
     def deactivate_user(self, user_id: str) -> dict[str, Any]:
         """Deactivate a user."""
         return self._client.request("POST", f"/api/v1/admin/users/{user_id}/deactivate")
-
-    def impersonate_user(self, user_id: str) -> dict[str, Any]:
-        """Impersonate a user."""
-        return self._client.request("POST", f"/api/v1/admin/users/{user_id}/impersonate")
 
     def unlock_user(self, user_id: str) -> dict[str, Any]:
         """Unlock a locked user account."""
@@ -374,53 +348,6 @@ class AdminAPI:
     def get_system_metrics(self) -> dict[str, Any]:
         """Get system metrics (CPU, memory, disk, etc.)."""
         return self._client.request("GET", "/api/v1/admin/system/metrics")
-
-    # ===========================================================================
-    # Credit Management
-    # ===========================================================================
-
-    def issue_credits(
-        self,
-        org_id: str,
-        amount: float,
-        reason: str,
-        *,
-        expires_at: str | None = None,
-    ) -> dict[str, Any]:
-        """Issue credits to an organization."""
-        payload: dict[str, Any] = {"amount": amount, "reason": reason}
-        if expires_at:
-            payload["expires_at"] = expires_at
-        return self._client.request(
-            "POST", f"/api/v1/admin/organizations/{org_id}/credits", json=payload
-        )
-
-    def get_credit_account(self, org_id: str) -> dict[str, Any]:
-        """Get credit account for an organization."""
-        return self._client.request("GET", f"/api/v1/admin/organizations/{org_id}/credits")
-
-    def list_credit_transactions(self, org_id: str, **kwargs: Any) -> dict[str, Any]:
-        """List credit transactions for an organization."""
-        return self._client.request(
-            "GET",
-            f"/api/v1/admin/organizations/{org_id}/credits/transactions",
-            params=kwargs if kwargs else None,
-        )
-
-    def adjust_credits(self, org_id: str, amount: float, reason: str) -> dict[str, Any]:
-        """Adjust credit balance for an organization."""
-        return self._client.request(
-            "POST",
-            f"/api/v1/admin/organizations/{org_id}/credits",
-            json={"amount": amount, "reason": reason},
-        )
-
-    def get_expiring_credits(self, org_id: str) -> dict[str, Any]:
-        """Get expiring credits for an organization."""
-        return self._client.request(
-            "GET",
-            f"/api/v1/admin/organizations/{org_id}/credits/expiring",
-        )
 
     # ===========================================================================
     # Security Maintenance
@@ -673,32 +600,8 @@ class AsyncAdminAPI:
         )
 
     # ===========================================================================
-    # Organization Management
-    # ===========================================================================
-
-    async def get_organization(self, org_id: str) -> dict[str, Any]:
-        """Get an organization by ID."""
-        return await self._client.request("GET", f"/api/v1/admin/organizations/{org_id}")
-
-    async def update_organization(self, org_id: str, **kwargs: Any) -> dict[str, Any]:
-        """Update an organization."""
-        return await self._client.request(
-            "PUT", f"/api/v1/admin/organizations/{org_id}", json=kwargs
-        )
-
-    # ===========================================================================
     # User Management
     # ===========================================================================
-
-    async def get_user(self, user_id: str) -> dict[str, Any]:
-        """Get a user by ID."""
-        return await self._client.request("GET", f"/api/v1/admin/users/{user_id}")
-
-    async def suspend_user(self, user_id: str, reason: str) -> dict[str, Any]:
-        """Suspend a user."""
-        return await self._client.request(
-            "POST", f"/api/v1/admin/users/{user_id}/suspend", json={"reason": reason}
-        )
 
     async def activate_user(self, user_id: str) -> dict[str, Any]:
         """Activate a user."""
@@ -707,10 +610,6 @@ class AsyncAdminAPI:
     async def deactivate_user(self, user_id: str) -> dict[str, Any]:
         """Deactivate a user."""
         return await self._client.request("POST", f"/api/v1/admin/users/{user_id}/deactivate")
-
-    async def impersonate_user(self, user_id: str) -> dict[str, Any]:
-        """Impersonate a user."""
-        return await self._client.request("POST", f"/api/v1/admin/users/{user_id}/impersonate")
 
     async def unlock_user(self, user_id: str) -> dict[str, Any]:
         """Unlock a locked user account."""
@@ -723,53 +622,6 @@ class AsyncAdminAPI:
     async def get_system_metrics(self) -> dict[str, Any]:
         """Get system metrics (CPU, memory, disk, etc.)."""
         return await self._client.request("GET", "/api/v1/admin/system/metrics")
-
-    # ===========================================================================
-    # Credit Management
-    # ===========================================================================
-
-    async def issue_credits(
-        self,
-        org_id: str,
-        amount: float,
-        reason: str,
-        *,
-        expires_at: str | None = None,
-    ) -> dict[str, Any]:
-        """Issue credits to an organization."""
-        payload: dict[str, Any] = {"amount": amount, "reason": reason}
-        if expires_at:
-            payload["expires_at"] = expires_at
-        return await self._client.request(
-            "POST", f"/api/v1/admin/organizations/{org_id}/credits", json=payload
-        )
-
-    async def get_credit_account(self, org_id: str) -> dict[str, Any]:
-        """Get credit account for an organization."""
-        return await self._client.request("GET", f"/api/v1/admin/organizations/{org_id}/credits")
-
-    async def list_credit_transactions(self, org_id: str, **kwargs: Any) -> dict[str, Any]:
-        """List credit transactions for an organization."""
-        return await self._client.request(
-            "GET",
-            f"/api/v1/admin/organizations/{org_id}/credits/transactions",
-            params=kwargs if kwargs else None,
-        )
-
-    async def adjust_credits(self, org_id: str, amount: float, reason: str) -> dict[str, Any]:
-        """Adjust credit balance for an organization."""
-        return await self._client.request(
-            "POST",
-            f"/api/v1/admin/organizations/{org_id}/credits",
-            json={"amount": amount, "reason": reason},
-        )
-
-    async def get_expiring_credits(self, org_id: str) -> dict[str, Any]:
-        """Get expiring credits for an organization."""
-        return await self._client.request(
-            "GET",
-            f"/api/v1/admin/organizations/{org_id}/credits/expiring",
-        )
 
     # ===========================================================================
     # Security Maintenance

--- a/sdk/python/aragora_sdk/namespaces/admin.py
+++ b/sdk/python/aragora_sdk/namespaces/admin.py
@@ -5,10 +5,9 @@ Provides methods for platform administration operations.
 Requires admin role for all operations.
 
 Features:
-- Organization and user management
+- Organization and user listing
 - Platform statistics and system metrics
 - Nomic loop control
-- Credit management
 - Security operations
 """
 
@@ -29,11 +28,10 @@ class AdminAPI:
     Synchronous Admin API.
 
     Provides methods for platform administration:
-    - Organization and user management
+    - Organization and user listing
     - Platform statistics and system metrics
     - Revenue analytics
     - Nomic loop control
-    - Credit management
     - Security operations
 
     Example:

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -52,6 +52,29 @@ on them. The interfaces used only by those methods (`WebhookDeliveryAttempt`,
 | `webhooks.rotateSecret(webhookId)` | `POST /api/v1/webhooks/{id}/rotate-secret` | `webhooks.delete(webhookId)` then `webhooks.create(...)`; the secret is returned once on creation |
 | `webhooks.getSigningInfo(webhookId)` | `GET /api/v1/webhooks/{id}/signing` | Deliveries are signed with HMAC-SHA256 as `sha256=<hex>`; see `docs/api/WEBHOOKS.md` |
 
+Removed 10 `admin` methods from `AdminAPI` that targeted routes no server
+handler dispatches. Below an organization or user id the admin handler only
+serves the `/activate`, `/deactivate` and `/unlock` user actions; impersonation
+is served as `POST /api/v1/admin/impersonate/{userId}` and credits under
+`/api/v1/admin/credits/{orgId}/...`. Every call below returned 405 from that
+handler, so no working integration depended on them. The
+`AdminClientInterface` entries used only by those methods (`getCreditAccount`,
+`listCreditTransactions`, `adjustCreditBalance`, `getExpiringCredits`) were
+removed with them.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `admin.getOrganization(orgId)` | `GET /api/v1/admin/organizations/{id}` | `organizations.get(orgId)` (`GET /api/v1/org/{id}`) |
+| `admin.updateOrganization(orgId, updates)` | `PUT /api/v1/admin/organizations/{id}` | No replacement; no in-spec route updates an organization by id |
+| `admin.getUser(userId)` | `GET /api/v1/admin/users/{id}` | `admin.listUsers(...)` and filter by id |
+| `admin.suspendUser(userId, reason)` | `POST /api/v1/admin/users/{id}/suspend` | `admin.deactivateUser(userId)` |
+| `admin.impersonateUser(userId)` | `POST /api/v1/admin/users/{id}/impersonate` | `openapi.requestPostApiV1AdminImpersonateByUserId(userId)` (`POST /api/v1/admin/impersonate/{userId}`) |
+| `admin.issueCredits(orgId, amount, reason, expiresAt)` | `POST /api/v1/admin/organizations/{id}/credits` | ``client.request('POST', `/api/v1/admin/credits/${orgId}/issue`, { body })`` |
+| `admin.adjustCredits(orgId, amount, reason)` | `POST /api/v1/admin/organizations/{id}/credits` | ``client.request('POST', `/api/v1/admin/credits/${orgId}/adjust`, { body })`` |
+| `admin.getCreditAccount(orgId)` | `GET /api/v1/admin/organizations/{id}/credits` | ``client.request('GET', `/api/v1/admin/credits/${orgId}`)`` |
+| `admin.listCreditTransactions(orgId, params)` | `GET /api/v1/admin/organizations/{id}/credits/transactions` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/transactions`, { params })`` |
+| `admin.getExpiringCredits(orgId)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/expiring`)`` |
+
 ---
 
 ## Migration Guides

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -60,12 +60,16 @@ is served as `POST /api/v1/admin/impersonate/{userId}` and credits under
 handler, so no working integration depended on them. The
 `AdminClientInterface` entries used only by those methods (`getCreditAccount`,
 `listCreditTransactions`, `adjustCreditBalance`, `getExpiringCredits`) were
-removed with them.
+removed with them. The legacy flat methods on `AragoraClient` that target the
+same routes (`getAdminOrganization`, `updateAdminOrganization`, `getAdminUser`,
+`suspendAdminUser`, `impersonateUser`, `issueCredits`, `getCreditAccount`,
+`listCreditTransactions`, `adjustCreditBalance`, `getExpiringCredits`) are
+unchanged here and still return 405; do not migrate to them.
 
 | Removed Method | Route | Migration |
 |----------------|-------|-----------|
 | `admin.getOrganization(orgId)` | `GET /api/v1/admin/organizations/{id}` | `organizations.get(orgId)` (`GET /api/v1/org/{id}`) |
-| `admin.updateOrganization(orgId, updates)` | `PUT /api/v1/admin/organizations/{id}` | No replacement; no in-spec route updates an organization by id |
+| `admin.updateOrganization(orgId, updates)` | `PUT /api/v1/admin/organizations/{id}` | `organizations.update(orgId, { name, settings })` (`PUT /api/v1/org/{id}`, served but not yet in the spec; org-admin scoped and accepts only `name` and `settings`) |
 | `admin.getUser(userId)` | `GET /api/v1/admin/users/{id}` | `admin.listUsers(...)` and filter by id |
 | `admin.suspendUser(userId, reason)` | `POST /api/v1/admin/users/{id}/suspend` | `admin.deactivateUser(userId)` |
 | `admin.impersonateUser(userId)` | `POST /api/v1/admin/users/{id}/impersonate` | `openapi.requestPostApiV1AdminImpersonateByUserId(userId)` (`POST /api/v1/admin/impersonate/{userId}`) |
@@ -73,7 +77,7 @@ removed with them.
 | `admin.adjustCredits(orgId, amount, reason)` | `POST /api/v1/admin/organizations/{id}/credits` | ``client.request('POST', `/api/v1/admin/credits/${orgId}/adjust`, { body })`` |
 | `admin.getCreditAccount(orgId)` | `GET /api/v1/admin/organizations/{id}/credits` | ``client.request('GET', `/api/v1/admin/credits/${orgId}`)`` |
 | `admin.listCreditTransactions(orgId, params)` | `GET /api/v1/admin/organizations/{id}/credits/transactions` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/transactions`, { params })`` |
-| `admin.getExpiringCredits(orgId)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/expiring`)`` |
+| `admin.getExpiringCredits(orgId)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/expiring`, { params: { within_days: 30 } })`` (`within_days` 1-365, default 30) |
 
 ---
 

--- a/sdk/typescript/src/namespaces/__tests__/admin.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/admin.test.ts
@@ -6,7 +6,6 @@
  * - Platform statistics and system metrics
  * - Revenue analytics
  * - Nomic loop control
- * - Credit management
  * - Security operations
  */
 
@@ -16,27 +15,16 @@ import { AdminAPI } from '../admin';
 interface MockClient {
   request: Mock;
   listOrganizations: Mock;
-  getAdminOrganization: Mock;
-  updateAdminOrganization: Mock;
   listAdminUsers: Mock;
-  getAdminUser: Mock;
-  suspendAdminUser: Mock;
   activateAdminUser: Mock;
   getAdminStats: Mock;
   getAdminSystemMetrics: Mock;
   getRevenue: Mock;
-  impersonateUser: Mock;
   getAdminNomicStatus: Mock;
   getAdminCircuitBreakers: Mock;
   resetNomic: Mock;
   pauseNomic: Mock;
   resumeNomic: Mock;
-  resetAdminCircuitBreakers: Mock;
-  issueCredits: Mock;
-  getCreditAccount: Mock;
-  listCreditTransactions: Mock;
-  adjustCreditBalance: Mock;
-  getExpiringCredits: Mock;
   getAdminSecurityStatus: Mock;
   rotateSecurityKey: Mock;
   getAdminSecurityHealth: Mock;
@@ -51,27 +39,16 @@ describe('AdminAPI Namespace', () => {
     mockClient = {
       request: vi.fn(),
       listOrganizations: vi.fn(),
-      getAdminOrganization: vi.fn(),
-      updateAdminOrganization: vi.fn(),
       listAdminUsers: vi.fn(),
-      getAdminUser: vi.fn(),
-      suspendAdminUser: vi.fn(),
       activateAdminUser: vi.fn(),
       getAdminStats: vi.fn(),
       getAdminSystemMetrics: vi.fn(),
       getRevenue: vi.fn(),
-      impersonateUser: vi.fn(),
       getAdminNomicStatus: vi.fn(),
       getAdminCircuitBreakers: vi.fn(),
       resetNomic: vi.fn(),
       pauseNomic: vi.fn(),
       resumeNomic: vi.fn(),
-      resetAdminCircuitBreakers: vi.fn(),
-      issueCredits: vi.fn(),
-      getCreditAccount: vi.fn(),
-      listCreditTransactions: vi.fn(),
-      adjustCreditBalance: vi.fn(),
-      getExpiringCredits: vi.fn(),
       getAdminSecurityStatus: vi.fn(),
       rotateSecurityKey: vi.fn(),
       getAdminSecurityHealth: vi.fn(),
@@ -117,40 +94,6 @@ describe('AdminAPI Namespace', () => {
       expect(mockClient.listOrganizations).toHaveBeenCalledWith({ limit: 1, offset: 50 });
       expect(result.total).toBe(100);
     });
-
-    it('should get organization by ID', async () => {
-      const mockOrg = {
-        id: 'org1',
-        name: 'Acme Corp',
-        created_at: '2024-01-01',
-        status: 'active',
-        plan: 'enterprise',
-        user_count: 250,
-      };
-      mockClient.request.mockResolvedValue(mockOrg);
-
-      const result = await api.getOrganization('org1');
-
-      expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/admin/organizations/org1');
-      expect(result.name).toBe('Acme Corp');
-    });
-
-    it('should update organization', async () => {
-      const mockUpdated = {
-        id: 'org1',
-        name: 'Acme Corporation',
-        status: 'active',
-        plan: 'enterprise',
-      };
-      mockClient.request.mockResolvedValue(mockUpdated);
-
-      const result = await api.updateOrganization('org1', { name: 'Acme Corporation' });
-
-      expect(mockClient.request).toHaveBeenCalledWith('PUT', '/api/v1/admin/organizations/org1', {
-        json: { name: 'Acme Corporation' },
-      });
-      expect(result.name).toBe('Acme Corporation');
-    });
   });
 
   // ===========================================================================
@@ -176,42 +119,6 @@ describe('AdminAPI Namespace', () => {
       expect(result.users).toHaveLength(2);
     });
 
-    it('should get user by ID', async () => {
-      const mockUser = {
-        id: 'u1',
-        email: 'admin@acme.com',
-        name: 'Admin User',
-        org_id: 'org1',
-        role: 'admin',
-        created_at: '2024-01-01',
-        last_login: '2024-01-20T10:00:00Z',
-        status: 'active',
-      };
-      mockClient.request.mockResolvedValue(mockUser);
-
-      const result = await api.getUser('u1');
-
-      expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/admin/users/u1');
-      expect(result.email).toBe('admin@acme.com');
-    });
-
-    it('should suspend user', async () => {
-      const mockAction = {
-        success: true,
-        user_id: 'u2',
-        status: 'suspended',
-        message: 'User suspended due to policy violation',
-      };
-      mockClient.request.mockResolvedValue(mockAction);
-
-      const result = await api.suspendUser('u2', 'Policy violation');
-
-      expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/v1/admin/users/u2/suspend', {
-        json: { reason: 'Policy violation' },
-      });
-      expect(result.status).toBe('suspended');
-    });
-
     it('should activate user', async () => {
       const mockAction = {
         success: true,
@@ -224,21 +131,6 @@ describe('AdminAPI Namespace', () => {
 
       expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/v1/admin/users/u2/activate');
       expect(result.status).toBe('active');
-    });
-
-    it('should impersonate user', async () => {
-      const mockToken = {
-        token: 'impersonation_token_123',
-        expires_at: '2024-01-20T11:00:00Z',
-        user_id: 'u2',
-        user_email: 'user@acme.com',
-      };
-      mockClient.request.mockResolvedValue(mockToken);
-
-      const result = await api.impersonateUser('u2');
-
-      expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/v1/admin/users/u2/impersonate');
-      expect(result.token).toBe('impersonation_token_123');
     });
   });
 
@@ -539,97 +431,6 @@ describe('AdminAPI Namespace', () => {
         { body: { value: false } },
       );
       expect(result.updated).toBe(true);
-    });
-  });
-
-  // ===========================================================================
-  // Credit Management
-  // ===========================================================================
-
-  describe('Credit Management', () => {
-    it('should issue credits', async () => {
-      const mockAccount = {
-        org_id: 'org1',
-        balance: 1000,
-        lifetime_issued: 1000,
-        lifetime_used: 0,
-        expires_at: '2024-12-31',
-      };
-      mockClient.request.mockResolvedValue(mockAccount);
-
-      const result = await api.issueCredits('org1', 1000, 'Welcome bonus', '2024-12-31');
-
-      expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/v1/admin/organizations/org1/credits', {
-        json: {
-          amount: 1000,
-          reason: 'Welcome bonus',
-          expires_at: '2024-12-31',
-        },
-      });
-      expect(result.balance).toBe(1000);
-    });
-
-    it('should get credit account', async () => {
-      const mockAccount = {
-        org_id: 'org1',
-        balance: 750,
-        lifetime_issued: 1000,
-        lifetime_used: 250,
-      };
-      mockClient.request.mockResolvedValue(mockAccount);
-
-      const result = await api.getCreditAccount('org1');
-
-      expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/admin/organizations/org1/credits');
-      expect(result.balance).toBe(750);
-    });
-
-    it('should list credit transactions', async () => {
-      const mockTransactions = {
-        transactions: [
-          { id: 't1', org_id: 'org1', amount: 1000, type: 'issue', reason: 'Welcome bonus' },
-          { id: 't2', org_id: 'org1', amount: -50, type: 'use', reason: 'Debate usage' },
-        ],
-        total: 2,
-      };
-      mockClient.request.mockResolvedValue(mockTransactions);
-
-      const result = await api.listCreditTransactions('org1');
-
-      expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/admin/organizations/org1/credits/transactions', { params: undefined });
-      expect(result.transactions).toHaveLength(2);
-    });
-
-    it('should adjust credit balance', async () => {
-      const mockAccount = {
-        org_id: 'org1',
-        balance: 500,
-        lifetime_issued: 1000,
-        lifetime_used: 500,
-      };
-      mockClient.request.mockResolvedValue(mockAccount);
-
-      const result = await api.adjustCredits('org1', -250, 'Refund adjustment');
-
-      expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/v1/admin/organizations/org1/credits', {
-        body: { amount: -250, reason: 'Refund adjustment' },
-      });
-      expect(result.balance).toBe(500);
-    });
-
-    it('should get expiring credits', async () => {
-      const mockExpiring = {
-        credits: [
-          { amount: 200, expires_at: '2024-01-31' },
-          { amount: 300, expires_at: '2024-02-28' },
-        ],
-      };
-      mockClient.request.mockResolvedValue(mockExpiring);
-
-      const result = await api.getExpiringCredits('org1');
-
-      expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/admin/organizations/org1/credits/expiring');
-      expect(result.credits).toHaveLength(2);
     });
   });
 

--- a/sdk/typescript/src/namespaces/admin.ts
+++ b/sdk/typescript/src/namespaces/admin.ts
@@ -109,10 +109,6 @@ interface AdminClientInterface {
   resetNomic(): Promise<{ success: boolean }>;
   pauseNomic(): Promise<{ success: boolean }>;
   resumeNomic(): Promise<{ success: boolean }>;
-  getCreditAccount(orgId: string): Promise<Record<string, unknown>>;
-  listCreditTransactions(orgId: string, params?: Record<string, unknown>): Promise<Record<string, unknown>>;
-  adjustCreditBalance(orgId: string, data: { amount: number; reason: string }): Promise<Record<string, unknown>>;
-  getExpiringCredits(orgId: string): Promise<Record<string, unknown>>;
   getAdminSecurityStatus(): Promise<SecurityStatus>;
   rotateSecurityKey(keyType: string): Promise<Record<string, unknown>>;
   getAdminSecurityHealth(): Promise<{ healthy: boolean; checks: Record<string, boolean> }>;
@@ -157,20 +153,6 @@ export class AdminAPI {
     return this.client.listOrganizations(params);
   }
 
-  /**
-   * Get an organization by ID.
-   */
-  async getOrganization(orgId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/admin/organizations/${orgId}`);
-  }
-
-  /**
-   * Update an organization.
-   */
-  async updateOrganization(orgId: string, updates: Record<string, unknown>): Promise<Record<string, unknown>> {
-    return this.client.request('PUT', `/api/v1/admin/organizations/${orgId}`, { json: updates });
-  }
-
   // ===========================================================================
   // Users
   // ===========================================================================
@@ -183,31 +165,10 @@ export class AdminAPI {
   }
 
   /**
-   * Get a user by ID.
-   */
-  async getUser(userId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/admin/users/${userId}`);
-  }
-
-  /**
-   * Suspend a user.
-   */
-  async suspendUser(userId: string, reason: string): Promise<Record<string, unknown>> {
-    return this.client.request('POST', `/api/v1/admin/users/${userId}/suspend`, { json: { reason } });
-  }
-
-  /**
    * Activate a user.
    */
   async activateUser(userId: string): Promise<Record<string, unknown>> {
     return this.client.request('POST', `/api/v1/admin/users/${userId}/activate`);
-  }
-
-  /**
-   * Impersonate a user.
-   */
-  async impersonateUser(userId: string): Promise<Record<string, unknown>> {
-    return this.client.request('POST', `/api/v1/admin/users/${userId}/impersonate`);
   }
 
   // ===========================================================================
@@ -279,47 +240,6 @@ export class AdminAPI {
    */
   async resetCircuitBreakers(): Promise<Record<string, unknown>> {
     return this.client.request('POST', '/api/v1/admin/circuit-breakers/reset');
-  }
-
-  // ===========================================================================
-  // Credit Management
-  // ===========================================================================
-
-  /**
-   * Issue credits to an organization.
-   */
-  async issueCredits(orgId: string, amount: number, reason: string, expiresAt?: string): Promise<Record<string, unknown>> {
-    return this.client.request('POST', `/api/v1/admin/organizations/${orgId}/credits`, {
-      json: { amount, reason, expires_at: expiresAt },
-    });
-  }
-
-  /**
-   * Get credit account for an organization.
-   */
-  async getCreditAccount(orgId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/admin/organizations/${orgId}/credits`);
-  }
-
-  /**
-   * List credit transactions for an organization.
-   */
-  async listCreditTransactions(orgId: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/admin/organizations/${orgId}/credits/transactions`, { params });
-  }
-
-  /**
-   * Adjust credit balance for an organization.
-   */
-  async adjustCredits(orgId: string, amount: number, reason: string): Promise<Record<string, unknown>> {
-    return this.client.request('POST', `/api/v1/admin/organizations/${orgId}/credits`, { body: { amount, reason } });
-  }
-
-  /**
-   * Get expiring credits for an organization.
-   */
-  async getExpiringCredits(orgId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/admin/organizations/${orgId}/credits/expiring`);
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

SDK drift paydown batch 03 of 6 (tranche 1; operator Decision "SDK PAYDOWN TRANCHE 1", `library/decision-ledger.md` L999 == `library/operator-approvals.md` L852, plus "SDK PAYDOWN TRANCHE 1 - AMENDMENT 1", `library/decision-ledger.md` L1002 == `library/operator-approvals.md` L858). Follows PR #9967 (batch 01) and PR #9969 (batch 02).

Deletes the matched Python + TypeScript `admin` methods whose `VERB /path` is absent from both `docs/api/openapi.json` and `docs/api/openapi_generated.json` AND that no handler under `aragora/server` dispatches. Route truth was read from the dispatch code, not a text grep: `AdminHandler.handle()` (`aragora/server/handlers/admin/handler.py` L396-505) claims every `/api/v1/admin*` path via `can_handle` and then only branches on the exact GET paths `/organizations`, `/users`, `/stats`, `/system/metrics`, `/revenue`, `/nomic/status`, `/nomic/circuit-breakers`, and the POST paths `/impersonate/{user_id}`, `/users/{id}/deactivate|activate|unlock`, `/nomic/reset|pause|resume|circuit-breakers/reset`; everything else falls through to `405 Method not allowed`. The FastAPI v2 admin router (`aragora/server/fastapi/routes/admin.py`, prefix `/api/v2/admin`) adds only `GET /organizations` and the same three user actions. Credits are served by `CreditsAdminHandler` at `/api/v1/admin/credits/{org_id}[/issue|/adjust|/transactions|/expiring]` and impersonation at `POST /api/v1/admin/impersonate/{user_id}`, both different shapes from the SDK URLs below. Each removed pair was re-verified individually; no spec entries added, no baselines edited.

### Removed (10 matched pairs, both SDKs, sync + async on the Python side)

| Route | Python (`AdminAPI` / `AsyncAdminAPI`) | TypeScript (`AdminAPI`) |
|---|---|---|
| `GET /api/v1/admin/organizations/{id}` | `get_organization` | `getOrganization` |
| `PUT /api/v1/admin/organizations/{id}` | `update_organization` | `updateOrganization` |
| `GET /api/v1/admin/users/{id}` | `get_user` | `getUser` |
| `POST /api/v1/admin/users/{id}/suspend` | `suspend_user` | `suspendUser` |
| `POST /api/v1/admin/users/{id}/impersonate` | `impersonate_user` | `impersonateUser` |
| `POST /api/v1/admin/organizations/{id}/credits` | `issue_credits` | `issueCredits` |
| `POST /api/v1/admin/organizations/{id}/credits` | `adjust_credits` | `adjustCredits` |
| `GET /api/v1/admin/organizations/{id}/credits` | `get_credit_account` | `getCreditAccount` |
| `GET /api/v1/admin/organizations/{id}/credits/transactions` | `list_credit_transactions` | `listCreditTransactions` |
| `GET /api/v1/admin/organizations/{id}/credits/expiring` | `get_expiring_credits` | `getExpiringCredits` |

Also removed: the four `AdminClientInterface` entries used only by the deleted methods (`getCreditAccount`, `listCreditTransactions`, `adjustCreditBalance`, `getExpiringCredits`; the interface is module-private and not re-exported) and the 10 vitest cases in `sdk/typescript/src/namespaces/__tests__/admin.test.ts` that exercised the removed methods, plus the mock-client keys that existed only for them. No Python SDK test referenced any removed method (`sdk/python/tests/test_admin.py` uses only `get_mfa_compliance` / `get_system_health_component`).

### SKIP-list reclassification (Amendment 1)

- `GET /api/v1/admin/users/{id}` (`get_user` / `getUser`) was listed as served-but-undocumented. Verified from the dispatch code: the GET branch of `AdminHandler.handle()` matches only the exact string `/api/v1/admin/users` (L399-403); the FastAPI router has no `GET /users/{user_id}`; the only `{user_id}` GET in `aragora/server` is the `EndpointAuth("/api/admin/users/{id}", "get", ...)` policy row in `auth_requirements.py`, which is an auth table, not a route. The pair is phantom and absent from both OpenAPI files, so it is deleted here as an in-scope matched pair (recorded in `library/tech-debt.md`).
- `POST /api/v1/admin/circuit-breakers/reset` (`reset_circuit_breakers` / `resetCircuitBreakers`) is declared in `AdminHandler.ROUTES` (L272) but has no dispatch branch, so at runtime it is also a 405. It is KEPT: `scripts/check_sdk_parity.py --strict` derives its route inventory from handler `ROUTES` declarations and fails with `NEW: /api/admin/circuit-breakers/reset` (missing_from_both 1/0) when both SDK methods are removed. Deleting the pair would need a `ROUTES` correction under `aragora/server`, which the Decision forbids for this PR. Recorded in `library/tech-debt.md`.
- `POST /api/v1/audience/suggestions` (`create_suggestion` / `createSuggestion`) is genuinely served by `AudienceSuggestionsHandler` (exact path, GET + POST) and stays.

### Skipped (assigned but out of the Decision's `sdk/`-only scope; noted in the mission tech-debt ledger)

- `audience: GET/POST /api/v1/debates/{id}/audience/suggestions` (`get_suggestions` / `submit_suggestion` and `getSuggestions` / `submitSuggestion`) are phantom (no handler dispatches the per-debate shape; the served route is `/api/v1/audience/suggestions`) but their tests live outside `sdk/`: `tests/sdk/test_audience_ns.py` and `tests/sdk/test_sdk_namespaces_new.py` (run by `sdk-test.yml` via `pytest tests/sdk/`) and `aragora/live/tests/sdk/test_sdk_namespaces_new.py`. Deleting the pair would break those suites, and touching them VOIDS the Decision for this PR (same reason batch 02 skipped `modes` / `spectate`). Left for a batch that can carry a `tests/sdk/` change under separate authority.
- The flat legacy `AragoraClient` methods in `sdk/typescript/src/client.ts` (L6420-6511, e.g. `getAdminOrganization`, `suspendAdminUser`, `adjustCreditBalance`) hit the same phantom paths. They are outside the `namespaces/` scan scope of every parity script and were left untouched by batches 01 and 02; not changed here.

### Docs

- `sdk/python/BREAKING_CHANGES.md` and `sdk/typescript/BREAKING_CHANGES.md`: 10 new rows with migrations under "Unreleased (2026-09-03)". Migrations name only routes present in the OpenAPI union: `organizations.get(org_id)` (`GET /api/v1/org/{id}`), `admin.list_users` / `admin.listUsers`, `admin.deactivate_user` / `admin.deactivateUser`, `POST /api/v1/admin/impersonate/{user_id}` (TS: `openapi.requestPostApiV1AdminImpersonateByUserId`; the Python `openapi` namespace has only the GET variant, so the row shows a raw `client.request`), and the `/api/v1/admin/credits/{org_id}/...` family via `client.request` (no curated method exists in either SDK). `update_organization` / `updateOrganization` migrates to `organizations.update(org_id, name=..., settings=...)` / `organizations.update(orgId, { name, settings })`: `PUT /api/v1/org/{id}` is dispatched by `aragora/server/handlers/organizations.py` L189-195 -> `_update_organization` (org-admin scoped via `_check_org_access(min_role="admin")` + `organizations.update` RBAC; accepts only `name` and `settings`). It is served but not yet in the spec, and the row says so. The expiring-credits rows carry the `within_days` query param the served route accepts (`aragora/server/handlers/admin/credits.py` L346-352; 1-365, default 30).
- The TypeScript migration examples pass `{ body }` because `AragoraClient.request` takes `RequestOptions { body?, params?, headers?, timeout?, responseType? }` (`sdk/typescript/src/client.ts` L318-324); the removed methods passed `{ json: ... }`, a key that signature does not carry (the module-private `AdminClientInterface.request` types options as `Record<string, unknown>`, so it compiled without ever sending a body).
- `sdk/python/aragora_sdk/namespaces/admin.py` module and `AdminAPI` docstrings now list "Organization and user listing" and no longer advertise "Credit management" (the TypeScript header was already updated). The TypeScript BREAKING_CHANGES prose names the untouched flat `AragoraClient` legacy admin methods that still target the same routes so nobody migrates to them.

## Measurements

`python3 scripts/verify_sdk_contracts.py --strict --baseline scripts/baselines/verify_sdk_contracts.json`

| | origin/main `eed97a23cc` (PR base) | this head `675703eecc` |
|---|---|---|
| Python SDK drift (endpoints not in spec) | 442 | **433** |
| TypeScript SDK drift (endpoints not in spec) | 298 | **289** |
| Baseline regressions | py=0 ts=0 stable=0 | py=0 ts=0 stable=0 |

- `git diff --numstat origin/main...HEAD`: +49 / -431 = **480 LOC** across 5 files, all under `sdk/`.
- `scripts/baselines/` byte-identical to origin/main (all 18 files; the six pinned sha256 values match the Decision).

## Local gates (all re-run on the committed head `675703eecc`)

- `python3 scripts/check_sdk_parity.py --strict --baseline … --budget …` PASS (missing_from_both 0/0, stale_python 24/36)
- `python3 scripts/check_sdk_namespace_parity.py --strict --baseline …` Regressions: 0
- `python3 scripts/check_cross_sdk_parity.py --strict --baseline …` PASS (python_only=0 typescript_only=0)
- `python3 scripts/verify_sdk_contracts.py --strict --baseline …` PASS (433 / 289, regressions 0)
- `sdk/python`: `ruff check` + `ruff format --check` clean; `python3 -m pytest tests/ --color=no` → `1395 passed, 3 warnings in 4.20s`
- `sdk/typescript`: `npx tsc --noEmit` exit 0 on this head; `npm ci` (184 packages) + `npm test -- --run` on the code-identical parent `a29c2c1bb9` (this head changes only `.md` files and Python docstrings) → `Tests 1 failed | 1710 passed (1711)`, `admin.test.ts` 31 tests green; the single failure is the pre-existing `parity-compat-routes.test.ts › maps debate stats compatibility routes` present on origin/main (`library/environment.md` 2026-09-03 R2 note)
- `make lint`, `ruff format --check aragora/ tests/ scripts/` (10891 files), `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh cache): clean
- AWS-neutralized `make test-smoke`: "Smoke tests passed!"
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok

## Review history (all tier-3 prepare-only rounds; nothing posted)

- Round 1 on `a29c2c1bb9`: openai PASS (grounded, would_count=true; one P3 on the `{ body }` vs `{ json }` option key, addressed in the body above); claude returned no review, the default `claude` CLI profile failed its liveness probe (`OAuth session expired and could not be refreshed`, default and sonnet rungs). Infrastructure failure, not a review round.
- Round 2 on `a29c2c1bb9` via the live `max-01` profile (`scripts/claude_profile.sh exec`, `ARAGORA_MODEL_TRANSPORT=direct`): openai PASS (grounded, would_count=true; P3 stale Python docstring); claude CHANGES-REQUESTED (grounded, counted dissent): P2 the `update_organization` migration row said "no replacement" although `PUT /api/v1/org/{id}` is dispatched; P3 flat `client.ts` legacy methods, P3 stale Python docstrings, P3 missing `within_days`. Both bodies SUPERSEDED by head `675703eecc`, which fixes every finding (this is the Decision's single fix-and-recollect round).
- Round 3 on `675703eecc`: see the posted review comments.

## Settlement

Tier 3 (`sdk/` prefix). Settles in-session under the recorded tranche Decision + Amendment 1: record-settlement while draft -> prepared reviewer bodies posted byte-exact -> ready -> model quorum -> merge-packet satisfied -> non-admin `--match-head-commit` squash merge.
