### PR TITLE
fix(cli): print full receipt ids in `receipt list` and add --json (#9985)

### DIFF
--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -138,6 +138,11 @@ Examples:
         help="Filter by receipt kind",
     )
     list_p.add_argument("--org-id", help="Filter by organization ID")
+    list_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON array of receipts (with full ids) instead of a table",
+    )
     list_p.set_defaults(func=cmd_receipt_list)
 
     # --- show ---
@@ -838,6 +843,7 @@ def cmd_receipt_list(args: argparse.Namespace) -> None:
     verdict = getattr(args, "verdict", None)
     kind = getattr(args, "kind", None)
     org_id = getattr(args, "org_id", None)
+    json_output = getattr(args, "json", False)
 
     results: list[Any] = []
     storage_error: Exception | None = None
@@ -872,15 +878,19 @@ def cmd_receipt_list(args: argparse.Namespace) -> None:
         results = [meta for meta in results if _receipt_kind(meta) == kind]
 
     if not results:
-        print("No receipts found.")
+        if json_output:
+            print(json.dumps([]))
+        else:
+            print("No receipts found.")
         return
 
-    print(f"{'ID':<14} {'TYPE':<10} {'VERDICT':<12} {'CONF':>6} {'FINDINGS':>8} {'CREATED':<20}")
-    print("-" * 75)
+    # Build the full row set once. The id is always the full, un-truncated
+    # value here — it must be safe to feed straight back into `receipt show`
+    # or `receipt export` (see #9985).
+    rows: list[dict[str, Any]] = []
     for meta in results:
         payload = _receipt_payload_dict(meta)
         row_id = _receipt_row_id(meta)
-        short_id = row_id[:12] + ".." if len(row_id) > 14 else row_id
         receipt_kind = _receipt_kind(meta)
         created = _format_receipt_created_at(getattr(meta, "created_at", None))
         findings = _receipt_findings_count(meta)
@@ -889,10 +899,32 @@ def cmd_receipt_list(args: argparse.Namespace) -> None:
             verdict=getattr(meta, "verdict", None),
             confidence=getattr(meta, "confidence", None),
         )
-        print(
-            f"{short_id:<14} {receipt_kind:<10} {verdict_value:<12} {confidence:>5.0%} {findings:>8} {created:<20}"
+        rows.append(
+            {
+                "id": row_id,
+                "type": receipt_kind,
+                "verdict": verdict_value,
+                "confidence": confidence,
+                "findings": findings,
+                "created": created,
+            }
         )
-    print(f"\n{len(results)} receipt(s) shown.")
+
+    if json_output:
+        print(json.dumps(rows, indent=2, default=str))
+        return
+
+    id_width = max([len("ID")] + [len(row["id"]) for row in rows])
+    print(
+        f"{'ID':<{id_width}} {'TYPE':<10} {'VERDICT':<12} {'CONF':>6} {'FINDINGS':>8} {'CREATED':<20}"
+    )
+    print("-" * (id_width + 61))
+    for row in rows:
+        print(
+            f"{row['id']:<{id_width}} {row['type']:<10} {row['verdict']:<12} "
+            f"{row['confidence']:>5.0%} {row['findings']:>8} {row['created']:<20}"
+        )
+    print(f"\n{len(rows)} receipt(s) shown.")
 
 
 def cmd_receipt_show(args: argparse.Namespace) -> None:

--- a/tests/cli/test_receipt_command.py
+++ b/tests/cli/test_receipt_command.py
@@ -14,6 +14,7 @@ import pytest
 
 from aragora.cli.commands.receipt import (
     _format_receipt_created_at,
+    cmd_receipt_export,
     cmd_receipt_list,
     cmd_receipt_show,
 )
@@ -54,7 +55,8 @@ def test_receipt_list_reads_durable_store_by_default(capsys: pytest.CaptureFixtu
             cmd_receipt_list(argparse.Namespace(limit=5, verdict=None, kind=None, org_id=None))
 
     output = capsys.readouterr().out
-    assert "rcpt-quickst.." in output
+    assert "rcpt-quickstart-123" in output
+    assert "rcpt-quickst.." not in output
     assert "decision" in output
     assert "PASS" in output
     assert "2" in output
@@ -80,7 +82,8 @@ def test_receipt_list_falls_back_to_legacy_when_durable_empty(
             cmd_receipt_list(argparse.Namespace(limit=5, verdict="fail", kind=None, org_id=None))
 
     output = capsys.readouterr().out
-    assert "gauntlet-leg.." in output
+    assert "gauntlet-legacy-123" in output
+    assert "gauntlet-leg.." not in output
     assert "other" in output
     assert "FAIL" in output
     assert "4" in output
@@ -140,7 +143,112 @@ def test_receipt_list_filters_by_kind(capsys: pytest.CaptureFixture[str]) -> Non
     output = capsys.readouterr().out
     assert "rcpt-inbox-123" in output
     assert "inbox" in output
-    assert "rcpt-decisio.." not in output
+    assert "rcpt-decision-456" not in output
+
+
+def test_receipt_list_prints_full_id_never_truncated(capsys: pytest.CaptureFixture[str]) -> None:
+    """Regression test for #9985: the table must print the full id, not a
+
+    12-char-plus-".." shortened form that cannot be fed back to `receipt show`
+    or `receipt export`.
+    """
+    long_id = "rcpt-" + "f" * 40
+    stored = _StoredReceiptStub(
+        receipt_id=long_id,
+        gauntlet_id=long_id,
+        verdict="PASS",
+        confidence=1.0,
+        created_at=1711300000.0,
+        data={"risk_summary": {"total": 0}},
+    )
+
+    with patch("aragora.cli.commands.receipt._load_storage_receipt_list", return_value=[stored]):
+        cmd_receipt_list(argparse.Namespace(limit=5, verdict=None, kind=None, org_id=None))
+
+    output = capsys.readouterr().out
+    assert long_id in output
+    assert ".." not in output
+
+
+def test_receipt_list_json_emits_full_ids(capsys: pytest.CaptureFixture[str]) -> None:
+    long_id = "rcpt-" + "a" * 40
+    stored = _StoredReceiptStub(
+        receipt_id=long_id,
+        gauntlet_id=long_id,
+        verdict="PASS",
+        confidence=0.9,
+        created_at=1711300000.0,
+        data={"risk_summary": {"total": 3}},
+    )
+
+    with patch("aragora.cli.commands.receipt._load_storage_receipt_list", return_value=[stored]):
+        cmd_receipt_list(
+            argparse.Namespace(limit=5, verdict=None, kind=None, org_id=None, json=True)
+        )
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["id"] == long_id
+    assert payload[0]["type"] == "decision"
+    assert payload[0]["verdict"] == "PASS"
+    assert payload[0]["findings"] == 3
+
+
+def test_receipt_list_id_round_trips_to_show_and_export(tmp_path) -> None:
+    """End-to-end regression test for #9985.
+
+    Creates a receipt in a real (temp-file) receipt store, runs `receipt list`
+    against it, and feeds the exact id `list` printed back into `receipt show
+    --format json` and `receipt export --format odr` — both must exit 0 (i.e.
+    not call sys.exit) rather than reporting "receipt not found".
+    """
+    from aragora.storage.receipt_store import ReceiptStore, set_receipt_store
+
+    long_id = "rcpt-" + "b" * 40
+    store = ReceiptStore(db_path=tmp_path / "receipts.db", file_receipt_dirs=[])
+    try:
+        set_receipt_store(store)
+        store.save(
+            {
+                "receipt_id": long_id,
+                "gauntlet_id": long_id,
+                "timestamp": "2026-03-24T12:00:00+00:00",
+                "verdict": "PASS",
+                "confidence": 0.9,
+                "risk_level": "LOW",
+                "risk_score": 0.1,
+                "checksum": "deadbeef",
+                "risk_summary": {"total": 0},
+            }
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        list_out = io.StringIO()
+        with redirect_stdout(list_out):
+            cmd_receipt_list(argparse.Namespace(limit=5, verdict=None, kind=None, org_id=None))
+        list_output = list_out.getvalue()
+        assert long_id in list_output
+
+        # Extract the id exactly as printed (first column) and feed it back.
+        printed_id = next(line.split()[0] for line in list_output.splitlines() if long_id in line)
+        assert printed_id == long_id
+
+        show_out = io.StringIO()
+        with redirect_stdout(show_out):
+            cmd_receipt_show(argparse.Namespace(id=printed_id, format="json", org_id=None))
+        show_payload = json.loads(show_out.getvalue())
+        assert show_payload["receipt_id"] == long_id
+
+        export_out = io.StringIO()
+        with redirect_stdout(export_out):
+            cmd_receipt_export(argparse.Namespace(receipt=printed_id, format="odr", output=None))
+        assert export_out.getvalue().strip()
+    finally:
+        set_receipt_store(None)
 
 
 def test_receipt_created_at_formats_epoch_and_iso_consistently() -> None:


### PR DESCRIPTION
## Summary
- `aragora receipt list` truncated ids to 12 chars + `".."`, so the id it prints is not the id `receipt show`/`receipt export` will accept — the only discovery path a new user has was a dead end (first-hour blocker for 2.10.0, found by the Receipt-First installed-acceptance validator, epic #9966).
- `cmd_receipt_list()` now prints the **full** receipt id in the default table (the ID column width now adapts to the longest id in the result set instead of a fixed 14 chars).
- Added `--json` to `receipt list`, emitting `json.dumps([{"id": ..., "type": ..., "verdict": ..., "confidence": ..., "findings": ..., "created": ...}, ...])` with full ids and the same fields the table shows.
- `--limit` behavior is unchanged.

## Files
- `aragora/cli/commands/receipt.py` — `cmd_receipt_list()` and the `list` subparser registration only.
- `tests/cli/test_receipt_command.py` — updated the three existing table-format assertions that encoded the truncated form, and added:
  - `test_receipt_list_prints_full_id_never_truncated`
  - `test_receipt_list_json_emits_full_ids`
  - `test_receipt_list_id_round_trips_to_show_and_export` (real temp-file `ReceiptStore`, no mocks: saves a receipt, runs `list`, feeds the exact printed id into `receipt show --format json` and `receipt export --format odr`, asserts both produce output rather than exiting)

No changes to `receipt show`/`receipt export`/storage, per the issue's Tier 1 scope and to avoid conflicting with the `m1-acta-projection-and-export` mission item touching the same file.

## Test commands
```
python3 -m pytest tests/cli/test_receipt_command.py tests/cli/test_debate_receipt.py tests/cli/test_inbox_wedge_command.py -q
# 33 passed

ruff check aragora/cli/commands/receipt.py tests/cli/test_receipt_command.py
ruff format --check aragora/cli/commands/receipt.py tests/cli/test_receipt_command.py
# All checks passed / already formatted
```

Manual smoke against the repo's real (shared-worktree) receipt store:
```
python3 -m aragora.cli.main receipt list --limit 5           # full ids, no ".."
python3 -m aragora.cli.main receipt list --limit 2 --json    # valid JSON array, full ids
python3 -m aragora.cli.main receipt show <printed-id> --format json   # exit 0
python3 -m aragora.cli.main receipt export <printed-id> --format odr  # exit 0
```
All four confirmed working end-to-end with an id copied verbatim from `list` output.

## Reviewed design tradeoffs
- **Full id in the table vs. a `--full` flag**: a flag defeats the point — the bug is that the *default*, only-discovery-path output is unusable. The issue's acceptance criteria is explicit that a short form, if kept at all, must be an *additional* column, never the sole identifier. Simplicity won: drop the short column entirely and just print the full id; the column auto-widens to the longest id in the current page rather than a fixed width, so normal ids (UUIDs, `rcpt-*`) don't force a needlessly wide table while pathological ids (there's a pre-existing unrelated data-quality issue producing very long `debate-<MagicMock ...>` ids from some historic demo runs) still render correctly instead of being clipped.
- **JSON output shape**: reuses exactly the fields already computed for the table (`id`, `type`, `verdict`, `confidence`, `findings`, `created`) rather than dumping raw storage rows, so `--json` stays a stable, documented contract independent of internal `StoredReceipt`/legacy-row shapes, and confidence/verdict normalization (trust-wedge overlay) is applied identically in both output modes.
- **No storage/id changes**: the bug is purely in list rendering (`row_id[:12] + ".."`); full ids read from the saved artifact already worked, so this stays a Tier 1, presentation-only fix.

Closes #9985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
