### PR TITLE
test(connectors): replace blanket except-pass with exact assertions

### DIFF
--- a/tests/connectors/chat/test_imessage_connector.py
+++ b/tests/connectors/chat/test_imessage_connector.py
@@ -193,19 +193,18 @@ class TestIMessageConnectorCircuitBreaker:
         mock_response.text = "BlueBubbles server error"
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
-                return_value=mock_response
-            )
+            post_mock = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = post_mock
 
-            # Trigger multiple failures to open circuit breaker
+            # HTTP 500 is reported as a failed send (never raised) and counted
+            # against the breaker; once it opens, the remaining calls short-circuit.
             for _ in range(10):
-                try:
-                    await connector.send_message("+1234567890", "test")
-                except Exception:
-                    pass
-
-            # Circuit breaker should now be open
-            result = await connector.send_message("+1234567890", "test")
-            # Either raises or returns failure
-            if result:
+                result = await connector.send_message("+1234567890", "test")
                 assert result.success is False
+            assert post_mock.await_count == connector._circuit_breaker_threshold
+
+            # Circuit breaker is now open: the call fails fast without an HTTP request
+            result = await connector.send_message("+1234567890", "test")
+            assert result.success is False
+            assert "Circuit breaker open for imessage" in result.error
+            assert post_mock.await_count == connector._circuit_breaker_threshold

--- a/tests/connectors/chat/test_signal_connector.py
+++ b/tests/connectors/chat/test_signal_connector.py
@@ -170,19 +170,18 @@ class TestSignalConnectorCircuitBreaker:
         mock_response.text = "Server error"
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
-                return_value=mock_response
-            )
+            post_mock = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = post_mock
 
-            # Trigger multiple failures to open circuit breaker
+            # HTTP 500 is reported as a failed send (never raised) and counted
+            # against the breaker; once it opens, the remaining calls short-circuit.
             for _ in range(10):
-                try:
-                    await connector.send_message("+9876543210", "test")
-                except Exception:
-                    pass
-
-            # Circuit breaker should now be open
-            result = await connector.send_message("+9876543210", "test")
-            # Either raises or returns failure
-            if result:
+                result = await connector.send_message("+9876543210", "test")
                 assert result.success is False
+            assert post_mock.await_count == connector._circuit_breaker_threshold
+
+            # Circuit breaker is now open: the call fails fast without an HTTP request
+            result = await connector.send_message("+9876543210", "test")
+            assert result.success is False
+            assert "Circuit breaker open for signal" in result.error
+            assert post_mock.await_count == connector._circuit_breaker_threshold

--- a/tests/connectors/enterprise/collaboration/test_confluence.py
+++ b/tests/connectors/enterprise/collaboration/test_confluence.py
@@ -469,7 +469,7 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_api_error(self, connector):
-        """Should handle API errors."""
+        """API errors from _api_request propagate out of _get_pages."""
         import httpx
 
         with patch.object(
@@ -479,15 +479,15 @@ class TestErrorHandling:
                 "Error", request=None, response=MagicMock(status_code=500)
             ),
         ):
-            # Get pages should handle errors gracefully
+            # _get_pages does not catch API errors: the HTTPStatusError
+            # propagates from the first iteration and no page is yielded.
             pages = []
-            try:
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
                 async for page in connector._get_pages("ENG"):
                     pages.append(page)
-            except Exception:
-                pass  # Expected to fail or return empty
 
-            assert isinstance(pages, list)
+            assert exc_info.value.response.status_code == 500
+            assert pages == []
 
 
 # =============================================================================

--- a/tests/connectors/enterprise/test_confluence.py
+++ b/tests/connectors/enterprise/test_confluence.py
@@ -17,6 +17,7 @@ import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from aragora.connectors.enterprise.base import SyncState, SyncStatus
@@ -442,20 +443,22 @@ class TestConfluenceErrorHandling:
 
     @pytest.mark.asyncio
     async def test_handles_api_error(self, mock_credentials):
-        """Should handle API errors gracefully."""
+        """API errors from _api_request propagate out of _get_spaces."""
         from aragora.connectors.enterprise.collaboration.confluence import ConfluenceConnector
 
         connector = ConfluenceConnector(base_url="https://test.atlassian.net/wiki")
         connector.credentials = mock_credentials
 
         with patch.object(connector, "_api_request", new_callable=AsyncMock) as mock_api:
-            mock_api.side_effect = Exception("API Error")
+            # _api_request surfaces HTTP failures via response.raise_for_status()
+            mock_api.side_effect = httpx.HTTPStatusError(
+                "API Error", request=MagicMock(), response=MagicMock(status_code=500)
+            )
 
-            try:
-                spaces = await connector._get_spaces()
-                assert spaces == [] or spaces is None
-            except Exception:
-                pass  # Expected - API error propagates
+            with pytest.raises(httpx.HTTPStatusError, match="API Error"):
+                await connector._get_spaces()
+
+            mock_api.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_handles_space_not_found(self, mock_credentials):
@@ -480,20 +483,21 @@ class TestConfluenceErrorHandling:
 
     @pytest.mark.asyncio
     async def test_handles_permission_denied(self, mock_credentials):
-        """Should handle permission denied errors."""
+        """A 403 from _api_request propagates out of _get_spaces."""
         from aragora.connectors.enterprise.collaboration.confluence import ConfluenceConnector
 
         connector = ConfluenceConnector(base_url="https://test.atlassian.net/wiki")
         connector.credentials = mock_credentials
 
         with patch.object(connector, "_api_request", new_callable=AsyncMock) as mock_api:
-            mock_api.side_effect = Exception("403 Forbidden")
+            mock_api.side_effect = httpx.HTTPStatusError(
+                "403 Forbidden", request=MagicMock(), response=MagicMock(status_code=403)
+            )
 
-            try:
-                spaces = await connector._get_spaces()
-                assert spaces == [] or spaces is None
-            except Exception:
-                pass  # Expected - permission error propagates
+            with pytest.raises(httpx.HTTPStatusError, match="403 Forbidden"):
+                await connector._get_spaces()
+
+            mock_api.assert_awaited_once()
 
 
 class TestConfluenceWebhooks:

--- a/tests/connectors/enterprise/test_notion.py
+++ b/tests/connectors/enterprise/test_notion.py
@@ -16,6 +16,7 @@ import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from aragora.connectors.enterprise.base import SyncState, SyncStatus
@@ -382,38 +383,44 @@ class TestNotionErrorHandling:
 
     @pytest.mark.asyncio
     async def test_handles_invalid_page_id(self, mock_credentials):
-        """Should handle invalid page ID gracefully."""
+        """A not-found error for the page's blocks propagates out of _get_page_content."""
         from aragora.connectors.enterprise.collaboration.notion import NotionConnector
 
         connector = NotionConnector()
         connector.credentials = mock_credentials
 
         with patch.object(connector, "_api_request", new_callable=AsyncMock) as mock_api:
-            mock_api.side_effect = Exception("object_not_found")
+            # Notion answers an unknown page id with HTTP 404 object_not_found,
+            # which _api_request surfaces via response.raise_for_status()
+            mock_api.side_effect = httpx.HTTPStatusError(
+                "object_not_found", request=MagicMock(), response=MagicMock(status_code=404)
+            )
 
-            try:
-                content = await connector._get_page_content("invalid-page-id")
-                assert content == "" or content is None
-            except Exception:
-                # Exception is acceptable for not found
-                pass
+            with pytest.raises(httpx.HTTPStatusError, match="object_not_found"):
+                await connector._get_page_content("invalid-page-id")
+
+            mock_api.assert_awaited_once_with(
+                "/blocks/invalid-page-id/children", params={"page_size": 100}
+            )
 
     @pytest.mark.asyncio
     async def test_handles_permission_denied(self, mock_credentials):
-        """Should handle permission denied errors."""
+        """A 403 restricted_resource error propagates out of _search_pages."""
         from aragora.connectors.enterprise.collaboration.notion import NotionConnector
 
         connector = NotionConnector()
         connector.credentials = mock_credentials
 
         with patch.object(connector, "_api_request", new_callable=AsyncMock) as mock_api:
-            mock_api.side_effect = Exception("restricted_resource")
+            # Notion answers a permission failure with HTTP 403 restricted_resource
+            mock_api.side_effect = httpx.HTTPStatusError(
+                "restricted_resource", request=MagicMock(), response=MagicMock(status_code=403)
+            )
 
-            try:
-                pages = await connector._search_pages()
-                assert pages == [] or pages is None
-            except Exception:
-                pass
+            with pytest.raises(httpx.HTTPStatusError, match="restricted_resource"):
+                await connector._search_pages()
+
+            mock_api.assert_awaited_once()
 
 
 class TestNotionRichTextExtraction:

--- a/tests/connectors/enterprise/test_slack.py
+++ b/tests/connectors/enterprise/test_slack.py
@@ -443,21 +443,21 @@ class TestSlackErrorHandling:
 
     @pytest.mark.asyncio
     async def test_handles_missing_permissions(self, mock_credentials):
-        """Should handle missing permission errors gracefully."""
+        """A missing_scope API error propagates out of _get_channels."""
         from aragora.connectors.enterprise.collaboration.slack import SlackConnector
 
         connector = SlackConnector()
         connector.credentials = mock_credentials
 
         with patch.object(connector, "_api_request", new_callable=AsyncMock) as mock_api:
-            mock_api.side_effect = Exception("missing_scope: channels:read")
+            # Slack reports a missing scope as ok=false, which _api_request
+            # raises as RuntimeError("Slack API error: <error>")
+            mock_api.side_effect = RuntimeError("Slack API error: missing_scope")
 
-            try:
-                channels = await connector._get_channels()
-                assert channels == [] or channels is None
-            except Exception:
-                # Exception is acceptable for permission errors
-                pass
+            with pytest.raises(RuntimeError, match="missing_scope"):
+                await connector._get_channels()
+
+            mock_api.assert_awaited_once()
 
 
 class TestSlackWebhookHandling:

--- a/tests/connectors/test_web_research.py
+++ b/tests/connectors/test_web_research.py
@@ -17,7 +17,7 @@ from aragora.connectors.web import WebConnector
 from aragora.connectors.base import Evidence
 from aragora.evidence.collector import EvidenceCollector
 from aragora.reasoning.provenance import SourceType
-from aragora.core import Environment
+from aragora.core import DebateResult, Environment
 from aragora.debate.orchestrator import Arena, DebateProtocol
 from aragora.core import Agent
 
@@ -174,11 +174,9 @@ async def test_arena_research_phase():
     mock_research = AsyncMock(return_value=research_context)
     arena.context_initializer._perform_research = mock_research
 
-    # Run debate (it will fail but we just want to test research phase)
-    try:
-        await arena.run()
-    except Exception:
-        pass  # Expected to fail without proper setup
+    # The debate completes with mock agents; research runs during context setup
+    result = await arena.run()
+    assert isinstance(result, DebateResult)
 
     # Check that research was called
     mock_research.assert_called_once_with(env.task)
@@ -200,10 +198,8 @@ async def test_research_enabled_by_default():
     mock_research = AsyncMock(return_value="Mock research context")
     arena.context_initializer._perform_research = mock_research
 
-    try:
-        await arena.run()
-    except Exception:
-        pass
+    result = await arena.run()
+    assert isinstance(result, DebateResult)
 
     # Research should be called since it's enabled by default
     mock_research.assert_called_once()
@@ -219,10 +215,8 @@ async def test_research_can_be_disabled():
     arena = Arena(env, agents, protocol)
 
     with patch.object(arena, "_perform_research", new_callable=AsyncMock) as mock_research:
-        try:
-            await arena.run()
-        except Exception:
-            pass
+        result = await arena.run()
+        assert isinstance(result, DebateResult)
 
         # Research should not be called when disabled
         mock_research.assert_not_called()


### PR DESCRIPTION
## Summary

Eleven `tests/connectors` sites wrapped the call under test in `try: ... except Exception: pass` (ruff S110), so any outcome passed. Each is now pinned to what the production connector actually does:

| Site | Production behaviour | Now asserts |
|---|---|---|
| `chat/test_imessage_connector.py`, `chat/test_signal_connector.py` | `send_message` never raises on HTTP 500; returns `success=False` and trips the circuit breaker at threshold 5 | every result `success is False`; POST count equals the breaker threshold (posts stop once open); final result carries "Circuit breaker open for imessage/signal" with no extra POST |
| `enterprise/collaboration/test_confluence.py`, `enterprise/test_confluence.py` (2) | `_get_pages` / `_get_spaces` propagate `httpx.HTTPStatusError` from `raise_for_status()` | `pytest.raises(httpx.HTTPStatusError, match=<status/message>)`, awaited exactly once |
| `enterprise/test_notion.py` (2) | `_get_page_content` and `_search_pages` propagate | `pytest.raises(httpx.HTTPStatusError, match="object_not_found" / "restricted_resource")`, exact request path asserted |
| `enterprise/test_slack.py` | Slack `ok:false` is wrapped as `RuntimeError("Slack API error: ...")` and propagated | `pytest.raises(RuntimeError, match="missing_scope")` |
| `test_web_research.py` (3) | `arena.run()` completes with the test's mock agents; the "expected to fail" comments were stale | direct `await arena.run()` plus `isinstance(result, DebateResult)`, existing research assertions kept |

Where a test injected a bare `Exception(...)`, the injected class is now the one production's `_api_request` actually raises, so `pytest.raises` names an exact class. Messages preserved; nothing loosened. **No production code changed; no `noqa` added.** Risk tier: tests-only.

## Reviewed design tradeoffs

- **Breaker tests assert the count of POSTs, not just the final flag.** "success is False" alone would pass if the breaker never opened; the POST count equalling the threshold proves it opened and stopped calling.
- **`pytest.raises` on `httpx.HTTPStatusError`, not a connector error class.** These connectors do not wrap the HTTP error; asserting the class production actually raises keeps the test honest about that (and would flag a deliberate change to wrapping).
- **Stale "expected to fail" paths replaced by a direct run.** Probed empirically: the arena completes with the mock agents, so the tolerant shape was hiding that the tests were not exercising failure at all.

## Test evidence

```
ruff check tests/connectors --select S110,S112   -> All checks passed!
python -m pytest <7 touched files> -q            -> 135 passed, 7 warnings in 8.33s
ruff check / ruff format --check on the 7 files  -> clean
```

## Observations left for follow-up (out of scope, unchanged)

- `test_web_research.py::test_research_can_be_disabled` is vacuous for a different reason: `arena_phases.py:317` binds `arena._perform_research` at construction, so patching the attribute afterwards patches a dead reference and `assert_not_called()` holds regardless of `enable_research`. Fix is to patch `arena.context_initializer._perform_research` like its siblings.
- Same-class vacuous siblings that S110 does not flag: `test_notion.py:381`, `test_slack.py:442` (`except Exception as e: assert ... or True`) and `test_web_research.py::test_research_failure_graceful`.

## Related

Part of the S110 pay-down tracked by the committed-ceiling budget in #10007; sibling cluster PRs cover `server`, `integration`, `chaos` and two tails. After they land, one `--tighten` run lowers the ceilings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
