### PR TITLE
test(agents): replace vacuous except-Exception error-path tests with exact assertions

### DIFF
--- a/tests/agents/api_agents/conftest.py
+++ b/tests/agents/api_agents/conftest.py
@@ -317,12 +317,11 @@ def mock_env_no_api_keys(monkeypatch):
     ]:
         monkeypatch.delenv(key, raising=False)
     # Reset secret manager cache so it doesn't reuse previously loaded AWS secrets.
-    try:
-        from aragora.config.secrets import reset_secret_manager
+    # reset_secret_manager() only nulls a module global and cannot fail; a blanket
+    # except here would just hide a broken reset behind a passing test.
+    from aragora.config.secrets import reset_secret_manager
 
-        reset_secret_manager()
-    except Exception:
-        pass
+    reset_secret_manager()
 
 
 @pytest.fixture

--- a/tests/agents/test_agent_anthropic.py
+++ b/tests/agents/test_agent_anthropic.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 
 from aragora.agents.api_agents.anthropic import AnthropicAPIAgent
+from aragora.agents.api_agents.common import AgentAPIError, AgentStreamError
+from tests.utils.aiohttp_mocks import make_mock_client_session, make_mock_response
 
 
 class TestAnthropicAgentInitialization:
@@ -191,31 +193,25 @@ class TestAnthropicGenerate:
             enable_fallback=True,
         )
 
-        mock_response = MagicMock()
-        mock_response.status = 429
-        mock_response.text = AsyncMock(return_value="Rate limit exceeded")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        mock_response = make_mock_response(status=429, text="Rate limit exceeded")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
             with patch.object(agent, "_build_fallback_providers", return_value=[]):
                 with patch.dict("os.environ", {"OPENROUTER_API_KEY": ""}, clear=False):
-                    # Should log warning when fallback unavailable (warning now comes from mixin)
+                    # The warning comes from QuotaFallbackMixin.fallback_generate; with no
+                    # providers the 429 then surfaces as a non-retryable AgentAPIError.
                     with patch("aragora.agents.fallback.logger") as mock_logger:
-                        # May return error string or raise - just verify warning logged
-                        try:
+                        with pytest.raises(
+                            AgentAPIError, match="Anthropic API error 429"
+                        ) as exc_info:
                             await agent.generate("Test prompt")
-                        except Exception:
-                            pass  # Some errors may still propagate
+                        assert exc_info.value.status_code == 429
                         mock_logger.warning.assert_called()
+                        assert any(
+                            "no fallback provider" in call.args[0]
+                            for call in mock_logger.warning.call_args_list
+                        )
 
     @pytest.mark.asyncio
     async def test_context_included_in_prompt(self, agent):
@@ -309,32 +305,17 @@ class TestAnthropicStreaming:
 
     @pytest.mark.asyncio
     async def test_streaming_error_response(self, agent):
-        """Test streaming with error response raises or returns error."""
-        mock_response = MagicMock()
-        mock_response.status = 500
-        mock_response.text = AsyncMock(return_value="Server Error")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        """Test streaming with a non-quota 5xx raises AgentStreamError."""
+        mock_response = make_mock_response(status=500, text="Server Error")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # Error may raise or return error message depending on decorator
-            chunks = []
-            try:
+            chunks: list[str] = []
+            with pytest.raises(AgentStreamError, match="Anthropic streaming API error 500"):
                 async for chunk in agent.generate_stream("Test"):
                     chunks.append(chunk)
-                # If no exception, result should indicate error
-                result = "".join(chunks)
-                assert "error" in result.lower() or result == ""
-            except (RuntimeError, Exception):
-                pass  # Expected behavior - error raised
+            # The error is raised before any stream data is read, so nothing is yielded.
+            assert chunks == []
 
 
 class TestAnthropicCritique:

--- a/tests/agents/test_agent_gemini.py
+++ b/tests/agents/test_agent_gemini.py
@@ -16,8 +16,9 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 
-from aragora.agents.api_agents.common import AgentAPIError
+from aragora.agents.api_agents.common import AgentAPIError, AgentStreamError
 from aragora.agents.api_agents.gemini import GeminiAgent
+from tests.utils.aiohttp_mocks import make_mock_client_session, make_mock_response
 
 
 class TestGeminiAgentInitialization:
@@ -371,36 +372,17 @@ class TestGeminiStreaming:
 
     @pytest.mark.asyncio
     async def test_streaming_error_response(self, agent):
-        """Test streaming with error response is handled."""
-        mock_response = MagicMock()
-        mock_response.status = 500
-        mock_response.text = AsyncMock(return_value="Server Error")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        """Test streaming with a non-quota 5xx raises AgentStreamError."""
+        mock_response = make_mock_response(status=500, text="Server Error")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # May raise or yield error - verify error is detected
-            chunks = []
-            error_detected = False
-            try:
+            chunks: list[str] = []
+            with pytest.raises(AgentStreamError, match="Gemini streaming API error 500"):
                 async for chunk in agent.generate_stream("Test"):
                     chunks.append(chunk)
-                # If no exception, check for error in output
-                result = "".join(chunks)
-                if "error" in result.lower():
-                    error_detected = True
-            except Exception:
-                error_detected = True
-
-            assert error_detected or chunks == []
+            # The error is raised before any stream data is read, so nothing is yielded.
+            assert chunks == []
 
     @pytest.mark.asyncio
     async def test_streaming_quota_error_triggers_fallback(self):

--- a/tests/agents/test_agent_mistral.py
+++ b/tests/agents/test_agent_mistral.py
@@ -14,6 +14,8 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aragora.agents.api_agents.mistral import MistralAPIAgent, CodestralAgent
+from aragora.agents.api_agents.common import AgentStreamError
+from tests.utils.aiohttp_mocks import make_mock_client_session, make_mock_response
 
 
 class TestMistralAgentInitialization:
@@ -302,34 +304,17 @@ class TestMistralStreaming:
 
     @pytest.mark.asyncio
     async def test_streaming_error_handled(self, agent):
-        """Test streaming error is handled appropriately."""
-        mock_response = MagicMock()
-        mock_response.status = 500
-        mock_response.text = AsyncMock(return_value="Server Error")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        """Test streaming with a non-quota 5xx raises AgentStreamError."""
+        mock_response = make_mock_response(status=500, text="Server Error")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # May raise or yield error - verify error is detected
-            chunks = []
-            error_detected = False
-            try:
+            chunks: list[str] = []
+            with pytest.raises(AgentStreamError, match="streaming API error 500"):
                 async for chunk in agent.generate_stream("Test"):
                     chunks.append(chunk)
-                if chunks and "error" in "".join(chunks).lower():
-                    error_detected = True
-            except Exception:
-                error_detected = True
-
-            assert error_detected or chunks == []
+            # The error is raised before any stream data is read, so nothing is yielded.
+            assert chunks == []
 
 
 class TestMistralCritique:

--- a/tests/agents/test_agent_openai.py
+++ b/tests/agents/test_agent_openai.py
@@ -16,6 +16,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 
 from aragora.agents.api_agents.openai import OpenAIAPIAgent
+from aragora.agents.api_agents.common import AgentAPIError, AgentStreamError
+from tests.utils.aiohttp_mocks import make_mock_client_session, make_mock_response
 
 
 class TestOpenAIAgentInitialization:
@@ -126,29 +128,16 @@ class TestOpenAIGenerate:
 
     @pytest.mark.asyncio
     async def test_api_error_handled(self, agent):
-        """Test API errors are handled (may raise or return error message)."""
-        mock_response = MagicMock()
-        mock_response.status = 500
-        mock_response.text = AsyncMock(return_value="Internal Server Error")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        """Test a non-quota 5xx raises AgentAPIError without retry."""
+        mock_response = make_mock_response(status=500, text="Internal Server Error")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # The handle_agent_errors decorator may wrap or handle errors
-            try:
-                result = await agent.generate("Test prompt")
-                # If no exception, result should indicate error
-                assert "error" in result.lower() or result == ""
-            except Exception:
-                pass  # Expected - error raised
+            with pytest.raises(AgentAPIError, match="API error 500") as exc_info:
+                await agent.generate("Test prompt")
+        assert exc_info.value.status_code == 500
+        # Exactly one HTTP call: AgentAPIError is not in the decorator's retryable set.
+        assert mock_session.post.call_count == 1
 
     @pytest.mark.asyncio
     async def test_quota_error_triggers_fallback(self):
@@ -196,30 +185,23 @@ class TestOpenAIGenerate:
             enable_fallback=True,
         )
 
-        mock_response = MagicMock()
-        mock_response.status = 429
-        mock_response.text = AsyncMock(return_value="Rate limit exceeded")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        mock_response = make_mock_response(status=429, text="Rate limit exceeded")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            with patch.dict("os.environ", {"OPENROUTER_API_KEY": ""}, clear=False):
-                # Should log warning when fallback unavailable
-                # The warning comes from QuotaFallbackMixin in aragora.agents.fallback
-                with patch("aragora.agents.fallback.logger") as mock_logger:
-                    try:
-                        await agent.generate("Test prompt")
-                    except Exception:
-                        pass  # Some errors may still propagate
-                    mock_logger.warning.assert_called()
+            with patch.object(agent, "_build_fallback_providers", return_value=[]):
+                with patch.dict("os.environ", {"OPENROUTER_API_KEY": ""}, clear=False):
+                    # The warning comes from QuotaFallbackMixin.fallback_generate; with no
+                    # providers the 429 then surfaces as a non-retryable AgentAPIError.
+                    with patch("aragora.agents.fallback.logger") as mock_logger:
+                        with pytest.raises(AgentAPIError, match="API error 429") as exc_info:
+                            await agent.generate("Test prompt")
+                        assert exc_info.value.status_code == 429
+                        mock_logger.warning.assert_called()
+                        assert any(
+                            "no fallback provider" in call.args[0]
+                            for call in mock_logger.warning.call_args_list
+                        )
 
     @pytest.mark.asyncio
     async def test_system_prompt_included(self):
@@ -310,32 +292,17 @@ class TestOpenAIStreaming:
 
     @pytest.mark.asyncio
     async def test_streaming_error_response(self, agent):
-        """Test streaming with error response raises or returns error."""
-        mock_response = MagicMock()
-        mock_response.status = 500
-        mock_response.text = AsyncMock(return_value="Server Error")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        """Test streaming with a non-quota 5xx raises AgentStreamError."""
+        mock_response = make_mock_response(status=500, text="Server Error")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # Error may raise or return error message depending on decorator
-            chunks = []
-            try:
+            chunks: list[str] = []
+            with pytest.raises(AgentStreamError, match="streaming API error 500"):
                 async for chunk in agent.generate_stream("Test"):
                     chunks.append(chunk)
-                # If no exception, result should indicate error
-                result = "".join(chunks)
-                assert "error" in result.lower() or result == ""
-            except (RuntimeError, Exception):
-                pass  # Expected behavior - error raised
+            # The error is raised before any stream data is read, so nothing is yielded.
+            assert chunks == []
 
     @pytest.mark.asyncio
     async def test_streaming_fallback_on_quota_error(self):
@@ -457,19 +424,8 @@ class TestOpenAIFallbackDisabled:
             enable_fallback=False,
         )
 
-        mock_response = MagicMock()
-        mock_response.status = 429
-        mock_response.text = AsyncMock(return_value="Rate limit")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        mock_response = make_mock_response(status=429, text="Rate limit")
+        mock_session = make_mock_client_session(mock_response)
 
         # Track whether fallback was called
         fallback_called = False
@@ -483,11 +439,11 @@ class TestOpenAIFallbackDisabled:
             with patch.dict("os.environ", {"OPENROUTER_API_KEY": "router-key"}):
                 # Mock the cached fallback agent from QuotaFallbackMixin
                 with patch.object(agent, "_get_cached_fallback_agent", mock_get_fallback):
-                    # Should not call fallback when disabled
-                    try:
+                    # With fallback disabled the 429 must surface as AgentAPIError
+                    # rather than being routed to OpenRouter.
+                    with pytest.raises(AgentAPIError, match="API error 429") as exc_info:
                         await agent.generate("Test")
-                    except Exception:
-                        pass  # Error may or may not be raised
+                    assert exc_info.value.status_code == 429
                     # Key assertion: fallback should not be called
                     assert not fallback_called
 

--- a/tests/agents/test_agent_openrouter.py
+++ b/tests/agents/test_agent_openrouter.py
@@ -21,6 +21,8 @@ from aragora.agents.api_agents.openrouter import (
     LlamaAgent,
     MistralAgent,
 )
+from aragora.agents.api_agents.common import AgentAPIError, AgentStreamError
+from tests.utils.aiohttp_mocks import make_mock_client_session, make_mock_response
 
 
 class TestOpenRouterAgentInitialization:
@@ -100,29 +102,16 @@ class TestOpenRouterGenerate:
 
     @pytest.mark.asyncio
     async def test_api_error_handled(self, agent):
-        """Test API errors are handled (may raise or return error message)."""
-        mock_response = MagicMock()
-        mock_response.status = 500
-        mock_response.headers = {}
-        mock_response.text = AsyncMock(return_value="Internal Server Error")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        """Test a non-429 error status raises AgentAPIError without retry."""
+        mock_response = make_mock_response(status=500, text="Internal Server Error")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            try:
-                result = await agent.generate("Test prompt")
-                # If no exception, result should indicate error
-                assert "error" in result.lower() or result == ""
-            except Exception:
-                pass  # Expected - error raised
+            with pytest.raises(AgentAPIError, match="OpenRouter API error 500") as exc_info:
+                await agent.generate("Test prompt")
+        assert exc_info.value.status_code == 500
+        # Exactly one HTTP call: AgentAPIError is not in the decorator's retryable set.
+        assert mock_session.post.call_count == 1
 
     @pytest.mark.asyncio
     async def test_rate_limit_retry(self, agent):
@@ -258,33 +247,17 @@ class TestOpenRouterStreaming:
 
     @pytest.mark.asyncio
     async def test_streaming_error_response(self, agent):
-        """Test streaming with error response raises or returns error."""
-        mock_response = MagicMock()
-        mock_response.status = 500
-        mock_response.headers = {}
-        mock_response.text = AsyncMock(return_value="Server Error")
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        mock_session.post = MagicMock(
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_response),
-                __aexit__=AsyncMock(return_value=False),
-            )
-        )
+        """Test streaming with a non-429 error status raises AgentStreamError."""
+        mock_response = make_mock_response(status=500, text="Server Error")
+        mock_session = make_mock_client_session(mock_response)
 
         with patch("aiohttp.ClientSession", return_value=mock_session):
-            # Error may raise or return error message depending on decorator
-            chunks = []
-            try:
+            chunks: list[str] = []
+            with pytest.raises(AgentStreamError, match="OpenRouter streaming API error 500"):
                 async for chunk in agent.generate_stream("Test"):
                     chunks.append(chunk)
-                # If no exception, result should indicate error
-                result = "".join(chunks)
-                assert "error" in result.lower() or result == ""
-            except (RuntimeError, Exception):
-                pass  # Expected behavior - error raised
+            # The error is raised before any stream data is read, so nothing is yielded.
+            assert chunks == []
 
 
 class TestOpenRouterCritique:

--- a/tests/agents/test_api_agents_rate_limiter.py
+++ b/tests/agents/test_api_agents_rate_limiter.py
@@ -20,6 +20,7 @@ from aragora.agents.api_agents.rate_limiter import (
     get_openrouter_limiter,
     set_openrouter_tier,
 )
+from aragora.services import ServiceRegistry
 
 
 # =============================================================================
@@ -50,41 +51,26 @@ def reset_global_limiter():
     """Reset global limiter state between tests.
 
     Also clears OPENROUTER_TIER env var to ensure default tier is used.
-    Clears both the legacy module-level variable and the ServiceRegistry
-    singleton (which is the actual backing store for get_openrouter_limiter).
+    The ServiceRegistry singleton is the sole backing store for
+    get_openrouter_limiter() (there is no module-level instance variable), so
+    unregistering the limiter there is the whole reset. ``unregister`` is
+    idempotent, and a failure here must surface rather than leak a stale
+    limiter into the next test.
     """
     import aragora.agents.api_agents.rate_limiter as module
+
+    def _clear_limiter() -> None:
+        # Hold the same lock get_openrouter_limiter() takes around its
+        # check-and-register so the reset cannot interleave with a creation.
+        with module._openrouter_limiter_lock:
+            ServiceRegistry.get().unregister(module.OpenRouterRateLimiter)
 
     # Clear environment variable to ensure default tier
     old_tier = os.environ.pop("OPENROUTER_TIER", None)
 
-    # Clear legacy module-level variable
-    with module._openrouter_limiter_lock:
-        module._openrouter_limiter = None
-
-    # Clear ServiceRegistry entry (the actual backing store)
-    try:
-        from aragora.services import ServiceRegistry
-
-        registry = ServiceRegistry.get()
-        if registry.has(module.OpenRouterRateLimiter):
-            registry.unregister(module.OpenRouterRateLimiter)
-    except Exception:
-        pass
-
+    _clear_limiter()
     yield
-
-    with module._openrouter_limiter_lock:
-        module._openrouter_limiter = None
-
-    try:
-        from aragora.services import ServiceRegistry
-
-        registry = ServiceRegistry.get()
-        if registry.has(module.OpenRouterRateLimiter):
-            registry.unregister(module.OpenRouterRateLimiter)
-    except Exception:
-        pass
+    _clear_limiter()
 
     # Restore original env var if it existed
     if old_tier is not None:


### PR DESCRIPTION
## Summary

Ten agent API error-path tests in `tests/agents/test_agent_{anthropic,openai,gemini,mistral,openrouter}.py` wrapped the call under test in `try: ... except Exception: pass` (or `except (RuntimeError, Exception): pass`), so any outcome passed, including an `AttributeError` from asserting on a `None` result. Each is now pinned to what the production path actually does on that response:

| Scenario | Now asserts |
|---|---|
| non-quota 5xx in `generate()` | `pytest.raises(AgentAPIError, match=...)`, `status_code`, exactly one POST (no retry) |
| non-quota 5xx in `generate_stream()` | `pytest.raises(AgentStreamError, match=...)`, no chunks yielded |
| 429 with no fallback providers | `AgentAPIError` 429 plus the mixin's "no fallback provider" warning |
| 429 with fallback disabled | `AgentAPIError` 429 and the fallback factory never called |

Second commit removes the same blanket except-pass shape from two fixtures (`reset_global_limiter` in `test_api_agents_rate_limiter.py`, `mock_env_no_api_keys` in `api_agents/conftest.py`). Both guarded calls are first-party and cannot raise, so the guard only hid a failed reset behind a passing test. The limiter fixture also set a `_openrouter_limiter` module attribute that no longer exists in production; that dead line is gone.

Mocks in the touched tests now use `tests.utils.aiohttp_mocks` (landed in #10002, which this branch was stacked on until it merged). **No production code changed.** Risk tier: tests-only.

## Reviewed design tradeoffs

- **`pytest.raises` over asserting an error string.** Production raises on non-200; a returned string would itself be a regression, so the old "raise or return" tolerance masked the very failure the test exists for.
- **`match=` on stable substrings only** (provider name and status code), never the full message text, so wording changes don't break the tests while a wrong status or provider still does.
- **The OpenAI quota test patches `_build_fallback_providers` to `[]`** so its outcome no longer depends on which provider keys happen to be set in the environment.
- **Fixtures call the reset helpers directly.** `ServiceRegistry.get/has/unregister` are lock-protected dict operations and `reset_secret_manager()` nulls a global; a blanket except there protects nothing and would mask cross-test pollution.
- **One POST asserted on 5xx** documents that these paths do not retry; if retry is added later the test should change deliberately, not silently pass.

## Test evidence

```
python -m pytest tests/agents/test_agent_{anthropic,openai,gemini,mistral,openrouter}.py tests/agents/test_api_agents_rate_limiter.py -q
192 passed, 7 warnings in 35.60s
python -m pytest tests/agents/api_agents/ -q
817 passed, 8 warnings in 115.73s (0:01:55)
ruff check / ruff format --check on all 7 files: clean
```

## Follow-ups (separate PRs)

- A ruff `S110`/`S112` committed-ceiling budget for `tests/` plus a suite-scan guard test, in the style of `scripts/check_sdk_parity.py`.
- The remaining `S110` sites in `tests/` (about 135 across `server`, `integration`, `chaos`, `connectors` and a tail), worked by cluster with the same method.
- Make the local `tsc-check` pre-push hook skip with a clear message when `aragora/live/node_modules` is absent in a fresh worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
