### PR TITLE
fix(automation): block issue creation when queue checks fail

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -19,6 +19,7 @@ import json
 import subprocess
 import sys
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -45,7 +46,8 @@ _GENERIC_PARENT_PHRASES: tuple[str, ...] = (
     "supporting tests",
     "think about it",
 )
-_OPEN_ISSUE_LIMIT = 500
+_OPEN_ISSUE_PAGE_SIZE = 100
+_OPEN_ISSUE_MAX_PAGES = 10
 _OPEN_PR_PAGE_SIZE = 100
 _OPEN_PR_MAX_PAGES = 10
 _OPEN_PR_FILES_PAGE_SIZE = 100
@@ -67,6 +69,52 @@ class DecompositionTelemetry:
     children_emitted: int = 0
     children_rejected: int = 0
     sanitizer_rejections: int = 0
+
+
+class _AdmissionError(RuntimeError):
+    """A required queue observation is unavailable or incomplete."""
+
+    def __init__(self, stage: str, reason: str) -> None:
+        self.stage = stage
+        self.reason = reason
+        super().__init__(f"{stage}: {reason}")
+
+
+def _github_json(stage: str, endpoint: str, *fields: str) -> object:
+    command = ["gh", "api", "--method", "GET", endpoint]
+    for field in fields:
+        command.extend(["-f", field])
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=30)
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise _AdmissionError(stage, f"{type(exc).__name__}: {exc}") from exc
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()[:200]
+        raise _AdmissionError(stage, f"gh failed rc={result.returncode} stderr={stderr!r}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise _AdmissionError(stage, f"invalid JSON: {exc}") from exc
+
+
+def _github_pages(endpoint: str, *, stage: str, page_size: int, max_pages: int) -> Iterator[dict]:
+    separator = "&" if "?" in endpoint else "?"
+    for page in range(1, max_pages + 1):
+        page_stage = f"{stage} page {page}"
+        payload = _github_json(page_stage, f"{endpoint}{separator}per_page={page_size}&page={page}")
+        if not isinstance(payload, list) or len(payload) > page_size:
+            raise _AdmissionError(page_stage, "expected a bounded list of records")
+        for record in payload:
+            if not isinstance(record, dict):
+                raise _AdmissionError(page_stage, "expected an object record")
+            yield record
+        if len(payload) < page_size:
+            return
+    raise _AdmissionError(stage, f"pagination exceeded configured cap ({max_pages} pages)")
+
+
+def _valid_count(value: object) -> bool:
+    return type(value) is int and value >= 0
 
 
 def format_boss_ready_body(candidate: BossIssueCandidate) -> str:
@@ -130,106 +178,56 @@ def format_boss_ready_body(candidate: BossIssueCandidate) -> str:
 
 def fetch_existing_boss_issues(repo: str) -> list[dict]:
     """Fetch open generated issues from GitHub, regardless of current labels."""
-    try:
-        result = subprocess.run(
-            [
-                "gh",
-                "issue",
-                "list",
-                "--repo",
-                repo,
-                "--state",
-                "open",
-                "--limit",
-                str(_OPEN_ISSUE_LIMIT),
-                "--json",
-                "number,title,body",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode == 0:
-            payload = json.loads(result.stdout or "[]")
-            if isinstance(payload, list):
-                return [
-                    issue
-                    for issue in payload
-                    if isinstance(issue, dict) and "<!-- fingerprint:" in (issue.get("body") or "")
-                ]
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
-        pass
-    return []
+    issues: list[dict] = []
+    for issue in _github_pages(
+        f"repos/{repo}/issues?state=open",
+        stage="open issues",
+        page_size=_OPEN_ISSUE_PAGE_SIZE,
+        max_pages=_OPEN_ISSUE_MAX_PAGES,
+    ):
+        number = issue.get("number")
+        if (
+            not _valid_count(number)
+            or number == 0
+            or not isinstance(issue.get("title"), str)
+            or "body" not in issue
+            or (issue["body"] is not None and not isinstance(issue["body"], str))
+        ):
+            raise _AdmissionError("open issues", "malformed issue number/title/body")
+        # The REST issues endpoint also includes PRs; they are checked separately.
+        if "pull_request" in issue:
+            if not isinstance(issue["pull_request"], dict):
+                raise _AdmissionError("open issues", "malformed pull_request marker")
+            continue
+        if "<!-- fingerprint:" in (issue["body"] or ""):
+            issues.append(issue)
+    return issues
 
 
 def fetch_open_pr_files(repo: str) -> set[str]:
     """Fetch file paths changed in open PRs."""
-    try:
-        files: set[str] = set()
-        for page in range(1, _OPEN_PR_MAX_PAGES + 1):
-            prs_result = subprocess.run(
-                [
-                    "gh",
-                    "api",
-                    f"repos/{repo}/pulls?state=open&per_page={_OPEN_PR_PAGE_SIZE}&page={page}",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if prs_result.returncode != 0:
-                return set()
-            prs = json.loads(prs_result.stdout or "[]")
-            if not isinstance(prs, list):
-                return set()
-            if not prs:
-                return files
-            for pr in prs:
-                if not isinstance(pr, dict):
-                    continue
-                number = pr.get("number")
-                if not isinstance(number, int):
-                    continue
-                for files_page in range(1, _OPEN_PR_FILES_MAX_PAGES + 1):
-                    files_result = subprocess.run(
-                        [
-                            "gh",
-                            "api",
-                            (
-                                f"repos/{repo}/pulls/{number}/files"
-                                f"?per_page={_OPEN_PR_FILES_PAGE_SIZE}&page={files_page}"
-                            ),
-                        ],
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
-                    )
-                    if files_result.returncode != 0:
-                        return set()
-                    payload = json.loads(files_result.stdout or "[]")
-                    if not isinstance(payload, list):
-                        return set()
-                    if not payload:
-                        break
-                    for item in payload:
-                        path = item.get("filename", "") if isinstance(item, dict) else str(item)
-                        if path:
-                            files.add(path)
-                    if len(payload) < _OPEN_PR_FILES_PAGE_SIZE:
-                        break
-                else:
-                    raise RuntimeError(
-                        "open PR file pagination exceeded configured cap "
-                        f"({_OPEN_PR_FILES_MAX_PAGES} pages) for PR #{number}"
-                    )
-            if len(prs) < _OPEN_PR_PAGE_SIZE:
-                return files
-        raise RuntimeError(
-            f"open PR pagination exceeded configured cap ({_OPEN_PR_MAX_PAGES} pages) for {repo}"
-        )
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
-        pass
-    return set()
+    files: set[str] = set()
+    for pr in _github_pages(
+        f"repos/{repo}/pulls?state=open",
+        stage="open PRs",
+        page_size=_OPEN_PR_PAGE_SIZE,
+        max_pages=_OPEN_PR_MAX_PAGES,
+    ):
+        number = pr.get("number")
+        if not _valid_count(number) or number == 0:
+            raise _AdmissionError("open PRs", "malformed PR number")
+        stage = f"open PR #{number} files"
+        for item in _github_pages(
+            f"repos/{repo}/pulls/{number}/files",
+            stage=stage,
+            page_size=_OPEN_PR_FILES_PAGE_SIZE,
+            max_pages=_OPEN_PR_FILES_MAX_PAGES,
+        ):
+            path = item.get("filename")
+            if not isinstance(path, str) or not path.strip():
+                raise _AdmissionError(stage, "malformed filename")
+            files.add(path)
+    return files
 
 
 def _normalize_tokens(text: str) -> set[str]:
@@ -509,59 +507,27 @@ def apply_net_closure_floor(
     )
 
 
-def _search_issue_total(repo: str, qualifier: str) -> int | None:
-    """Return the total_count of a GitHub issue search, or None on failure.
-
-    Failures are reported (never silent): the underlying gh exit code /
-    stderr / parse error is printed so a fail-open closure floor is always
-    attributable to a concrete cause.
-    """
+def _search_issue_total(repo: str, qualifier: str) -> int:
+    """Return a verified count, rejecting failed or incomplete searches."""
     query = f"repo:{repo} type:issue {qualifier}"
-    try:
-        result = subprocess.run(
-            [
-                "gh",
-                "api",
-                "-X",
-                "GET",
-                "search/issues",
-                "-f",
-                f"q={query}",
-                "-f",
-                "per_page=1",
-                "--jq",
-                ".total_count",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode == 0:
-            return int(result.stdout.strip() or "0")
-        stderr = (result.stderr or "").strip()
-        print(
-            f"  gh search failed for {qualifier!r}: rc={result.returncode} stderr={stderr[:200]!r}"
-        )
-    except (subprocess.TimeoutExpired, OSError, ValueError) as exc:
-        print(f"  gh search failed for {qualifier!r}: {type(exc).__name__}: {exc}")
-    return None
+    stage = f"closure counts ({qualifier})"
+    payload = _github_json(stage, "search/issues", f"q={query}", "per_page=1")
+    if not isinstance(payload, dict) or not _valid_count(payload.get("total_count")):
+        raise _AdmissionError(stage, "missing or invalid total_count")
+    if payload.get("incomplete_results") is not False:
+        raise _AdmissionError(stage, "search completeness unverified (incomplete_results)")
+    return payload["total_count"]
 
 
-def fetch_closure_counts_7d(repo: str) -> tuple[int, int] | None:
-    """Fetch (created_7d, closed_7d) issue counts via the gh REST search API.
-
-    Returns None when either count is unavailable so the caller can fail open
-    with an explicit report instead of throttling on bad data.
-    """
+def fetch_closure_counts_7d(repo: str) -> tuple[int, int]:
+    """Fetch complete (created_7d, closed_7d) counts or block admission."""
     since = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%d")
     created = _search_issue_total(repo, f"created:>={since}")
     closed = _search_issue_total(repo, f"closed:>={since}")
-    if created is None or closed is None:
-        return None
     return created, closed
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(
         description="Generate boss-ready GitHub issues by scanning the codebase"
     )
@@ -672,15 +638,15 @@ def main() -> None:
 
     # 2. Deduplicate against existing issues (always fetch, even in dry-run)
     print("Fetching existing boss-ready issues...")
-    existing = fetch_existing_boss_issues(args.repo)
-    print(f"  {len(existing)} existing issues")
-
-    # 3. Check PR conflicts (always fetch, even in dry-run)
-    print("Fetching open PR files...")
     try:
+        existing = fetch_existing_boss_issues(args.repo)
+        print(f"  {len(existing)} existing issues")
+
+        # 3. Check PR conflicts (always fetch, even in dry-run)
+        print("Fetching open PR files...")
         pr_files = fetch_open_pr_files(args.repo)
-    except RuntimeError as exc:
-        print(f"Error: {exc}")
+    except _AdmissionError as exc:
+        print(f"BLOCKED: {exc}; 0 issues created")
         return 1
     print(f"  {len(pr_files)} files in open PRs")
 
@@ -762,30 +728,29 @@ def main() -> None:
     # the trailing-7d closed:created ratio falls below the floor.
     created_7d = args.created_7d
     closed_7d = args.closed_7d
-    counts_available = True
-    if args.closure_floor > 0 and (created_7d is None or closed_7d is None):
-        counts = fetch_closure_counts_7d(args.repo)
-        if counts is None:
-            counts_available = False
-            print(
-                f"  Closure floor {args.closure_floor:g}: 7d issue counts "
-                "unavailable (gh search failed); floor NOT applied "
-                f"(fail-open, allowed={args.max_issues})"
-            )
-        else:
-            if created_7d is None:
-                created_7d = counts[0]
-            if closed_7d is None:
-                closed_7d = counts[1]
-    if counts_available:
-        allowed, closure_reason = apply_net_closure_floor(
-            args.max_issues, created_7d or 0, closed_7d or 0, args.closure_floor
-        )
-        print(f"  {closure_reason}")
-        if allowed < len(to_create):
-            # Re-apply the substrate cap at the throttled budget so the
-            # cap's composition is preserved while the total shrinks.
-            to_create, _ = select_with_substrate_cap(to_create, allowed, effective_substrate_cap)
+    try:
+        if args.closure_floor > 0:
+            if created_7d is None or closed_7d is None:
+                counts = fetch_closure_counts_7d(args.repo)
+                if counts is None:
+                    raise _AdmissionError("closure counts", "7d issue counts unavailable")
+                if created_7d is None:
+                    created_7d = counts[0]
+                if closed_7d is None:
+                    closed_7d = counts[1]
+            if not _valid_count(created_7d) or not _valid_count(closed_7d):
+                raise _AdmissionError("closure counts", "counts must be non-negative integers")
+    except _AdmissionError as exc:
+        print(f"BLOCKED: {exc}; 0 issues created")
+        return 1
+    allowed, closure_reason = apply_net_closure_floor(
+        args.max_issues, created_7d or 0, closed_7d or 0, args.closure_floor
+    )
+    print(f"  {closure_reason}")
+    if allowed < len(to_create):
+        # Re-apply the substrate cap at the throttled budget so the
+        # cap's composition is preserved while the total shrinks.
+        to_create, _ = select_with_substrate_cap(to_create, allowed, effective_substrate_cap)
 
     # 6. Create or dry-run
     if args.dry_run:
@@ -824,7 +789,8 @@ def main() -> None:
             time.sleep(1)  # Rate limit safety
 
         print(f"\nDone: {created} created, {failed} failed")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 from aragora.swarm.issue_scanner import BossIssueCandidate
 from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
 from scripts import generate_boss_issues as mod
+
+_FETCH_CLOSURE_COUNTS_7D = mod.fetch_closure_counts_7d
 
 
 @pytest.fixture(autouse=True)
@@ -403,28 +407,23 @@ def test_fetch_existing_boss_issues_includes_fingerprinted_open_issues_without_l
     assert seen_cmds == [
         [
             "gh",
-            "issue",
-            "list",
-            "--repo",
-            "org/repo",
-            "--state",
-            "open",
-            "--limit",
-            str(mod._OPEN_ISSUE_LIMIT),
-            "--json",
-            "number,title,body",
+            "api",
+            "--method",
+            "GET",
+            "repos/org/repo/issues?state=open&per_page=100&page=1",
         ]
     ]
 
 
-def test_fetch_existing_boss_issues_returns_empty_on_invalid_payload(monkeypatch) -> None:
+def test_fetch_existing_boss_issues_blocks_on_invalid_payload(monkeypatch) -> None:
     monkeypatch.setattr(
         mod.subprocess,
         "run",
         lambda cmd, **_: SimpleNamespace(returncode=0, stdout=json.dumps({"items": []}), stderr=""),
     )
 
-    assert mod.fetch_existing_boss_issues("org/repo") == []
+    with pytest.raises(mod._AdmissionError, match="open issues page 1"):
+        mod.fetch_existing_boss_issues("org/repo")
 
 
 @pytest.mark.parametrize(
@@ -794,7 +793,7 @@ def test_fetch_open_pr_files_raises_when_open_pr_pagination_cap_exhausted(monkey
 
     monkeypatch.setattr(mod.subprocess, "run", fake_run)
 
-    with pytest.raises(RuntimeError, match="open PR pagination exceeded configured cap"):
+    with pytest.raises(mod._AdmissionError, match="open PRs: pagination exceeded configured cap"):
         mod.fetch_open_pr_files("org/repo")
 
 
@@ -823,7 +822,7 @@ def test_fetch_open_pr_files_raises_when_pr_files_pagination_cap_exhausted(monke
 
     monkeypatch.setattr(mod.subprocess, "run", fake_run)
 
-    with pytest.raises(RuntimeError, match="open PR file pagination exceeded configured cap"):
+    with pytest.raises(mod._AdmissionError, match="open PR #101 files: pagination exceeded"):
         mod.fetch_open_pr_files("org/repo")
 
 
@@ -836,14 +835,14 @@ def test_main_returns_error_when_open_pr_pagination_exhausted(monkeypatch, capsy
     monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
 
     def raise_pagination_error(repo: str) -> set[str]:
-        raise RuntimeError("open PR pagination exceeded configured cap (10 pages) for org/repo")
+        raise mod._AdmissionError("open PRs", "pagination exceeded configured cap (10 pages)")
 
     monkeypatch.setattr(mod, "fetch_open_pr_files", raise_pagination_error)
     monkeypatch.setattr(sys, "argv", ["generate_boss_issues.py", "--repo", "org/repo"])
 
     assert mod.main() == 1
     out = capsys.readouterr().out
-    assert "Error: open PR pagination exceeded configured cap (10 pages) for org/repo" in out
+    assert "BLOCKED: open PRs: pagination exceeded configured cap (10 pages)" in out
 
 
 def test_create_github_issue_passes_extra_labels_as_repeated_flags(monkeypatch) -> None:
@@ -1216,7 +1215,7 @@ class TestClosureFloorMainWiring:
         assert "would create 3 issues" in out
         assert "created_7d=10" in out and "closed_7d=10" in out
 
-    def test_counts_unavailable_fails_open_with_report(self, monkeypatch, capsys) -> None:
+    def test_counts_unavailable_blocks_with_report(self, monkeypatch, capsys) -> None:
         self._patch_pipeline(monkeypatch, self._eligible(3))
         monkeypatch.setattr(mod, "fetch_closure_counts_7d", lambda repo: None)
         monkeypatch.setattr(
@@ -1235,10 +1234,11 @@ class TestClosureFloorMainWiring:
                 "0.25",
             ],
         )
-        mod.main()
+        assert mod.main() == 1
         out = capsys.readouterr().out
         assert "unavailable" in out.lower()
-        assert "would create 3 issues" in out
+        assert "BLOCKED:" in out
+        assert "would create" not in out
 
     def test_partial_throttle_preserves_substrate_cap_composition(
         self, monkeypatch, capsys
@@ -1285,24 +1285,222 @@ class TestSearchIssueTotalFailureReporting:
     """gh search failures are reported with cause, never swallowed silently
     (grok review task 3 on PR #8148)."""
 
-    def test_nonzero_exit_reports_rc_and_stderr(self, monkeypatch, capsys) -> None:
+    def test_nonzero_exit_reports_rc_and_stderr(self, monkeypatch) -> None:
         monkeypatch.setattr(
             mod.subprocess,
             "run",
             lambda *a, **k: SimpleNamespace(returncode=4, stdout="", stderr="gh: API rate limit"),
         )
-        assert mod._search_issue_total("org/repo", "created:>=2026-06-03") is None
-        out = capsys.readouterr().out
-        assert "gh search failed" in out
-        assert "rc=4" in out
-        assert "rate limit" in out
+        with pytest.raises(mod._AdmissionError) as caught:
+            mod._search_issue_total("org/repo", "created:>=2026-06-03")
+        assert caught.value.stage == "closure counts (created:>=2026-06-03)"
+        assert "rc=4" in caught.value.reason
+        assert "rate limit" in caught.value.reason
 
-    def test_exception_reports_type_and_message(self, monkeypatch, capsys) -> None:
+    def test_exception_reports_type_and_message(self, monkeypatch) -> None:
         def _raise(*a, **k):
             raise OSError("gh not found")
 
         monkeypatch.setattr(mod.subprocess, "run", _raise)
-        assert mod._search_issue_total("org/repo", "closed:>=2026-06-03") is None
-        out = capsys.readouterr().out
-        assert "gh search failed" in out
-        assert "OSError" in out and "gh not found" in out
+        with pytest.raises(mod._AdmissionError, match="OSError: gh not found"):
+            mod._search_issue_total("org/repo", "closed:>=2026-06-03")
+
+
+def _response(payload: object) -> SimpleNamespace:
+    return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+@pytest.fixture
+def admission_pipeline(monkeypatch):
+    """Exercise real admission lookups with an otherwise eligible candidate."""
+    candidate = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
+    monkeypatch.setattr(mod, "scan_all", lambda *a, **kw: [candidate])
+    monkeypatch.setattr(mod, "format_boss_ready_body", lambda c: "valid body")
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda root: None)
+    monkeypatch.setattr(mod, "fetch_closure_counts_7d", _FETCH_CLOSURE_COUNTS_7D)
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
+    create = Mock(return_value=True)
+    monkeypatch.setattr(mod, "create_github_issue", create)
+    return create
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+@pytest.mark.parametrize("stage", ["issues", "prs", "files", "created", "closed"])
+@pytest.mark.parametrize(
+    "failure", ["nonzero", "timeout", "oserror", "invalid_json", "empty", "shape", "record"]
+)
+def test_main_blocks_every_unavailable_input(
+    monkeypatch, capsys, admission_pipeline, stage, failure, dry_run
+) -> None:
+    def fake_run(cmd, **kwargs):
+        assert cmd[:4] == ["gh", "api", "--method", "GET"]
+        assert kwargs["timeout"] == 30
+        endpoint = cmd[4]
+        if "/issues?" in endpoint:
+            current, healthy = "issues", []
+        elif "/pulls?" in endpoint:
+            current, healthy = "prs", [{"number": 1}]
+        elif "/pulls/1/files?" in endpoint:
+            current, healthy = "files", [{"filename": "aragora/unrelated.py"}]
+        else:
+            assert endpoint == "search/issues"
+            current = "created" if "created:" in cmd[6] else "closed"
+            healthy = {"total_count": 1, "incomplete_results": False}
+        if current != stage:
+            return _response(healthy)
+        if failure == "nonzero":
+            return SimpleNamespace(returncode=1, stdout="[]", stderr="rate limit")
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired(cmd, 30)
+        if failure == "oserror":
+            raise OSError("gh unavailable")
+        if failure in {"invalid_json", "empty"}:
+            return SimpleNamespace(
+                returncode=0, stdout="{" if failure == "invalid_json" else "", stderr=""
+            )
+        if failure == "shape":
+            return _response(None)
+        malformed = {
+            "issues": [{"number": 1, "title": "title", "body": []}],
+            "prs": [{"number": True}],
+            "files": [{"filename": None}],
+            "created": {"total_count": True, "incomplete_results": False},
+            "closed": {"total_count": 1, "incomplete_results": True},
+        }
+        return _response(malformed[stage])
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate_boss_issues.py", "--label", "lane:test"] + (["--dry-run"] if dry_run else []),
+    )
+    assert mod.main() == 1
+    admission_pipeline.assert_not_called()
+    out = capsys.readouterr().out
+    assert "BLOCKED:" in out and "0 issues created" in out
+    assert "would create" not in out
+
+
+@pytest.mark.parametrize("stage", ["issues", "prs", "files"])
+@pytest.mark.parametrize("failure", ["later_page", "cap", "non_object"])
+def test_partial_inventory_never_admits_work(
+    monkeypatch, capsys, admission_pipeline, stage, failure
+) -> None:
+    monkeypatch.setattr(mod, "_OPEN_ISSUE_PAGE_SIZE", 1)
+    monkeypatch.setattr(mod, "_OPEN_PR_PAGE_SIZE", 1)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_PAGE_SIZE", 1)
+    monkeypatch.setattr(mod, "_OPEN_ISSUE_MAX_PAGES", 2)
+    monkeypatch.setattr(mod, "_OPEN_PR_MAX_PAGES", 2)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_MAX_PAGES", 2)
+    seen = []
+
+    def fake_run(cmd, **kwargs):
+        endpoint = cmd[-1]
+        seen.append(endpoint)
+        second_page = endpoint.endswith("page=2")
+        if "/issues?" in endpoint:
+            current = "issues"
+            record = {"number": 1, "title": "title", "body": "<!-- fingerprint:other -->"}
+        elif "/pulls?" in endpoint:
+            current, record = "prs", {"number": 2 if second_page else 1}
+        else:
+            current, record = "files", {"filename": "aragora/unrelated.py"}
+        if current == stage:
+            if failure == "later_page" and second_page:
+                raise subprocess.TimeoutExpired(cmd, 30)
+            if failure == "non_object":
+                return _response([None])
+            return _response([record])
+        return _response([] if second_page else [record])
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["generate_boss_issues.py", "--label", "lane:test"])
+    assert mod.main() == 1
+    admission_pipeline.assert_not_called()
+    assert "BLOCKED:" in capsys.readouterr().out
+    if failure != "non_object":
+        assert any(endpoint.endswith("page=2") for endpoint in seen)
+
+
+def test_issue_pagination_counts_prs_but_excludes_them_from_duplicates(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_OPEN_ISSUE_PAGE_SIZE", 2)
+    issue = {"number": 1, "title": "title", "body": "<!-- fingerprint:abc -->"}
+    pages = [
+        [issue, dict(issue, number=2, pull_request={"url": "https://api.github.com/pulls/2"})],
+        [dict(issue, number=3, body=None), dict(issue, number=4)],
+        [],
+    ]
+    run = Mock(side_effect=[_response(page) for page in pages])
+    monkeypatch.setattr(mod.subprocess, "run", run)
+    assert mod.fetch_existing_boss_issues("org/repo") == [issue, dict(issue, number=4)]
+    assert run.call_count == 3
+    assert run.call_args.args[0][-1].endswith("page=3")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"total_count": -1, "incomplete_results": False},
+        {"total_count": "0", "incomplete_results": False},
+        {"total_count": 1.5, "incomplete_results": False},
+        {"total_count": 0},
+        {"total_count": 0, "incomplete_results": "false"},
+        {"total_count": 0, "incomplete_results": 0},
+    ],
+)
+def test_search_rejects_unverified_counts(monkeypatch, payload) -> None:
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **kw: _response(payload))
+    with pytest.raises(mod._AdmissionError, match="closure counts"):
+        mod._search_issue_total("org/repo", "created:>=2026-09-01")
+
+
+@pytest.mark.parametrize("count", [0, 1234])
+def test_search_accepts_complete_counts(monkeypatch, count) -> None:
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *a, **kw: _response({"total_count": count, "incomplete_results": False}),
+    )
+    assert mod._search_issue_total("org/repo", "created:>=2026-09-01") == count
+
+
+@pytest.mark.parametrize(
+    "options", [[], ["--closure-floor", "0"], ["--created-7d", "1", "--closed-7d", "1"]]
+)
+def test_verified_empty_inventory_allows_same_candidate(
+    monkeypatch, admission_pipeline, options
+) -> None:
+    def fake_run(cmd, **kwargs):
+        if cmd[4] == "search/issues":
+            assert not options, "disabled floor or explicit overrides must skip search"
+            return _response({"total_count": 1, "incomplete_results": False})
+        return _response([])
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["generate_boss_issues.py", "--label", "lane:test", *options])
+    assert mod.main() == 0
+    admission_pipeline.assert_called_once()
+    assert admission_pipeline.call_args.args[1] == "Add tests for eligible_module"
+
+
+def test_executable_propagates_admission_failure() -> None:
+    # Run the actual __main__ block in a child; all inventory I/O is mocked there.
+    code = """
+import runpy
+import subprocess
+import sys
+from unittest.mock import patch
+
+with patch('aragora.swarm.issue_scanner.scan_all', return_value=[]), \\
+     patch('subprocess.run', side_effect=subprocess.TimeoutExpired('gh', 30)):
+    sys.argv = ['generate_boss_issues.py', '--dry-run']
+    runpy.run_path('scripts/generate_boss_issues.py', run_name='__main__')
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code], cwd=mod.REPO_ROOT, capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 1, result.stderr
+    assert "BLOCKED: open issues page 1: TimeoutExpired" in result.stdout
+    assert "would create" not in result.stdout

--- a/tests/scripts/test_run_boss_cycle.py
+++ b/tests/scripts/test_run_boss_cycle.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "run_boss_cycle.sh"
@@ -32,6 +33,9 @@ fi
 if [[ "${1:-}" == "-c" && "${2:-}" == *"${FAKE_PYTHON3_IMPORT_FAIL_PATTERN:-__never_match__}"* ]]; then
   exit "${FAKE_PYTHON3_IMPORT_FAIL_EXIT:-23}"
 fi
+if [[ "${1:-}" == "-c" ]]; then
+  exit 0
+fi
 exit "${FAKE_PYTHON3_REFILL_EXIT:-0}"
 """,
         encoding="utf-8",
@@ -50,16 +54,21 @@ def _runtime_calls(log_path: Path) -> list[list[str]]:
     return [call for call in _read_calls(log_path) if call[:1] != ["-c"]]
 
 
-def test_run_boss_cycle_runs_post_loop_refill_after_success(tmp_path: Path) -> None:
+@pytest.mark.parametrize("refill_exit", [0, 1])
+def test_run_boss_cycle_propagates_post_loop_refill_status(
+    tmp_path: Path, refill_exit: int
+) -> None:
     _fake_python3, log_path = _write_fake_python3(tmp_path)
     env = os.environ.copy()
     env["PATH"] = f"{tmp_path}:/usr/bin:/bin:/usr/sbin:/sbin"
     env["FAKE_PYTHON3_LOG"] = str(log_path)
     env["FAKE_PYTHON3_BOSS_EXIT"] = "0"
-    env["FAKE_PYTHON3_REFILL_EXIT"] = "0"
+    env["FAKE_PYTHON3_REFILL_EXIT"] = str(refill_exit)
     env["ARAGORA_POST_LOOP_DRY_RUN"] = "1"
     env["ARAGORA_POST_LOOP_MAX_ISSUES"] = "7"
     env["ARAGORA_POST_LOOP_ISSUE_REFILL"] = "1"
+    env["ARAGORA_SUBSTRATE_CAP"] = "0.3"
+    env["ARAGORA_CLOSURE_FLOOR"] = "0.25"
 
     result = subprocess.run(
         [
@@ -79,7 +88,7 @@ def test_run_boss_cycle_runs_post_loop_refill_after_success(tmp_path: Path) -> N
         check=False,
     )
 
-    assert result.returncode == 0
+    assert result.returncode == refill_exit
     calls = _runtime_calls(log_path)
     assert len(calls) == 2
     assert calls[0][:5] == ["-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
@@ -93,6 +102,10 @@ def test_run_boss_cycle_runs_post_loop_refill_after_success(tmp_path: Path) -> N
         "7",
         "--label",
         "lane:test",
+        "--substrate-cap",
+        "0.3",
+        "--closure-floor",
+        "0.25",
         "--dry-run",
     ]
 


### PR DESCRIPTION
## Summary

- Stop issue generation when required GitHub issue, PR, PR-file, or closure-count observations are unavailable or incomplete. Previously a failed lookup looked like an empty queue, and unavailable closure counts left admission enabled.
- Replace the fixed 500-issue sample with bounded REST pagination (100 entries/page, 10 pages). Reject failed requests, invalid JSON/records, incomplete searches, and unproven pagination completion with a stage-specific `BLOCKED` report and exit 1, including preview mode.
- Keep existing candidate selection, duplicate matching, priorities, substrate caps, valid count overrides, and `--closure-floor 0`. No workflow, schedule, review-policy, merge, evidence, or settlement changes.

## Scope and Risk

Prepared under the operator-approved "Stop Creating Work When Queue Checks Fail" plan. Expected Tier 2: live automation/CLI behavior; draft only, not merge authorization.

Production changes are confined to `scripts/generate_boss_issues.py`. Tests cover the generator plus `run_boss_cycle.sh` exit propagation. The caller test's stale expected arguments were aligned with the existing closure-floor/substrate-cap flags; the shell script itself is unchanged.

The REST issues endpoint includes PR rows: those consume the pagination budget but are excluded from the generated-issue duplicate set and checked separately through PR files. A full tenth page blocks rather than assuming completion. This deliberately stops generation on queues too large to prove complete within the configured budget.

## Validation

Base: `20cd29a930fcd35327eefa0a8f3ec7858e5d4896`.
Head: `b24e2ae6ff4680c09603ad390f672fc537a9a15b`.

```text
python3 -m pytest -q tests/scripts/test_generate_boss_issues.py tests/scripts/test_run_boss_cycle.py
141 passed, 7 pre-existing deprecation warnings in 4.14s

python3 -m ruff check scripts/generate_boss_issues.py tests/scripts/test_generate_boss_issues.py tests/scripts/test_run_boss_cycle.py
All checks passed!

git diff --check origin/main...HEAD
Passed

bash scripts/automation_pr_preflight.sh --json origin/main HEAD
status=ok; source_without_tests=false; forbidden_files=[]

Pre-commit hooks: passed without bypasses.
Pre-push hooks: passed without bypasses.
```

The failure matrix mocks GitHub and asserts zero creation calls for both normal and preview admission. It covers all five lookup stages, timeout/process/JSON/record failures, failure after a successful page, and page caps. Additional tests cover complete counts, empty/populated inventories, REST PR exclusion, overrides/disabled floor, the real Python `__main__` exit status in a subprocess, and shell caller exit propagation. Healthy-input selection/filtering tests remain in place. No full-repo test-suite claim is made.

## Single Live Preview

Ran once from the isolated branch checkout, with the existing shared-root backpressure signal read-only:

```text
python3 scripts/generate_boss_issues.py --dry-run --max-issues 1 \
  --backpressure-signal-file /Users/armand/Development/aragora/.aragora/backpressure.json

Found 66 candidates across 5 categories
Fetching existing boss-ready issues...
BLOCKED: open issues: pagination exceeded configured cap (10 pages); 0 issues created
exit=1 duration_s=12.04
```

No live issue creation was run. Preview proved the currently oversized inventory is no longer silently sampled and treated as sufficient deduplication proof.

## Limits and Follow-up

This prevents unavailable-input admission; it does not provide a transactional queue snapshot or race-free/idempotent creation across concurrent publishers. Historical duplicate creation is not attributed solely to this bug. Measure subsequent duplicate creation and cleanup effort after landing before selecting another repair. Strategy-consult frequency, deterministic-proof reuse, and low-risk review policy remain separate decisions. No existing model-refresh/readiness work is duplicated.
