### PR TITLE
fix(scoreboard): key Atlas rounds on pr.number so row 6 counts the real dataset

### DIFF
--- a/scripts/receipt_first_scoreboard.py
+++ b/scripts/receipt_first_scoreboard.py
@@ -201,6 +201,12 @@ def metric_5(ctx: Any) -> Row:
     return r | {"status": "ok" if merged and assets else "fail"}
 
 
+def atlas_pr_number(rec: dict[str, Any]) -> Any:
+    """Atlas records carry ``pr`` as an object (schema.json); a bare scalar is the legacy form."""
+    pr = rec.get("pr")
+    return pr.get("number") if isinstance(pr, dict) else pr
+
+
 def metric_6(ctx: Any) -> Row:
     r: Row = {"now": None, "upper_bound": True, "quorum_runs": ctx.quorum_runs}
     r["note"] = "upper bound from the Atlas JSONL; ok needs the post-M2 advisory-summary count"
@@ -215,7 +221,7 @@ def metric_6(ctx: Any) -> Row:
     recs = [json.loads(line) for line in jsonl.read_text().splitlines() if line.strip()]
     cr = sum(x.get("verdict") == "changes_requested" for x in recs)
     posted = sum(bool(x.get("posted_to_thread")) for x in recs)
-    rounds = len({(x.get("pr"), x.get("head_sha")) for x in recs})
+    rounds = len({(atlas_pr_number(x), x.get("head_sha")) for x in recs})
     r.update(now=cr, posted=posted, rounds=rounds, records=len(recs), source=str(jsonl))
     return r | {"ratio": round(posted / rounds, 3) if rounds else None, "status": "fail"}
 

--- a/tests/scripts/test_receipt_first_scoreboard.py
+++ b/tests/scripts/test_receipt_first_scoreboard.py
@@ -294,17 +294,48 @@ def test_row8_counts_odr_assets_on_receipts_releases(fake, capsys):
     assert r[8]["first_hour_run_ok"] is False and r[8]["status"] == "fail"
 
 
-def test_row6_counts_atlas_jsonl(fake, capsys, root):
-    (root / "docs/atlas").mkdir()
+ATLAS_SAMPLE = Path(sb.__file__).resolve().parents[1] / "docs/atlas/atlas-v1.sample.jsonl"
+
+
+def write_atlas(root: Path, recs: list[dict]) -> None:
+    (root / "docs/atlas").mkdir(parents=True, exist_ok=True)
+    (root / "docs/atlas/atlas-v1.jsonl").write_text("".join(json.dumps(x) + "\n" for x in recs))
+
+
+@pytest.mark.parametrize("limit", [None, 60])
+def test_row6_counts_atlas_jsonl(fake, capsys, root, limit):
+    recs = [json.loads(x) for x in ATLAS_SAMPLE.read_text().splitlines() if x.strip()][:limit]
+    assert recs and all(
+        isinstance(x["pr"], dict) and isinstance(x["pr"]["number"], int) for x in recs
+    )
+    write_atlas(root, recs)
+    cr = sum(x["verdict"] == "changes_requested" for x in recs)
+    posted = sum(bool(x["posted_to_thread"]) for x in recs)
+    rounds = len({(x["pr"]["number"], x["head_sha"]) for x in recs})
+    if limit is None:
+        assert (cr, posted, rounds, len(recs)) == (18, 187, 189, 200)
+    _, r = rows(capsys, "--offline", "--quorum-runs", "4")
+    assert "reason" not in r[6] and r[6]["status"] == "fail"
+    assert (r[6]["now"], r[6]["posted"], r[6]["rounds"], r[6]["records"]) == (
+        cr,
+        posted,
+        rounds,
+        len(recs),
+    )
+    assert r[6]["ratio"] == round(posted / rounds, 3) and r[6]["delta"] == cr - 53
+    assert r[6]["quorum_runs"] == 4 and r[6]["upper_bound"] is True
+
+
+def test_row6_accepts_legacy_scalar_pr(fake, capsys, root):
     recs = [
         {"pr": 1, "head_sha": "x", "verdict": "changes_requested", "posted_to_thread": True},
         {"pr": 1, "head_sha": "x", "verdict": "pass", "posted_to_thread": False},
+        {"pr": {"number": 1}, "head_sha": "x", "verdict": "pass", "posted_to_thread": True},
         {"pr": 2, "head_sha": "y", "verdict": "pass", "posted_to_thread": True},
     ]
-    (root / "docs/atlas/atlas-v1.jsonl").write_text("".join(json.dumps(x) + "\n" for x in recs))
-    _, r = rows(capsys, "--offline", "--quorum-runs", "4")
-    assert (r[6]["now"], r[6]["posted"], r[6]["rounds"], r[6]["records"]) == (1, 2, 2, 3)
-    assert r[6]["quorum_runs"] == 4 and r[6]["upper_bound"] is True and r[6]["delta"] == 1 - 53
+    write_atlas(root, recs)
+    _, r = rows(capsys, "--offline")
+    assert (r[6]["now"], r[6]["posted"], r[6]["rounds"], r[6]["records"]) == (1, 3, 2, 4)
 
 
 def test_post_creates_new_comment_with_refs(fake, capsys):


### PR DESCRIPTION
## Summary

`metric_6` in `scripts/receipt_first_scoreboard.py` built the round set as `{(x.get("pr"), x.get("head_sha"))}`, but every Atlas record carries `pr` as an OBJECT (`docs/atlas/schema.json` `properties.pr` is `type: object` with required `number`). The comprehension raised `TypeError: unhashable type: 'dict'`, `build_rows` caught it, and row 6 was emitted as `now: null`, `delta: "53 → null"`, `status: unavailable`, `reason: TypeError…` with none of the `posted`/`rounds`/`records` fields. The unit test passed because its fixture used a hand-written scalar `"pr": 1`.

This PR adds `atlas_pr_number()` (dict → `pr["number"]`, scalar → itself as the legacy fallback), keys rounds on `(pr_number, head_sha)`, and re-fixtures the row-6 test from the committed `docs/atlas/atlas-v1.sample.jsonl` (200 records, every `pr` an object) with an in-test independent recount. Every other row-6 field (`ratio`, `note`, `upper_bound`, `quorum_runs`, the `status` logic, the M0 shape) and the baseline constants are unchanged. Two files, 51 LOC.

## Exit metric moved: row 6 (measurement repair — hygiene; no target moves)

Row 6 baseline cell `53 CHANGES-REQUESTED / 1659 records` stays byte-identical. On the real `atlas-v1` dataset (1661 records) the row now prints `now 55`, `posted 1648`, `rounds 917`, `records 1661`, `delta 2`, `upper_bound true`, `status fail`, no `reason` key. Row 6 status remains `fail` until the post-M2 advisory-summary count exists; this PR only repairs the measurement.

## Test commands

```
timeout 300 python3 -m pytest tests/scripts/test_receipt_first_scoreboard.py -q -p no:cacheprovider
# red (old metric_6, new sample fixture): 3 failed, 20 passed — row 6 carried reason "TypeError: unhashable type: 'dict'"
# green (this head): 23 passed in 0.93s

python3 scripts/receipt_first_scoreboard.py --json --offline --parked-file <ledger> | jq '.metrics[]|select(.id==6)'
# {"id": 6, "baseline": 53, "baseline_cell": "53 CHANGES-REQUESTED / 1659 records", "now": 55, "upper_bound": true,
#  "quorum_runs": null, "status": "fail", "posted": 1648, "rounds": 917, "records": 1661, "ratio": 1.797, "delta": 2}

python3 scripts/receipt_first_scoreboard.py --markdown --offline --parked-file <ledger> | grep '^| 6 '
# | 6 | Dissent visibility | 53 CHANGES-REQUESTED / 1659 records | 55 | 2 | fail |

bin/gate.sh lint / typecheck / contracts / guardrails / test → all GATE PASSED (test: 3888 passed, 3 skipped; mypy 1744, .mypy-baseline 3115; cycles 138 ≤ 140)
bash scripts/automation_pr_preflight.sh origin/main HEAD → preflight: ok
```

## Reviewed design tradeoffs

- **Rejected: the wider row-6/row-8 restructuring** (post-M2 advisory-summary counting, `ok` rules, `--quorum-runs` denominator). That belongs to `m2-scoreboard-row6-row8-rules` and would widen this hygiene fix past a measurement repair; this PR keeps the M0 output shape exactly.
- **Rejected: dropping the scalar fallback.** `pr` is an object in every committed and published record, but the helper keeps the scalar form so any legacy JSONL still counts instead of silently collapsing rounds.
- **Rejected: keeping a hand-written fixture.** The test now slices the committed sample and recounts independently over `r["pr"]["number"]` (whole sample: 18 / 187 / 189 / 200), so a schema drift in the sample fails the test rather than hiding behind an invented shape.

## Risks

- The M0 boundary post (https://github.com/synaptent/aragora/issues/9966#issuecomment-5537973524) keeps its `null` row-6 cell by design; it is immutable and is not re-posted. The M1 boundary post carries the corrected row.
- `delta` for row 6 changes from the string `"53 → null"` to the number `2`; consumers that parsed the arrow form for this row (none in-repo) would see the numeric form now, which is the documented `now − baseline` contract.
