### PR TITLE
chore(sdk): remove 12 phantom tenants/media endpoint pairs from both SDKs (paydown batch 04)

### DIFF
--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -71,17 +71,22 @@ returned 405 from that handler, so no working integration depended on them.
 | `admin.get_expiring_credits(org_id)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/expiring", params={"within_days": 30})` (`within_days` 1-365, default 30) |
 
 Removed 10 `tenants` methods (sync `TenantsAPI` and async `AsyncTenantsAPI`)
-that targeted routes no server handler dispatches. The HTTP server routes only
-the `/api/v1/tenants` collection (declared by the organizations handler);
-nothing dispatches `/api/v1/tenants/{id}` or any path below it, and the opt-in
-FastAPI `/api/v2/admin/tenants` surface is a separate admin family outside the
-spec. Every call below returned 404, so no working integration depended on
-them. `tenants.list(...)` and `tenants.create(...)` remain.
+that targeted routes no server handler dispatches. Nothing under
+`/api/v1/tenants/{id}` is routed, so every call below returned 404 and no
+working integration depended on them. There is no self-service tenant read or
+write on the HTTP server at all: `/api/v1/tenants` is declared by the
+organizations handler and `GET` is in the spec, but the handler has no branch
+for it, so `tenants.list(...)` and `tenants.create(...)` (kept because their
+route is spec-listed) currently fail too. Tenant administration lives only on
+the opt-in FastAPI surface (`ARAGORA_USE_FASTAPI`): `GET`/`POST
+/api/v2/admin/tenants` and `PUT /api/v2/admin/tenants/{tenant_id}` (`name`,
+`tier`, `is_active`, `config`; `admin:tenants:write`), none of which is in the
+spec or wrapped by this SDK.
 
 | Removed Method | Route | Migration |
 |----------------|-------|-----------|
-| `tenants.get(tenant_id)` | `GET /api/v1/tenants/{id}` | `tenants.list(...)` and filter by id |
-| `tenants.update(tenant_id, name=..., plan=..., settings=..., quotas=...)` | `PATCH /api/v1/tenants/{id}` | `organizations.update(org_id, name=..., settings=...)` (`PUT /api/v1/org/{id}`, served but not in the spec; org-admin scoped and accepts only `name` and `settings`; plan and quota changes have no self-service route) |
+| `tenants.get(tenant_id)` | `GET /api/v1/tenants/{id}` | No replacement; no tenant read is served (see above) |
+| `tenants.update(tenant_id, name=..., plan=..., settings=..., quotas=...)` | `PATCH /api/v1/tenants/{id}` | `organizations.update(org_id, name=..., settings=...)` (`PUT /api/v1/org/{id}`, served but not in the spec; org-admin scoped and accepts only `name` and `settings`). Plan and quota changes have no self-service route; admins can use `PUT /api/v2/admin/tenants/{tenant_id}` (`client.request`) when the FastAPI surface is enabled |
 | `tenants.delete(tenant_id)` | `DELETE /api/v1/tenants/{id}` | No replacement; tenant deletion is not served |
 | `tenants.suspend(tenant_id, reason)` | `POST /api/v1/tenants/{id}/suspend` | No replacement; tenant suspension is not served |
 | `tenants.reactivate(tenant_id)` | `POST /api/v1/tenants/{id}/reactivate` | No replacement; tenant reactivation is not served |

--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -70,6 +70,39 @@ returned 405 from that handler, so no working integration depended on them.
 | `admin.list_credit_transactions(org_id, **params)` | `GET /api/v1/admin/organizations/{id}/credits/transactions` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/transactions", params={...})` |
 | `admin.get_expiring_credits(org_id)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | `client.request("GET", f"/api/v1/admin/credits/{org_id}/expiring", params={"within_days": 30})` (`within_days` 1-365, default 30) |
 
+Removed 10 `tenants` methods (sync `TenantsAPI` and async `AsyncTenantsAPI`)
+that targeted routes no server handler dispatches. The HTTP server routes only
+the `/api/v1/tenants` collection (declared by the organizations handler);
+nothing dispatches `/api/v1/tenants/{id}` or any path below it, and the opt-in
+FastAPI `/api/v2/admin/tenants` surface is a separate admin family outside the
+spec. Every call below returned 404, so no working integration depended on
+them. `tenants.list(...)` and `tenants.create(...)` remain.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `tenants.get(tenant_id)` | `GET /api/v1/tenants/{id}` | `tenants.list(...)` and filter by id |
+| `tenants.update(tenant_id, name=..., plan=..., settings=..., quotas=...)` | `PATCH /api/v1/tenants/{id}` | `organizations.update(org_id, name=..., settings=...)` (`PUT /api/v1/org/{id}`, served but not in the spec; org-admin scoped and accepts only `name` and `settings`; plan and quota changes have no self-service route) |
+| `tenants.delete(tenant_id)` | `DELETE /api/v1/tenants/{id}` | No replacement; tenant deletion is not served |
+| `tenants.suspend(tenant_id, reason)` | `POST /api/v1/tenants/{id}/suspend` | No replacement; tenant suspension is not served |
+| `tenants.reactivate(tenant_id)` | `POST /api/v1/tenants/{id}/reactivate` | No replacement; tenant reactivation is not served |
+| `tenants.get_usage(tenant_id)` | `GET /api/v1/tenants/{id}/usage` | `quotas.get_usage(period)` (`GET /api/v1/quotas/usage`); scoped to the caller's own organization, not an arbitrary tenant id |
+| `tenants.get_quotas(tenant_id)` | `GET /api/v1/tenants/{id}/quotas` | `quotas.list()` (`GET /api/v1/quotas`); scoped to the caller's own organization |
+| `tenants.update_quotas(tenant_id, quotas)` | `PUT /api/v1/tenants/{id}/quotas` | `quotas.request_increase(resource, requested_limit=..., justification=...)` (`POST /api/v1/quotas/request-increase`) files a request; there is no direct quota write |
+| `tenants.list_members(tenant_id)` | `GET /api/v1/tenants/{id}/members` | `organizations.list_members(org_id)` (`GET /api/v1/org/{id}/members`); unpaginated, caller must be an org member |
+| `tenants.invite_member(tenant_id, email, role)` | `POST /api/v1/tenants/{id}/members/invite` | `organizations.invite_member(org_id, email, role)` (`POST /api/v1/org/{id}/invite`, served but only the `GET` verb is in the spec; caller must be an org admin and `role` must be `member` or `admin`) |
+
+Removed 2 `media` methods (sync and async) that targeted per-file audio routes
+no server handler dispatches. The audio handler serves only
+`/audio/{debate_id}.mp3`, `/api/v1/podcast/feed.xml` and the
+`/api/v1/podcast/episodes` collection; `/api/v1/media/audio/{id}` returned 404.
+`media.upload_audio(...)` (`POST /api/v1/media/audio`) is kept: that path is
+declared by the audio handler even though no POST branch serves it yet.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `media.get_audio(audio_id)` | `GET /api/v1/media/audio/{id}` | `media.get_audio_url(debate_id)` builds the served `/audio/{debate_id}.mp3` URL; there is no per-file metadata route |
+| `media.delete_audio(audio_id)` | `DELETE /api/v1/media/audio/{id}` | No replacement; audio deletion is not served |
+
 ---
 
 ### v2.4.0 (2026-01-25)

--- a/sdk/python/aragora_sdk/namespaces/media.py
+++ b/sdk/python/aragora_sdk/namespaces/media.py
@@ -25,14 +25,14 @@ class MediaAPI:
     Synchronous Media API.
 
     Provides methods for media asset access:
-    - Get audio file metadata and URLs
+    - List audio files and build direct audio URLs
     - List and browse podcast episodes
     - Access RSS feed for subscription
     - Media format conversions
 
     Example:
         >>> client = AragoraClient(base_url="https://api.aragora.ai")
-        >>> audio = client.media.get_audio("audio_123")
+        >>> audio_files = client.media.list_audio(debate_id="debate_123")
         >>> episodes = client.media.list_podcast_episodes()
         >>> feed_url = client.media.get_feed_url()
     """
@@ -43,18 +43,6 @@ class MediaAPI:
     # =========================================================================
     # Audio Files
     # =========================================================================
-
-    def get_audio(self, audio_id: str) -> dict[str, Any]:
-        """
-        Get audio file metadata by ID.
-
-        Args:
-            audio_id: The audio file identifier.
-
-        Returns:
-            Audio file metadata including format, duration, size, and URL.
-        """
-        return self._client._request("GET", f"/api/v1/media/audio/{audio_id}")
 
     def get_audio_url(self, audio_id: str) -> str:
         """
@@ -130,18 +118,6 @@ class MediaAPI:
             data["metadata"] = metadata
 
         return self._client._request("POST", "/api/v1/media/audio", json=data)
-
-    def delete_audio(self, audio_id: str) -> dict[str, Any]:
-        """
-        Delete an audio file.
-
-        Args:
-            audio_id: The audio file identifier.
-
-        Returns:
-            Dict confirming deletion.
-        """
-        return self._client._request("DELETE", f"/api/v1/media/audio/{audio_id}")
 
     # =========================================================================
     # Podcast Episodes
@@ -266,10 +242,6 @@ class AsyncMediaAPI:
     # Audio Files
     # =========================================================================
 
-    async def get_audio(self, audio_id: str) -> dict[str, Any]:
-        """Get audio file metadata by ID."""
-        return await self._client._request("GET", f"/api/v1/media/audio/{audio_id}")
-
     def get_audio_url(self, audio_id: str) -> str:
         """Get the direct audio file URL."""
         base_url = getattr(self._client, "_base_url", "https://api.aragora.ai")
@@ -313,10 +285,6 @@ class AsyncMediaAPI:
             data["metadata"] = metadata
 
         return await self._client._request("POST", "/api/v1/media/audio", json=data)
-
-    async def delete_audio(self, audio_id: str) -> dict[str, Any]:
-        """Delete an audio file."""
-        return await self._client._request("DELETE", f"/api/v1/media/audio/{audio_id}")
 
     # =========================================================================
     # Podcast Episodes

--- a/sdk/python/aragora_sdk/namespaces/media.py
+++ b/sdk/python/aragora_sdk/namespaces/media.py
@@ -25,14 +25,14 @@ class MediaAPI:
     Synchronous Media API.
 
     Provides methods for media asset access:
-    - List audio files and build direct audio URLs
+    - Build direct audio URLs
     - List and browse podcast episodes
     - Access RSS feed for subscription
     - Media format conversions
 
     Example:
         >>> client = AragoraClient(base_url="https://api.aragora.ai")
-        >>> audio_files = client.media.list_audio(debate_id="debate_123")
+        >>> audio_url = client.media.get_audio_url("debate_123")
         >>> episodes = client.media.list_podcast_episodes()
         >>> feed_url = client.media.get_feed_url()
     """

--- a/sdk/python/aragora_sdk/namespaces/tenants.py
+++ b/sdk/python/aragora_sdk/namespaces/tenants.py
@@ -45,18 +45,6 @@ class TenantsAPI:
 
         return self._client._request("GET", "/api/v1/tenants", params=params)
 
-    def get(self, tenant_id: str) -> dict[str, Any]:
-        """
-        Get tenant details.
-
-        Args:
-            tenant_id: Tenant identifier
-
-        Returns:
-            Tenant details
-        """
-        return self._client._request("GET", f"/api/v1/tenants/{tenant_id}")
-
     def create(
         self,
         name: str,
@@ -90,147 +78,6 @@ class TenantsAPI:
 
         return self._client._request("POST", "/api/v1/tenants", json=data)
 
-    def update(
-        self,
-        tenant_id: str,
-        name: str | None = None,
-        plan: str | None = None,
-        settings: dict[str, Any] | None = None,
-        quotas: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """
-        Update a tenant.
-
-        Args:
-            tenant_id: Tenant identifier
-            name: New tenant name
-            plan: New subscription plan
-            settings: Updated settings
-            quotas: Updated quotas
-
-        Returns:
-            Updated tenant record
-        """
-        data: dict[str, Any] = {}
-        if name is not None:
-            data["name"] = name
-        if plan is not None:
-            data["plan"] = plan
-        if settings is not None:
-            data["settings"] = settings
-        if quotas is not None:
-            data["quotas"] = quotas
-
-        return self._client._request("PATCH", f"/api/v1/tenants/{tenant_id}", json=data)
-
-    def delete(self, tenant_id: str) -> dict[str, Any]:
-        """
-        Delete a tenant.
-
-        Args:
-            tenant_id: Tenant identifier
-
-        Returns:
-            Deletion confirmation
-        """
-        return self._client._request("DELETE", f"/api/v1/tenants/{tenant_id}")
-
-    def suspend(self, tenant_id: str, reason: str | None = None) -> dict[str, Any]:
-        """
-        Suspend a tenant.
-
-        Args:
-            tenant_id: Tenant identifier
-            reason: Suspension reason
-
-        Returns:
-            Updated tenant
-        """
-        data: dict[str, Any] = {}
-        if reason:
-            data["reason"] = reason
-
-        return self._client._request("POST", f"/api/v1/tenants/{tenant_id}/suspend", json=data)
-
-    def reactivate(self, tenant_id: str) -> dict[str, Any]:
-        """
-        Reactivate a suspended tenant.
-
-        Args:
-            tenant_id: Tenant identifier
-
-        Returns:
-            Updated tenant
-        """
-        return self._client._request("POST", f"/api/v1/tenants/{tenant_id}/reactivate")
-
-    def get_usage(self, tenant_id: str) -> dict[str, Any]:
-        """
-        Get tenant usage statistics.
-
-        Args:
-            tenant_id: Tenant identifier
-
-        Returns:
-            Usage statistics
-        """
-        return self._client._request("GET", f"/api/v1/tenants/{tenant_id}/usage")
-
-    def get_quotas(self, tenant_id: str) -> dict[str, Any]:
-        """
-        Get tenant quotas.
-
-        Args:
-            tenant_id: Tenant identifier
-
-        Returns:
-            Quota configuration and current usage
-        """
-        return self._client._request("GET", f"/api/v1/tenants/{tenant_id}/quotas")
-
-    def update_quotas(self, tenant_id: str, quotas: dict[str, Any]) -> dict[str, Any]:
-        """
-        Update tenant quotas.
-
-        Args:
-            tenant_id: Tenant identifier
-            quotas: New quota values
-
-        Returns:
-            Updated quotas
-        """
-        return self._client._request("PUT", f"/api/v1/tenants/{tenant_id}/quotas", json=quotas)
-
-    def list_members(self, tenant_id: str) -> dict[str, Any]:
-        """
-        List tenant members.
-
-        Args:
-            tenant_id: Tenant identifier
-
-        Returns:
-            List of members
-        """
-        return self._client._request("GET", f"/api/v1/tenants/{tenant_id}/members")
-
-    def invite_member(self, tenant_id: str, email: str, role: str = "member") -> dict[str, Any]:
-        """
-        Invite a member to the tenant.
-
-        Args:
-            tenant_id: Tenant identifier
-            email: Email to invite
-            role: Member role
-
-        Returns:
-            Invitation record
-        """
-        return self._client._request(
-            "POST",
-            f"/api/v1/tenants/{tenant_id}/members/invite",
-            json={"email": email, "role": role},
-        )
-
 
 class AsyncTenantsAPI:
     """Asynchronous tenants API."""
@@ -250,10 +97,6 @@ class AsyncTenantsAPI:
             params["status"] = status
 
         return await self._client._request("GET", "/api/v1/tenants", params=params)
-
-    async def get(self, tenant_id: str) -> dict[str, Any]:
-        """Get tenant details."""
-        return await self._client._request("GET", f"/api/v1/tenants/{tenant_id}")
 
     async def create(
         self,
@@ -275,70 +118,3 @@ class AsyncTenantsAPI:
             data["quotas"] = quotas
 
         return await self._client._request("POST", "/api/v1/tenants", json=data)
-
-    async def update(
-        self,
-        tenant_id: str,
-        name: str | None = None,
-        plan: str | None = None,
-        settings: dict[str, Any] | None = None,
-        quotas: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Update a tenant."""
-        data: dict[str, Any] = {}
-        if name is not None:
-            data["name"] = name
-        if plan is not None:
-            data["plan"] = plan
-        if settings is not None:
-            data["settings"] = settings
-        if quotas is not None:
-            data["quotas"] = quotas
-
-        return await self._client._request("PATCH", f"/api/v1/tenants/{tenant_id}", json=data)
-
-    async def delete(self, tenant_id: str) -> dict[str, Any]:
-        """Delete a tenant."""
-        return await self._client._request("DELETE", f"/api/v1/tenants/{tenant_id}")
-
-    async def suspend(self, tenant_id: str, reason: str | None = None) -> dict[str, Any]:
-        """Suspend a tenant."""
-        data: dict[str, Any] = {}
-        if reason:
-            data["reason"] = reason
-
-        return await self._client._request(
-            "POST", f"/api/v1/tenants/{tenant_id}/suspend", json=data
-        )
-
-    async def reactivate(self, tenant_id: str) -> dict[str, Any]:
-        """Reactivate a suspended tenant."""
-        return await self._client._request("POST", f"/api/v1/tenants/{tenant_id}/reactivate")
-
-    async def get_usage(self, tenant_id: str) -> dict[str, Any]:
-        """Get tenant usage statistics."""
-        return await self._client._request("GET", f"/api/v1/tenants/{tenant_id}/usage")
-
-    async def get_quotas(self, tenant_id: str) -> dict[str, Any]:
-        """Get tenant quotas."""
-        return await self._client._request("GET", f"/api/v1/tenants/{tenant_id}/quotas")
-
-    async def update_quotas(self, tenant_id: str, quotas: dict[str, Any]) -> dict[str, Any]:
-        """Update tenant quotas."""
-        return await self._client._request(
-            "PUT", f"/api/v1/tenants/{tenant_id}/quotas", json=quotas
-        )
-
-    async def list_members(self, tenant_id: str) -> dict[str, Any]:
-        """List tenant members."""
-        return await self._client._request("GET", f"/api/v1/tenants/{tenant_id}/members")
-
-    async def invite_member(
-        self, tenant_id: str, email: str, role: str = "member"
-    ) -> dict[str, Any]:
-        """Invite a member to the tenant."""
-        return await self._client._request(
-            "POST",
-            f"/api/v1/tenants/{tenant_id}/members/invite",
-            json={"email": email, "role": role},
-        )

--- a/sdk/python/tests/test_media.py
+++ b/sdk/python/tests/test_media.py
@@ -10,24 +10,6 @@ from aragora_sdk.client import AragoraAsyncClient, AragoraClient
 class TestMediaAudio:
     """Tests for audio file operations."""
 
-    def test_get_audio(self, client: AragoraClient, mock_request) -> None:
-        """Get audio file metadata."""
-        mock_request.return_value = {
-            "id": "audio_123",
-            "debate_id": "debate_456",
-            "format": "mp3",
-            "duration_seconds": 300,
-            "size_bytes": 5000000,
-        }
-
-        result = client.media.get_audio("audio_123")
-
-        mock_request.assert_called_once_with(
-            "GET", "/api/v1/media/audio/audio_123", params=None, json=None, headers=None
-        )
-        assert result["format"] == "mp3"
-        assert result["duration_seconds"] == 300
-
     def test_get_audio_url(self, client: AragoraClient) -> None:
         """Get direct audio URL."""
         url = client.media.get_audio_url("audio_123")
@@ -76,21 +58,6 @@ class TestMediaAudio:
         assert call_json["debate_id"] == "debate_123"
         assert call_json["format"] == "mp3"
         assert result["status"] == "processing"
-
-    def test_delete_audio(self, client: AragoraClient, mock_request) -> None:
-        """Delete an audio file."""
-        mock_request.return_value = {"deleted": True}
-
-        result = client.media.delete_audio("audio_123")
-
-        mock_request.assert_called_once_with(
-            "DELETE",
-            "/api/v1/media/audio/audio_123",
-            params=None,
-            json=None,
-            headers=None,
-        )
-        assert result["deleted"] is True
 
 
 class TestMediaPodcast:
@@ -191,16 +158,6 @@ class TestMediaConversions:
 
 class TestAsyncMedia:
     """Tests for async media API."""
-
-    @pytest.mark.asyncio
-    async def test_async_get_audio(self, mock_async_request) -> None:
-        """Get audio asynchronously."""
-        mock_async_request.return_value = {"id": "audio_async", "format": "mp3"}
-
-        async with AragoraAsyncClient(base_url="https://api.aragora.ai") as client:
-            result = await client.media.get_audio("audio_async")
-
-            assert result["format"] == "mp3"
 
     @pytest.mark.asyncio
     async def test_async_get_audio_url(self) -> None:

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -79,6 +79,45 @@ unchanged here and still return 405; do not migrate to them.
 | `admin.listCreditTransactions(orgId, params)` | `GET /api/v1/admin/organizations/{id}/credits/transactions` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/transactions`, { params })`` |
 | `admin.getExpiringCredits(orgId)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/expiring`, { params: { within_days: 30 } })`` (`within_days` 1-365, default 30) |
 
+Removed 10 `tenants` methods from `TenantsAPI` that targeted routes no server
+handler dispatches. The HTTP server routes only the `/api/v1/tenants`
+collection (declared by the organizations handler); nothing dispatches
+`/api/v1/tenants/{id}` or any path below it, and the opt-in FastAPI
+`/api/v2/admin/tenants` surface is a separate admin family outside the spec.
+Every call below returned 404, so no working integration depended on them. The
+`TenantsClientInterface` entries and the local `UpdateTenantRequest`,
+`QuotaStatus` and `QuotaUpdate` interfaces used only by those methods were
+removed with them (the same-named package-root types in `types.ts` are
+unchanged). The legacy flat `*Tenant*` methods on `AragoraClient` that target
+the same routes are unchanged here and still return 404; do not migrate to
+them. `tenants.list`, `tenants.create`, `tenants.addMember` and
+`tenants.removeMember` remain.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `tenants.get(tenantId)` | `GET /api/v1/tenants/{id}` | `tenants.list(params)` and filter by id |
+| `tenants.update(tenantId, body)` | `PATCH /api/v1/tenants/{id}` | `organizations.update(orgId, { name, settings })` (`PUT /api/v1/org/{id}`, served but not in the spec; org-admin scoped and accepts only `name` and `settings`; plan and quota changes have no self-service route) |
+| `tenants.delete(tenantId)` | `DELETE /api/v1/tenants/{id}` | No replacement; tenant deletion is not served |
+| `tenants.suspend(tenantId)` | `POST /api/v1/tenants/{id}/suspend` | No replacement; tenant suspension is not served |
+| `tenants.reactivate(tenantId)` | `POST /api/v1/tenants/{id}/reactivate` | No replacement; tenant reactivation is not served |
+| `tenants.getUsage(tenantId)` | `GET /api/v1/tenants/{id}/usage` | ``client.request('GET', '/api/v1/quotas/usage')`` (in the spec; `quotas.getUsageHistory()` targets the unversioned `/api/quotas/usage` alias); scoped to the caller's own organization, not an arbitrary tenant id |
+| `tenants.getQuotas(tenantId)` | `GET /api/v1/tenants/{id}/quotas` | `quotas.list()` (`GET /api/v1/quotas`); scoped to the caller's own organization |
+| `tenants.updateQuotas(tenantId, body)` | `PUT /api/v1/tenants/{id}/quotas` | `quotas.requestIncrease(resource, requestedLimit, reason)` (`POST /api/v1/quotas/request-increase`) files a request; there is no direct quota write |
+| `tenants.listMembers(tenantId, params)` | `GET /api/v1/tenants/{id}/members` | `organizations.listMembers(orgId, params)` (`GET /api/v1/org/{id}/members`); the server ignores pagination and the caller must be an org member |
+| `tenants.inviteMember(tenantId, body)` | `POST /api/v1/tenants/{id}/members/invite` | `organizations.invite(orgId, { email, role })` (`POST /api/v1/org/{id}/invite`, served but only the `GET` verb is in the spec; caller must be an org admin and `role` must be `member` or `admin`) |
+
+Removed 2 `media` methods that targeted per-file audio routes no server
+handler dispatches. The audio handler serves only `/audio/{debateId}.mp3`,
+`/api/v1/podcast/feed.xml` and the `/api/v1/podcast/episodes` collection;
+`/api/v1/media/audio/{id}` returned 404. `media.uploadAudio(params)`
+(`POST /api/v1/media/audio`) is kept: that path is declared by the audio
+handler even though no POST branch serves it yet.
+
+| Removed Method | Route | Migration |
+|----------------|-------|-----------|
+| `media.getAudio(audioId)` | `GET /api/v1/media/audio/{id}` | `media.getAudioUrl(debateId)` builds the served `/audio/{debateId}.mp3` path; there is no per-file metadata route |
+| `media.deleteAudio(audioId)` | `DELETE /api/v1/media/audio/{id}` | No replacement; audio deletion is not served |
+
 ---
 
 ## Migration Guides

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -80,23 +80,30 @@ unchanged here and still return 405; do not migrate to them.
 | `admin.getExpiringCredits(orgId)` | `GET /api/v1/admin/organizations/{id}/credits/expiring` | ``client.request('GET', `/api/v1/admin/credits/${orgId}/expiring`, { params: { within_days: 30 } })`` (`within_days` 1-365, default 30) |
 
 Removed 10 `tenants` methods from `TenantsAPI` that targeted routes no server
-handler dispatches. The HTTP server routes only the `/api/v1/tenants`
-collection (declared by the organizations handler); nothing dispatches
-`/api/v1/tenants/{id}` or any path below it, and the opt-in FastAPI
-`/api/v2/admin/tenants` surface is a separate admin family outside the spec.
-Every call below returned 404, so no working integration depended on them. The
-`TenantsClientInterface` entries and the local `UpdateTenantRequest`,
-`QuotaStatus` and `QuotaUpdate` interfaces used only by those methods were
-removed with them (the same-named package-root types in `types.ts` are
-unchanged). The legacy flat `*Tenant*` methods on `AragoraClient` that target
-the same routes are unchanged here and still return 404; do not migrate to
-them. `tenants.list`, `tenants.create`, `tenants.addMember` and
-`tenants.removeMember` remain.
+handler dispatches. Nothing under `/api/v1/tenants/{id}` is routed, so every
+call below returned 404 and no working integration depended on them. There is
+no self-service tenant read or write on the HTTP server at all:
+`/api/v1/tenants` is declared by the organizations handler and `GET` is in the
+spec, but the handler has no branch for it, so `tenants.list` and
+`tenants.create` (kept because their route is spec-listed) currently fail too.
+`tenants.addMember` and `tenants.removeMember` are also kept only because they
+are thin aliases of the flat client methods that own those paths
+(`POST /api/v1/tenants/{id}/members`, `DELETE /api/v1/tenants/{id}/members/{userId}`);
+those routes are equally unrouted and return 404. Tenant administration lives
+only on the opt-in FastAPI surface (`ARAGORA_USE_FASTAPI`): `GET`/`POST
+/api/v2/admin/tenants` and `PUT /api/v2/admin/tenants/{tenant_id}` (`name`,
+`tier`, `is_active`, `config`; `admin:tenants:write`), none of which is in the
+spec or wrapped by this SDK. The `TenantsClientInterface` entries and the
+local `UpdateTenantRequest`, `QuotaStatus` and `QuotaUpdate` interfaces used
+only by the removed methods were removed with them (the same-named
+package-root types in `types.ts` are unchanged). The legacy flat `*Tenant*`
+methods on `AragoraClient` that target the same routes are unchanged here and
+still return 404; do not migrate to them.
 
 | Removed Method | Route | Migration |
 |----------------|-------|-----------|
-| `tenants.get(tenantId)` | `GET /api/v1/tenants/{id}` | `tenants.list(params)` and filter by id |
-| `tenants.update(tenantId, body)` | `PATCH /api/v1/tenants/{id}` | `organizations.update(orgId, { name, settings })` (`PUT /api/v1/org/{id}`, served but not in the spec; org-admin scoped and accepts only `name` and `settings`; plan and quota changes have no self-service route) |
+| `tenants.get(tenantId)` | `GET /api/v1/tenants/{id}` | No replacement; no tenant read is served (see above) |
+| `tenants.update(tenantId, body)` | `PATCH /api/v1/tenants/{id}` | `organizations.update(orgId, { name, settings })` (`PUT /api/v1/org/{id}`, served but not in the spec; org-admin scoped and accepts only `name` and `settings`). Plan and quota changes have no self-service route; admins can use `PUT /api/v2/admin/tenants/{tenant_id}` (`client.request`) when the FastAPI surface is enabled |
 | `tenants.delete(tenantId)` | `DELETE /api/v1/tenants/{id}` | No replacement; tenant deletion is not served |
 | `tenants.suspend(tenantId)` | `POST /api/v1/tenants/{id}/suspend` | No replacement; tenant suspension is not served |
 | `tenants.reactivate(tenantId)` | `POST /api/v1/tenants/{id}/reactivate` | No replacement; tenant reactivation is not served |

--- a/sdk/typescript/src/__tests__/enterprise-namespaces.test.ts
+++ b/sdk/typescript/src/__tests__/enterprise-namespaces.test.ts
@@ -293,22 +293,21 @@ describe('Enterprise Namespace APIs', () => {
     it('should expose tenants namespace', () => {
       const client = createClient({ baseUrl: 'https://api.example.com' });
       expect(client.tenants).toBeDefined();
-      expect(typeof client.tenants.get).toBe('function');
+      expect(typeof client.tenants.list).toBe('function');
     });
 
-    it('should get current tenant via namespace', async () => {
+    it('should list tenants via namespace', async () => {
       const client = createClient({ baseUrl: 'https://api.example.com' });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
         text: () => Promise.resolve(JSON.stringify({
-          id: 'tenant-123',
-          name: 'Acme Tenant'
+          tenants: [{ id: 'tenant-123', name: 'Acme Tenant' }]
         })),
       });
 
-      const tenant = await client.tenants.get();
-      expect(tenant.name).toBe('Acme Tenant');
+      const result = await client.tenants.list();
+      expect(result.tenants[0].name).toBe('Acme Tenant');
     });
   });
 

--- a/sdk/typescript/src/namespaces/__tests__/tenants.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/tenants.test.ts
@@ -2,8 +2,7 @@
  * Tenants Namespace Tests
  *
  * Comprehensive tests for the tenants namespace API including:
- * - Tenant CRUD operations
- * - Quota management
+ * - Tenant listing and creation
  * - Member management
  */
 
@@ -12,13 +11,7 @@ import { TenantsAPI } from '../tenants';
 
 interface MockClient {
   listTenants: Mock;
-  getTenant: Mock;
   createTenant: Mock;
-  updateTenant: Mock;
-  deleteTenant: Mock;
-  getTenantQuotas: Mock;
-  updateTenantQuotas: Mock;
-  listTenantMembers: Mock;
   addTenantMember: Mock;
   removeTenantMember: Mock;
 }
@@ -30,13 +23,7 @@ describe('TenantsAPI Namespace', () => {
   beforeEach(() => {
     mockClient = {
       listTenants: vi.fn(),
-      getTenant: vi.fn(),
       createTenant: vi.fn(),
-      updateTenant: vi.fn(),
-      deleteTenant: vi.fn(),
-      getTenantQuotas: vi.fn(),
-      updateTenantQuotas: vi.fn(),
-      listTenantMembers: vi.fn(),
       addTenantMember: vi.fn(),
       removeTenantMember: vi.fn(),
     };
@@ -44,10 +31,10 @@ describe('TenantsAPI Namespace', () => {
   });
 
   // ===========================================================================
-  // Tenant CRUD
+  // Tenant listing and creation
   // ===========================================================================
 
-  describe('Tenant CRUD', () => {
+  describe('Tenant listing and creation', () => {
     it('should list tenants', async () => {
       const mockTenants = {
         tenants: [
@@ -73,23 +60,6 @@ describe('TenantsAPI Namespace', () => {
       expect(mockClient.listTenants).toHaveBeenCalledWith({ limit: 10, offset: 20 });
     });
 
-    it('should get tenant by ID', async () => {
-      const mockTenant = {
-        id: 't1',
-        name: 'Acme Corp',
-        plan: 'enterprise',
-        status: 'active',
-        created_at: '2024-01-01T00:00:00Z',
-        settings: { theme: 'dark' },
-      };
-      mockClient.getTenant.mockResolvedValue(mockTenant);
-
-      const result = await api.get('t1');
-
-      expect(mockClient.getTenant).toHaveBeenCalledWith('t1');
-      expect(result.name).toBe('Acme Corp');
-    });
-
     it('should create tenant', async () => {
       const mockTenant = {
         id: 't_new',
@@ -104,64 +74,6 @@ describe('TenantsAPI Namespace', () => {
       expect(mockClient.createTenant).toHaveBeenCalledWith({ name: 'New Tenant', plan: 'pro' });
       expect(result.id).toBe('t_new');
     });
-
-    it('should update tenant', async () => {
-      const mockTenant = { id: 't1', name: 'Updated Name', plan: 'enterprise' };
-      mockClient.updateTenant.mockResolvedValue(mockTenant);
-
-      const result = await api.update('t1', { name: 'Updated Name' });
-
-      expect(mockClient.updateTenant).toHaveBeenCalledWith('t1', { name: 'Updated Name' });
-      expect(result.name).toBe('Updated Name');
-    });
-
-    it('should delete tenant', async () => {
-      mockClient.deleteTenant.mockResolvedValue(undefined);
-
-      await api.delete('t1');
-
-      expect(mockClient.deleteTenant).toHaveBeenCalledWith('t1');
-    });
-  });
-
-  // ===========================================================================
-  // Quota Management
-  // ===========================================================================
-
-  describe('Quota Management', () => {
-    it('should get tenant quotas', async () => {
-      const mockQuotas = {
-        debates_per_month: { used: 150, limit: 500, percentage: 30 },
-        agent_calls_per_month: { used: 3000, limit: 10000, percentage: 30 },
-        storage_mb: { used: 250, limit: 5000, percentage: 5 },
-        members: { used: 10, limit: 50, percentage: 20 },
-      };
-      mockClient.getTenantQuotas.mockResolvedValue(mockQuotas);
-
-      const result = await api.getQuotas('t1');
-
-      expect(mockClient.getTenantQuotas).toHaveBeenCalledWith('t1');
-      expect(result.debates_per_month.used).toBe(150);
-    });
-
-    it('should update tenant quotas', async () => {
-      const mockQuotas = {
-        debates_per_month: { used: 150, limit: 1000, percentage: 15 },
-        members: { used: 10, limit: 100, percentage: 10 },
-      };
-      mockClient.updateTenantQuotas.mockResolvedValue(mockQuotas);
-
-      const result = await api.updateQuotas('t1', {
-        debates_per_month: 1000,
-        members: 100,
-      });
-
-      expect(mockClient.updateTenantQuotas).toHaveBeenCalledWith('t1', {
-        debates_per_month: 1000,
-        members: 100,
-      });
-      expect(result.debates_per_month.limit).toBe(1000);
-    });
   });
 
   // ===========================================================================
@@ -169,31 +81,6 @@ describe('TenantsAPI Namespace', () => {
   // ===========================================================================
 
   describe('Member Management', () => {
-    it('should list tenant members', async () => {
-      const mockMembers = {
-        members: [
-          { id: 'u1', email: 'admin@acme.com', role: 'admin', joined_at: '2024-01-01' },
-          { id: 'u2', email: 'user@acme.com', role: 'member', joined_at: '2024-01-02' },
-        ],
-        total: 2,
-      };
-      mockClient.listTenantMembers.mockResolvedValue(mockMembers);
-
-      const result = await api.listMembers('t1');
-
-      expect(mockClient.listTenantMembers).toHaveBeenCalledWith('t1', undefined);
-      expect(result.members).toHaveLength(2);
-    });
-
-    it('should list members with pagination', async () => {
-      const mockMembers = { members: [], total: 50 };
-      mockClient.listTenantMembers.mockResolvedValue(mockMembers);
-
-      await api.listMembers('t1', { limit: 10, offset: 20 });
-
-      expect(mockClient.listTenantMembers).toHaveBeenCalledWith('t1', { limit: 10, offset: 20 });
-    });
-
     it('should add tenant member', async () => {
       const mockMember = {
         id: 'u_new',

--- a/sdk/typescript/src/namespaces/media.ts
+++ b/sdk/typescript/src/namespaces/media.ts
@@ -4,9 +4,8 @@
  * Provides access to media assets including audio files and podcast episodes.
  *
  * Features:
- * - Audio file listing
  * - Direct audio URL generation
- * - Audio upload
+ * - Audio file listing and upload
  * - Podcast episode management
  * - RSS feed access
  *
@@ -14,8 +13,8 @@
  * ```typescript
  * const client = createClient({ baseUrl: 'https://api.aragora.ai', apiKey: 'your-key' });
  *
- * // List audio files for a debate
- * const { audio_files } = await client.media.listAudio({ debateId: 'debate_456' });
+ * // Build a direct playback URL for a debate's audio
+ * const url = client.media.getAudioUrl('debate_456');
  *
  * // List podcast episodes
  * const { episodes } = await client.media.listPodcastEpisodes({ limit: 10 });
@@ -163,7 +162,7 @@ interface MediaClientInterface {
  * Media API namespace.
  *
  * Provides methods for media asset management:
- * - List and upload audio files
+ * - Direct audio URLs, audio listing and upload
  * - Podcast episode management
  * - RSS feed access
  *
@@ -171,11 +170,11 @@ interface MediaClientInterface {
  * ```typescript
  * const client = createClient({ baseUrl: 'https://api.aragora.ai', apiKey: 'your-key' });
  *
- * // List audio files for a debate
- * const { audio_files } = await client.media.listAudio({ debateId: 'debate_456' });
+ * // Build a direct playback URL for a debate's audio
+ * const url = client.media.getAudioUrl('debate_456');
  *
- * // Build a direct playback URL
- * const url = client.media.getAudioUrl('audio_123');
+ * // Browse podcast episodes
+ * const { episodes } = await client.media.listPodcastEpisodes({ limit: 10 });
  * ```
  */
 export class MediaAPI {

--- a/sdk/typescript/src/namespaces/media.ts
+++ b/sdk/typescript/src/namespaces/media.ts
@@ -4,7 +4,7 @@
  * Provides access to media assets including audio files and podcast episodes.
  *
  * Features:
- * - Audio file metadata retrieval and management
+ * - Audio file listing
  * - Direct audio URL generation
  * - Audio upload
  * - Podcast episode management
@@ -14,8 +14,8 @@
  * ```typescript
  * const client = createClient({ baseUrl: 'https://api.aragora.ai', apiKey: 'your-key' });
  *
- * // Get audio metadata
- * const audio = await client.media.getAudio('audio_123');
+ * // List audio files for a debate
+ * const { audio_files } = await client.media.listAudio({ debateId: 'debate_456' });
  *
  * // List podcast episodes
  * const { episodes } = await client.media.listPodcastEpisodes({ limit: 10 });
@@ -163,7 +163,7 @@ interface MediaClientInterface {
  * Media API namespace.
  *
  * Provides methods for media asset management:
- * - Get, list, upload, and delete audio files
+ * - List and upload audio files
  * - Podcast episode management
  * - RSS feed access
  *
@@ -171,11 +171,11 @@ interface MediaClientInterface {
  * ```typescript
  * const client = createClient({ baseUrl: 'https://api.aragora.ai', apiKey: 'your-key' });
  *
- * // Get audio metadata
- * const audio = await client.media.getAudio('audio_123');
- *
  * // List audio files for a debate
  * const { audio_files } = await client.media.listAudio({ debateId: 'debate_456' });
+ *
+ * // Build a direct playback URL
+ * const url = client.media.getAudioUrl('audio_123');
  * ```
  */
 export class MediaAPI {
@@ -184,22 +184,6 @@ export class MediaAPI {
   // =========================================================================
   // Audio Files
   // =========================================================================
-
-  /**
-   * Get audio file metadata by ID.
-   *
-   * @param audioId - The audio file identifier
-   * @returns Audio file metadata including format, duration, size, and URL
-   *
-   * @example
-   * ```typescript
-   * const audio = await client.media.getAudio('audio_123');
-   * console.log(`Duration: ${audio.duration_seconds}s, Format: ${audio.format}`);
-   * ```
-   */
-  async getAudio(audioId: string): Promise<AudioFile> {
-    return this.client.request('GET', `/api/v1/media/audio/${audioId}`);
-  }
 
   /**
    * Get the direct audio file URL for a debate or audio file.
@@ -281,22 +265,6 @@ export class MediaAPI {
     if (params.metadata !== undefined) json.metadata = params.metadata;
 
     return this.client.request('POST', '/api/v1/media/audio', { json });
-  }
-
-  /**
-   * Delete an audio file.
-   *
-   * @param audioId - The audio file identifier
-   * @returns Confirmation of deletion
-   *
-   * @example
-   * ```typescript
-   * const result = await client.media.deleteAudio('audio_123');
-   * console.log(result.message); // "Audio file deleted"
-   * ```
-   */
-  async deleteAudio(audioId: string): Promise<{ deleted: boolean; message: string }> {
-    return this.client.request('DELETE', `/api/v1/media/audio/${audioId}`);
   }
 
   // =========================================================================

--- a/sdk/typescript/src/namespaces/tenants.ts
+++ b/sdk/typescript/src/namespaces/tenants.ts
@@ -5,18 +5,8 @@
  */
 
 interface TenantsClientInterface {
-  request<T = unknown>(method: string, path: string, options?: Record<string, unknown>): Promise<T>;
   listTenants(params?: { limit?: number; offset?: number }): Promise<any>;
-  getTenant(tenantId: string): Promise<any>;
   createTenant(body: CreateTenantRequest): Promise<any>;
-  updateTenant(tenantId: string, body: UpdateTenantRequest): Promise<any>;
-  deleteTenant(tenantId: string): Promise<void>;
-  getTenantQuotas(tenantId: string): Promise<any>;
-  updateTenantQuotas(tenantId: string, body: QuotaUpdate): Promise<any>;
-  listTenantMembers(
-    tenantId: string,
-    params?: { limit?: number; offset?: number }
-  ): Promise<any>;
   addTenantMember(tenantId: string, body: { email: string; role?: string }): Promise<any>;
   removeTenantMember(tenantId: string, userId: string): Promise<void>;
 }
@@ -43,15 +33,6 @@ export interface CreateTenantRequest {
 }
 
 /**
- * Update tenant request.
- */
-export interface UpdateTenantRequest {
-  name?: string;
-  plan?: string;
-  metadata?: Record<string, unknown>;
-}
-
-/**
  * Tenant member.
  */
 export interface TenantMember {
@@ -62,31 +43,10 @@ export interface TenantMember {
 }
 
 /**
- * Quota status.
- */
-export interface QuotaStatus {
-  tenant_id: string;
-  quotas: Record<string, { used: number; limit: number }>;
-}
-
-/**
- * Quota update request.
- */
-export interface QuotaUpdate {
-  debates_per_month?: number;
-  agents_per_debate?: number;
-  storage_bytes?: number;
-  api_calls_per_minute?: number;
-  members?: number;
-  overage_allowed?: boolean;
-}
-
-/**
  * Tenants API namespace.
  *
  * Provides methods for multi-tenancy management:
- * - Creating and managing tenants
- * - Quota management
+ * - Listing and creating tenants
  * - Member management
  */
 export class TenantsAPI {
@@ -109,88 +69,6 @@ export class TenantsAPI {
   }
 
   /**
-   * Get a tenant by ID.
-   * @route GET /api/v1/tenants/{tenant_id}
-   */
-  async get(tenantId: string): Promise<Tenant> {
-    if ('getTenant' in this.client && typeof this.client.getTenant === 'function') {
-      return this.client.getTenant(tenantId);
-    }
-    return this.client.request(
-      'GET',
-      `/api/v1/tenants/${encodeURIComponent(tenantId)}`
-    ) as Promise<Tenant>;
-  }
-
-  /**
-   * Update a tenant.
-   * @route PATCH /api/v1/tenants/{tenant_id}
-   */
-  async update(tenantId: string, body: UpdateTenantRequest): Promise<Tenant> {
-    return this.client.updateTenant(tenantId, body);
-  }
-
-  /**
-   * Delete a tenant.
-   * @route DELETE /api/v1/tenants/{tenant_id}
-   */
-  async delete(tenantId: string): Promise<void> {
-    return this.client.deleteTenant(tenantId);
-  }
-
-  /**
-   * Get tenant quota status.
-   * @route GET /api/v1/tenants/{tenant_id}/quotas
-   */
-  async getQuotas(tenantId: string): Promise<QuotaStatus> {
-    if ('getTenantQuotas' in this.client && typeof this.client.getTenantQuotas === 'function') {
-      return this.client.getTenantQuotas(tenantId);
-    }
-    return this.client.request(
-      'GET',
-      `/api/v1/tenants/${encodeURIComponent(tenantId)}/quotas`
-    ) as Promise<QuotaStatus>;
-  }
-
-  /**
-   * Update tenant quotas.
-   * @route PUT /api/v1/tenants/{tenant_id}/quotas
-   */
-  async updateQuotas(tenantId: string, body: QuotaUpdate): Promise<QuotaStatus> {
-    return this.client.updateTenantQuotas(tenantId, body);
-  }
-
-  /**
-   * List tenant members.
-   * @route GET /api/v1/tenants/{tenant_id}/members
-   */
-  async listMembers(tenantId: string, params?: { limit?: number; offset?: number }): Promise<{ members: TenantMember[] }> {
-    if ('listTenantMembers' in this.client && typeof this.client.listTenantMembers === 'function') {
-      return this.client.listTenantMembers(tenantId, params);
-    }
-    return this.client.request(
-      'GET',
-      `/api/v1/tenants/${encodeURIComponent(tenantId)}/members`,
-      { params: params as Record<string, unknown> | undefined }
-    ) as Promise<{ members: TenantMember[] }>;
-  }
-
-  /**
-   * Invite a member to a tenant.
-   * @route POST /api/v1/tenants/{tenant_id}/members/invite
-   */
-  async inviteMember(tenantId: string, body: { email: string; role?: string }): Promise<TenantMember> {
-    if ('addTenantMember' in this.client && typeof this.client.addTenantMember === 'function') {
-      return this.client.addTenantMember(tenantId, body);
-    }
-    return this.client.request(
-      'POST',
-      `/api/v1/tenants/${encodeURIComponent(tenantId)}/members/invite`,
-      { body }
-    ) as Promise<TenantMember>;
-  }
-
-  /**
    * Add a member to a tenant.
    * Compatibility alias for the flat client method.
    */
@@ -204,38 +82,5 @@ export class TenantsAPI {
    */
   async removeMember(tenantId: string, userId: string): Promise<void> {
     return this.client.removeTenantMember(tenantId, userId);
-  }
-
-  /**
-   * Get tenant usage.
-   * @route GET /api/v1/tenants/{tenant_id}/usage
-   */
-  async getUsage(tenantId: string): Promise<Record<string, unknown>> {
-    return this.client.request(
-      'GET',
-      `/api/v1/tenants/${encodeURIComponent(tenantId)}/usage`
-    ) as Promise<Record<string, unknown>>;
-  }
-
-  /**
-   * Suspend a tenant.
-   * @route POST /api/v1/tenants/{tenant_id}/suspend
-   */
-  async suspend(tenantId: string): Promise<Tenant> {
-    return this.client.request(
-      'POST',
-      `/api/v1/tenants/${encodeURIComponent(tenantId)}/suspend`
-    ) as Promise<Tenant>;
-  }
-
-  /**
-   * Reactivate a suspended tenant.
-   * @route POST /api/v1/tenants/{tenant_id}/reactivate
-   */
-  async reactivate(tenantId: string): Promise<Tenant> {
-    return this.client.request(
-      'POST',
-      `/api/v1/tenants/${encodeURIComponent(tenantId)}/reactivate`
-    ) as Promise<Tenant>;
   }
 }


### PR DESCRIPTION
## Summary

SDK drift paydown batch 04 of 6 (tranche 1; operator Decision "SDK PAYDOWN TRANCHE 1", `library/decision-ledger.md` L999 == `library/operator-approvals.md` L852, plus "SDK PAYDOWN TRANCHE 1 - AMENDMENT 1", `library/decision-ledger.md` L1002 == `library/operator-approvals.md` L858). Follows PR #9967 (batch 01), PR #9969 (batch 02) and PR #9976 (batch 03).

Deletes the matched Python + TypeScript `tenants` and `media` methods whose `VERB /path` is absent from both `docs/api/openapi.json` and `docs/api/openapi_generated.json` AND that no handler under `aragora/server` dispatches. Route truth was read from the dispatch code, not a text grep:

- **tenants.** The only tenant path anywhere in the HTTP handler layer is the literal `/api/v1/tenants` in `OrganizationsHandler.ROUTES` (`aragora/server/handlers/organizations.py` L106). `OrganizationsHandler.can_handle` (L129-144) matches only the `ORG_PATTERN` / `MEMBERS_PATTERN` / `INVITE_PATTERN` / ... regexes, all anchored on `/api(/v1)?/org/...`, `/api(/v1)?/user/organizations...` or `/api(/v1)?/invitations/...`; `handle()` (L147+) branches only on those same patterns. The request router (`aragora/server/handler_registry/__init__.py` L374-398) resolves a handler via the exact-route index, then prefix + `can_handle`, then a `can_handle` sweep over the registry, and returns `False` (404) when nothing matches, so every `/api/v1/tenants/{id}...` request below is a 404. The FastAPI admin router (`aragora/server/fastapi/routes/admin.py`, opt-in via `ARAGORA_USE_FASTAPI`) serves `/api/v2/admin/tenants[/{tenant_id}]` only, a different admin-permission family that is not in the spec and not the shape the SDK targeted.
- **media.** `AudioHandler.ROUTES` (`aragora/server/handlers/features/audio.py` L89-96) declares `/audio/*`, `/api/v1/media/audio`, the podcast feed paths and `/api/v1/podcast/episodes`; `can_handle` (L98-104) accepts only `/audio/*.mp3`, `/api/v1/podcast/feed.xml` and `/api/v1/podcast/episodes`; `handle()` (L163-189) is GET-only and there is no `handle_post` / `handle_delete`. `/api/v1/media/audio/{id}` matches nothing and is a 404 for both GET and DELETE.

Each removed pair was re-verified individually; no spec entries added, no baselines edited.

### Removed (12 matched pairs, both SDKs, sync + async on the Python side)

| Route | Python (`TenantsAPI` / `AsyncTenantsAPI`) | TypeScript (`TenantsAPI`) |
|---|---|---|
| `GET /api/v1/tenants/{id}` | `get` | `get` |
| `PATCH /api/v1/tenants/{id}` | `update` | `update` |
| `DELETE /api/v1/tenants/{id}` | `delete` | `delete` |
| `POST /api/v1/tenants/{id}/suspend` | `suspend` | `suspend` |
| `POST /api/v1/tenants/{id}/reactivate` | `reactivate` | `reactivate` |
| `GET /api/v1/tenants/{id}/usage` | `get_usage` | `getUsage` |
| `GET /api/v1/tenants/{id}/quotas` | `get_quotas` | `getQuotas` |
| `PUT /api/v1/tenants/{id}/quotas` | `update_quotas` | `updateQuotas` |
| `GET /api/v1/tenants/{id}/members` | `list_members` | `listMembers` |
| `POST /api/v1/tenants/{id}/members/invite` | `invite_member` | `inviteMember` |

| Route | Python (`MediaAPI` / `AsyncMediaAPI`) | TypeScript (`MediaAPI`) |
|---|---|---|
| `GET /api/v1/media/audio/{id}` | `get_audio` | `getAudio` |
| `DELETE /api/v1/media/audio/{id}` | `delete_audio` | `deleteAudio` |

Seven of the tenants pairs are the assigned batch-04 list. `update` / `delete` / `update_quotas` were added as matched pairs because `scripts/check_cross_sdk_parity.py --strict` went red on the dirty tree after the assigned seven: the TypeScript `get` and `getQuotas` methods carried the only `this.client.request(...)` fallbacks for `/api/v1/tenants/{id}` and `/api/v1/tenants/{id}/quotas` (the TS `update` / `delete` / `updateQuotas` delegate to the flat client and are invisible to the path scanner), so removing the assigned pairs alone left the two paths Python-only (`NEW python_only`). All three extra pairs are phantom by the same dispatch reading and absent from both OpenAPI files. `tenants.list` / `tenants.create` (`/api/v1/tenants`, `GET` is in the spec) and the TS `addMember` / `removeMember` aliases remain.

Also removed: the `TenantsClientInterface` entries used only by the deleted methods (`getTenant`, `updateTenant`, `deleteTenant`, `getTenantQuotas`, `updateTenantQuotas`, `listTenantMembers`, and the now-unused `request<T>` member), the local `UpdateTenantRequest` / `QuotaStatus` / `QuotaUpdate` interfaces that only those methods used (the same-named package-root types in `sdk/typescript/src/types.ts` are unchanged and still exported from `index.ts`), the 7 vitest cases in `sdk/typescript/src/namespaces/__tests__/tenants.test.ts` that exercised the removed methods plus their mock-client keys, the `tenants.get` case in `sdk/typescript/src/__tests__/enterprise-namespaces.test.ts` (now exercises `tenants.list`), and the 3 `sdk/python/tests/test_media.py` cases for `get_audio` / `delete_audio` (sync + async). No Python SDK test referenced any `tenants` method.

### Assigned pair deferred (LOC cap)

- `GET /api/v1/podcast/episodes/{id}` (`media.get_podcast_episode` / `media.getPodcastEpisode`) is phantom by the same `AudioHandler` reading and absent from both OpenAPI files, but the same path is also referenced by `podcast.get_episode` (`sdk/python/aragora_sdk/namespaces/podcast.py`), `audio.get_episode` (`namespaces/audio.py`) and `podcast.getEpisode` (`sdk/typescript/src/namespaces/podcast.ts`), so the governed counts only move when all four references go together (verify counts per unique `VERB /path` per SDK). That full set measured 842 LOC with the tenants work, over the Decision's 800 cap, so the episode family is left intact here and recorded in `library/tech-debt.md` for a later batch. Removing only the `media` copy would change nothing in the governed numbers and leave a stale pair split.

### SKIP-list check (Amendment 1)

- `POST /api/v1/media/audio` (`media.upload_audio` / `media.uploadAudio`) was listed as served-but-undocumented. Verified from the dispatch code: the path IS declared in `AudioHandler.ROUTES` (L92) but `can_handle` never accepts it and `handle()` is GET-only, so at runtime it is a 404 too. It is KEPT: `scripts/check_sdk_parity.py --strict` derives its route inventory from handler `ROUTES` declarations (the same class as the batch-03 `reset_circuit_breakers` pair), and the Decision's "absent server-side (rg aragora/server)" criterion is not met while the `ROUTES` line exists. Removing it needs a `ROUTES` correction under `aragora/server`, which the Decision forbids for this PR. Recorded in `library/tech-debt.md`.

### Docs

- `sdk/python/BREAKING_CHANGES.md` and `sdk/typescript/BREAKING_CHANGES.md`: 12 new rows with migrations under the existing "Unreleased" section, after the batch-03 admin rows. Every migration target was checked against the dispatch code and the spec:
  - The tenants prose states plainly that NO self-service tenant read or write is served on the HTTP server: `/api/v1/tenants` is in `OrganizationsHandler.ROUTES` (L106) and `GET` is in the spec, but `handle()` has no branch for it and the handler defines no `handle_post`, so the kept `tenants.list` / `tenants.create` currently fail too (kept only because their route is spec-listed; the Decision forbids touching non-phantom pairs). The `tenants.get` row therefore says "No replacement" rather than pointing at `tenants.list`. The prose names the opt-in FastAPI surface (`ARAGORA_USE_FASTAPI`: `GET`/`POST /api/v2/admin/tenants`, `PUT /api/v2/admin/tenants/{tenant_id}` with `name` / `tier` / `is_active` / `config`, `admin:tenants:write`, `aragora/server/fastapi/routes/admin.py` L1230-1262) as the only served tenant administration, not in the spec and not wrapped by either SDK; the `tenants.update` row mentions it for admins. The TypeScript prose also says the kept `addMember` / `removeMember` aliases (flat-client-owned `POST /api/v1/tenants/{id}/members`, `DELETE .../members/{userId}`) are equally unrouted.
  - The row for `tenants.update` points at `organizations.update` (`PUT /api/v1/org/{id}`, dispatched by `organizations.py` L189-195 -> `_update_organization`, org-admin scoped, accepts only `name` and `settings`) and says "served but not in the spec".
  - `tenants.list_members` -> `organizations.list_members(org_id)` / `organizations.listMembers(orgId, params)` (`GET /api/v1/org/{id}/members`, in the spec; `_list_members` L578 ignores pagination and requires org membership).
  - `tenants.invite_member` -> `organizations.invite_member(org_id, email, role)` / `organizations.invite(orgId, { email, role })` (`POST /api/v1/org/{id}/invite`, dispatched at L207-212 -> `_invite_member` L608; org-admin via `organizations.invite` RBAC; `role` must be `member` or `admin`). The spec lists only the `GET` verb for that path, and the row says so.
  - `tenants.get_usage` -> `quotas.get_usage(period)` (`GET /api/v1/quotas/usage`, in the spec, served by `aragora/server/handlers/usage_metering.py` L115, scoped to the caller's org). The TypeScript row uses a raw `client.request('GET', '/api/v1/quotas/usage')` because `quotas.getUsageHistory()` targets the unversioned `/api/quotas/usage`, which is not in the spec.
  - `tenants.get_quotas` -> `quotas.list()` (`GET /api/v1/quotas`, in the spec, L112); `tenants.update_quotas` -> `quotas.request_increase(...)` / `quotas.requestIncrease(...)` (`POST /api/v1/quotas/request-increase`, in the spec, L118-124), with the caveat that it files a request rather than writing a quota.
  - `tenants.delete` / `suspend` / `reactivate` and `media.delete_audio` say "No replacement": nothing under `aragora/server` dispatches those actions.
  - `media.get_audio` -> `media.get_audio_url(debate_id)` / `media.getAudioUrl(debateId)`, which builds the served `/audio/{debate_id}.mp3` path (`GET /audio/{audio_id}` is in the spec); there is no per-file metadata route.
  - The TypeScript prose notes that the flat `AragoraClient` `*Tenant*` methods in `sdk/typescript/src/client.ts` (L5501-5558) still target the same phantom routes and are unchanged here (outside the `namespaces/` scan scope of every parity script, same as the batch-03 flat admin methods).
- `sdk/python/aragora_sdk/namespaces/media.py` and `sdk/typescript/src/namespaces/media.ts` docstring / JSDoc examples now lead with `get_audio_url` / `getAudioUrl` (the one served audio route, `/audio/{debate_id}.mp3`) instead of the removed `get_audio` / `getAudio`; they no longer headline `list_audio` / `listAudio`, whose `GET /api/v1/media/audio` is spec-listed and `ROUTES`-declared but has no `can_handle` / `handle()` branch (same class as the kept `upload_audio`).

## Measurements

`python3 scripts/verify_sdk_contracts.py --strict --baseline scripts/baselines/verify_sdk_contracts.json`

| | origin/main `b512e13055` (PR base) | this head `35253cb410` |
|---|---|---|
| Python SDK drift (endpoints not in spec) | 433 | **421** |
| TypeScript SDK drift (endpoints not in spec) | 289 | **280** |
| Baseline regressions | py=0 ts=0 stable=0 | py=0 ts=0 stable=0 |

(TypeScript moves by 9, not 12: the TS `update` / `delete` / `updateQuotas` delegated to the flat client and never appeared in the namespace path scan.)

- `git diff --numstat origin/main...HEAD`: +103 / -620 = **723 LOC** across 9 files, all under `sdk/`.
- `scripts/baselines/` byte-identical to origin/main (all 18 files).

## Local gates (all run on the committed head `35253cb410`)

- `python3 scripts/check_sdk_parity.py --strict --baseline … --budget …` PASS (missing_from_both 0/0, stale_python 16/36)
- `python3 scripts/check_sdk_namespace_parity.py --strict --baseline …` Regressions: 0
- `python3 scripts/check_cross_sdk_parity.py --strict --baseline …` PASS (python_only=0 typescript_only=0)
- `python3 scripts/verify_sdk_contracts.py --strict --baseline …` PASS (421 / 280, regressions 0)
- `sdk/python`: `ruff check` + `ruff format --check` clean; `python3 -m pytest tests/ --color=no` → `1392 passed, 3 warnings in 5.21s`
- `sdk/typescript`: `npm ci` exit 0; `npx tsc --noEmit` exit 0; `npm test` → `Tests 1 failed | 1703 passed (1704)`, `tenants.test.ts` 5 tests, `media.test.ts` and `enterprise-namespaces.test.ts` green; the single failure is the pre-existing `parity-compat-routes.test.ts › maps debate stats compatibility routes` present on origin/main (`library/environment.md` 2026-09-03 R2 note)
- `make lint`, `ruff format --check aragora/ tests/ scripts/` (10893 files), `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh cache): clean
- AWS-neutralized `make test-smoke`: "Smoke tests passed!"
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok

## Review history (tier-3 prepare-only rounds)

- Round 1 on `248a3227f7` (both reviewers via the live `max-01` Claude profile, `scripts/claude_profile.sh exec`, `ARAGORA_MODEL_TRANSPORT=direct`; the default `claude` profile and 12 other seats failed their liveness probe with `401 OAuth access token has been revoked` until the 07:07Z VibeProxy token rotation): openai PASS (grounded, would_count=true, no findings); claude CHANGES-REQUESTED (grounded, counted dissent): P2 the `tenants.get` migration row pointed at `tenants.list`, whose `/api/v1/tenants` collection is `ROUTES`-declared and spec-listed but has no dispatch branch either (verified: `organizations.py` `handle()` L147-265 never matches it), plus P3s on the kept `addMember` / `removeMember` aliases, the `list_audio` / `listAudio` docstring examples, the `PUT /api/v2/admin/tenants/{tenant_id}` FastAPI route, docs prose (`docs/DEVELOPER_GUIDE.md` L193, out of the tranche's `sdk/`-only scope, already in `library/tech-debt.md`), the `NotImplementedError` guards left in `media.py` (pre-existing pattern, not this PR's), the `aragora/client/resources/tenants.py` legacy client (outside `sdk/`), and vitest not being run by the reviewer (it was: see gates). Both bodies SUPERSEDED by head `35253cb410` (the Decision's single fix-and-recollect round), which addresses the P2 and the first three P3s in the two BREAKING_CHANGES files and the media docstrings only; no SDK method changed.
- Round 2 on `35253cb410`: see the posted review comments.

## Settlement

Tier 3 (`sdk/` prefix). Settles in-session under the recorded tranche Decision + Amendment 1: record-settlement while draft -> prepared reviewer bodies posted byte-exact -> ready -> model quorum -> merge-packet satisfied -> non-admin `--match-head-commit` squash merge.
