### PR TITLE
fix(cli): restore Python 3.10 startup compatibility

### DIFF
--- a/aragora/epistemic/gardening.py
+++ b/aragora/epistemic/gardening.py
@@ -19,12 +19,14 @@ import json
 import os
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
 from aragora.epistemic.coherence import CoherenceIssue, IncoherenceKind
 from aragora.epistemic.crux_receipt import CruxEntry, CruxReceipt
+
+UTC = timezone.utc
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 

--- a/aragora/epistemic/genealogy.py
+++ b/aragora/epistemic/genealogy.py
@@ -22,8 +22,10 @@ import json
 import os
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Literal, Protocol, get_args, runtime_checkable
+
+UTC = timezone.utc
 
 EntryKind = Literal["decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"]
 

--- a/aragora/epistemic/genealogy_report.py
+++ b/aragora/epistemic/genealogy_report.py
@@ -9,10 +9,12 @@ Live queue effect: none.  Gate: same as DIC-23..28.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from aragora.epistemic.genealogy import CodeUnitGenealogy, GenealogyStore, get_genealogy
+
+UTC = timezone.utc
 
 
 def _utc_now_iso() -> str:

--- a/aragora/epistemic/repair.py
+++ b/aragora/epistemic/repair.py
@@ -21,10 +21,12 @@ import hashlib
 import json
 import os
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 from aragora.epistemic.decay_monitor import DecaySignal
+
+UTC = timezone.utc
 
 RepairKind = Literal["report_only", "shadow_candidate", "pr_candidate"]
 

--- a/aragora/epistemic/runtime_loop.py
+++ b/aragora/epistemic/runtime_loop.py
@@ -41,7 +41,7 @@ import logging
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import Any
 
@@ -52,6 +52,8 @@ from aragora.epistemic.quarantine_policy import (
     apply_quarantine_policy,
 )
 from aragora.epistemic.repair import RepairSpec, propose_repair
+
+UTC = timezone.utc
 
 _FLAG = "ARAGORA_DIALECTICAL_RUNTIME_ENABLED"
 

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,6 +19,34 @@ from aragora.epistemic.runtime_loop import (
     dialectical_runtime_enabled,
     run_dialectical_loop,
 )
+
+
+def test_epistemic_imports_without_python311_utc_alias():
+    # A fresh interpreter avoids package imports cached by test collection.
+    probe = """
+import datetime
+import importlib
+
+if hasattr(datetime, "UTC"):
+    del datetime.UTC
+for name in ("runtime_loop", "repair", "gardening", "genealogy", "genealogy_report"):
+    module = importlib.import_module("aragora.epistemic." + name)
+    assert module.UTC is datetime.timezone.utc, name
+from aragora.epistemic.runtime_loop import dialectical_runtime_enabled
+assert not dialectical_runtime_enabled()
+"""
+    env = dict(os.environ, ARAGORA_USE_SECRETS_MANAGER="false", AWS_EC2_METADATA_DISABLED="true")
+    env.pop("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", None)
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Refs #9039 and #9966. Release-to-Use defect R2U-C02; Tier 2 live-CLI compatibility repair.

The advertised Python >=3.10 base wheel fails to start because parser registration eagerly imports the epistemic package, whose five modules import `datetime.UTC` (Python 3.11+). Use the identical `datetime.timezone.utc` singleton through a local `UTC` alias. Timestamp formatting, feature flags, IDs, and runtime policy are unchanged.

Add a fresh-interpreter regression that removes the Python 3.11 alias when present, imports all five modules, verifies singleton identity, and confirms the dialectical runtime stays disabled. The original code fails this test with the same ImportError as the installed Python 3.10 wheel.

## Scope and Ownership

- Five existing epistemic source files plus `tests/epistemic/test_runtime_loop.py` only.
- No parser, quickstart, package/dependency manifest, workflow, signing, schema, or generated-documentation edits.
- Current open-PR file sets and active leases were overlap-free for these six paths. Historical worktrees and unpublished branches were inspected and preserved unchanged.
- Clean disposable worktree, branch lease `8cdf2794-f55`, work identity `issue:9039`. One normal push; no published history rewriting.

## Validation

Base: `1ad1162d59079ae2b0d8536bbf48037ff030a930`.
Candidate: `9b30a68a497a60b0e6acacf1578b180fd17ca43a`.

- Regression before repair: 1 failed with `ImportError: cannot import name 'UTC' from 'datetime'`.
- `pytest -q tests/epistemic/test_runtime_loop.py tests/epistemic/test_repair.py tests/epistemic/test_gardening.py tests/epistemic/test_genealogy.py tests/epistemic/test_genealogy_report.py`: **129 passed**.
- Ruff check and format check on all six changed files: passed.
- Fresh-cache targeted mypy on the five source files, both follow-imports=silent and the CI-aligned skip profile: passed.
- Commit hooks, automation preflight, and `git diff --check`: passed.
- Pre-push hooks: all applicable checks passed with `PRE_COMMIT_NO_CONCURRENCY=1` and a fresh cache. Default split execution and a fresh-cache split retry both hit a mypy 2.1.0 internal error; these failures are retained. No hook/configuration was disabled or edited.
- Built a non-editable wheel from a clean tracked candidate archive. All **4,331** producer payload files match source and installed wheel bytes.
- Real Linux/aarch64 CPython **3.10.21**, offline execution, isolated HOME and no source path injection: `aragora --help`, `aragora quickstart --help`, `aragora doctor`, and all five UTC import/identity checks pass.
- Image: `python@sha256:fd76ade0c607f27677bc04be3c60749f400eedc941d9e72967e19a4cedff80c2`.
- Candidate wheel SHA256: `e35d7d217c46b3c2e67e95fe988368fc060474a1acd9bfec58c3d391236501e7`.

## Remaining Release Blockers

This is **not** a passing full Python 3.10 acceptance result. The broader installed diagnostic now reaches demo execution and exposes another pre-existing compatibility defect: `quickstart._run_sync` calls Python 3.11-only `asyncio.Runner`. That file is owned by #9989 and was not changed. The separate base-wheel signing dependency gap also remains owner-gated. Both failures remain in the release ledger; no acceptance case was skipped into green.

Marked ready for review on 2026-09-05 at the unchanged candidate head after live Tier-2, ownership, and required-check validation. The transition triggered normal CI. No model evidence, manual CI rerun, settlement, or merge has been performed. Model evidence remains pending reviewer-capacity and exact-head checks; the governing two-family Tier-2 requirement is retained even though the helper currently reports a one-signal minimum.
