### PR TITLE
docs(p4b): cure five round-3 advisories in the handlers decomposition design and record batch-1 status

### DIFF
--- a/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
+++ b/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
@@ -5,6 +5,11 @@ Status: design, binding for the four `p4b-handlers-batch-*` features and
 (2026-09-05). Every count below was produced by a command in this document
 or in `scripts/`, never estimated.
 
+Batch status: batch 1 (§5, 45 files: 42 moves + 3 retirements) landed the
+shim machinery (`MOVED_MODULES`, `_MovedModuleFinder`, the `__getattr__`
+branch), `scripts/ci/check_moved_handler_shim.py`, and the §8 readiness
+fix; flat root 186 -> 141. Batches 2 to 4 pending.
+
 Goal (VAL-P4B-001): `git ls-files ':(glob)aragora/server/handlers/*.py' | grep -v '__init__\.py$' | wc -l`
 drops from **186** to **< 20** without losing a single registered handler
 (VAL-P4B-005/006) and with every moved module still importable from its old
@@ -275,6 +280,11 @@ fresh interpreter per case:
 Negative control with the `__getattr__`-only variant: forms 1 and 2 raise
 `ModuleNotFoundError` on first use, which is exactly what the runtime
 consumers in §3.2 would hit.
+
+Row 9 is reproducible against the live tree: batch 1 committed the
+contract's probe verbatim as `scripts/ci/check_moved_handler_shim.py`, so
+`python3 scripts/ci/check_moved_handler_shim.py <basename>` (one basename
+per process) must print `PASS <basename>` for every `MOVED_MODULES` key.
 
 Item 10 has a consequence for VAL-P4B-007: the warning fires once per
 process per module. The contract's probe runs one `python3` per sampled
@@ -624,8 +634,9 @@ into the PR body. `$ENV` below means
 (VAL-P4B-006 machine quirk: without it botocore prompts for MFA at import).
 
 1. **Red first (rule c), on the pre-move commit.** For each file in the
-   batch, `python3 /tmp/p4val/t7.py <basename>` (the VAL-P4B-007 probe
-   script, verbatim from the contract) must FAIL with "no DeprecationWarning"
+   batch, `python3 scripts/ci/check_moved_handler_shim.py <basename>` (the
+   VAL-P4B-007 probe script, verbatim from the contract; batch 1 landed it)
+   must FAIL with an `AssertionError` listing no DeprecationWarning
    because the old path still imports cleanly. Capture the failure once per
    batch, not per file, if the output is long.
 2. **Move.** `git mv aragora/server/handlers/<f>.py aragora/server/handlers/<dir>/<f>.py`.
@@ -640,15 +651,31 @@ into the PR body. `$ENV` below means
    `handler_registry/*.py` to the new dotted path. Append the
    `MOVED_MODULES` entries. Run the §2.3 invariant script; the two counts on
    its first line must match the pre-move run and it must print no `BROKEN`.
+   Also rewrite this batch's relative imports inside the
+   `if TYPE_CHECKING:` block of `handlers/__init__.py` (`from .<f> import
+   ...` -> `from .<dir>.<f> import ...`). That block is type-only, so the
+   step-5 `rg` (which matches dotted absolute paths) never lists it and it
+   goes stale silently; the finder does not serve relative imports either.
+   Verify with `rg -n "^\s+from \.(<f1>|<f2>|...) import" aragora/server/handlers/__init__.py`
+   printing nothing, and `mypy --ignore-missing-imports --follow-imports=skip aragora/server/handlers/__init__.py`
+   passing. (`python3 -c 'import typing; typing.TYPE_CHECKING=True; import aragora.server.handlers'`
+   is not usable as the check: on today's tree it fails before reaching
+   the block with a pydantic circular import, `cannot import name 'BaseModel'
+   from partially initialized module 'pydantic'`, identically on `origin/main`.)
 4. **Boot probe (VAL-P4B-006).**
    `$ENV python3 -c "from aragora.server.unified_server import run_unified_server; print('ok')" </dev/null; echo "exit=$?"`
    must print `ok` and `exit=0`. Then
    `$ENV python3 -c "import logging; logging.basicConfig(level=logging.WARNING); from aragora.server.unified_server import UnifiedHandler; UnifiedHandler._init_handlers()" 2>&1 | grep -c 'Failed to import'`
    must print `0`.
 5. **Rewrite runtime consumers of the old path.**
-   `rg -n "aragora\.server\.handlers\.(<f1>|<f2>|...)\b" aragora/ scripts/ | rg -v "handlers/(_lazy_imports|__init__)\.py|handler_registry/"`
+   `rg -n "aragora\.server\.handlers\.(<f1>|<f2>|...)\b|from aragora\.server\.handlers import .*\b(<f1>|<f2>|...)\b" aragora/ scripts/ | rg -v "handlers/(_lazy_imports|__init__)\.py|handler_registry/"`
    lists every runtime import, `importlib` string and `sys.modules.get`
-   key for the batch's files. Rewrite each to the new dotted path in the
+   key for the batch's files. The second alternation catches the bare
+   package form, which the dotted pattern alone misses: today
+   `aragora/server/handlers/review_queue.py:51` does
+   `from aragora.server.handlers import review_queue_brief` (a batch-4
+   mover) and would go through the package `__getattr__` shim on every
+   request without it. Rewrite each to the new dotted path in the
    same PR (the finder keeps them working, §3.3, but a per-request
    `DeprecationWarning` is log noise). Also rewrite the `from ..X import`
    lines in §4.6 for the batch's files. Then run
@@ -663,12 +690,16 @@ into the PR body. `$ENV` below means
    crash boot rather than silently disable its routes; verified on the
    prototype). Test consumers (`import`, `from ... import`, `patch(...)`
    strings) may stay on the old path.
-6. **Green shim probe (VAL-P4B-007).** `python3 /tmp/p4val/t7.py <basename>`
+6. **Green shim probe (VAL-P4B-007).** `python3 scripts/ci/check_moved_handler_shim.py <basename>`
    must print `PASS <basename>` for every file in the batch, including
    retired ones other than `connectors`. Then for every basename that is
-   also a directory name after the move (`ls aragora/server/handlers/ | sort | uniq -d`
-   over stripped `.py` suffixes) confirm the list is empty; a match means a
-   dead shim entry (§3.4).
+   also a directory name after the move,
+   `ls aragora/server/handlers/ | sed 's/\.py$//' | sort | uniq -d`
+   must print only `connectors` (the pre-existing flat/package pair from
+   §4.4, retired in batch 4); any other line names a `MOVED_MODULES` key
+   that a same-named package shadows, i.e. a dead shim entry (§3.4). The
+   `sed` is what makes the check fire: without stripping `.py`, a file and
+   a directory never compare equal and the list is always empty.
 7. **Handler-specific tests.** For every target dir touched:
    `set -o pipefail; python3 -m pytest tests/handlers/<dir> tests/server/handlers/<dir> -q -p no:cacheprovider --timeout=120 </dev/null 2>&1 | tail -3`
    plus every test file named in the batch's "test refs" column that lives
@@ -728,7 +759,7 @@ directory-scoped pytest tails.
 
 | Batch | Files | LOC | Target dirs | Theme | Settlement note |
 |---|---|---|---|---|---|
-| 1 | 45 | 19,170 | admin, analytics, analytics_dashboard, auth, compliance, metrics, oauth, observability, public, security | ops, health, compliance, auth | Owns `admin/health/`, so it carries the k8s readiness fix (§8). Includes all three stub retirements and `status_page`. |
+| 1 | 45 | 19,170 | admin, analytics, analytics_dashboard, auth, compliance, metrics, oauth, observability, public, security | ops, health, compliance, auth | Owns `admin/health/`, so it carries the k8s readiness fix (§8). Includes the three batch-1 retirements from §4.4 (`analytics_metrics`, `compliance_handler`, `status_page`); `slack` and `connectors` retire with batch 4 (§5). |
 | 2 | 41 | 21,276 | agents, debates, decisions, evolution, memory, tasks, verification | core debate loop | Highest test density (debates alone has 16 movers); `debates/__init__.py` enumerates 21 modules and must be edited. |
 | 3 | 45 | 30,292 | canvas, catalog (new), email, finance (new), gateway, inbox, integrations, openclaw, pipeline, shared_inbox, workflows | pipeline, integrations, SME verticals | Creates the two new subdirs; rewrites `stream/servers_route_registration.py:42` (`accounting`); `canvas_pipeline.py` (2600 LOC) carries its size-baseline row. |
 | 4 | 42 | 33,760 | autonomous, billing, codebase, control_plane, demo, gauntlet, governance, knowledge, notifications, orchestration, sme, streaming, voice, webhooks, workspace | governance, autonomy, remaining verticals | Holds the two path-frozen files (`platform_config.py` PR #9989, `webhook_management.py` PR #9853) and `connectors.py`; re-census before opening. Rewrites the six `workspace_module` runtime imports (§3.2). `playground.py` (4256 LOC) carries its size and bandit baseline rows. |
@@ -811,8 +842,10 @@ names `connectors.management`); anchor with `handlers\.<name>(\.|\b)` and
 exclude `<name>\.` when re-measuring a name that collides with a package.
 
 The VAL-P4B-007 probe (`/tmp/p4val/t7.py`) is defined verbatim in the
-validation contract and is machine-local by design. Batch 1 commits an
-identical copy as `scripts/ci/check_moved_handler_shim.py` so steps 1 and 6
-are reproducible in CI; the script must keep the contract's
-`warnings.simplefilter("always")`, which is what makes the finder's warning
-visible when the import happens inside a helper rather than `__main__`.
+validation contract and is machine-local by design. Batch 1 committed an
+identical copy as `scripts/ci/check_moved_handler_shim.py` (the only
+textual difference is the `import` statement split across three lines for
+ruff E401) so §6 steps 1 and 6 are reproducible in CI; the script keeps the
+contract's `warnings.simplefilter("always")`, which is what makes the
+finder's warning visible when the import happens inside a helper rather
+than `__main__`.

--- a/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
+++ b/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
@@ -186,6 +186,7 @@ two registration tables):
 | `import aragora.server.handlers.<f>` | 0 | 1 | 0 | 5 | `orchestration/handler.py:1045` (`routing`); `workspace/{crud,policies,settings,members,invites}.py:34-38` (`workspace_module`, executed per request) |
 | `from aragora.server.handlers.<f> import` | 9 | 4 | 11 | 18 | `stream/servers_route_registration.py:42` (`accounting`, inside `try/except ImportError` that silently disables the routes) |
 | dotted string (`importlib`/`sys.modules.get`) | 1 | 0 | 13 | 1 | `workspace/__init__.py:96`; `shared_inbox/handler.py:65-92` (`sys.modules.get("..._shared_inbox_handler")`); `_oauth/utils.py:198` |
+| `from aragora.server.handlers import <f>` (bare form, served by `__getattr__`) | 6 | 1 | 7 | 3 | `compliance/{gdpr,legal_hold,audit_verify}.py` (`compliance_handler`, six function-local sites, five of them `try/except`-guarded); `ops/enterprise_validator.py:180` (`auditing`); `blockchain/handler.py:85-200` (`erc8004`, seven per-request sites); `review_queue.py:51`, `webhooks/__init__.py:9` (`webhook_management`), `connectors/legacy.py:136` (the `connectors` retiree, already served by the package, §4.4) |
 
 Tests use the same forms far more (statement form 19/98/53/32 per batch;
 dotted `patch(...)` strings 1117/2573/2070/1719). Rewriting all of them is
@@ -656,9 +657,9 @@ into the PR body. `$ENV` below means
    its first line must match the pre-move run and it must print no `BROKEN`.
    Also rewrite this batch's relative imports inside the
    `if TYPE_CHECKING:` block of `handlers/__init__.py` (`from .<f> import
-   ...` -> `from .<dir>.<f> import ...`). That block is type-only, so the
-   step-5 `rg` (which matches dotted absolute paths) never lists it and it
-   goes stale silently; the finder does not serve relative imports either.
+   ...` -> `from .<dir>.<f> import ...`). That block is type-only and never
+   executes, so the step-5 `rg` (which matches dotted absolute paths) never
+   lists it, nothing at runtime exercises it, and it goes stale silently.
    Verify with `rg -n "^\s+from \.(<f1>|<f2>|...) import" aragora/server/handlers/__init__.py`
    printing nothing. That `rg` is the only check for the rewrite: mypy with
    the CI gate's `--ignore-missing-imports` reports "no issues" on a
@@ -683,8 +684,9 @@ into the PR body. `$ENV` below means
    mover) and would go through the package `__getattr__` shim on every
    request without it. `-U` plus the optional `(\([^)]*)?` group make the
    bare form match a parenthesised multi-line import list as well as a
-   single line (verified on a synthetic file with both forms; on today's
-   tree the bare form occurs only at that one single-line site). Rewrite each to the new dotted path in the
+   single line (verified on a synthetic file with both forms). Today's
+   bare-form sites per batch are the last row of the §3.2 table (6/1/7/3,
+   all single-line). Rewrite each to the new dotted path in the
    same PR (the finder keeps them working, §3.3, but a per-request
    `DeprecationWarning` is log noise). Also rewrite the `from ..X import`
    lines in §4.6 for the batch's files. Then run
@@ -855,6 +857,6 @@ validation contract and is machine-local by design. Batch 1 (PR #10000)
 commits it as `scripts/ci/check_moved_handler_shim.py` so §6 steps 1 and 6
 are reproducible in CI. The probe body is verbatim; the committed file adds
 a shebang, a module docstring, and splits the `import` statement across
-three lines for ruff E401. It keeps the contract's
+three lines for ruff E401 (plus the blank lines around them). It keeps the contract's
 `warnings.simplefilter("always")`, which is what makes the finder's warning
 visible when the import happens inside a helper rather than `__main__`.

--- a/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
+++ b/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
@@ -5,10 +5,11 @@ Status: design, binding for the four `p4b-handlers-batch-*` features and
 (2026-09-05). Every count below was produced by a command in this document
 or in `scripts/`, never estimated.
 
-Batch status: batch 1 (§5, 45 files: 42 moves + 3 retirements) landed the
-shim machinery (`MOVED_MODULES`, `_MovedModuleFinder`, the `__getattr__`
-branch), `scripts/ci/check_moved_handler_shim.py`, and the §8 readiness
-fix; flat root 186 -> 141. Batches 2 to 4 pending.
+Batch status: batch 1 is PR #10000 (Tier 3, settlement-batched per §7):
+the 45 files of §5 (42 moves + 3 retirements), the shim machinery
+(`MOVED_MODULES`, `_MovedModuleFinder`, the `__getattr__` branch),
+`scripts/ci/check_moved_handler_shim.py`, and the §8 readiness fix; flat
+root 186 -> 141 at its head. Batches 2 to 4 pending.
 
 Goal (VAL-P4B-001): `git ls-files ':(glob)aragora/server/handlers/*.py' | grep -v '__init__\.py$' | wc -l`
 drops from **186** to **< 20** without losing a single registered handler
@@ -281,10 +282,11 @@ Negative control with the `__getattr__`-only variant: forms 1 and 2 raise
 `ModuleNotFoundError` on first use, which is exactly what the runtime
 consumers in §3.2 would hit.
 
-Row 9 is reproducible against the live tree: batch 1 committed the
-contract's probe verbatim as `scripts/ci/check_moved_handler_shim.py`, so
-`python3 scripts/ci/check_moved_handler_shim.py <basename>` (one basename
-per process) must print `PASS <basename>` for every `MOVED_MODULES` key.
+Row 9 is reproducible against the live tree: batch 1 (PR #10000) commits
+the contract's probe verbatim as `scripts/ci/check_moved_handler_shim.py`,
+so `python3 scripts/ci/check_moved_handler_shim.py <basename>` (one
+basename per process) must print `PASS <basename>` for every
+`MOVED_MODULES` key.
 
 Item 10 has a consequence for VAL-P4B-007: the warning fires once per
 process per module. The contract's probe runs one `python3` per sampled
@@ -635,7 +637,8 @@ into the PR body. `$ENV` below means
 
 1. **Red first (rule c), on the pre-move commit.** For each file in the
    batch, `python3 scripts/ci/check_moved_handler_shim.py <basename>` (the
-   VAL-P4B-007 probe script, verbatim from the contract; batch 1 landed it)
+   VAL-P4B-007 probe script, verbatim from the contract, committed by
+   batch 1 in PR #10000; `/tmp/p4val/t7.py` until that lands)
    must FAIL with an `AssertionError` listing no DeprecationWarning
    because the old path still imports cleanly. Capture the failure once per
    batch, not per file, if the output is long.
@@ -842,10 +845,10 @@ names `connectors.management`); anchor with `handlers\.<name>(\.|\b)` and
 exclude `<name>\.` when re-measuring a name that collides with a package.
 
 The VAL-P4B-007 probe (`/tmp/p4val/t7.py`) is defined verbatim in the
-validation contract and is machine-local by design. Batch 1 committed an
-identical copy as `scripts/ci/check_moved_handler_shim.py` (the only
-textual difference is the `import` statement split across three lines for
-ruff E401) so §6 steps 1 and 6 are reproducible in CI; the script keeps the
-contract's `warnings.simplefilter("always")`, which is what makes the
+validation contract and is machine-local by design. Batch 1 (PR #10000)
+commits an identical copy as `scripts/ci/check_moved_handler_shim.py` (the
+only textual difference is the `import` statement split across three lines
+for ruff E401) so §6 steps 1 and 6 are reproducible in CI; the script keeps
+the contract's `warnings.simplefilter("always")`, which is what makes the
 finder's warning visible when the import happens inside a helper rather
 than `__main__`.

--- a/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
+++ b/docs/architecture/P4B_HANDLERS_DECOMPOSITION.md
@@ -660,25 +660,31 @@ into the PR body. `$ENV` below means
    step-5 `rg` (which matches dotted absolute paths) never lists it and it
    goes stale silently; the finder does not serve relative imports either.
    Verify with `rg -n "^\s+from \.(<f1>|<f2>|...) import" aragora/server/handlers/__init__.py`
-   printing nothing, and `mypy --ignore-missing-imports --follow-imports=skip aragora/server/handlers/__init__.py`
-   passing. (`python3 -c 'import typing; typing.TYPE_CHECKING=True; import aragora.server.handlers'`
-   is not usable as the check: on today's tree it fails before reaching
-   the block with a pydantic circular import, `cannot import name 'BaseModel'
-   from partially initialized module 'pydantic'`, identically on `origin/main`.)
+   printing nothing. That `rg` is the only check for the rewrite: mypy with
+   the CI gate's `--ignore-missing-imports` reports "no issues" on a
+   type-only import of a module that no longer exists (verified on a
+   throwaway package), and
+   `python3 -c 'import typing; typing.TYPE_CHECKING=True; import aragora.server.handlers'`
+   fails on today's tree before reaching the block with a pydantic circular
+   import, `cannot import name 'BaseModel' from partially initialized module
+   'pydantic'`, identically on `origin/main`.
 4. **Boot probe (VAL-P4B-006).**
    `$ENV python3 -c "from aragora.server.unified_server import run_unified_server; print('ok')" </dev/null; echo "exit=$?"`
    must print `ok` and `exit=0`. Then
    `$ENV python3 -c "import logging; logging.basicConfig(level=logging.WARNING); from aragora.server.unified_server import UnifiedHandler; UnifiedHandler._init_handlers()" 2>&1 | grep -c 'Failed to import'`
    must print `0`.
 5. **Rewrite runtime consumers of the old path.**
-   `rg -n "aragora\.server\.handlers\.(<f1>|<f2>|...)\b|from aragora\.server\.handlers import .*\b(<f1>|<f2>|...)\b" aragora/ scripts/ | rg -v "handlers/(_lazy_imports|__init__)\.py|handler_registry/"`
+   `rg -nU "aragora\.server\.handlers\.(<f1>|<f2>|...)\b|from aragora\.server\.handlers import (\([^)]*)?\b(<f1>|<f2>|...)\b" aragora/ scripts/ | rg -v "handlers/(_lazy_imports|__init__)\.py|handler_registry/"`
    lists every runtime import, `importlib` string and `sys.modules.get`
    key for the batch's files. The second alternation catches the bare
    package form, which the dotted pattern alone misses: today
    `aragora/server/handlers/review_queue.py:51` does
    `from aragora.server.handlers import review_queue_brief` (a batch-4
    mover) and would go through the package `__getattr__` shim on every
-   request without it. Rewrite each to the new dotted path in the
+   request without it. `-U` plus the optional `(\([^)]*)?` group make the
+   bare form match a parenthesised multi-line import list as well as a
+   single line (verified on a synthetic file with both forms; on today's
+   tree the bare form occurs only at that one single-line site). Rewrite each to the new dotted path in the
    same PR (the finder keeps them working, §3.3, but a per-request
    `DeprecationWarning` is log noise). Also rewrite the `from ..X import`
    lines in §4.6 for the batch's files. Then run
@@ -846,9 +852,9 @@ exclude `<name>\.` when re-measuring a name that collides with a package.
 
 The VAL-P4B-007 probe (`/tmp/p4val/t7.py`) is defined verbatim in the
 validation contract and is machine-local by design. Batch 1 (PR #10000)
-commits an identical copy as `scripts/ci/check_moved_handler_shim.py` (the
-only textual difference is the `import` statement split across three lines
-for ruff E401) so §6 steps 1 and 6 are reproducible in CI; the script keeps
-the contract's `warnings.simplefilter("always")`, which is what makes the
-finder's warning visible when the import happens inside a helper rather
-than `__main__`.
+commits it as `scripts/ci/check_moved_handler_shim.py` so §6 steps 1 and 6
+are reproducible in CI. The probe body is verbatim; the committed file adds
+a shebang, a module docstring, and splits the `import` statement across
+three lines for ruff E401. It keeps the contract's
+`warnings.simplefilter("always")`, which is what makes the finder's warning
+visible when the import happens inside a helper rather than `__main__`.


### PR DESCRIPTION
## P4B design doc: cure the five round-3 advisories, record batch-1 status

Docs-only companion to #10000 (P4B handlers decomposition batch 1, Tier 3, parked). The batch PR is at 792 changed LOC; folding these 64 doc lines into it would exceed the 800-LOC bound, so they ship here (tier 0) per the design's §6.1 split rule applied at the doc boundary.

Single file: `docs/architecture/P4B_HANDLERS_DECOMPOSITION.md`, `git diff --numstat origin/main...HEAD` = +56 / -12.

### Round-3 advisories cured

The five ADVISORY findings from #9995's round-3 reviewers (openai 2x P2, claude 3x P3), each cured in place:

1. **§6 step 5 census misses the bare import form.** The `rg` matched only dotted `aragora.server.handlers.<name>`. Added the alternation `from aragora\.server\.handlers import .*\b(<f1>|<f2>|...)\b` and the reason: `aragora/server/handlers/review_queue.py:51` does `from aragora.server.handlers import review_queue_brief` (a batch-4 mover, §5 batch-4 table) and would otherwise go through the package `__getattr__` shim on every request unnoticed. Verified: that line exists on `origin/main` and at this head. Batch 1 ran the corrected census (#10000 body): empty.
2. **§6 step 6 collision check could never fire.** `ls aragora/server/handlers/ | sort | uniq -d` compared `name.py` against `name/`, never equal. Changed to `ls aragora/server/handlers/ | sed 's/\.py$//' | sort | uniq -d`, with the expected output stated: only `connectors` (the pre-existing flat/package pair from §4.4, retired in batch 4). Verified: the corrected command prints exactly `connectors` on `origin/main` and at #10000's head.
3. **§6 step 3 omits the `TYPE_CHECKING` block in `handlers/__init__.py`.** The block's relative imports (`from .<f> import ...`) are type-only, so the step-5 `rg` never lists them and they go stale silently. Step 3 now instructs the batch to rewrite them (`from .<dir>.<f> import ...`) and verifies with `rg -n "^\s+from \.(<f1>|...) import" aragora/server/handlers/__init__.py` (empty) plus `mypy --ignore-missing-imports --follow-imports=skip aragora/server/handlers/__init__.py`. The suggested `python3 -c 'import typing; typing.TYPE_CHECKING=True; import aragora.server.handlers'` is recorded as unusable: on `origin/main` (`1c8307b26e`) and at #10000's head it fails identically, before reaching the block, with `ImportError: cannot import name 'BaseModel' from partially initialized module 'pydantic' (most likely due to a circular import)`. Batch 1 rewrote its 22 lines (#10000).
4. **§7 batch-1 row vs §5 batch-4 table on `slack.py`.** The row said "Includes all three stub retirements", but §5 places `slack.py` (retire -> `bots/slack.py`) in batch 4. Reconciled the row to name only the batch-1 retirements (`analytics_metrics`, `compliance_handler`, `status_page`) and to say `slack` and `connectors` retire with batch 4. §5 unchanged.
5. **§3.3 prototype table is now verifiable.** Added one paragraph after the negative control pointing row 9 at `scripts/ci/check_moved_handler_shim.py` (committed by #10000), one basename per process, `PASS <basename>` for every `MOVED_MODULES` key.

### Also in this PR (same doc, same reason)

- §6 steps 1 and 6 and §10 now name `scripts/ci/check_moved_handler_shim.py` instead of only `/tmp/p4val/t7.py`, and §10 records the one textual difference from the contract's probe (the `import` statement split into three lines for ruff E401). Step 1's expected failure is stated as it actually appears: an `AssertionError` whose payload lists the captured warnings, none naming the basename.
- A "Batch status" paragraph under the header: batch 1 is PR #10000; flat root 186 -> 141 at its head; batches 2 to 4 pending.

### Verification

- Every path, count and command in the changed prose was re-run against the tree: `review_queue.py:51`, `review_queue_brief.py` in the batch-4 table (L597 on `origin/main`, L609 at this head), the collision command output, the TYPE_CHECKING failure text on both refs, 22 rewritten TYPE_CHECKING lines and 141 flat files at #10000's head.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`.
- No code changes; no `docs/METRICS.md` edits.

### Round 1 review at `48887f4b71` (cured in `84298a3625`)

- openai [P2] (uncounted under the severity gate, cured anyway): the bare-import alternation only matched single-line imports. Step 5 now uses `rg -nU ... from aragora\.server\.handlers import (\([^)]*)?\b(<f1>|...)\b` so a parenthesised multi-line import list also matches; verified on a synthetic file containing both forms and on the tree (still exactly `review_queue.py:51`).
- claude [P3]: the mypy clause in step 3 could not detect a stale type-only import under `--ignore-missing-imports` (verified on a throwaway package). Dropped; the `rg` check is the sole verifier and the text says why.
- claude [P3]: §10 now states the exact differences between the committed probe and the contract text (shebang, module docstring, three-line import split; the probe body is verbatim).

### Round 2 review at `84298a3625` (cured in `2b92612d95`)

openai PASS (counted, posted). claude CHANGES-REQUESTED with one P2 and two P3s, all uncounted under the severity gate but all genuine, so cured:

- [P2] "the bare form occurs only at that one single-line site" was wrong: a census over `aragora/` and `scripts/` (excluding the two registration tables and `handler_registry/`) finds 6/1/7/3 bare-form sites for batches 1-4 (`compliance/{gdpr,legal_hold,audit_verify}.py` x6 for `compliance_handler`; `ops/enterprise_validator.py:180`; `blockchain/handler.py` x7 for `erc8004`; `review_queue.py:51`, `webhooks/__init__.py:9`, `connectors/legacy.py:136`). Added as a fourth row of the §3.2 form table and step 5 now points at that row.
- [P3] Step 3 said "the finder does not serve relative imports either"; it does (verified on the batch tree: `from .system_health import ...` from a sibling resolves through the finder and warns). Rationale reworded to "the block never executes".
- [P3] §10 now also names the blank lines the committed probe adds around its import block. The body diff against the contract text is: `import importlib, sys, warnings` -> three import lines with a blank line before and after; nothing else.
