### PR TITLE
test: close runner-mock coroutines and align stale Gmail watch tests with fail-closed behavior

### DIFF
--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.utils.async_helpers import close_coroutine_then
+
 from aragora.cli.doctor import (
     check_api_keys,
     check_environment,
@@ -773,7 +775,10 @@ class TestMain:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 
         # Make asyncio.run raise an exception
-        with patch("asyncio.run", side_effect=RuntimeError("Test error")):
+        with patch(
+            "asyncio.run",
+            side_effect=close_coroutine_then(raise_=RuntimeError("Test error")),
+        ):
             result = main()
 
         captured = capsys.readouterr()

--- a/tests/connectors/enterprise/communication/gmail/test_watch.py
+++ b/tests/connectors/enterprise/communication/gmail/test_watch.py
@@ -570,10 +570,10 @@ class TestHandlePubSubNotification:
                 assert messages[0].id == "good_msg"
 
     @pytest.mark.asyncio
-    async def test_handle_notification_handles_message_fetch_error(
+    async def test_handle_notification_raises_on_message_fetch_error(
         self, watch_mixin, sample_pubsub_payload
     ):
-        """Test notification handles errors when fetching individual messages."""
+        """A failed per-message fetch fails the webhook closed: raise and record the error."""
         watch_mixin._gmail_state = GmailSyncState(
             user_id="me",
             email_address="test@example.com",
@@ -589,10 +589,11 @@ class TestHandlePubSubNotification:
             with patch.object(watch_mixin, "get_message") as mock_get:
                 mock_get.side_effect = RuntimeError("Failed to fetch")
 
-                # Should not raise, just log warning
-                messages = await watch_mixin.handle_pubsub_notification(sample_pubsub_payload)
+                with pytest.raises(RuntimeError, match="Failed to fetch message msg_1"):
+                    await watch_mixin.handle_pubsub_notification(sample_pubsub_payload)
 
-                assert messages == []
+        assert watch_mixin._gmail_state.sync_errors == 1
+        assert watch_mixin._gmail_state.last_error == "Webhook processing failed"
 
     @pytest.mark.asyncio
     async def test_handle_notification_with_pagination(self, watch_mixin, sample_pubsub_payload):
@@ -764,32 +765,31 @@ class TestWatchRenewal:
             )
 
     @pytest.mark.asyncio
-    async def test_watch_renewal_loop_retries_on_failure(self, watch_mixin):
-        """Test renewal loop retries on setup failure."""
+    async def test_watch_renewal_loop_stops_and_raises_on_failure(self, watch_mixin):
+        """A failed renewal stops the loop and re-raises (fail closed, no silent retry)."""
         call_count = 0
 
         async def mock_setup_watch(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            if call_count == 1:
-                raise RuntimeError("Setup failed")
-            else:
-                watch_mixin._watch_running = False
-                return {"success": True}
+            raise RuntimeError("Setup failed")
 
         with patch.object(watch_mixin, "setup_watch", side_effect=mock_setup_watch):
             with patch("asyncio.sleep") as mock_sleep:
                 mock_sleep.return_value = None
 
                 watch_mixin._watch_running = True
-                await watch_mixin._watch_renewal_loop(
-                    topic_name="test-topic",
-                    renewal_hours=144,
-                    project_id="my-project",
-                )
+                with pytest.raises(RuntimeError, match="Setup failed"):
+                    await watch_mixin._watch_renewal_loop(
+                        topic_name="test-topic",
+                        renewal_hours=144,
+                        project_id="my-project",
+                    )
 
-                # Should have called sleep with 60 seconds for retry
-                assert any(call[0][0] == 60 for call in mock_sleep.call_args_list)
+        assert call_count == 1
+        assert watch_mixin._watch_running is False
+        # The loop stops rather than scheduling a retry back-off.
+        assert not any(call[0][0] == 60 for call in mock_sleep.call_args_list)
 
 
 # =============================================================================

--- a/tests/server/handlers/test_orchestration.py
+++ b/tests/server/handlers/test_orchestration.py
@@ -25,6 +25,8 @@ from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 import pytest
 
+from tests.utils.async_helpers import close_coroutine_then
+
 from aragora.server.handlers.orchestration import (
     OrchestrationHandler,
     OrchestrationRequest,
@@ -38,6 +40,15 @@ from aragora.server.handlers.orchestration import (
     _orchestration_requests,
     _orchestration_results,
 )
+
+
+def _stub_create_task():
+    """Stand in for ``asyncio.create_task`` in sync tests (no running loop).
+
+    Closes the queued coroutine so it is not reported as "never awaited" and
+    returns an inert task object.
+    """
+    return patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock()))
 
 
 # =============================================================================
@@ -1584,7 +1595,8 @@ class TestTemplateApplication:
             "template": "code_review",
         }
 
-        result = handler._handle_deliberate(data, None, None, sync=False)
+        with _stub_create_task():
+            result = handler._handle_deliberate(data, None, None, sync=False)
 
         # Request should be created with template defaults
         # (The result is queued, so we verify it was processed)
@@ -1935,12 +1947,13 @@ class TestErrorHandling:
         handler = OrchestrationHandler({})
 
         # Malformed data that might cause parsing errors
-        result = handler._handle_deliberate(
-            {"question": "Test", "knowledge_sources": [{"invalid": "data"}]},
-            None,
-            None,
-            sync=False,
-        )
+        with _stub_create_task():
+            result = handler._handle_deliberate(
+                {"question": "Test", "knowledge_sources": [{"invalid": "data"}]},
+                None,
+                None,
+                sync=False,
+            )
 
         # Should return 202 (queued) or 500 (error), not raise
         assert result is not None
@@ -1965,7 +1978,8 @@ class TestErrorHandling:
         """
         handler = OrchestrationHandler({})
 
-        result = handler._handle_deliberate({"question": "   "}, None, None, sync=False)
+        with _stub_create_task():
+            result = handler._handle_deliberate({"question": "   "}, None, None, sync=False)
 
         # Should return a valid response (either queued or error)
         assert result is not None
@@ -1977,7 +1991,8 @@ class TestErrorHandling:
 
         long_question = "Test " * 10000  # ~50000 chars
 
-        result = handler._handle_deliberate({"question": long_question}, None, None, sync=False)
+        with _stub_create_task():
+            result = handler._handle_deliberate({"question": long_question}, None, None, sync=False)
 
         # Should either queue or error, not crash
         assert result is not None
@@ -1988,12 +2003,13 @@ class TestErrorHandling:
         handler = OrchestrationHandler({})
 
         # agents should be list of strings, not dict
-        result = handler._handle_deliberate(
-            {"question": "Test", "agents": {"invalid": "type"}},
-            None,
-            None,
-            sync=False,
-        )
+        with _stub_create_task():
+            result = handler._handle_deliberate(
+                {"question": "Test", "agents": {"invalid": "type"}},
+                None,
+                None,
+                sync=False,
+            )
 
         # Should handle gracefully
         assert result is not None
@@ -2002,12 +2018,13 @@ class TestErrorHandling:
         """Test handling of None values in request."""
         handler = OrchestrationHandler({})
 
-        result = handler._handle_deliberate(
-            {"question": "Test", "knowledge_sources": None},
-            None,
-            None,
-            sync=False,
-        )
+        with _stub_create_task():
+            result = handler._handle_deliberate(
+                {"question": "Test", "knowledge_sources": None},
+                None,
+                None,
+                sync=False,
+            )
 
         # Should handle gracefully
         assert result is not None
@@ -2193,22 +2210,23 @@ class TestSyncVsAsyncDeliberation:
     """Tests for synchronous vs asynchronous deliberation."""
 
     def test_async_deliberate_returns_202_or_queued(self):
-        """Test that async deliberate returns 202 Accepted or a queued status."""
+        """Test that async deliberate queues the request and returns 202."""
         handler = OrchestrationHandler({})
 
-        result = handler._handle_deliberate(
-            {"question": "Async test question"},
-            None,
-            None,
-            sync=False,
-        )
+        # There is no running loop in this sync test, so stand in for
+        # asyncio.create_task and close the queued coroutine.
+        with _stub_create_task():
+            result = handler._handle_deliberate(
+                {"question": "Async test question"},
+                None,
+                None,
+                sync=False,
+            )
 
-        # May return 202 (queued) or 500 (error if asyncio task fails to create)
-        assert result.status_code in [202, 500]
-        if result.status_code == 202:
-            body = json.loads(result.body)
-            assert body["status"] == "queued"
-            assert "request_id" in body
+        assert result.status_code == 202
+        body = json.loads(result.body)
+        assert body["status"] == "queued"
+        assert "request_id" in body
 
     def test_sync_deliberate_returns_result(self):
         """Test that sync deliberate returns a result.
@@ -2233,7 +2251,7 @@ class TestSyncVsAsyncDeliberation:
         ):
             with patch(
                 "aragora.server.handlers.orchestration.handler.run_async",
-                return_value=mock_result,
+                side_effect=close_coroutine_then(mock_result),
             ):
                 result = handler._handle_deliberate(
                     {"question": "Sync test question"},
@@ -2251,17 +2269,18 @@ class TestSyncVsAsyncDeliberation:
         """Test that async response includes status URL hint."""
         handler = OrchestrationHandler({})
 
-        result = handler._handle_deliberate(
-            {"question": "Test question"},
-            None,
-            None,
-            sync=False,
-        )
+        with _stub_create_task():
+            result = handler._handle_deliberate(
+                {"question": "Test question"},
+                None,
+                None,
+                sync=False,
+            )
 
-        if result.status_code == 202:
-            body = json.loads(result.body)
-            assert "message" in body
-            assert "/api/v1/orchestration/status/" in body["message"]
+        assert result.status_code == 202
+        body = json.loads(result.body)
+        assert "message" in body
+        assert "/api/v1/orchestration/status/" in body["message"]
 
 
 # =============================================================================
@@ -2317,9 +2336,11 @@ class TestHandlerPostMethod:
             with patch.object(handler, "check_permission", return_value=True):
                 with patch(
                     "aragora.server.handlers.orchestration.handler.run_async",
-                    return_value=OrchestrationResult(
-                        request_id="sync-123",
-                        success=True,
+                    side_effect=close_coroutine_then(
+                        OrchestrationResult(
+                            request_id="sync-123",
+                            success=True,
+                        )
                     ),
                 ):
                     result = await handler.handle_post(

--- a/tests/server/handlers/test_orchestration_handler.py
+++ b/tests/server/handlers/test_orchestration_handler.py
@@ -30,6 +30,8 @@ from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 import pytest
 
+from tests.utils.async_helpers import close_coroutine_then
+
 from aragora.server.handlers.orchestration import (
     OrchestrationHandler,
     OrchestrationRequest,
@@ -589,7 +591,7 @@ class TestDeliberateEndpoint:
     async def test_deliberate_async_returns_queued(self, handler, mock_auth_context):
         """Test async deliberate returns 202 Accepted."""
         # Use patch to prevent asyncio.create_task from actually running
-        with patch("asyncio.create_task") as mock_create_task:
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
             with patch.object(handler, "check_permission", return_value=True):
                 result = handler._handle_deliberate(
                     {"question": "What should we do?"},
@@ -609,7 +611,7 @@ class TestDeliberateEndpoint:
             "question": "Review this PR for security issues",
             "template": "code_review",
         }
-        with patch("asyncio.create_task"):
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
             with patch.object(handler, "check_permission", return_value=True):
                 result = handler._handle_deliberate(data, None, mock_auth_context, sync=False)
             assert result.status_code == 202
@@ -618,7 +620,7 @@ class TestDeliberateEndpoint:
     async def test_deliberate_request_stored(self, handler, mock_auth_context):
         """Test that deliberate stores request for status checking."""
         data = {"question": "Should we refactor this module?"}
-        with patch("asyncio.create_task"):
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
             with patch.object(handler, "check_permission", return_value=True):
                 result = handler._handle_deliberate(data, None, mock_auth_context, sync=False)
                 body = json.loads(result.body)
@@ -1130,7 +1132,7 @@ class TestTemplateApplication:
             # Without explicit agents, template should provide them
             # Note: Template application happens in _handle_deliberate
             data = {"question": "Review code", "template": "code_review"}
-            with patch("asyncio.create_task"):
+            with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
                 with patch.object(handler, "check_permission", return_value=True):
                     result = handler._handle_deliberate(data, None, mock_auth_context, sync=False)
                     assert result.status_code == 202
@@ -1343,7 +1345,7 @@ class TestEdgeCases:
     async def test_very_long_question(self, handler, mock_auth_context):
         """Test handling of very long question."""
         long_question = "x" * 10000
-        with patch("asyncio.create_task"):
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
             with patch.object(handler, "check_permission", return_value=True):
                 result = handler._handle_deliberate(
                     {"question": long_question},
@@ -1358,7 +1360,7 @@ class TestEdgeCases:
     async def test_unicode_question(self, handler, mock_auth_context):
         """Test handling of unicode characters in question."""
         unicode_question = "What about these characters: (emoji) and chinese?"
-        with patch("asyncio.create_task"):
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
             with patch.object(handler, "check_permission", return_value=True):
                 result = handler._handle_deliberate(
                     {"question": unicode_question},
@@ -1401,7 +1403,7 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_empty_knowledge_sources_list(self, handler, mock_auth_context):
         """Test request with empty knowledge sources."""
-        with patch("asyncio.create_task"):
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
             with patch.object(handler, "check_permission", return_value=True):
                 result = handler._handle_deliberate(
                     {"question": "Test", "knowledge_sources": []},
@@ -1414,7 +1416,7 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_empty_output_channels_list(self, handler, mock_auth_context):
         """Test request with empty output channels."""
-        with patch("asyncio.create_task"):
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
             with patch.object(handler, "check_permission", return_value=True):
                 result = handler._handle_deliberate(
                     {"question": "Test", "output_channels": []},

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -20,6 +20,7 @@ from tests.utils.aiohttp_mocks import (
 from tests.utils.async_helpers import (
     DEFAULT_TIMEOUT,
     AsyncTestContext,
+    close_coroutine_then,
     gather_with_timeout,
     run_with_cancellation,
     run_with_timeout,
@@ -47,6 +48,7 @@ __all__ = [
     "run_with_cancellation",
     "gather_with_timeout",
     "AsyncTestContext",
+    "close_coroutine_then",
     # aiohttp mock builders (see aiohttp_mocks.py for the __aexit__ gotcha)
     "make_async_context_manager",
     "make_mock_client_session",

--- a/tests/utils/async_helpers.py
+++ b/tests/utils/async_helpers.py
@@ -5,8 +5,9 @@ timeout handling and clear error messages.
 """
 
 import asyncio
+import inspect
 from typing import Any, Optional, TypeVar
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 
 T = TypeVar("T")
 
@@ -152,10 +153,46 @@ class AsyncTestContext:
                 pass  # Cleanup errors are not fatal
 
 
+def close_coroutine_then(
+    result: Any = None,
+    *,
+    raise_: BaseException | None = None,
+) -> Callable[..., Any]:
+    """Build a ``side_effect`` for mocks that stand in for a coroutine *runner*.
+
+    ``asyncio.run``, ``asyncio.create_task`` and
+    ``aragora.utils.async_utils.run_async`` all receive an already-created
+    coroutine object.  Patching them with a plain ``return_value`` (or a bare
+    ``side_effect`` exception) leaves that coroutine unconsumed, and Python then
+    emits ``RuntimeWarning: coroutine '...' was never awaited`` at garbage
+    collection, attributed to whichever test happens to be running.  This side
+    effect closes the coroutine first, then returns ``result`` or raises
+    ``raise_``.
+
+    Usage::
+
+        with patch("asyncio.run", side_effect=close_coroutine_then(raise_=RuntimeError("x"))):
+            main()
+
+        with patch("asyncio.create_task", side_effect=close_coroutine_then(MagicMock())):
+            handler.enqueue(...)
+    """
+
+    def _side_effect(coro: Any, *args: Any, **kwargs: Any) -> Any:
+        if inspect.iscoroutine(coro):
+            coro.close()
+        if raise_ is not None:
+            raise raise_
+        return result
+
+    return _side_effect
+
+
 __all__ = [
     "DEFAULT_TIMEOUT",
     "run_with_timeout",
     "run_with_cancellation",
     "gather_with_timeout",
     "AsyncTestContext",
+    "close_coroutine_then",
 ]

--- a/tests/utils/test_close_coroutine_then.py
+++ b/tests/utils/test_close_coroutine_then.py
@@ -1,0 +1,49 @@
+"""Tests for ``tests.utils.async_helpers.close_coroutine_then``."""
+
+from __future__ import annotations
+
+import asyncio
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.utils.async_helpers import close_coroutine_then
+
+
+async def _work() -> str:
+    return "ran"
+
+
+def test_returns_result_and_closes_coroutine():
+    coro = _work()
+    side_effect = close_coroutine_then("stubbed")
+    assert side_effect(coro) == "stubbed"
+    # A closed coroutine cannot be resumed.
+    with pytest.raises(RuntimeError, match="cannot reuse already awaited coroutine"):
+        asyncio.run(coro)
+
+
+def test_raises_after_closing_coroutine():
+    coro = _work()
+    side_effect = close_coroutine_then(raise_=RuntimeError("boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        side_effect(coro)
+    with pytest.raises(RuntimeError, match="cannot reuse already awaited coroutine"):
+        asyncio.run(coro)
+
+
+def test_non_coroutine_argument_is_left_alone():
+    sentinel = object()
+    assert close_coroutine_then(7)(sentinel) == 7
+
+
+def test_patched_runner_emits_no_never_awaited_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with patch("asyncio.run", side_effect=close_coroutine_then(MagicMock())):
+            asyncio.run(_work())
+        import gc
+
+        gc.collect()
+    assert not [w for w in caught if "never awaited" in str(w.message)]


### PR DESCRIPTION
Follow-up to #10002 (stacked on its branch so the diff shows only this change; retarget to main once #10002 lands).

Two more classes of test that were green for the wrong reason, found while auditing the aiohttp `__aexit__` mock fix.

## Runner mocks that drop coroutines
Patching `asyncio.run`, `asyncio.create_task` or `run_async` with a plain `return_value` (or a bare `side_effect` exception) leaves the coroutine argument unconsumed, so Python reports `coroutine ... was never awaited` at GC time against whichever test happens to be running. This adds `tests.utils.async_helpers.close_coroutine_then()`, a `side_effect` that closes the coroutine and then returns or raises, and uses it at all 13 sites in the orchestration handler tests and the doctor CLI test. The 5 warnings are gone, and the async-deliberate tests that accepted `202 or 500` (500 only because `create_task` has no loop in a sync test) now assert 202 deterministically.

## Gmail watch tests asserting pre-April behavior
`watch.py` was made fail-closed in #2846/#2874 (per-message fetch failures re-raise; a failed renewal stops the loop and re-raises), but `tests/connectors` is `--ignore`d by every CI shard, so the two tests that still asserted "log and continue" / "retry after 60s" have been silently red on main for five months. They now assert the fail-closed behavior and the recorded sync-error state. No production code changes.

## Reviewed design tradeoffs
- A suite-wide guard for never-awaited coroutines was considered and rejected: the warning fires at GC and is attributed to an arbitrary later test, and forcing `gc.collect()` per test across ~216k tests is too expensive. Fixing the runner-mock shape at the source and providing the helper is the bounded cure.
- The Gmail tests assert the behavior that has been in production since April rather than reverting it; whether `tests/connectors` should gain a CI shard is a separate decision.

## Verification
- 321 passed across the touched files plus helper tests; 0 never-awaited warnings (was 5).
- `ruff check` / `ruff format --check` clean; `report_code_quality.py --check` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)