### PR TITLE
fix(automation): prove terminal lane branch preservation

### DIFF
--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -2050,6 +2050,18 @@ def build_worktree_reference_preservation_proof(
             "worktree_inspections": inspections,
         }
 
+    if clean_worktrees:
+        # A merged historical head does not preserve a present worktree's current tip.
+        return {
+            "available": False,
+            "reason": "remote_branch_missing_for_present_worktree",
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "remote": remote,
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+        }
+
     merged_pr = _merged_pr_commit_list_proof(desired_head, repo_root=repo_root, runner=runner)
     if merged_pr.get("proven") is True:
         return {

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -1513,7 +1513,7 @@ def _proof_covers_worktree_paths(
     proof: dict[str, Any] | None,
     paths: list[tuple[str, str]],
 ) -> bool:
-    if not _proof_has_upstream_preservation(proof):
+    if proof is None or not _proof_has_upstream_preservation(proof):
         return False
     proven_paths = {str(path) for path in proof.get("worktree_paths") or []}
     return all(path in proven_paths for _, path in paths)
@@ -1678,6 +1678,32 @@ def _remote_branch_head(
     return {"status": "exists", "head_sha": head}
 
 
+def _local_branch_head(
+    branch: str,
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    """Return the local branch tip without resolving or changing the worktree."""
+
+    try:
+        proc = runner(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+            repo_root,
+            _PRESERVATION_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "lookup_failed", "reason": str(exc)}
+    if proc.returncode == 1 and not (proc.stdout or "").strip():
+        return {"status": "missing"}
+    if proc.returncode != 0:
+        return {"status": "lookup_failed", "reason": proc.stderr.strip()}
+    head = (proc.stdout or "").strip()
+    if not _SHA_RE.fullmatch(head):
+        return {"status": "lookup_failed", "reason": "unexpected rev-parse output"}
+    return {"status": "exists", "head_sha": head}
+
+
 def _repo_slug_from_origin(repo_root: Path, *, runner: CommandRunner) -> str | None:
     try:
         proc = runner(
@@ -1822,10 +1848,10 @@ def build_worktree_reference_preservation_proof(
     Fail closed unless the recorded worktree is absent/noop by
     ``safe_worktree_cleanup.py inspect`` and either the desired head is
     preserved upstream by an exact remote branch or merged PR commit
-    list. A terminal no-record lane with a remote branch anchor remains
-    visible in the returned proof, but it is not proven preservation and
-    cannot discount a possible local worktree tip. Dirty/local-work
-    markers are never discounted.
+    list. For a terminal no-record lane, an absent registered worktree plus
+    a remote branch is sufficient only when the corresponding local branch
+    is absent or has the exact same tip. A divergent local branch, lookup
+    failure, or dirty/local-work marker remains blocking.
     """
 
     paths = _worktree_reference_paths(lane, ledger_entry)
@@ -1876,6 +1902,32 @@ def build_worktree_reference_preservation_proof(
             and lane_status.strip().lower() in TERMINAL_LANE_STATUSES
         ):
             remote_head = remote.get("head_sha")
+            local = _local_branch_head(branch, repo_root=repo_root, runner=runner)
+            if local.get("status") == "lookup_failed":
+                return {
+                    "available": False,
+                    "reason": "local_branch_lookup_failed",
+                    "branch": branch,
+                    "remote": remote,
+                    "local": local,
+                    "worktree_paths": [path for _, path in paths],
+                    "worktree_inspections": inspections,
+                }
+            if local.get("status") == "exists" and local.get("head_sha") != remote_head:
+                return {
+                    "available": False,
+                    "reason": "local_remote_branch_head_mismatch",
+                    "branch": branch,
+                    "remote": remote,
+                    "local": local,
+                    "worktree_paths": [path for _, path in paths],
+                    "worktree_inspections": inspections,
+                }
+            method = (
+                "remote_branch_matches_local_branch_no_record"
+                if local.get("status") == "exists"
+                else "remote_branch_only_no_local_record"
+            )
             return {
                 "available": True,
                 "branch": branch,
@@ -1884,11 +1936,14 @@ def build_worktree_reference_preservation_proof(
                 "lane_status": lane_status.strip().lower(),
                 "worktree_paths": [path for _, path in paths],
                 "worktree_inspections": inspections,
+                "local_branch": local,
                 "upstream_preservation": {
-                    "proven": False,
-                    "method": "remote_branch_anchor_no_local_record",
+                    "proven": True,
+                    "method": method,
                     "remote_head_sha": remote_head,
-                    "scope": "remote branch anchors the terminal lane but does not prove an unknown local tip",
+                    "scope": (
+                        "registered worktree is absent and no divergent local branch tip exists"
+                    ),
                 },
             }
         return {
@@ -2138,16 +2193,10 @@ def assess_owner_liveness(
                 method = (
                     (local_work_preservation or {}).get("upstream_preservation", {}).get("method")
                 )
-                if method == "remote_branch_anchor_no_local_record":
-                    conditions.append(
-                        "recorded worktree reference is absent/noop; no local-work claim "
-                        "or desired head was recorded; terminal lane branch still exists remotely"
-                    )
-                else:
-                    conditions.append(
-                        "recorded worktree reference is absent/noop and preserved upstream"
-                        + (f" via {method}" if method else "")
-                    )
+                conditions.append(
+                    "recorded worktree reference is absent/noop and preserved upstream"
+                    + (f" via {method}" if method else "")
+                )
             else:
                 conditions.append("no worktree or local-work claim on the owner record")
             advisory = {

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -1563,16 +1563,34 @@ def _safe_worktree_absent_noop_proof(
         and "missing_path" in blockers
         and classification == "absent_noop"
     )
+    clean_inactive = (
+        payload.get("exists") is True
+        and payload.get("tracked_worktree") is True
+        and payload.get("dirty") is False
+        and payload.get("active_session") is False
+        and bool(str(payload.get("branch") or "").strip())
+    )
     if absent_noop:
         return {
             "path": path,
             "absent_noop": True,
+            "clean_inactive": False,
+            "source": "safe_worktree_cleanup.inspect",
+            "classification": classification,
+        }
+    if clean_inactive:
+        return {
+            "path": path,
+            "absent_noop": False,
+            "clean_inactive": True,
+            "branch": str(payload["branch"]).strip(),
             "source": "safe_worktree_cleanup.inspect",
             "classification": classification,
         }
     return {
         "path": path,
         "absent_noop": False,
+        "clean_inactive": False,
         "reason": "worktree_not_absent_noop",
         "exists": payload.get("exists"),
         "classification": classification,
@@ -1845,13 +1863,13 @@ def build_worktree_reference_preservation_proof(
 ) -> dict[str, Any] | None:
     """Prove a bare worktree reference is not evidence of local-only work.
 
-    Fail closed unless the recorded worktree is absent/noop by
-    ``safe_worktree_cleanup.py inspect`` and either the desired head is
-    preserved upstream by an exact remote branch or merged PR commit
-    list. For a terminal no-record lane, an absent registered worktree plus
-    a remote branch is sufficient only when the corresponding local branch
-    is absent or has the exact same tip. A divergent local branch, lookup
-    failure, or dirty/local-work marker remains blocking.
+    Fail closed unless ``safe_worktree_cleanup.py inspect`` reports each
+    recorded worktree absent/noop or clean, inactive, and on the recorded
+    branch, and the corresponding commit is preserved upstream. For a
+    terminal no-record lane, the remote branch is sufficient only when the
+    local branch is absent or has the exact same tip. A present clean
+    worktree additionally requires exact local/remote branch equality.
+    Divergence, lookup failure, or dirty/local-work markers remain blocking.
     """
 
     paths = _worktree_reference_paths(lane, ledger_entry)
@@ -1875,7 +1893,10 @@ def build_worktree_reference_preservation_proof(
         _safe_worktree_absent_noop_proof(path, repo_root=repo_root, runner=runner)
         for _, path in paths
     ]
-    if not all(item.get("absent_noop") is True for item in inspections):
+    if not all(
+        item.get("absent_noop") is True or item.get("clean_inactive") is True
+        for item in inspections
+    ):
         return {
             "available": False,
             "reason": "worktree_not_absent_noop",
@@ -1891,6 +1912,15 @@ def build_worktree_reference_preservation_proof(
         return {
             "available": False,
             "reason": "branch_unavailable",
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+        }
+    clean_worktrees = [item for item in inspections if item.get("clean_inactive") is True]
+    if any(item.get("branch") != branch for item in clean_worktrees):
+        return {
+            "available": False,
+            "reason": "worktree_branch_mismatch",
+            "branch": branch,
             "worktree_paths": [path for _, path in paths],
             "worktree_inspections": inspections,
         }
@@ -1923,8 +1953,20 @@ def build_worktree_reference_preservation_proof(
                     "worktree_paths": [path for _, path in paths],
                     "worktree_inspections": inspections,
                 }
+            if clean_worktrees and local.get("status") != "exists":
+                return {
+                    "available": False,
+                    "reason": "local_branch_missing_for_present_worktree",
+                    "branch": branch,
+                    "remote": remote,
+                    "local": local,
+                    "worktree_paths": [path for _, path in paths],
+                    "worktree_inspections": inspections,
+                }
             method = (
-                "remote_branch_matches_local_branch_no_record"
+                "remote_branch_matches_clean_worktree_no_record"
+                if clean_worktrees
+                else "remote_branch_matches_local_branch_no_record"
                 if local.get("status") == "exists"
                 else "remote_branch_only_no_local_record"
             )
@@ -1961,6 +2003,19 @@ def build_worktree_reference_preservation_proof(
 
     remote = _remote_branch_head(branch, repo_root=repo_root, runner=runner)
     if remote.get("status") == "exists":
+        if clean_worktrees:
+            local = _local_branch_head(branch, repo_root=repo_root, runner=runner)
+            if local.get("status") != "exists" or local.get("head_sha") != remote.get("head_sha"):
+                return {
+                    "available": False,
+                    "reason": "clean_worktree_branch_not_preserved",
+                    "branch": branch,
+                    "desired_head_sha": desired_head,
+                    "remote": remote,
+                    "local": local,
+                    "worktree_paths": [path for _, path in paths],
+                    "worktree_inspections": inspections,
+                }
         if remote.get("head_sha") == desired_head:
             return {
                 "available": True,

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -285,18 +285,18 @@ def _worktree_is_dirty(path: Path) -> bool:
         return False
     try:
         proc = subprocess.run(
-            ["git", "status", "--short"],
+            ["git", "status", "--porcelain", "--untracked-files=all"],
             cwd=path,
             text=True,
             capture_output=True,
             check=False,
             timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
         )
-    except subprocess.TimeoutExpired:
-        # Conservatively treat status timeouts as dirty so cleanup is blocked.
+    except (OSError, subprocess.TimeoutExpired):
+        # A failed inspection is not evidence that local work is absent.
         return True
     if proc.returncode != 0:
-        return False
+        return True
     return bool(proc.stdout.strip())
 
 

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1319,14 +1319,21 @@ def completed(
     return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
 
 
-def safe_inspect_payload(*, exists: bool) -> str:
+def safe_inspect_payload(
+    *,
+    exists: bool,
+    branch: str | None = None,
+    dirty: bool = False,
+    active_session: bool = False,
+) -> str:
     blockers = [] if exists else ["missing_path"]
     return json.dumps(
         {
             "exists": exists,
             "tracked_worktree": exists,
-            "active_session": False,
-            "dirty": False,
+            "branch": branch,
+            "active_session": active_session,
+            "dirty": dirty,
             "blockers": blockers,
             "cleanup_safety": {
                 "classification": "cleanup_candidate" if exists else "absent_noop",
@@ -2406,6 +2413,107 @@ class TestWorktreeReferencePreservationProof:
         assert proof["available"] is False
         assert proof["reason"] == "worktree_not_absent_noop"
         assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] == "possible_unpushed_work"
+
+    def test_clean_inactive_terminal_worktree_exact_remote_branch_is_reassignable(
+        self, tmp_path: Path
+    ) -> None:
+        branch_sha = "abababababababababababababababababababab"
+        branch = "codex/no-local-record-clean-present"
+        lane = {
+            "lane_id": "Q-no-local-record-clean-present",
+            "owner_session": "codex-no-local-record-clean-present",
+            "branch": branch,
+            "worktree": str(tmp_path / "present-no-local-record-clean"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "completed",
+            "launched_at": _hours_ago(7.0),
+        }
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(
+                    cmd,
+                    stdout=safe_inspect_payload(exists=True, branch=branch),
+                    returncode=1,
+                )
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                return completed(cmd, stdout=f"{branch_sha}\trefs/heads/{branch}\n")
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return completed(cmd, stdout=f"{branch_sha}\n")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+
+        assert proof["upstream_preservation"]["proven"] is True
+        assert (
+            proof["upstream_preservation"]["method"]
+            == "remote_branch_matches_clean_worktree_no_record"
+        )
+        assert proof["worktree_inspections"][0]["clean_inactive"] is True
+        assert result["owner_blocking_state"] == "stale_terminal_owner"
+        assert result["advisory_withheld"] is None
+
+    def test_dirty_terminal_worktree_still_withholds(self, tmp_path: Path) -> None:
+        branch = "codex/no-local-record-dirty-present"
+        lane = {
+            "lane_id": "Q-no-local-record-dirty-present",
+            "owner_session": "codex-no-local-record-dirty-present",
+            "branch": branch,
+            "worktree": str(tmp_path / "present-no-local-record-dirty"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "completed",
+            "launched_at": _hours_ago(7.0),
+        }
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(
+                    cmd,
+                    stdout=safe_inspect_payload(exists=True, branch=branch, dirty=True),
+                    returncode=1,
+                )
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+
+        assert proof["available"] is False
+        assert proof["reason"] == "worktree_not_absent_noop"
+        assert result["owner_blocking_state"] == "stale_owner"
         assert result["advisory_withheld"] == "possible_unpushed_work"
 
     def test_q379_absent_worktree_merged_pr_commit_yields_advisory_when_remote_gone(

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1970,7 +1970,7 @@ class TestWorktreeReferencePreservationProof:
         assert result["stale_claim_advisory"]["available"] is True
         assert result["advisory_withheld"] is None
 
-    def test_absent_terminal_worktree_remote_branch_without_recorded_sha_still_withholds(
+    def test_absent_terminal_worktree_remote_branch_without_local_branch_is_reassignable(
         self, tmp_path: Path
     ) -> None:
         remote_sha = "dddddddddddddddddddddddddddddddddddddddd"
@@ -1994,6 +1994,8 @@ class TestWorktreeReferencePreservationProof:
                 return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
             if cmd[:3] == ["git", "ls-remote", "origin"]:
                 return completed(cmd, stdout=f"{remote_sha}\trefs/heads/{branch}\n")
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return completed(cmd, returncode=1)
             raise AssertionError(f"unexpected command: {cmd}")
 
         proof = ilo.build_worktree_reference_preservation_proof(
@@ -2015,11 +2017,13 @@ class TestWorktreeReferencePreservationProof:
         assert proof["desired_head_sha"] is None
         assert proof["desired_head_source"] == "not_recorded"
         assert proof["lane_status"] == "completed"
-        assert proof["upstream_preservation"]["proven"] is False
-        assert proof["upstream_preservation"]["method"] == "remote_branch_anchor_no_local_record"
+        assert proof["local_branch"]["status"] == "missing"
+        assert proof["upstream_preservation"]["proven"] is True
+        assert proof["upstream_preservation"]["method"] == "remote_branch_only_no_local_record"
         assert proof["upstream_preservation"]["remote_head_sha"] == remote_sha
-        assert result["stale_claim_advisory"] is None
-        assert result["advisory_withheld"] == "possible_unpushed_work"
+        assert result["stale_claim_advisory"]["available"] is True
+        assert result["owner_blocking_state"] == "stale_terminal_owner"
+        assert result["advisory_withheld"] is None
 
     def test_absent_terminal_worktree_without_recorded_sha_dirty_marker_withholds(
         self, tmp_path: Path
@@ -2066,7 +2070,7 @@ class TestWorktreeReferencePreservationProof:
         assert result["stale_claim_advisory"] is None
         assert result["advisory_withheld"] == "possible_unpushed_work"
 
-    def test_absent_terminal_worktree_without_recorded_sha_false_marker_still_withholds(
+    def test_absent_terminal_worktree_without_recorded_sha_false_marker_is_reassignable(
         self, tmp_path: Path
     ) -> None:
         remote_sha = "ffffffffffffffffffffffffffffffffffffffff"
@@ -2092,6 +2096,8 @@ class TestWorktreeReferencePreservationProof:
                 return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
             if cmd[:3] == ["git", "ls-remote", "origin"]:
                 return completed(cmd, stdout=f"{remote_sha}\trefs/heads/{branch}\n")
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return completed(cmd, returncode=1)
             raise AssertionError(f"unexpected command: {cmd}")
 
         proof = ilo.build_worktree_reference_preservation_proof(
@@ -2110,9 +2116,161 @@ class TestWorktreeReferencePreservationProof:
         )
 
         assert proof["available"] is True
-        assert proof["upstream_preservation"]["method"] == "remote_branch_anchor_no_local_record"
-        assert proof["upstream_preservation"]["proven"] is False
-        assert result["stale_claim_advisory"] is None
+        assert proof["upstream_preservation"]["method"] == "remote_branch_only_no_local_record"
+        assert proof["upstream_preservation"]["proven"] is True
+        assert result["stale_claim_advisory"]["available"] is True
+        assert result["owner_blocking_state"] == "stale_terminal_owner"
+        assert result["advisory_withheld"] is None
+
+    def test_absent_terminal_worktree_matching_local_and_remote_branch_is_reassignable(
+        self, tmp_path: Path
+    ) -> None:
+        branch_sha = "abababababababababababababababababababab"
+        branch = "codex/no-local-record-matching-branch"
+        lane = {
+            "lane_id": "Q-no-local-record-matching",
+            "owner_session": "codex-no-local-record-matching",
+            "branch": branch,
+            "worktree": str(tmp_path / "absent-no-local-record-matching"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "completed",
+            "launched_at": _hours_ago(7.0),
+        }
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                return completed(cmd, stdout=f"{branch_sha}\trefs/heads/{branch}\n")
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return completed(cmd, stdout=f"{branch_sha}\n")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+
+        assert proof["upstream_preservation"]["proven"] is True
+        assert (
+            proof["upstream_preservation"]["method"]
+            == "remote_branch_matches_local_branch_no_record"
+        )
+        assert result["owner_blocking_state"] == "stale_terminal_owner"
+        assert result["advisory_withheld"] is None
+
+    def test_absent_terminal_worktree_divergent_local_branch_still_withholds(
+        self, tmp_path: Path
+    ) -> None:
+        remote_sha = "abababababababababababababababababababab"
+        local_sha = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+        branch = "codex/no-local-record-divergent-branch"
+        lane = {
+            "lane_id": "Q-no-local-record-divergent",
+            "owner_session": "codex-no-local-record-divergent",
+            "branch": branch,
+            "worktree": str(tmp_path / "absent-no-local-record-divergent"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "completed",
+            "launched_at": _hours_ago(7.0),
+        }
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                return completed(cmd, stdout=f"{remote_sha}\trefs/heads/{branch}\n")
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return completed(cmd, stdout=f"{local_sha}\n")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+
+        assert proof["available"] is False
+        assert proof["reason"] == "local_remote_branch_head_mismatch"
+        assert proof["local"]["head_sha"] == local_sha
+        assert proof["remote"]["head_sha"] == remote_sha
+        assert result["owner_blocking_state"] == "stale_owner"
+        assert result["advisory_withheld"] == "possible_unpushed_work"
+
+    def test_absent_terminal_worktree_local_branch_lookup_failure_still_withholds(
+        self, tmp_path: Path
+    ) -> None:
+        remote_sha = "abababababababababababababababababababab"
+        branch = "codex/no-local-record-lookup-failure"
+        lane = {
+            "lane_id": "Q-no-local-record-lookup-failure",
+            "owner_session": "codex-no-local-record-lookup-failure",
+            "branch": branch,
+            "worktree": str(tmp_path / "absent-no-local-record-lookup-failure"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "completed",
+            "launched_at": _hours_ago(7.0),
+        }
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                return completed(cmd, stdout=f"{remote_sha}\trefs/heads/{branch}\n")
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return completed(cmd, returncode=128)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+
+        assert proof["available"] is False
+        assert proof["reason"] == "local_branch_lookup_failed"
+        assert proof["local"]["status"] == "lookup_failed"
+        assert result["owner_blocking_state"] == "stale_owner"
         assert result["advisory_withheld"] == "possible_unpushed_work"
 
     def test_absent_in_progress_worktree_remote_branch_without_recorded_sha_still_withholds(

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -2516,6 +2516,65 @@ class TestWorktreeReferencePreservationProof:
         assert result["owner_blocking_state"] == "stale_owner"
         assert result["advisory_withheld"] == "possible_unpushed_work"
 
+    @pytest.mark.parametrize(
+        ("remote_sha", "local_sha"),
+        [(None, "a" * 40), (None, "b" * 40), ("a" * 40, "a" * 40), ("a" * 40, "b" * 40)],
+    )
+    def test_clean_terminal_worktree_recorded_head_requires_live_remote_preservation(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        remote_sha: str | None,
+        local_sha: str,
+    ) -> None:
+        desired_sha = "a" * 40
+        branch = "codex/clean-recorded-head"
+        lane = {
+            "lane_id": "Q-clean-recorded-head",
+            "owner_session": "codex-clean-recorded-head",
+            "branch": branch,
+            "worktree": str(tmp_path / "clean-recorded-head"),
+            "desired_head_sha": desired_sha,
+            "status": "completed",
+            "updated_at": _hours_ago(7.0),
+        }
+        merged_lookup_calls: list[str] = []
+
+        def merged_proof(head: str, **kwargs: Any) -> dict[str, Any]:
+            merged_lookup_calls.append(head)
+            return {"proven": True, "method": "merged_pr_commit_list"}
+
+        monkeypatch.setattr(ilo, "_merged_pr_commit_list_proof", merged_proof)
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=True, branch=branch))
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                output = f"{remote_sha}\trefs/heads/{branch}\n" if remote_sha else ""
+                return completed(cmd, stdout=output)
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return completed(cmd, stdout=f"{local_sha}\n")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane, repo_root=tmp_path, state_root=tmp_path / ".aragora", runner=runner
+        )
+        result = ilo.assess_owner_liveness(lane, now=_liveness_now(), local_work_preservation=proof)
+
+        assert merged_lookup_calls == []
+        assert proof["available"] is (remote_sha == local_sha)
+        if remote_sha != local_sha:
+            assert proof["reason"] == (
+                "remote_branch_missing_for_present_worktree"
+                if remote_sha is None
+                else "clean_worktree_branch_not_preserved"
+            )
+            assert result["owner_blocking_state"] == "stale_owner"
+            assert result["advisory_withheld"] == "possible_unpushed_work"
+        else:
+            assert proof["upstream_preservation"]["method"] == "remote_branch_exact_head"
+            assert result["owner_blocking_state"] == "stale_terminal_owner"
+
     def test_q379_absent_worktree_merged_pr_commit_yields_advisory_when_remote_gone(
         self, tmp_path: Path
     ) -> None:

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -197,6 +197,77 @@ def test_status_timeout_blocks_cleanup_as_dirty(
     assert mod._worktree_is_dirty(worktree) is True
 
 
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "dirty"),
+    [(0, "", False), (0, "?? untracked.txt\n", True), (1, "", True), (128, "", True)],
+)
+def test_status_result_requires_successful_clean_inspection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    returncode: int,
+    stdout: str,
+    dirty: bool,
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["git", "status", "--porcelain", "--untracked-files=all"]
+        assert kwargs["cwd"] == tmp_path
+        return subprocess.CompletedProcess(cmd, returncode, stdout, "fatal" if returncode else "")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    assert mod._worktree_is_dirty(tmp_path) is dirty
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError("git missing"), PermissionError("denied")])
+def test_status_launch_failure_blocks_cleanup_as_dirty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: OSError
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    def fake_run(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    assert mod._worktree_is_dirty(tmp_path) is True
+
+
+def test_corrupt_index_blocks_real_worktree_inspection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    subprocess.run(["git", "init", "--quiet", str(tmp_path)], check=True)
+    (tmp_path / ".git" / "index").write_bytes(b"invalid index")
+    status = subprocess.run(["git", "status", "--short"], cwd=tmp_path, capture_output=True)
+    assert status.returncode != 0
+    assert mod._worktree_is_dirty(tmp_path) is True
+
+    monkeypatch.setattr(
+        mod,
+        "_get_worktree_entry",
+        lambda *_args: mod.autopilot.WorktreeEntry(tmp_path, "codex/test"),
+    )
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda *_args: (0, False))
+    monkeypatch.setattr(mod, "_lookup_open_prs", lambda *_args: ([], False))
+    inspection = mod.inspect_worktree(tmp_path, tmp_path)
+    assert inspection.dirty is True
+    assert "dirty_worktree" in inspection.blockers
+    assert mod.cleanup_safety(inspection)["removable"] is False
+
+
+def test_status_detects_untracked_files_despite_local_git_config(tmp_path: Path) -> None:
+    import safe_worktree_cleanup as mod
+
+    subprocess.run(["git", "init", "--quiet", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "config", "--local", "status.showUntrackedFiles", "no"], cwd=tmp_path, check=True
+    )
+    (tmp_path / "recoverable.txt").write_text("local work\n")
+    assert mod._worktree_is_dirty(tmp_path) is True
+
+
 def test_remove_purges_residual_path_after_failed_git_remove(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- classify terminal stale lanes as reassignable when their recorded work is independently preserved
- accept either an absent worktree with no divergent local tip, or an existing worktree that is clean, inactive, on the recorded branch, and exactly synchronized with its remote branch
- preserve fail-closed behavior for active or dirty worktrees, divergent local tips, lookup failures, branch mismatch, non-terminal lanes, and missing remote branches
- make the preservation method explicit in `owner_blocking_state` output and add focused regressions

## Validation
- `python3 -m pytest tests/scripts/test_identify_lane_owner.py tests/scripts/test_resolve_lane_conflicts.py -q` (163 passed)
- `python3 -m ruff check scripts/identify_lane_owner.py tests/scripts/test_identify_lane_owner.py`
- `python3 -m mypy scripts/identify_lane_owner.py`
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

## Live proof
On stale terminal lane `codex-foreman-cycle110-pr9102-auth-refresh`, current main reports `stale_owner`; this branch reports `stale_terminal_owner` after proving the registered worktree absent and the local and remote branch heads equal. The currently active #10012 worktree remains blocking while this task is active, proving that the extension does not erase live-owner protection.