### PR TITLE
test: pin __aexit__ mocks to return_value=False so exceptions propagate

### DIFF
--- a/tests/agents/api_agents/test_langgraph_agent.py
+++ b/tests/agents/api_agents/test_langgraph_agent.py
@@ -453,12 +453,12 @@ class TestLangGraphGenerate:
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=mock_langgraph_response)
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
+        mock_response.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(return_value=mock_response)
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
             "aragora.agents.api_agents.langgraph_agent.create_client_session",
@@ -480,12 +480,12 @@ class TestLangGraphGenerate:
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=mock_langgraph_response)
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
+        mock_response.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(return_value=mock_response)
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
             "aragora.agents.api_agents.langgraph_agent.create_client_session",
@@ -537,12 +537,12 @@ class TestLangGraphInvoke:
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=mock_langgraph_response)
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
+        mock_response.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(return_value=mock_response)
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
             "aragora.agents.api_agents.langgraph_agent.create_client_session",
@@ -601,12 +601,12 @@ class TestLangGraphStream:
         mock_response.status = 200
         mock_response.content = mock_content
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
+        mock_response.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(return_value=mock_response)
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
             "aragora.agents.api_agents.langgraph_agent.create_client_session",
@@ -656,12 +656,12 @@ class TestLangGraphStream:
         mock_response.status = 200
         mock_response.content = mock_content
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
+        mock_response.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(return_value=mock_response)
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
             "aragora.agents.api_agents.langgraph_agent.create_client_session",
@@ -717,12 +717,12 @@ class TestLangGraphState:
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=mock_state)
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
+        mock_response.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.get = MagicMock(return_value=mock_response)
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
             "aragora.agents.api_agents.langgraph_agent.create_client_session",
@@ -758,12 +758,12 @@ class TestLangGraphState:
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=mock_response_data)
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
+        mock_response.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(return_value=mock_response)
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
             "aragora.agents.api_agents.langgraph_agent.create_client_session",

--- a/tests/agents/test_agent_anthropic.py
+++ b/tests/agents/test_agent_anthropic.py
@@ -110,10 +110,11 @@ class TestAnthropicGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -133,10 +134,11 @@ class TestAnthropicGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -160,10 +162,11 @@ class TestAnthropicGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_anthropic_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_anthropic_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -194,10 +197,11 @@ class TestAnthropicGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -230,12 +234,13 @@ class TestAnthropicGenerate:
             nonlocal captured_payload
             captured_payload = kwargs.get("json", {})
             return MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = capture_post
 
         context = [
@@ -283,10 +288,11 @@ class TestAnthropicStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -310,10 +316,11 @@ class TestAnthropicStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/agents/test_agent_gemini.py
+++ b/tests/agents/test_agent_gemini.py
@@ -16,6 +16,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 
+from aragora.agents.api_agents.common import AgentAPIError
 from aragora.agents.api_agents.gemini import GeminiAgent
 
 
@@ -121,10 +122,11 @@ class TestGeminiGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -149,10 +151,11 @@ class TestGeminiGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -176,10 +179,11 @@ class TestGeminiGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_gemini_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_gemini_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -196,7 +200,7 @@ class TestGeminiGenerate:
 
     @pytest.mark.asyncio
     async def test_empty_response_handled(self, agent):
-        """Test empty response is handled appropriately."""
+        """Empty content raises AgentAPIError (finishReason STOP)."""
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.json = AsyncMock(
@@ -205,24 +209,21 @@ class TestGeminiGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # Decorator may catch and return None, error string, or raise
-            result = await agent.generate("Test prompt")
-            # Empty response should either return None, error string, or raise
-            # (decorator catches exceptions)
-            if result is not None:
-                assert isinstance(result, str)
+            with pytest.raises(AgentAPIError, match="empty content"):
+                await agent.generate("Test prompt")
 
     @pytest.mark.asyncio
     async def test_safety_blocked_handled(self, agent):
-        """Test SAFETY finish reason is handled appropriately."""
+        """SAFETY finish reason with no content raises AgentAPIError."""
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.json = AsyncMock(
@@ -231,19 +232,17 @@ class TestGeminiGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # Decorator may catch and return None, error string, or raise
-            result = await agent.generate("Test prompt")
-            # Safety blocked should either return None, error string, or raise
-            if result is not None:
-                assert isinstance(result, str)
+            with pytest.raises(AgentAPIError, match="SAFETY"):
+                await agent.generate("Test prompt")
 
     @pytest.mark.asyncio
     async def test_truncated_response_with_content_returns_partial(self, agent):
@@ -264,10 +263,11 @@ class TestGeminiGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -300,12 +300,13 @@ class TestGeminiGenerate:
             nonlocal captured_payload
             captured_payload = kwargs.get("json", {})
             return MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = capture_post
 
         context = [
@@ -346,10 +347,11 @@ class TestGeminiStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -376,10 +378,11 @@ class TestGeminiStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -414,10 +417,11 @@ class TestGeminiStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/agents/test_agent_grok.py
+++ b/tests/agents/test_agent_grok.py
@@ -118,10 +118,11 @@ class TestGrokGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -145,10 +146,11 @@ class TestGrokGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_grok_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_grok_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -191,10 +193,11 @@ class TestGrokStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/agents/test_agent_local.py
+++ b/tests/agents/test_agent_local.py
@@ -75,10 +75,11 @@ class TestOllamaAvailability:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.get = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -95,10 +96,11 @@ class TestOllamaAvailability:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.get = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -132,10 +134,11 @@ class TestOllamaModelDiscovery:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.get = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -153,10 +156,11 @@ class TestOllamaModelDiscovery:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.get = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -183,10 +187,11 @@ class TestOllamaGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -203,7 +208,7 @@ class TestOllamaGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             side_effect=aiohttp.ClientConnectorError(MagicMock(), OSError("Connection refused"))
         )
@@ -308,10 +313,11 @@ class TestLMStudioAvailability:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.get = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -345,10 +351,11 @@ class TestLMStudioModelDiscovery:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.get = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -396,10 +403,11 @@ class TestLMStudioGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -423,12 +431,13 @@ class TestLMStudioGenerate:
             nonlocal captured_payload
             captured_payload = kwargs.get("json", {})
             return MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = capture_post
 
         with patch("aiohttp.ClientSession", return_value=mock_session):

--- a/tests/agents/test_agent_mistral.py
+++ b/tests/agents/test_agent_mistral.py
@@ -134,10 +134,11 @@ class TestMistralGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -160,10 +161,11 @@ class TestMistralGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -187,10 +189,11 @@ class TestMistralGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_mistral_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_mistral_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -225,12 +228,13 @@ class TestMistralGenerate:
             nonlocal captured_payload
             captured_payload = kwargs.get("json", {})
             return MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = capture_post
 
         context = [
@@ -272,10 +276,11 @@ class TestMistralStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -304,10 +309,11 @@ class TestMistralStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -418,10 +424,11 @@ class TestCodestralGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/agents/test_agent_openai.py
+++ b/tests/agents/test_agent_openai.py
@@ -111,10 +111,11 @@ class TestOpenAIGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -132,10 +133,11 @@ class TestOpenAIGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -164,10 +166,11 @@ class TestOpenAIGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_openai_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_openai_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -199,10 +202,11 @@ class TestOpenAIGenerate:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -235,12 +239,13 @@ class TestOpenAIGenerate:
             nonlocal captured_payload
             captured_payload = kwargs.get("json", {})
             return MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = capture_post
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
@@ -284,10 +289,11 @@ class TestOpenAIStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -311,10 +317,11 @@ class TestOpenAIStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -345,10 +352,11 @@ class TestOpenAIStreaming:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -455,10 +463,11 @@ class TestOpenAIFallbackDisabled:
 
         mock_session = MagicMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock()
+        mock_session.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(
             return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/auth/test_oidc_root.py
+++ b/tests/auth/test_oidc_root.py
@@ -456,7 +456,7 @@ class TestTokenExchange:
 
             mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock()
+            mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.aclose = AsyncMock()  # http_client_pool awaits this
             mock_client_class.return_value = mock_client

--- a/tests/billing/test_forecaster_alerts.py
+++ b/tests/billing/test_forecaster_alerts.py
@@ -47,7 +47,7 @@ def _make_tracker(monthly_limit=100.0, current_spend=50.0, daily_costs=None):
     # Mock usage buffer for _get_daily_costs
     tracker._buffer_lock = AsyncMock()
     tracker._buffer_lock.__aenter__ = AsyncMock()
-    tracker._buffer_lock.__aexit__ = AsyncMock()
+    tracker._buffer_lock.__aexit__ = AsyncMock(return_value=False)
     tracker._usage_buffer = []
 
     return tracker

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -608,12 +608,12 @@ class TestCheckServer:
         mock_session = MagicMock()
         mock_context = MagicMock()
         mock_context.__aenter__ = AsyncMock(side_effect=ConnectionError("Connection refused"))
-        mock_context.__aexit__ = AsyncMock()
+        mock_context.__aexit__ = AsyncMock(return_value=False)
         mock_session.get.return_value = mock_context
 
         mock_client_session = MagicMock()
         mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_client_session.__aexit__ = AsyncMock()
+        mock_client_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch("aiohttp.ClientSession", return_value=mock_client_session):
             result = await check_server()
@@ -628,14 +628,14 @@ class TestCheckServer:
 
         mock_response_ctx = MagicMock()
         mock_response_ctx.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response_ctx.__aexit__ = AsyncMock()
+        mock_response_ctx.__aexit__ = AsyncMock(return_value=False)
 
         mock_session = MagicMock()
         mock_session.get.return_value = mock_response_ctx
 
         mock_client_session = MagicMock()
         mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_client_session.__aexit__ = AsyncMock()
+        mock_client_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch("aiohttp.ClientSession", return_value=mock_client_session):
             result = await check_server()

--- a/tests/connectors/accounting/test_accounting_connectors.py
+++ b/tests/connectors/accounting/test_accounting_connectors.py
@@ -82,7 +82,7 @@ class TestQuickBooksConnector:
                 return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
             )
             mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
-            mock_session.return_value.__aexit__ = AsyncMock()
+            mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
 
             credentials = await qbo_connector.exchange_code(
                 authorization_code="test_code",

--- a/tests/connectors/accounting/test_qbo.py
+++ b/tests/connectors/accounting/test_qbo.py
@@ -735,7 +735,7 @@ class TestQuickBooksConnectorOAuth:
 
         mock_pool = MagicMock()
         mock_pool.get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_pool.get_session.return_value.__aexit__ = AsyncMock()
+        mock_pool.get_session.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("aragora.connectors.accounting.qbo.get_http_pool", return_value=mock_pool):
             creds = await connector.refresh_tokens()
@@ -1504,7 +1504,7 @@ class TestQuickBooksConnectorRetry:
 
         mock_pool = MagicMock()
         mock_pool.get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_pool.get_session.return_value.__aexit__ = AsyncMock()
+        mock_pool.get_session.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("aragora.connectors.accounting.qbo.get_http_pool", return_value=mock_pool):
             with patch("asyncio.sleep", new=AsyncMock()):
@@ -1526,7 +1526,7 @@ class TestQuickBooksConnectorRetry:
 
         mock_pool = MagicMock()
         mock_pool.get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_pool.get_session.return_value.__aexit__ = AsyncMock()
+        mock_pool.get_session.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("aragora.connectors.accounting.qbo.get_http_pool", return_value=mock_pool):
             with patch("asyncio.sleep", new=AsyncMock()):
@@ -2660,7 +2660,7 @@ class TestRetryResilienceExtended:
 
         mock_pool = MagicMock()
         mock_pool.get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_pool.get_session.return_value.__aexit__ = AsyncMock()
+        mock_pool.get_session.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("aragora.connectors.accounting.qbo.get_http_pool", return_value=mock_pool):
             with patch("asyncio.sleep", new=AsyncMock()):

--- a/tests/connectors/base_connector_test.py
+++ b/tests/connectors/base_connector_test.py
@@ -101,7 +101,7 @@ class ConnectorTestMixin:
         with patch("aiohttp.ClientSession") as mock:
             session_instance = MagicMock()
             mock.return_value.__aenter__ = AsyncMock(return_value=session_instance)
-            mock.return_value.__aexit__ = AsyncMock()
+            mock.return_value.__aexit__ = AsyncMock(return_value=False)
             yield session_instance
 
     @pytest.fixture

--- a/tests/connectors/chat/test_typing_indicators.py
+++ b/tests/connectors/chat/test_typing_indicators.py
@@ -25,7 +25,7 @@ class TestTelegramTypingIndicator:
             mock_client_instance = AsyncMock()
             mock_client_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             result = await connector.send_typing_indicator("123456789")
 
@@ -46,7 +46,7 @@ class TestTelegramTypingIndicator:
             mock_client_instance = AsyncMock()
             mock_client_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             result = await connector.send_typing_indicator("123456789")
 

--- a/tests/connectors/enterprise/collaboration/test_teams_enterprise.py
+++ b/tests/connectors/enterprise/collaboration/test_teams_enterprise.py
@@ -87,7 +87,7 @@ class TestTeamsAuthentication:
             mock_client_instance = AsyncMock()
             mock_client_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             token = await connector._get_access_token()
 
@@ -370,7 +370,7 @@ class TestSearch:
             mock_client_instance = AsyncMock()
             mock_client_instance.post = AsyncMock(side_effect=Exception("API Error"))
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             results = await connector.search("test")
 

--- a/tests/connectors/enterprise/communication/gmail/test_labels.py
+++ b/tests/connectors/enterprise/communication/gmail/test_labels.py
@@ -202,7 +202,7 @@ class TestCreateLabel:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, label_data))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             label = await labels_mixin.create_label("New Label")
@@ -220,7 +220,7 @@ class TestCreateLabel:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, label_data))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             await labels_mixin.create_label("Test")
@@ -269,7 +269,7 @@ class TestModifyMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, response_data))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             result = await labels_mixin.modify_message(
@@ -291,7 +291,7 @@ class TestModifyMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, response_data))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             result = await labels_mixin.modify_message(
@@ -317,7 +317,7 @@ class TestModifyMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=error_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             with pytest.raises(RuntimeError, match="Failed to modify message"):
@@ -333,7 +333,7 @@ class TestModifyMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=error_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             with pytest.raises(RuntimeError):
@@ -349,7 +349,7 @@ class TestModifyMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, response_data))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             await labels_mixin.modify_message("msg_123", add_labels=["STARRED"])
@@ -391,7 +391,7 @@ class TestTrashMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, {}))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             result = await labels_mixin.trash_message("msg_123")
@@ -413,7 +413,7 @@ class TestTrashMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, {}))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             result = await labels_mixin.untrash_message("msg_123")
@@ -431,7 +431,7 @@ class TestTrashMessage:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=error_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             with pytest.raises(RuntimeError):
@@ -646,7 +646,7 @@ class TestBatchModify:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             result = await labels_mixin.batch_modify(
@@ -667,7 +667,7 @@ class TestBatchModify:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             await labels_mixin.batch_modify(
@@ -698,7 +698,7 @@ class TestBatchModify:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=error_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             with pytest.raises(RuntimeError):
@@ -748,7 +748,7 @@ class TestBatchTrash:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             result = await labels_mixin.batch_trash(["msg_1", "msg_2"])
@@ -765,7 +765,7 @@ class TestBatchTrash:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             await labels_mixin.batch_trash(["msg_1", "msg_2"])
@@ -791,7 +791,7 @@ class TestBatchTrash:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             await labels_mixin.batch_trash(["msg_1"])
@@ -813,7 +813,7 @@ class TestConnectionErrorHandling:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=ConnectionError("Network error"))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             with pytest.raises(ConnectionError):
@@ -827,7 +827,7 @@ class TestConnectionErrorHandling:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=OSError("Connection refused"))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             with pytest.raises(OSError):
@@ -841,7 +841,7 @@ class TestConnectionErrorHandling:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=ConnectionError("Network error"))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(labels_mixin, "_get_client", return_value=mock_client):
             with pytest.raises(ConnectionError):

--- a/tests/connectors/enterprise/communication/gmail/test_watch.py
+++ b/tests/connectors/enterprise/communication/gmail/test_watch.py
@@ -159,7 +159,7 @@ class TestSetupWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, watch_response))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "my-project"}):
             with patch.object(watch_mixin, "_get_client", return_value=mock_client):
@@ -185,7 +185,7 @@ class TestSetupWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, watch_response))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         assert watch_mixin._gmail_state is None
 
@@ -214,7 +214,7 @@ class TestSetupWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, watch_response))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "my-project"}):
             with patch.object(watch_mixin, "_get_client", return_value=mock_client):
@@ -240,7 +240,7 @@ class TestSetupWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, watch_response))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict("os.environ", {}, clear=True):
             with patch.object(watch_mixin, "_get_client", return_value=mock_client):
@@ -259,7 +259,7 @@ class TestSetupWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, watch_response))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "my-project"}):
             with patch.object(watch_mixin, "_get_client", return_value=mock_client):
@@ -284,7 +284,7 @@ class TestSetupWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=error_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "my-project"}):
             with patch.object(watch_mixin, "_get_client", return_value=mock_client):
@@ -301,7 +301,7 @@ class TestSetupWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, watch_response))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "my-project"}):
             with patch.object(watch_mixin, "_get_client", return_value=mock_client):
@@ -327,7 +327,7 @@ class TestStopWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(watch_mixin, "_get_client", return_value=mock_client):
             result = await watch_mixin.stop_watch()
@@ -350,7 +350,7 @@ class TestStopWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(watch_mixin, "_get_client", return_value=mock_client):
             await watch_mixin.stop_watch()
@@ -375,7 +375,7 @@ class TestStopWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(watch_mixin, "_get_client", return_value=mock_client):
             await watch_mixin.stop_watch()
@@ -400,7 +400,7 @@ class TestStopWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=error_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(watch_mixin, "_get_client", return_value=mock_client):
             result = await watch_mixin.stop_watch()
@@ -417,7 +417,7 @@ class TestStopWatch:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(watch_mixin, "_get_client", return_value=mock_client):
             await watch_mixin.stop_watch()
@@ -728,7 +728,7 @@ class TestWatchRenewal:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_httpx_response(200, watch_response))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         watch_mixin._watch_running = True
 

--- a/tests/connectors/enterprise/communication/test_gmail.py
+++ b/tests/connectors/enterprise/communication/test_gmail.py
@@ -300,7 +300,7 @@ class TestAuthentication:
                     return_value=mock_httpx_response(200, token_response)
                 )
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 result = await gmail_connector.authenticate(
@@ -334,7 +334,7 @@ class TestAuthentication:
                     return_value=mock_httpx_response(200, token_response)
                 )
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 result = await gmail_connector.authenticate(
@@ -385,7 +385,7 @@ class TestAuthentication:
                     return_value=mock_httpx_response(401, {"error": "invalid_grant"})
                 )
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 result = await gmail_connector.authenticate(
@@ -442,7 +442,7 @@ class TestTokenManagement:
                     return_value=mock_httpx_response(200, token_response)
                 )
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 token = await authenticated_connector._get_access_token()
@@ -476,7 +476,7 @@ class TestApiRequests:
             mock_instance = AsyncMock()
             mock_instance.request = AsyncMock(return_value=mock_httpx_response(200, response_data))
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-            mock_instance.__aexit__ = AsyncMock()
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
             mock_client.return_value = mock_instance
 
             result = await authenticated_connector._api_request("/messages")
@@ -520,7 +520,7 @@ class TestApiRequests:
             mock_instance = AsyncMock()
             mock_instance.request = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-            mock_instance.__aexit__ = AsyncMock()
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
             mock_client.return_value = mock_instance
 
             with patch.object(authenticated_connector, "record_failure") as mock_failure:
@@ -588,7 +588,7 @@ class TestUserInfoAndLabels:
                 mock_client = AsyncMock()
                 mock_client.post = AsyncMock(return_value=mock_httpx_response(200, label_data))
                 mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                mock_client.__aexit__ = AsyncMock()
+                mock_client.__aexit__ = AsyncMock(return_value=False)
                 mock_get_client.return_value = mock_client
 
                 label = await authenticated_connector.create_label("New Label")
@@ -1227,7 +1227,7 @@ class TestSendMessage:
                         return_value=mock_httpx_response(200, response_data)
                     )
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.send_message(
@@ -1252,7 +1252,7 @@ class TestSendMessage:
                         return_value=mock_httpx_response(200, response_data)
                     )
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.send_message(
@@ -1278,7 +1278,7 @@ class TestSendMessage:
                         return_value=mock_httpx_response(200, response_data)
                     )
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.send_message(
@@ -1346,7 +1346,7 @@ class TestReplyToMessage:
                             return_value=mock_httpx_response(200, response_data)
                         )
                         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                        mock_client.__aexit__ = AsyncMock()
+                        mock_client.__aexit__ = AsyncMock(return_value=False)
                         mock_get_client.return_value = mock_client
 
                         result = await authenticated_connector.reply_to_message(
@@ -1383,7 +1383,7 @@ class TestEmailActions:
                         return_value=mock_httpx_response(200, response_data)
                     )
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.modify_message(
@@ -1415,7 +1415,7 @@ class TestEmailActions:
                     mock_client = AsyncMock()
                     mock_client.post = AsyncMock(return_value=mock_httpx_response(200, {}))
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.trash_message("msg_123")
@@ -1431,7 +1431,7 @@ class TestEmailActions:
                     mock_client = AsyncMock()
                     mock_client.post = AsyncMock(return_value=mock_httpx_response(200, {}))
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.untrash_message("msg_123")
@@ -1559,7 +1559,7 @@ class TestBatchOperations:
                     mock_response.status_code = 204
                     mock_client.post = AsyncMock(return_value=mock_response)
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.batch_modify(
@@ -1596,7 +1596,7 @@ class TestBatchOperations:
                     mock_response.status_code = 204
                     mock_client.post = AsyncMock(return_value=mock_response)
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.batch_trash(["msg_1", "msg_2"])
@@ -1634,7 +1634,7 @@ class TestPubSubWatch:
                             return_value=mock_httpx_response(200, watch_response)
                         )
                         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                        mock_client.__aexit__ = AsyncMock()
+                        mock_client.__aexit__ = AsyncMock(return_value=False)
                         mock_get_client.return_value = mock_client
 
                         result = await authenticated_connector.setup_watch(
@@ -1664,7 +1664,7 @@ class TestPubSubWatch:
                     mock_response.status_code = 204
                     mock_client.post = AsyncMock(return_value=mock_response)
                     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                    mock_client.__aexit__ = AsyncMock()
+                    mock_client.__aexit__ = AsyncMock(return_value=False)
                     mock_get_client.return_value = mock_client
 
                     result = await authenticated_connector.stop_watch()

--- a/tests/connectors/enterprise/communication/test_outlook.py
+++ b/tests/connectors/enterprise/communication/test_outlook.py
@@ -257,7 +257,7 @@ class TestAuthentication:
                     return_value=mock_httpx_response(200, token_response)
                 )
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 result = await outlook_connector.authenticate(
@@ -291,7 +291,7 @@ class TestAuthentication:
                     return_value=mock_httpx_response(200, token_response)
                 )
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 result = await outlook_connector.authenticate(
@@ -340,7 +340,7 @@ class TestAuthentication:
                 mock_instance = AsyncMock()
                 mock_instance.post = AsyncMock(side_effect=ConnectionError("invalid_grant"))
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 result = await outlook_connector.authenticate(
@@ -397,7 +397,7 @@ class TestTokenManagement:
                     return_value=mock_httpx_response(200, token_response)
                 )
                 mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-                mock_instance.__aexit__ = AsyncMock()
+                mock_instance.__aexit__ = AsyncMock(return_value=False)
                 mock_client.return_value = mock_instance
 
                 token = await authenticated_connector._get_access_token()
@@ -431,7 +431,7 @@ class TestApiRequests:
             mock_instance = AsyncMock()
             mock_instance.request = AsyncMock(return_value=mock_httpx_response(200, response_data))
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-            mock_instance.__aexit__ = AsyncMock()
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
             mock_client.return_value = mock_instance
 
             result = await authenticated_connector._api_request("/messages")
@@ -450,7 +450,7 @@ class TestApiRequests:
             mock_instance = AsyncMock()
             mock_instance.request = AsyncMock(return_value=mock_httpx_response(200, response_data))
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
-            mock_instance.__aexit__ = AsyncMock()
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
             mock_client.return_value = mock_instance
 
             result = await authenticated_connector._api_request(delta_url)

--- a/tests/connectors/enterprise/crm/test_salesforce.py
+++ b/tests/connectors/enterprise/crm/test_salesforce.py
@@ -90,7 +90,7 @@ class TestSalesforceAuthentication:
             mock_client_instance = AsyncMock()
             mock_client_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             token = await connector._get_access_token()
 
@@ -123,7 +123,7 @@ class TestSalesforceAuthentication:
             mock_client_instance = AsyncMock()
             mock_client_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             token = await connector._get_access_token()
 

--- a/tests/connectors/enterprise/documents/test_dropbox.py
+++ b/tests/connectors/enterprise/documents/test_dropbox.py
@@ -265,7 +265,8 @@ class TestDropboxAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -292,7 +293,8 @@ class TestDropboxAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -324,7 +326,8 @@ class TestDropboxAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -354,7 +357,8 @@ class TestDropboxAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/connectors/enterprise/documents/test_gsheets.py
+++ b/tests/connectors/enterprise/documents/test_gsheets.py
@@ -82,7 +82,7 @@ class TestGoogleSheetsAuthentication:
             mock_client_instance = AsyncMock()
             mock_client_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             token = await connector._get_access_token()
 

--- a/tests/connectors/enterprise/documents/test_onedrive.py
+++ b/tests/connectors/enterprise/documents/test_onedrive.py
@@ -315,7 +315,8 @@ class TestOneDriveAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -343,7 +344,8 @@ class TestOneDriveAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -375,7 +377,8 @@ class TestOneDriveAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -405,7 +408,8 @@ class TestOneDriveAuthentication:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/connectors/enterprise/streaming/test_snssqs.py
+++ b/tests/connectors/enterprise/streaming/test_snssqs.py
@@ -457,7 +457,7 @@ class TestSNSSQSConnectorConnection:
 
         # Setup mock client
         mock_client = AsyncMock()
-        mock_client.__aexit__ = AsyncMock()
+        mock_client.__aexit__ = AsyncMock(return_value=False)
         connector._sqs_client = mock_client
 
         await connector.disconnect()

--- a/tests/connectors/fixtures.py
+++ b/tests/connectors/fixtures.py
@@ -214,7 +214,7 @@ class MockHTTPSession:
 
         ctx = MagicMock()
         ctx.__aenter__ = AsyncMock(return_value=response)
-        ctx.__aexit__ = AsyncMock()
+        ctx.__aexit__ = AsyncMock(return_value=False)
         return ctx
 
     def get(self, url: str, **kwargs):
@@ -255,7 +255,7 @@ def mock_aiohttp_session(mock_http_session):
     with patch("aiohttp.ClientSession") as mock:
         ctx = MagicMock()
         ctx.__aenter__ = AsyncMock(return_value=mock_http_session)
-        ctx.__aexit__ = AsyncMock()
+        ctx.__aexit__ = AsyncMock(return_value=False)
         mock.return_value = ctx
         yield mock_http_session
 
@@ -266,7 +266,7 @@ def mock_httpx_client(mock_http_session):
     with patch("httpx.AsyncClient") as mock:
         ctx = MagicMock()
         ctx.__aenter__ = AsyncMock(return_value=mock_http_session)
-        ctx.__aexit__ = AsyncMock()
+        ctx.__aexit__ = AsyncMock(return_value=False)
         mock.return_value = ctx
         yield mock_http_session
 

--- a/tests/gateway/openclaw/test_sandbox.py
+++ b/tests/gateway/openclaw/test_sandbox.py
@@ -155,12 +155,12 @@ class TestOpenClawSandbox:
                 }
             )
             mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-            mock_response.__aexit__ = AsyncMock()
+            mock_response.__aexit__ = AsyncMock(return_value=False)
 
             mock_session_instance = MagicMock()
             mock_session_instance.post = MagicMock(return_value=mock_response)
             mock_session_instance.__aenter__ = AsyncMock(return_value=mock_session_instance)
-            mock_session_instance.__aexit__ = AsyncMock()
+            mock_session_instance.__aexit__ = AsyncMock(return_value=False)
             mock_session.return_value = mock_session_instance
 
             result = await sandbox.execute(simple_task)

--- a/tests/integrations/test_email_providers.py
+++ b/tests/integrations/test_email_providers.py
@@ -215,7 +215,7 @@ class TestSendGridProvider:
         mock_session = MagicMock()
         mock_session.post = MagicMock()
         mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_session.post.return_value.__aexit__ = AsyncMock()
+        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(integration, "_get_session", return_value=mock_session):
             result = await integration._send_via_sendgrid(
@@ -239,7 +239,7 @@ class TestSendGridProvider:
         mock_session = MagicMock()
         mock_session.post = MagicMock()
         mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_session.post.return_value.__aexit__ = AsyncMock()
+        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(integration, "_get_session", return_value=mock_session):
             result = await integration._send_via_sendgrid(
@@ -260,7 +260,7 @@ class TestSendGridProvider:
         mock_session.post.return_value.__aenter__ = AsyncMock(
             side_effect=aiohttp.ClientError("Connection refused")
         )
-        mock_session.post.return_value.__aexit__ = AsyncMock()
+        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(integration, "_get_session", return_value=mock_session):
             result = await integration._send_via_sendgrid(
@@ -292,7 +292,7 @@ class TestSendGridProvider:
         mock_session = MagicMock()
         mock_context = MagicMock()
         mock_context.__aenter__ = capture_post
-        mock_context.__aexit__ = AsyncMock()
+        mock_context.__aexit__ = AsyncMock(return_value=False)
         mock_session.post = MagicMock(return_value=mock_context)
 
         with patch.object(integration, "_get_session", return_value=mock_session):

--- a/tests/notifications/test_service.py
+++ b/tests/notifications/test_service.py
@@ -930,7 +930,7 @@ class TestErrorHandling:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(side_effect=OSError("Connection refused")),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 

--- a/tests/persistence/migrations/postgres/test_data_migrator.py
+++ b/tests/persistence/migrations/postgres/test_data_migrator.py
@@ -83,7 +83,7 @@ def mock_pool():
     # Create acquire context manager
     mock_acquire = MagicMock()
     mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_acquire.__aexit__ = AsyncMock()
+    mock_acquire.__aexit__ = AsyncMock(return_value=False)
     pool.acquire = MagicMock(return_value=mock_acquire)
     pool.close = AsyncMock()
 

--- a/tests/persistence/migrations/postgres/test_memory_migrator.py
+++ b/tests/persistence/migrations/postgres/test_memory_migrator.py
@@ -296,7 +296,8 @@ class TestPostgresOperations:
         mock_connection.fetchrow.return_value = [True]
         mock_pool.acquire = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_connection), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_connection),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
 
@@ -308,7 +309,7 @@ class TestPostgresOperations:
             return mock_connection
 
         mock_pool.acquire.return_value.__aenter__ = async_ctx
-        mock_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await migrator._table_exists_pg(mock_pool, "debates")
         assert result is True
@@ -450,7 +451,7 @@ class TestMigrateTableAsync:
 
         mock_acquire = MagicMock()
         mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_acquire.__aexit__ = AsyncMock()
+        mock_acquire.__aexit__ = AsyncMock(return_value=False)
         pool.acquire = MagicMock(return_value=mock_acquire)
         pool.close = AsyncMock()
 
@@ -602,7 +603,7 @@ class TestMigrateConsensusMemory:
 
         mock_acquire = MagicMock()
         mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_acquire.__aexit__ = AsyncMock()
+        mock_acquire.__aexit__ = AsyncMock(return_value=False)
         pool.acquire = MagicMock(return_value=mock_acquire)
         pool.close = AsyncMock()
 
@@ -683,7 +684,7 @@ class TestMigrateCritiqueStore:
 
         mock_acquire = MagicMock()
         mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_acquire.__aexit__ = AsyncMock()
+        mock_acquire.__aexit__ = AsyncMock(return_value=False)
         pool.acquire = MagicMock(return_value=mock_acquire)
         pool.close = AsyncMock()
 
@@ -749,7 +750,7 @@ class TestMigrateAll:
 
         mock_acquire = MagicMock()
         mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_acquire.__aexit__ = AsyncMock()
+        mock_acquire.__aexit__ = AsyncMock(return_value=False)
         pool.acquire = MagicMock(return_value=mock_acquire)
         pool.close = AsyncMock()
 
@@ -784,8 +785,10 @@ class TestMigrateAll:
         from aragora.persistence.migrations.postgres.memory_migrator import MemoryMigrator
 
         pool, conn = mock_pool_full
-        # Make executemany fail
-        conn.executemany = AsyncMock(side_effect=Exception("DB error"))
+        # Make executemany fail with a type migrate_table actually catches
+        # (OSError, ConnectionError, RuntimeError, ValueError); a bare
+        # Exception would propagate straight out of migrate_all().
+        conn.executemany = AsyncMock(side_effect=RuntimeError("DB error"))
 
         migrator = MemoryMigrator(
             sqlite_path=temp_full_db,
@@ -795,8 +798,10 @@ class TestMigrateAll:
 
         report = await migrator.migrate_all()
 
-        # Should still complete but with errors
+        # Should still complete but with errors recorded
         assert report.completed_at is not None
+        assert report.total_errors > 0
+        assert any("DB error" in e for t in report.tables for e in t.errors)
 
 
 # ===========================================================================

--- a/tests/persistence/migrations/postgres/test_postgres_runner.py
+++ b/tests/persistence/migrations/postgres/test_postgres_runner.py
@@ -32,13 +32,13 @@ def mock_pool():
     # Create transaction context manager
     mock_tx = MagicMock()
     mock_tx.__aenter__ = AsyncMock()
-    mock_tx.__aexit__ = AsyncMock()
+    mock_tx.__aexit__ = AsyncMock(return_value=False)
     mock_conn.transaction = MagicMock(return_value=mock_tx)
 
     # Create acquire context manager
     mock_acquire = MagicMock()
     mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_acquire.__aexit__ = AsyncMock()
+    mock_acquire.__aexit__ = AsyncMock(return_value=False)
     pool.acquire = MagicMock(return_value=mock_acquire)
     pool.close = AsyncMock()
 
@@ -274,7 +274,7 @@ class TestMigrate:
                 tx.__aenter__ = AsyncMock(side_effect=RuntimeError("SQL error"))
             else:
                 tx.__aenter__ = AsyncMock()
-            tx.__aexit__ = AsyncMock()
+            tx.__aexit__ = AsyncMock(return_value=False)
             return tx
 
         conn.transaction = counting_transaction

--- a/tests/persistence/test_postgres_pool.py
+++ b/tests/persistence/test_postgres_pool.py
@@ -1075,7 +1075,8 @@ class TestEdgeCases:
         with patch(
             "asyncio.timeout",
             return_value=MagicMock(
-                __aenter__=AsyncMock(side_effect=asyncio.TimeoutError()), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(side_effect=asyncio.TimeoutError()),
+                __aexit__=AsyncMock(return_value=False),
             ),
         ):
             await pool._check_replica_health()

--- a/tests/server/debate_origin/test_stores.py
+++ b/tests/server/debate_origin/test_stores.py
@@ -341,7 +341,7 @@ class TestPostgresOriginStore:
         conn.execute = AsyncMock()
         conn.fetchrow = AsyncMock()
         pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
-        pool.acquire.return_value.__aexit__ = AsyncMock()
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
         return pool, conn
 
     @pytest.fixture

--- a/tests/server/handlers/github/test_audit_bridge.py
+++ b/tests/server/handlers/github/test_audit_bridge.py
@@ -271,10 +271,10 @@ class TestGitHubAuditClientCreateIssue:
         with patch("aiohttp.ClientSession") as mock_session_class:
             mock_session = MagicMock()
             mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_session.__aexit__ = AsyncMock()
+            mock_session.__aexit__ = AsyncMock(return_value=False)
             mock_session.post = MagicMock(return_value=mock_response)
             mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-            mock_response.__aexit__ = AsyncMock()
+            mock_response.__aexit__ = AsyncMock(return_value=False)
             mock_session_class.return_value = mock_session
 
             result = await client.create_issue(

--- a/tests/server/handlers/test_exception_logging.py
+++ b/tests/server/handlers/test_exception_logging.py
@@ -29,7 +29,7 @@ class TestIntegrationManagementLogging:
             mock_client.return_value.__aenter__ = AsyncMock(
                 side_effect=ConnectionError("Connection failed")
             )
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with caplog.at_level(logging.WARNING):
                 result = await handler._check_slack_health(mock_workspace)
@@ -52,7 +52,7 @@ class TestIntegrationManagementLogging:
             mock_client.return_value.__aenter__ = AsyncMock(
                 side_effect=ConnectionError("Graph API error")
             )
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with caplog.at_level(logging.WARNING):
                 result = await handler._check_teams_health(mock_workspace)
@@ -74,7 +74,7 @@ class TestIntegrationManagementLogging:
                 mock_client.return_value.__aenter__ = AsyncMock(
                     side_effect=ConnectionError("Discord API error")
                 )
-                mock_client.return_value.__aexit__ = AsyncMock()
+                mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
                 with caplog.at_level(logging.WARNING):
                     result = await handler._check_discord_health()

--- a/tests/server/handlers/test_orchestration.py
+++ b/tests/server/handlers/test_orchestration.py
@@ -1482,7 +1482,7 @@ class TestOutputChannelRouting:
 
         with patch("aiohttp.ClientSession") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             await handler._send_to_webhook(channel, result)
 
@@ -1510,7 +1510,7 @@ class TestOutputChannelRouting:
 
         with patch("aiohttp.ClientSession") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_client.return_value.__aexit__ = AsyncMock()
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
 
             # Should not raise, just log warning
             await handler._send_to_webhook(channel, result)

--- a/tests/server/handlers/test_orchestration_handler.py
+++ b/tests/server/handlers/test_orchestration_handler.py
@@ -911,11 +911,11 @@ class TestOutputChannelRouting:
             mock_session.post = MagicMock(
                 return_value=MagicMock(
                     __aenter__=AsyncMock(return_value=mock_response),
-                    __aexit__=AsyncMock(),
+                    __aexit__=AsyncMock(return_value=False),
                 )
             )
             mock_session_class.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_session_class.return_value.__aexit__ = AsyncMock()
+            mock_session_class.return_value.__aexit__ = AsyncMock(return_value=False)
 
             await routing_handler._send_to_webhook(channel, result)
 

--- a/tests/server/test_postgres_storage.py
+++ b/tests/server/test_postgres_storage.py
@@ -155,7 +155,7 @@ class TestSchemaConstants:
         """SCHEMA_NAME should be defined."""
         mock_pool.acquire = MagicMock()
         mock_pool.acquire.return_value.__aenter__ = AsyncMock()
-        mock_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         store = PostgresDebateStorage(mock_pool, use_resilient=False)
         assert store.SCHEMA_NAME == "debate_storage"
@@ -164,7 +164,7 @@ class TestSchemaConstants:
         """SCHEMA_VERSION should be a positive integer."""
         mock_pool.acquire = MagicMock()
         mock_pool.acquire.return_value.__aenter__ = AsyncMock()
-        mock_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         store = PostgresDebateStorage(mock_pool, use_resilient=False)
         assert store.SCHEMA_VERSION >= 1
@@ -174,7 +174,7 @@ class TestSchemaConstants:
         """INITIAL_SCHEMA should create debates table."""
         mock_pool.acquire = MagicMock()
         mock_pool.acquire.return_value.__aenter__ = AsyncMock()
-        mock_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         store = PostgresDebateStorage(mock_pool, use_resilient=False)
         assert "CREATE TABLE IF NOT EXISTS debates" in store.INITIAL_SCHEMA
@@ -183,7 +183,7 @@ class TestSchemaConstants:
         """INITIAL_SCHEMA should create required indexes."""
         mock_pool.acquire = MagicMock()
         mock_pool.acquire.return_value.__aenter__ = AsyncMock()
-        mock_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         store = PostgresDebateStorage(mock_pool, use_resilient=False)
         assert "idx_debates_slug" in store.INITIAL_SCHEMA

--- a/tests/services/test_threat_intelligence.py
+++ b/tests/services/test_threat_intelligence.py
@@ -2676,7 +2676,8 @@ class TestVirusTotalAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2700,12 +2701,14 @@ class TestVirusTotalAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response_404), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response_404),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_submit_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_submit_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2724,7 +2727,8 @@ class TestVirusTotalAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2778,7 +2782,8 @@ class TestVirusTotalAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2798,7 +2803,8 @@ class TestVirusTotalAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2844,7 +2850,8 @@ class TestAbuseIPDBAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2879,7 +2886,8 @@ class TestAbuseIPDBAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2898,7 +2906,8 @@ class TestAbuseIPDBAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2928,7 +2937,8 @@ class TestAbuseIPDBAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.get = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2970,7 +2980,8 @@ class TestPhishTankAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -2998,7 +3009,8 @@ class TestPhishTankAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -3026,7 +3038,8 @@ class TestPhishTankAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -3050,7 +3063,8 @@ class TestPhishTankAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -3108,7 +3122,8 @@ class TestURLhausAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -3133,7 +3148,8 @@ class TestURLhausAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -3160,7 +3176,8 @@ class TestURLhausAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -3187,7 +3204,8 @@ class TestURLhausAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -3206,7 +3224,8 @@ class TestURLhausAPIResponseHandling:
         mock_session = AsyncMock()
         mock_session.post = MagicMock(
             return_value=AsyncMock(
-                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+                __aenter__=AsyncMock(return_value=mock_response),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session

--- a/tests/services/threat_intelligence/test_service.py
+++ b/tests/services/threat_intelligence/test_service.py
@@ -144,7 +144,7 @@ class TestVirusTotalFileHashLookups:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -182,7 +182,7 @@ class TestVirusTotalFileHashLookups:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -221,7 +221,7 @@ class TestVirusTotalFileHashLookups:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -244,7 +244,7 @@ class TestVirusTotalFileHashLookups:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -262,7 +262,7 @@ class TestVirusTotalFileHashLookups:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -279,7 +279,7 @@ class TestVirusTotalFileHashLookups:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(side_effect=asyncio.TimeoutError()),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -312,7 +312,7 @@ class TestVirusTotalFileHashLookups:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -354,7 +354,7 @@ class TestAbuseIPDBIPReputation:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -391,7 +391,7 @@ class TestAbuseIPDBIPReputation:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -425,7 +425,7 @@ class TestAbuseIPDBIPReputation:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -455,7 +455,7 @@ class TestAbuseIPDBIPReputation:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -485,7 +485,7 @@ class TestAbuseIPDBIPReputation:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -504,7 +504,7 @@ class TestAbuseIPDBIPReputation:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -551,7 +551,7 @@ class TestPhishTankURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -581,7 +581,7 @@ class TestPhishTankURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -608,7 +608,7 @@ class TestPhishTankURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -630,7 +630,7 @@ class TestPhishTankURLChecks:
         mock_post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         mock_session.post = mock_post
@@ -651,7 +651,7 @@ class TestPhishTankURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -693,7 +693,7 @@ class TestURLhausMalwareURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -724,7 +724,7 @@ class TestURLhausMalwareURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -752,7 +752,7 @@ class TestURLhausMalwareURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -776,7 +776,7 @@ class TestURLhausMalwareURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -803,7 +803,7 @@ class TestURLhausMalwareURLChecks:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -900,7 +900,7 @@ class TestBatchLookups:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1248,7 +1248,7 @@ class TestEventEmission:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1316,7 +1316,7 @@ class TestEventEmission:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1347,7 +1347,7 @@ class TestEventEmission:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1383,7 +1383,7 @@ class TestEmailPrioritization:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1439,7 +1439,7 @@ class TestEmailPrioritization:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1468,7 +1468,7 @@ class TestEmailPrioritization:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1537,7 +1537,7 @@ class TestEmailThreatScoreCalculation:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1567,7 +1567,7 @@ class TestEmailThreatScoreCalculation:
                             200, {"results": {"in_database": True, "verified": True}}
                         )
                     ),
-                    __aexit__=AsyncMock(),
+                    __aexit__=AsyncMock(return_value=False),
                 )
             else:
                 return AsyncMock(
@@ -1576,7 +1576,7 @@ class TestEmailThreatScoreCalculation:
                             200, {"results": {"in_database": False, "verified": False}}
                         )
                     ),
-                    __aexit__=AsyncMock(),
+                    __aexit__=AsyncMock(return_value=False),
                 )
 
         mock_session = AsyncMock()
@@ -1764,7 +1764,7 @@ class TestAggregateThreatAssessment:
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1785,13 +1785,13 @@ class TestAggregateThreatAssessment:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(side_effect=ConnectionError("API Error")),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         mock_session.post = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(side_effect=ConnectionError("API Error")),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1977,7 +1977,7 @@ class TestErrorHandling:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(side_effect=asyncio.TimeoutError()),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session
@@ -1998,7 +1998,7 @@ class TestErrorHandling:
         mock_session.get = MagicMock(
             return_value=AsyncMock(
                 __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
             )
         )
         service._http_session = mock_session

--- a/tests/storage/test_connection_router.py
+++ b/tests/storage/test_connection_router.py
@@ -165,7 +165,7 @@ class TestConnectionRouter:
         mock_conn = MagicMock()
         mock_pool = MagicMock()
         mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
         mock_pool.get_size.return_value = 5
 
         router._primary_pool = mock_pool
@@ -183,7 +183,7 @@ class TestConnectionRouter:
         mock_conn = MagicMock()
         mock_replica_pool = MagicMock()
         mock_replica_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_replica_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_replica_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         mock_primary_pool = MagicMock()
         mock_primary_pool.get_size.return_value = 5
@@ -211,7 +211,7 @@ class TestConnectionRouter:
         mock_primary_pool.acquire.return_value.__aenter__ = AsyncMock(
             return_value=mock_primary_conn
         )
-        mock_primary_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_primary_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         router._primary_pool = mock_primary_pool
         router._replica_pools = [mock_replica_pool]
@@ -229,12 +229,12 @@ class TestConnectionRouter:
         mock_conn = MagicMock()
         mock_transaction = MagicMock()
         mock_transaction.__aenter__ = AsyncMock()
-        mock_transaction.__aexit__ = AsyncMock()
+        mock_transaction.__aexit__ = AsyncMock(return_value=False)
         mock_conn.transaction.return_value = mock_transaction
 
         mock_pool = MagicMock()
         mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_pool.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         router._primary_pool = mock_pool
         router._replica_pools = [MagicMock()]  # Has replicas
@@ -379,11 +379,11 @@ class TestRouterIntegration:
 
         mock_pool1 = MagicMock()
         mock_pool1.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn1)
-        mock_pool1.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool1.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         mock_pool2 = MagicMock()
         mock_pool2.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn2)
-        mock_pool2.acquire.return_value.__aexit__ = AsyncMock()
+        mock_pool2.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
         mock_primary = MagicMock()
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -12,6 +12,11 @@ These utilities solve common test infrastructure issues:
 3. Unclear error messages on timeouts
 """
 
+from tests.utils.aiohttp_mocks import (
+    make_async_context_manager,
+    make_mock_client_session,
+    make_mock_response,
+)
 from tests.utils.async_helpers import (
     DEFAULT_TIMEOUT,
     AsyncTestContext,
@@ -42,6 +47,10 @@ __all__ = [
     "run_with_cancellation",
     "gather_with_timeout",
     "AsyncTestContext",
+    # aiohttp mock builders (see aiohttp_mocks.py for the __aexit__ gotcha)
+    "make_async_context_manager",
+    "make_mock_client_session",
+    "make_mock_response",
     # State reset helpers
     "unset_env_vars",
     "invalidate_legacy_config_module",

--- a/tests/utils/aiohttp_mocks.py
+++ b/tests/utils/aiohttp_mocks.py
@@ -1,0 +1,138 @@
+"""Mock builders for ``aiohttp.ClientSession`` and its responses.
+
+Gotcha this module exists to prevent
+==================================
+
+A hand-rolled aiohttp mock usually assigns a bare ``AsyncMock()`` (no
+``return_value``) to ``__aexit__`` on both the session and the
+``session.post(...)`` context manager.  That swallows exceptions:
+
+``AsyncMock()`` with no ``return_value`` resolves to a fresh ``MagicMock`` when
+awaited, and a ``MagicMock`` is truthy.  Under the ``async with`` protocol a
+truthy ``__aexit__`` return means "I handled the exception", so every
+exception raised inside the mocked ``async with session.post(...)`` block is
+silently discarded and the surrounding call returns ``None``.  A test written
+as ``with pytest.raises(AgentAPIError)`` then reports ``DID NOT RAISE`` even
+though the ``raise`` executed, and a test that merely asserts on the result
+passes for the wrong reason.
+
+The real ``aiohttp`` context managers return ``None`` from ``__aexit__``, so
+the builders here pin ``__aexit__`` to ``AsyncMock(return_value=False)``.  Use
+them instead of copy-pasting the shape above.
+
+Usage::
+
+    from tests.utils.aiohttp_mocks import make_mock_client_session, make_mock_response
+
+    response = make_mock_response(status=500, text="Server Error")
+    session = make_mock_client_session(response)
+    with patch("aiohttp.ClientSession", return_value=session):
+        with pytest.raises(AgentAPIError):
+            await agent.generate("prompt")
+
+Pass a list of responses to serve them in order across successive calls, or
+override a verb after construction for connection-level failures::
+
+    session = make_mock_client_session([first_response, second_response])
+    session.post = MagicMock(side_effect=aiohttp.ClientConnectorError(...))
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+HTTP_VERBS: tuple[str, ...] = ("get", "post", "put", "patch", "delete", "head", "request")
+
+
+def make_async_context_manager(value: Any) -> MagicMock:
+    """Return a ``MagicMock`` usable as ``async with cm as value``.
+
+    ``__aexit__`` is pinned falsy so exceptions raised inside the block
+    propagate exactly as they would through a real aiohttp context manager.
+    """
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=value)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def make_mock_response(
+    *,
+    status: int = 200,
+    json_data: Any = None,
+    text: str = "",
+    headers: Mapping[str, str] | None = None,
+    content: Any = None,
+) -> MagicMock:
+    """Build a mock ``aiohttp.ClientResponse``.
+
+    ``json()`` and ``text()`` are awaitable.  ``content`` (for streaming tests)
+    is attached verbatim when given.  The response is itself an async context
+    manager so it works both as ``session.post(...)`` return value and when a
+    test awaits ``__aenter__`` directly.
+    """
+    response = MagicMock()
+    response.status = status
+    response.headers = dict(headers or {})
+    response.json = AsyncMock(return_value={} if json_data is None else json_data)
+    response.text = AsyncMock(return_value=text)
+    response.read = AsyncMock(return_value=text.encode("utf-8"))
+    if content is not None:
+        response.content = content
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    return response
+
+
+def make_mock_client_session(
+    response: Any = None,
+    *,
+    verbs: Iterable[str] = HTTP_VERBS,
+) -> MagicMock:
+    """Build a mock ``aiohttp.ClientSession``.
+
+    Args:
+        response: A single mock response served for every call, or a sequence
+            of responses served in order (one per call, across all verbs).
+            ``None`` serves a bare ``make_mock_response()``.
+        verbs: HTTP method names to wire up (default: all common verbs).
+
+    Every configured verb returns an async context manager whose
+    ``__aenter__`` yields the response and whose ``__aexit__`` is falsy, so
+    exceptions raised inside ``async with session.post(...) as resp:`` reach
+    the caller.  The session is also an async context manager yielding itself,
+    and exposes an awaitable ``close()``.
+    """
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.close = AsyncMock(return_value=None)
+    session.closed = False
+
+    if response is None:
+        response = make_mock_response()
+
+    if isinstance(response, Sequence) and not isinstance(response, (str, bytes)):
+        shared_side_effect = [make_async_context_manager(r) for r in response]
+        # One shared iterator so ordering holds across verbs.
+        iterator = iter(shared_side_effect)
+        for verb in verbs:
+            setattr(session, verb, MagicMock(side_effect=lambda *a, **k: next(iterator)))
+    else:
+        for verb in verbs:
+            setattr(
+                session,
+                verb,
+                MagicMock(return_value=make_async_context_manager(response)),
+            )
+    return session
+
+
+__all__ = [
+    "HTTP_VERBS",
+    "make_async_context_manager",
+    "make_mock_client_session",
+    "make_mock_response",
+]

--- a/tests/utils/test_aiohttp_mocks.py
+++ b/tests/utils/test_aiohttp_mocks.py
@@ -1,0 +1,157 @@
+"""Tests for ``tests.utils.aiohttp_mocks`` and a guard against the bare
+``__aexit__`` AsyncMock shape that silently swallows exceptions.
+
+See the module docstring of ``tests/utils/aiohttp_mocks.py`` for the gotcha.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests.utils.aiohttp_mocks import (
+    make_async_context_manager,
+    make_mock_client_session,
+    make_mock_response,
+)
+
+TESTS_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Boom(RuntimeError):
+    pass
+
+
+class TestMakeAsyncContextManager:
+    @pytest.mark.asyncio
+    async def test_aenter_yields_value(self):
+        cm = make_async_context_manager("payload")
+        async with cm as value:
+            assert value == "payload"
+
+    @pytest.mark.asyncio
+    async def test_exception_inside_block_propagates(self):
+        cm = make_async_context_manager("payload")
+        with pytest.raises(_Boom):
+            async with cm:
+                raise _Boom("inside")
+        cm.__aexit__.assert_awaited_once()
+
+
+class TestMakeMockResponse:
+    @pytest.mark.asyncio
+    async def test_defaults(self):
+        response = make_mock_response()
+        assert response.status == 200
+        assert await response.json() == {}
+        assert await response.text() == ""
+        assert response.headers == {}
+
+    @pytest.mark.asyncio
+    async def test_configured_fields(self):
+        response = make_mock_response(
+            status=429,
+            json_data={"error": "rate"},
+            text='{"error": "rate"}',
+            headers={"Retry-After": "30"},
+        )
+        assert response.status == 429
+        assert await response.json() == {"error": "rate"}
+        assert await response.text() == '{"error": "rate"}'
+        assert await response.read() == b'{"error": "rate"}'
+        assert response.headers["Retry-After"] == "30"
+
+    @pytest.mark.asyncio
+    async def test_response_is_async_context_manager_that_propagates(self):
+        response = make_mock_response(status=500)
+        with pytest.raises(_Boom):
+            async with response as resp:
+                assert resp is response
+                raise _Boom("inside response cm")
+
+
+class TestMakeMockClientSession:
+    @pytest.mark.asyncio
+    async def test_post_yields_response(self):
+        response = make_mock_response(json_data={"ok": True})
+        session = make_mock_client_session(response)
+        async with session as s:
+            assert s is session
+            async with s.post("https://example.invalid", json={}) as resp:
+                assert resp is response
+                assert await resp.json() == {"ok": True}
+        session.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exception_inside_post_block_propagates(self):
+        """The regression this module guards: a raise inside the mocked
+        ``async with session.post(...)`` must reach the caller."""
+        session = make_mock_client_session(make_mock_response(status=500))
+        with pytest.raises(_Boom, match="from handler"):
+            async with session as s:
+                async with s.post("https://example.invalid") as resp:
+                    if resp.status != 200:
+                        raise _Boom("from handler")
+
+    @pytest.mark.asyncio
+    async def test_exception_propagates_through_patched_client_session(self):
+        import aiohttp
+
+        session = make_mock_client_session(make_mock_response(status=503))
+        with patch("aiohttp.ClientSession", return_value=session):
+            with pytest.raises(_Boom):
+                async with aiohttp.ClientSession() as s:
+                    async with s.get("https://example.invalid") as resp:
+                        raise _Boom(f"status {resp.status}")
+
+    @pytest.mark.asyncio
+    async def test_sequence_of_responses_served_in_order(self):
+        first = make_mock_response(status=429)
+        second = make_mock_response(status=200, json_data={"n": 2})
+        session = make_mock_client_session([first, second])
+        async with session.post("u") as r1:
+            assert r1 is first
+        async with session.get("u") as r2:
+            assert r2 is second
+
+    @pytest.mark.asyncio
+    async def test_default_response_and_close(self):
+        session = make_mock_client_session()
+        async with session.get("u") as resp:
+            assert resp.status == 200
+        await session.close()
+        session.close.assert_awaited_once()
+        assert session.closed is False
+
+
+class TestNoBareAsyncMockAexitInSuite:
+    """Guard: nobody re-introduces a bare ``AsyncMock()`` (no ``return_value``)
+    as ``__aexit__``.  Use ``make_mock_client_session`` /
+    ``make_async_context_manager`` or write ``AsyncMock(return_value=False)``.
+    """
+
+    # Built from parts so this file does not itself match.
+    _BARE = re.compile(r"__aexit__\s*=\s*AsyncMock\(\s*\)")
+
+    def test_no_bare_async_mock_aexit(self):
+        offenders: list[str] = []
+        for path in sorted(TESTS_ROOT.rglob("*.py")):
+            if path.resolve() == Path(__file__).resolve():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if self._BARE.search(line):
+                    offenders.append(f"{path.relative_to(TESTS_ROOT.parent)}:{lineno}")
+        assert not offenders, (
+            "A bare AsyncMock() (no return_value) assigned to __aexit__ swallows exceptions "
+            "raised inside the "
+            "mocked `async with` block (truthy return suppresses them). Pin it with "
+            "`AsyncMock(return_value=False)` or use tests.utils.aiohttp_mocks. "
+            "Offenders:\n  " + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
A bare AsyncMock() assigned to __aexit__ awaits to a truthy MagicMock, which
the async-with protocol reads as 'exception handled'. Every exception raised
inside a mocked 'async with session.post(...)' block was silently discarded and
the call returned None, so pytest.raises reported DID NOT RAISE and result
assertions passed for the wrong reason.

- Rewrite all 288 occurrences across 41 test files to AsyncMock(return_value=False)
  (ruff format re-wrapped 11 files; all were format-clean beforehand).
- Add tests/utils/aiohttp_mocks.py (make_mock_client_session, make_mock_response,
  make_async_context_manager) with __aexit__ pinned falsy, exported from tests.utils.
- Add tests/utils/test_aiohttp_mocks.py: helper coverage plus a suite-wide guard
  that fails on any reintroduced bare __aexit__ = AsyncMock().
- Tighten three tests that were green only because their raise was swallowed:
  Gemini empty-content and SAFETY tests now assert AgentAPIError; the memory
  migrator error-aggregation test now raises a RuntimeError the code actually
  catches and asserts errors were recorded.

Verified: 1936 passed across the 41 files + helper tests; the 2 remaining
failures in gmail/test_watch.py are pre-existing on main.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Reviewed design tradeoffs
- Mechanical rewrite to `AsyncMock(return_value=False)` rather than migrating every call site to the new helper: keeps the diff reviewable (one token per occurrence) and lets `ruff format` re-wrap only the touched lines. Helper adoption can follow incrementally.
- Guard test scans `tests/` for the bare shape instead of a lint rule: no new tooling, runs in the normal suite, and the failure message names the offenders.
- The three tightened tests assert the production behavior that already exists (deliberate `AgentAPIError` raises; narrowed migrator except clauses). No production code changed.

## Verification
- Baseline vs post-fix on all 41 touched files + new helper tests: 1936 passed. The 2 remaining failures (`gmail/test_watch.py`) fail identically on main before this change.
- `ruff check` and `ruff format --check` clean on all 44 changed/new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)