### PR TITLE
fix(sdk): preserve buffered stream events and truthful termination

### DIFF
--- a/docs/guides/SDK_QUICKSTART_TYPESCRIPT.md
+++ b/docs/guides/SDK_QUICKSTART_TYPESCRIPT.md
@@ -100,6 +100,11 @@ try {
 
 Accepted events drain before a transport failure is thrown; disconnection is not
 `debate_end`. Close errors expose `WS_CLOSE_<number>` and numeric `responseBody.code`.
+A transport error waits up to 1,000 ms for close details; repeated errors do not
+extend that window. If close never arrives, the sanitized error has no close code
+and is non-retryable; parsing errors fail immediately and are also non-retryable.
+Handle these explicitly rather than assuming the failure is permanent. A genuine
+terminal event accepted before finalization still wins, and buffered events drain.
 `isRetryableError(error)` reports eligibility, not automatic retry or guaranteed
 replay. This iterator never resumes after closure. If reconnecting is appropriate,
 use bounded backoff and account for possible gaps or duplicates; do not restart blindly.

--- a/docs/guides/SDK_QUICKSTART_TYPESCRIPT.md
+++ b/docs/guides/SDK_QUICKSTART_TYPESCRIPT.md
@@ -81,24 +81,28 @@ main();
 ## Real-time Streaming
 
 ```typescript
-import { createClient } from '@aragora/sdk';
+import { ConnectionError, createClient } from '@aragora/sdk';
 
 const client = createClient({ baseUrl: 'http://localhost:8080' });
 
 // Stream debate events
 const stream = client.streamDebate('debate-123');
 
-for await (const event of stream) {
-  switch (event.type) {
-    case 'agent_message':
-      console.log(event.data);
-      break;
-    case 'consensus':
-      console.log('Consensus reached:', event.data);
-      break;
+try {
+  for await (const event of stream) {
+    console.log(event.type, event.data);
   }
+} catch (error) {
+  if (!(error instanceof ConnectionError)) throw error;
+  console.warn('Stream interrupted; debate completion is unknown', error.code);
 }
 ```
+
+Accepted events drain before a transport failure is thrown; disconnection is not
+`debate_end`. Close errors expose `WS_CLOSE_<number>` and numeric `responseBody.code`.
+`isRetryableError(error)` reports eligibility, not automatic retry or guaranteed
+replay. This iterator never resumes after closure. If reconnecting is appropriate,
+use bounded backoff and account for possible gaps or duplicates; do not restart blindly.
 
 ## Key APIs
 

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -16,6 +16,13 @@ events before ending. A socket close without a genuine terminal event throws
 Wrap `for await` in `try/catch` (see the [streaming example](../../docs/guides/SDK_QUICKSTART_TYPESCRIPT.md#real-time-streaming)).
 Close errors expose `WS_CLOSE_<number>` via `error.code`/`error.errorCode` and the
 numeric value via `error.responseBody.code`, without the raw remote reason.
+A native transport error may precede close: the iterator retains close diagnostics
+for up to 1,000 ms after the first error; repeated errors do not restart the window.
+If no close arrives, it throws a sanitized, non-retryable `ConnectionError` without
+a close code. Parsing errors fail immediately and are also non-retryable. Here,
+non-retryable means explicit caller handling is required, not proof of permanence.
+Buffered events still drain; an accepted genuine terminal event before finalization
+takes precedence. Close arriving after finalization cannot revise the outcome.
 `isRetryableError` respects the new optional fifth `ConnectionError` constructor
 argument, `retryable` (default `true` for existing callers). Only close codes
 1001,1006,1011,1012,1013,4029 are retryable; all others, including premature1000,

--- a/sdk/typescript/BREAKING_CHANGES.md
+++ b/sdk/typescript/BREAKING_CHANGES.md
@@ -10,6 +10,19 @@ This document tracks breaking changes specific to the Aragora TypeScript SDK. Fo
 
 #### Breaking Changes
 
+`streamDebate`, `streamDebateById`, and client stream wrappers now drain accepted
+events before ending. A socket close without a genuine terminal event throws
+`ConnectionError` after buffered delivery; it no longer manufactures `debate_end`.
+Wrap `for await` in `try/catch` (see the [streaming example](../../docs/guides/SDK_QUICKSTART_TYPESCRIPT.md#real-time-streaming)).
+Close errors expose `WS_CLOSE_<number>` via `error.code`/`error.errorCode` and the
+numeric value via `error.responseBody.code`, without the raw remote reason.
+`isRetryableError` respects the new optional fifth `ConnectionError` constructor
+argument, `retryable` (default `true` for existing callers). Only close codes
+1001,1006,1011,1012,1013,4029 are retryable; all others, including premature1000,
+require explicit caller handling. This is eligibility, not automatic retry:
+the iterator does not resume, and a new connection guarantees neither replay nor
+gap-free delivery. Bound application retries with backoff; do not restart blindly.
+
 Batch 06 removes 11 matched phantom operations from `IndexAPI`, `ReplaysAPI`, and `DocumentsAPI`.
 For each removed index method, the named route is absent from both OpenAPI documents and is not accepted by the knowledge-base handler: `getIndexStats` (`GET /api/v1/index/{name}/stats`), `addDocuments` (`POST /api/v1/index/{name}/documents`), `updateDocument` (`PUT /api/v1/index/{name}/documents/{documentId}`), `deleteDocuments` (`DELETE /api/v1/index/{name}/documents`), `rebuildIndex` (`POST /api/v1/index/{name}/rebuild`), and `optimizeIndex` (`POST /api/v1/index/{name}/optimize`). The `IndexDocument` and `UpdateDocumentOptions` interfaces are deleted with `addDocuments` and `updateDocument` and are no longer re-exported by the `namespaces` barrel.
 For each removed replay method, the named route is absent from both OpenAPI documents and is not accepted by `ReplaysHandler.can_handle`: `getFromDebate` (`GET /api/v1/debates/{debateId}/replay`), `export` (`GET /api/v1/replays/{replayId}/export`), and `getSummary` (`GET /api/v1/replays/{replayId}/summary`). `replays.getFromDebate` was the only method removed in this batch that carried an `@deprecated` tag.

--- a/sdk/typescript/src/__tests__/errors.test.ts
+++ b/sdk/typescript/src/__tests__/errors.test.ts
@@ -327,6 +327,15 @@ describe('TimeoutError', () => {
 });
 
 describe('ConnectionError', () => {
+  it.each([undefined, true, false])('honors retryable=%s without changing error metadata', (retryable) => {
+    const error = new ConnectionError('closed', 'WS_CLOSE_4003', undefined, { code: 4003 }, retryable);
+    expect(error.retryable).toBe(retryable ?? true);
+    expect(isRetryableError(error)).toBe(retryable ?? true);
+    expect(error.code).toBe('WS_CLOSE_4003');
+    expect(error.responseBody).toEqual({ code: 4003 });
+    expect(error.statusCode).toBeUndefined();
+  });
+
   it('should use default message', () => {
     const error = new ConnectionError();
     expect(error.message).toBe('Connection failed');

--- a/sdk/typescript/src/__tests__/websocket.test.ts
+++ b/sdk/typescript/src/__tests__/websocket.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AragoraClient } from '../client';
+import { ConnectionError } from '../errors';
+import { AragoraWebSocket, streamDebate, streamDebateById } from '../websocket';
+import type { WebSocketEvent } from '../types';
+
+// Exercise the real SDK socket handlers without network or wall-clock waits.
+class FakeSocket {
+  static latest: FakeSocket;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  close = vi.fn();
+  send = vi.fn();
+
+  constructor(public url: string) { FakeSocket.latest = this; }
+  open() { this.onopen?.(); }
+  message(event: WebSocketEvent) { this.onmessage?.({ data: JSON.stringify(event) }); }
+  drop(code = 1006) { this.onclose?.({ code, reason: 'untrusted remote reason' }); }
+}
+
+const config = { baseUrl: 'https://example.test' };
+const event = (type: WebSocketEvent['type'], content: string = type, debateId = 'debate-1'): WebSocketEvent => ({
+  type, debate_id: debateId, timestamp: '2026-09-06T00:00:00Z', data: { content },
+});
+const done = { done: true, value: undefined };
+
+describe('streamDebate terminal delivery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeSocket);
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function checkCleanup(socket: FakeSocket, off: { mock: { calls: unknown[][] } }) {
+    expect(socket.close).toHaveBeenCalledExactlyOnceWith(1000, 'Client disconnect');
+    expect(off.mock.calls.map(([name]) => name)).toEqual(['message', 'error', 'disconnected']);
+    expect(vi.getTimerCount()).toBe(0);
+  }
+
+  it.each(['debate_end', 'error'] as const)('drains pre-pull work and the genuine %s event', async (terminal) => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    const events = [event('agent_message', 'one'), event('agent_message', 'two'), event(terminal)];
+    events.forEach((value) => socket.message(value));
+    expect(await first).toEqual({ done: false, value: events[0] });
+    expect(await stream.next()).toEqual({ done: false, value: events[1] });
+    expect(await stream.next()).toEqual({ done: false, value: events[2] });
+    expect(await stream.next()).toEqual(done);
+    checkCleanup(socket, off);
+  });
+
+  it('preserves order when terminal arrives between consumer pulls', async () => {
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    await Promise.resolve(); // Wait for the iterator to request its first event.
+    socket.message(event('agent_message', 'one'));
+    expect((await first).value).toEqual(event('agent_message', 'one'));
+    socket.message(event('agent_message', 'two'));
+    socket.message(event('debate_end'));
+    expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+    expect((await stream.next()).value).toEqual(event('debate_end'));
+    expect(await stream.next()).toEqual(done);
+  });
+
+  it.each([1000, 1006])('rejects a pending pull on non-terminal close %s', async (code) => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message'));
+    await first;
+    const pending = stream.next();
+    const rejected = expect(pending).rejects.toBeInstanceOf(ConnectionError);
+    socket.drop(code);
+    await rejected;
+    expect(await stream.next()).toEqual(done);
+    checkCleanup(socket, off);
+  });
+
+  it('drains accepted work before reporting a between-pull disconnect', async () => {
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message', 'one'));
+    expect((await first).value).toEqual(event('agent_message', 'one'));
+    socket.message(event('agent_message', 'two'));
+    socket.drop();
+    expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+    await expect(stream.next()).rejects.toMatchObject({ name: 'ConnectionError' });
+    expect(await stream.next()).toEqual(done);
+  });
+
+  it('retains transport errors received between pulls, after buffered work', async () => {
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message', 'one'));
+    await first;
+    socket.message(event('agent_message', 'two'));
+    socket.onerror?.();
+    expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+    await expect(stream.next()).rejects.toThrow('WebSocket error');
+  });
+
+  it('rejects a waiting pull on transport error', async () => {
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message'));
+    await first;
+    const rejected = expect(stream.next()).rejects.toThrow('WebSocket error');
+    socket.onerror?.();
+    await rejected;
+    expect(socket.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not replace a genuine terminal event with later messages or transport failures', async () => {
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('debate_end'));
+    socket.message(event('agent_message', 'too late'));
+    socket.onerror?.();
+    socket.drop();
+    expect((await first).value).toEqual(event('debate_end'));
+    expect(await stream.next()).toEqual(done);
+  });
+
+  it('cleans up handlers and socket when connection establishment fails', async () => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const rejected = expect(first).rejects.toThrow('WebSocket error');
+    const socket = FakeSocket.latest;
+    socket.onerror?.();
+    await rejected;
+    checkCleanup(socket, off);
+  });
+
+  it('terminates setup when the socket closes without opening or emitting an error', async () => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    const first = stream.next();
+    let failure: unknown;
+    void first.catch((error: unknown) => { failure = error; });
+    const socket = FakeSocket.latest;
+    socket.drop();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(failure).toBeInstanceOf(ConnectionError);
+    checkCleanup(socket, off);
+  });
+
+  it.each(['debate_end', 'disconnect'] as const)('releases transport on %s even while the consumer pauses', async (terminal) => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config, { reconnectDelay: 10 });
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message', 'one'));
+    await first;
+    socket.message(event('agent_message', 'two'));
+    if (terminal === 'disconnect') socket.drop();
+    else socket.message(event('debate_end'));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(FakeSocket.latest).toBe(socket);
+    checkCleanup(socket, off);
+    expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+    if (terminal === 'disconnect') {
+      await expect(stream.next()).rejects.toBeInstanceOf(ConnectionError);
+    } else {
+      expect((await stream.next()).value).toEqual(event('debate_end'));
+      expect(await stream.next()).toEqual(done);
+    }
+    checkCleanup(socket, off);
+  });
+
+  it.each(['return', 'throw'] as const)('cleans up on consumer %s after a delivered event', async (method) => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message'));
+    await first;
+    if (method === 'return') {
+      expect(await stream.return()).toEqual(done);
+    } else {
+      const failure = new Error('consumer stopped');
+      await expect(stream.throw(failure)).rejects.toBe(failure);
+    }
+    checkCleanup(socket, off);
+  });
+
+  it.each(['by-id', 'client', 'all'] as const)('preserves %s wrapper filtering and server event payloads', async (wrapper) => {
+    const client = new AragoraClient(config);
+    const stream = wrapper === 'by-id' ? streamDebateById(config, 'debate-1')
+      : wrapper === 'client' ? client.streamDebate('debate-1')
+      : client.streamAllDebates({ debateId: 'debate-1' });
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    expect(socket.url).toContain('debate_id=debate-1');
+    socket.open();
+    socket.message(event('debate_end', 'unrelated', 'debate-2'));
+    const warning: WebSocketEvent = { type: 'warning', timestamp: 'now', data: { message: 'notice' } };
+    socket.message(warning);
+    socket.message(event('consensus'));
+    socket.message(event('debate_end'));
+    expect((await first).value).toEqual(warning);
+    expect((await stream.next()).value).toEqual(event('consensus'));
+    expect((await stream.next()).value).toEqual(event('debate_end'));
+    expect(await stream.next()).toEqual(done);
+  });
+});

--- a/sdk/typescript/src/__tests__/websocket.test.ts
+++ b/sdk/typescript/src/__tests__/websocket.test.ts
@@ -141,25 +141,39 @@ describe('streamDebate terminal delivery', () => {
     socket.message(event('agent_message', 'two'));
     socket.onerror?.();
     expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+    await vi.advanceTimersByTimeAsync(1000);
     await expect(stream.next()).rejects.toBeInstanceOf(ConnectionError);
   });
 
-  it.each(['same-turn', 'later-turn'] as const)('types an error followed by %s close after draining accepted work', async (timing) => {
+  it.each([1006, 1008, 4003, 4029].flatMap((code) =>
+    ['connecting', 'waiting', 'paused'].flatMap((phase) =>
+      [0, 10].map((delay) => [code, phase, delay] as const))))(
+    'preserves error-before-close %i in %s with delay %i', async (code, phase, delay) => {
     const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
     const stream = streamDebate(config);
     const first = stream.next();
     const socket = FakeSocket.latest;
-    socket.open();
-    socket.message(event('agent_message', 'one'));
-    await first;
-    socket.message(event('agent_message', 'two'));
+    let pending: Promise<unknown> = first.catch((error: unknown) => error);
+    if (phase !== 'connecting') {
+      socket.open(); socket.message(event('agent_message', 'one')); await first;
+      socket.message(event('agent_message', 'two'));
+      if (phase === 'waiting') {
+        expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+        pending = stream.next().catch((error: unknown) => error);
+      }
+    }
     socket.onerror?.();
-    if (timing === 'later-turn') await vi.advanceTimersByTimeAsync(0);
-    socket.drop();
-    expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
-    const failure = await stream.next().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(delay);
+    socket.drop(code);
+    if (phase === 'paused') {
+      expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+      pending = stream.next().catch((error: unknown) => error);
+    }
+    const failure = await pending;
     expect(failure).toBeInstanceOf(ConnectionError);
-    expect(isRetryableError(failure)).toBe(true);
+    expect(failure).toMatchObject({ code: `WS_CLOSE_${code}`, errorCode: `WS_CLOSE_${code}`, responseBody: { code } });
+    expect(isRetryableError(failure)).toBe(code === 1006 || code === 4029);
+    expect(JSON.stringify(failure)).not.toContain('untrusted remote reason');
     checkCleanup(socket, off);
   });
 
@@ -174,9 +188,11 @@ describe('streamDebate terminal delivery', () => {
     const failure = await stream.next().catch((error: unknown) => error);
     expect(failure).toBeInstanceOf(ConnectionError);
     expect(String(failure)).not.toContain('private malformed payload');
+    expect(isRetryableError(failure)).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('rejects a waiting pull on transport error', async () => {
+  it('rejects a waiting pull after the transport close-observation deadline', async () => {
     const stream = streamDebate(config);
     const first = stream.next();
     const socket = FakeSocket.latest;
@@ -185,6 +201,7 @@ describe('streamDebate terminal delivery', () => {
     await first;
     const rejected = expect(stream.next()).rejects.toBeInstanceOf(ConnectionError);
     socket.onerror?.();
+    await vi.advanceTimersByTimeAsync(1000);
     await rejected;
     expect(socket.close).toHaveBeenCalledOnce();
   });
@@ -209,6 +226,7 @@ describe('streamDebate terminal delivery', () => {
     const rejected = expect(first).rejects.toBeInstanceOf(ConnectionError);
     const socket = FakeSocket.latest;
     socket.onerror?.();
+    await vi.advanceTimersByTimeAsync(1000);
     await rejected;
     checkCleanup(socket, off);
   });
@@ -250,7 +268,8 @@ describe('streamDebate terminal delivery', () => {
     checkCleanup(socket, off);
   });
 
-  it.each(['return', 'throw'] as const)('cleans up on consumer %s after a delivered event', async (method) => {
+  it.each(['return', 'throw'].flatMap((method) => [false, true].map((fault) => [method, fault] as const)))(
+    'cleans up on consumer %s after a delivered event, observing close=%s', async (method, fault) => {
     const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
     const stream = streamDebate(config);
     const first = stream.next();
@@ -258,6 +277,7 @@ describe('streamDebate terminal delivery', () => {
     socket.open();
     socket.message(event('agent_message'));
     await first;
+    if (fault) socket.onerror?.();
     if (method === 'return') {
       expect(await stream.return()).toEqual(done);
     } else {
@@ -265,6 +285,82 @@ describe('streamDebate terminal delivery', () => {
       await expect(stream.throw(failure)).rejects.toBe(failure);
     }
     checkCleanup(socket, off);
+  });
+
+  it.each(['connecting', 'waiting', 'paused'])('bounds repeated errors and ignores a late close in %s', async (phase) => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    let settled = false;
+    let pending: Promise<unknown> = stream.next().catch((error: unknown) => error);
+    const socket = FakeSocket.latest;
+    if (phase !== 'connecting') {
+      socket.open(); socket.message(event('agent_message')); await pending;
+      pending = phase === 'waiting' ? stream.next().catch((error: unknown) => error) : new Promise(() => {});
+    }
+    void pending.then(() => { settled = true; });
+    socket.onerror?.();
+    await vi.advanceTimersByTimeAsync(500); socket.onerror?.();
+    await vi.advanceTimersByTimeAsync(499);
+    expect(settled).toBe(false); expect(socket.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    checkCleanup(socket, off); // Even a paused consumer releases the transport.
+    if (phase === 'paused') pending = stream.next().catch((error: unknown) => error);
+    const failure = await pending;
+    expect(failure).toBeInstanceOf(ConnectionError);
+    expect(isRetryableError(failure)).toBe(false);
+    expect(failure).toMatchObject({ code: undefined, errorCode: undefined, responseBody: undefined });
+    const before = JSON.stringify(failure);
+    socket.drop(4029); socket.onerror?.(); await vi.advanceTimersByTimeAsync(1000);
+    expect(JSON.stringify(failure)).toBe(before); checkCleanup(socket, off);
+  });
+
+  it.each([true, false])('finalizes once at the deadline, close callback first=%s', async (closeFirst) => {
+    const stream = streamDebate(config);
+    const first = stream.next(); const socket = FakeSocket.latest;
+    socket.open(); socket.message(event('agent_message')); await first;
+    const pending = stream.next().catch((error: unknown) => error);
+    if (closeFirst) setTimeout(() => socket.drop(4029), 1000);
+    socket.onerror?.();
+    if (!closeFirst) setTimeout(() => socket.drop(4029), 1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    const failure = await pending;
+    expect(failure).toBeInstanceOf(ConnectionError);
+    expect(isRetryableError(failure)).toBe(closeFirst);
+    expect((failure as ConnectionError).code).toBe(closeFirst ? 'WS_CLOSE_4029' : undefined);
+    expect(socket.close).toHaveBeenCalledOnce(); expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each(['debate_end', 'error'] as const)('lets genuine %s win during close observation', async (terminal) => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    const first = stream.next(); const socket = FakeSocket.latest;
+    socket.open(); socket.message(event('agent_message')); await first;
+    socket.message(event('agent_message', 'saved')); socket.onerror?.();
+    await vi.advanceTimersByTimeAsync(500); socket.message(event(terminal));
+    await vi.advanceTimersByTimeAsync(0); checkCleanup(socket, off);
+    expect((await stream.next()).value).toEqual(event('agent_message', 'saved'));
+    expect((await stream.next()).value).toEqual(event(terminal));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(await stream.next()).toEqual(done);
+  });
+
+  it('keeps constructor failures immediate rather than awaiting close', async () => {
+    const failure = new Error('setup failed');
+    vi.stubGlobal('WebSocket', class { constructor() { throw failure; } });
+    await expect(streamDebate(config).next()).rejects.toBe(failure);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('preserves standalone callback errors and automatic reconnection', async () => {
+    const socketClient = new AragoraWebSocket(config, { reconnectDelay: 10 });
+    const errors = vi.fn(); socketClient.on('error', errors);
+    const connect = socketClient.connect(); const socket = FakeSocket.latest;
+    const rejected = expect(connect).rejects.toThrow('WebSocket error');
+    socket.onerror?.(); await rejected;
+    expect(errors).toHaveBeenCalledOnce(); expect(vi.getTimerCount()).toBe(0);
+    socket.drop(); await vi.advanceTimersByTimeAsync(10);
+    expect(FakeSocket.latest).not.toBe(socket);
+    socketClient.disconnect(); expect(vi.getTimerCount()).toBe(0);
   });
 
   it.each(['by-id', 'client', 'all'] as const)('preserves %s wrapper filtering and server event payloads', async (wrapper) => {

--- a/sdk/typescript/src/__tests__/websocket.test.ts
+++ b/sdk/typescript/src/__tests__/websocket.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AragoraClient } from '../client';
-import { ConnectionError } from '../errors';
+import { ConnectionError, isRetryableError } from '../errors';
 import { AragoraWebSocket, streamDebate, streamDebateById } from '../websocket';
 import type { WebSocketEvent } from '../types';
 
@@ -114,7 +114,39 @@ describe('streamDebate terminal delivery', () => {
     socket.message(event('agent_message', 'two'));
     socket.onerror?.();
     expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
-    await expect(stream.next()).rejects.toThrow('WebSocket error');
+    await expect(stream.next()).rejects.toBeInstanceOf(ConnectionError);
+  });
+
+  it.each(['same-turn', 'later-turn'] as const)('types an error followed by %s close after draining accepted work', async (timing) => {
+    const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message', 'one'));
+    await first;
+    socket.message(event('agent_message', 'two'));
+    socket.onerror?.();
+    if (timing === 'later-turn') await vi.advanceTimersByTimeAsync(0);
+    socket.drop();
+    expect((await stream.next()).value).toEqual(event('agent_message', 'two'));
+    const failure = await stream.next().catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(ConnectionError);
+    expect(isRetryableError(failure)).toBe(true);
+    checkCleanup(socket, off);
+  });
+
+  it('reports a malformed frame without exposing its raw payload in the error', async () => {
+    const stream = streamDebate(config);
+    const first = stream.next();
+    const socket = FakeSocket.latest;
+    socket.open();
+    socket.message(event('agent_message'));
+    await first;
+    socket.onmessage?.({ data: 'private malformed payload' });
+    const failure = await stream.next().catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(ConnectionError);
+    expect(String(failure)).not.toContain('private malformed payload');
   });
 
   it('rejects a waiting pull on transport error', async () => {
@@ -124,7 +156,7 @@ describe('streamDebate terminal delivery', () => {
     socket.open();
     socket.message(event('agent_message'));
     await first;
-    const rejected = expect(stream.next()).rejects.toThrow('WebSocket error');
+    const rejected = expect(stream.next()).rejects.toBeInstanceOf(ConnectionError);
     socket.onerror?.();
     await rejected;
     expect(socket.close).toHaveBeenCalledOnce();
@@ -147,7 +179,7 @@ describe('streamDebate terminal delivery', () => {
     const off = vi.spyOn(AragoraWebSocket.prototype, 'off');
     const stream = streamDebate(config);
     const first = stream.next();
-    const rejected = expect(first).rejects.toThrow('WebSocket error');
+    const rejected = expect(first).rejects.toBeInstanceOf(ConnectionError);
     const socket = FakeSocket.latest;
     socket.onerror?.();
     await rejected;

--- a/sdk/typescript/src/__tests__/websocket.test.ts
+++ b/sdk/typescript/src/__tests__/websocket.test.ts
@@ -27,6 +27,33 @@ const event = (type: WebSocketEvent['type'], content: string = type, debateId = 
 const done = { done: true, value: undefined };
 
 describe('streamDebate terminal delivery', () => {
+  it.each([
+    [1000, false], [1001, true], [1002, false], [1003, false], [1005, false],
+    [1006, true], [1007, false], [1008, false], [1009, false], [1010, false],
+    [1011, true], [1012, true], [1013, true], [1015, false],
+    [4003, false], [4029, true], [4999, false],
+  ])('exposes close %i with retryable=%s after buffered work', async (code, retryable) => {
+    for (const waiting of [false, true]) {
+      const stream = streamDebateById(config, 'debate-1');
+      const first = stream.next();
+      const socket = FakeSocket.latest;
+      socket.open(); socket.message(event('agent_message', 'first')); await first;
+      socket.message(event('agent_message', 'saved'));
+      if (waiting) expect((await stream.next()).value).toEqual(event('agent_message', 'saved'));
+      const pending = waiting ? stream.next().catch((error: unknown) => error) : undefined;
+      socket.drop(code as number);
+      if (!waiting) expect((await stream.next()).value).toEqual(event('agent_message', 'saved'));
+      const failure = waiting ? await pending : await stream.next().catch((error: unknown) => error);
+      expect(failure).toBeInstanceOf(ConnectionError);
+      expect(failure).toMatchObject({ code: `WS_CLOSE_${code}`, errorCode: `WS_CLOSE_${code}`, retryable, responseBody: { code } });
+      expect(isRetryableError(failure)).toBe(retryable);
+      expect(JSON.stringify(failure)).not.toContain('untrusted remote reason');
+      expect(socket.close).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+      expect(await stream.next()).toEqual(done);
+    }
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.stubGlobal('WebSocket', FakeSocket);

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -398,7 +398,9 @@ export class ConnectionError extends AragoraError {
     message: string = 'Connection failed',
     errorCode?: ErrorCode | string,
     traceId?: string,
-    responseBody?: Record<string, unknown>
+    responseBody?: Record<string, unknown>,
+    /** Retry eligibility, not automatic retry or guaranteed stream replay. */
+    readonly retryable: boolean = true
   ) {
     super(message, undefined, errorCode, traceId, responseBody);
     this.name = 'ConnectionError';
@@ -433,7 +435,7 @@ export function isValidationError(error: unknown): error is ValidationError {
 export function isRetryableError(error: unknown): boolean {
   if (error instanceof ServerError) return true;
   if (error instanceof TimeoutError) return true;
-  if (error instanceof ConnectionError) return true;
+  if (error instanceof ConnectionError) return error.retryable;
   if (error instanceof RateLimitError) return true;
   return false;
 }

--- a/sdk/typescript/src/websocket.ts
+++ b/sdk/typescript/src/websocket.ts
@@ -391,6 +391,9 @@ function getEventDebateId(event: WebSocketEvent): string | undefined {
   );
 }
 
+// Transient RFC WebSocket closes plus Aragora's application rate-limit close.
+const RETRYABLE_WEBSOCKET_CLOSE_CODES = new Set([1001, 1006, 1011, 1012, 1013, 4029]);
+
 /**
  * Create an async iterable stream for debate events.
  *
@@ -405,17 +408,19 @@ function getEventDebateId(event: WebSocketEvent): string | undefined {
  *
  * @example
  * ```typescript
- * import { streamDebate } from '@aragora/sdk';
+ * import { ConnectionError, streamDebate } from '@aragora/sdk';
  *
  * const config = { baseUrl: 'http://localhost:8080' };
  * const stream = streamDebate(config, { debateId: 'my-debate-id' });
  *
- * for await (const event of stream) {
- *   console.log(`${event.type}:`, event.data);
- *
- *   if (event.type === 'debate_end') {
- *     break;
+ * try {
+ *   for await (const event of stream) {
+ *     console.log(`${event.type}:`, event.data);
  *   }
+ * } catch (error) {
+ *   if (!(error instanceof ConnectionError)) throw error;
+ *   console.warn('Stream interrupted; debate completion is unknown', error.code);
+ *   // Retry eligibility does not guarantee replay. Do not restart blindly.
  * }
  * ```
  *
@@ -424,9 +429,7 @@ function getEventDebateId(event: WebSocketEvent): string | undefined {
  * // Stream all events (no filter)
  * const stream = streamDebate({ baseUrl: 'http://localhost:8080' });
  *
- * for await (const event of stream) {
- *   console.log(event);
- * }
+ * // Consume with the same try/catch shown above.
  * ```
  */
 export async function* streamDebate(
@@ -504,9 +507,10 @@ export async function* streamDebate(
     if (ended) return;
     terminalError = new ConnectionError(
       'WebSocket disconnected before a terminal debate event',
+      `WS_CLOSE_${code}`,
       undefined,
-      undefined,
-      { code }
+      { code },
+      RETRYABLE_WEBSOCKET_CLOSE_CODES.has(code)
     );
     ended = true;
     wake();
@@ -559,11 +563,7 @@ export async function* streamDebate(
  * const config = { baseUrl: 'http://localhost:8080' };
  * const stream = streamDebateById(config, 'debate-123');
  *
- * for await (const event of stream) {
- *   if (event.type === 'agent_message') {
- *     console.log(`${event.data.agent}: ${event.data.content}`);
- *   }
- * }
+ * // Consume with streamDebate's try/catch example; interruptions throw here too.
  * ```
  */
 export function streamDebateById(

--- a/sdk/typescript/src/websocket.ts
+++ b/sdk/typescript/src/websocket.ts
@@ -489,7 +489,12 @@ export async function* streamDebate(
   // Handle errors
   const unsubError = ws.on('error', (error) => {
     if (ended) return;
-    terminalError = error;
+    // A transport error commonly precedes close; type it immediately rather than
+    // waiting for a close callback that cleanup may already have detached.
+    // Low-level parse errors can contain raw frames, so do not copy their text.
+    terminalError = error instanceof ConnectionError
+      ? error
+      : new ConnectionError('WebSocket stream failed');
     ended = true;
     wake();
   });

--- a/sdk/typescript/src/websocket.ts
+++ b/sdk/typescript/src/websocket.ts
@@ -21,6 +21,7 @@ import type {
   UserVoteEvent,
   WarningEvent,
 } from './types';
+import { ConnectionError } from './errors';
 
 // Keep Node fallback local to this file without requiring global @types/node.
 declare const require: (moduleName: string) => unknown;
@@ -394,7 +395,9 @@ function getEventDebateId(event: WebSocketEvent): string | undefined {
  * Create an async iterable stream for debate events.
  *
  * This provides a convenient way to consume debate events using async iteration.
- * The stream will automatically handle WebSocket connection, reconnection, and cleanup.
+ * The stream handles connection and cleanup, draining accepted events before ending.
+ * A disconnect without a server terminal event raises ConnectionError after draining;
+ * it does not imply debate completion or resume this iterator on reconnection.
  *
  * @param config - Aragora configuration (baseUrl, apiKey, etc.)
  * @param options - Stream options including optional debateId filter
@@ -432,10 +435,32 @@ export async function* streamDebate(
 ): AsyncGenerator<WebSocketEvent, void, unknown> {
   const ws = new AragoraWebSocket(config, options);
   const eventQueue: WebSocketEvent[] = [];
-  let resolveNext: ((event: WebSocketEvent) => void) | null = null;
-  let rejectNext: ((error: Error) => void) | null = null;
+  let wakeNext: (() => void) | null = null;
   let ended = false;
+  let terminalError: Error | null = null;
+  let signalEnd: () => void;
+  const terminalSignal = new Promise<void>((resolve) => {
+    signalEnd = resolve;
+  });
   const { debateId } = options;
+
+  const wake = () => {
+    if (ended) {
+      signalEnd();
+      // Let connect's onerror finish rejecting before disconnect changes its state.
+      // Cleanup must not depend on when a paused consumer requests another event.
+      queueMicrotask(() => {
+        try {
+          cleanup();
+        } catch {
+          terminalError ??= new ConnectionError('Failed to clean up WebSocket');
+        }
+      });
+    }
+    const notify = wakeNext;
+    wakeNext = null;
+    notify?.();
+  };
 
   // Filter events by debate ID if specified
   const shouldEmit = (event: WebSocketEvent): boolean => {
@@ -448,68 +473,69 @@ export async function* streamDebate(
 
   // Handle incoming messages
   const unsubMessage = ws.on('message', (event) => {
-    if (!shouldEmit(event)) {
+    if (ended || !shouldEmit(event)) {
       return;
     }
 
-    if (resolveNext) {
-      resolveNext(event);
-      resolveNext = null;
-    } else {
-      eventQueue.push(event);
-    }
+    eventQueue.push(event);
 
     // Check for terminal events
     if (event.type === 'debate_end' || event.type === 'error') {
       ended = true;
     }
+    wake();
   });
 
   // Handle errors
   const unsubError = ws.on('error', (error) => {
-    if (rejectNext) {
-      rejectNext(error);
-      rejectNext = null;
-    }
+    if (ended) return;
+    terminalError = error;
     ended = true;
+    wake();
   });
 
   // Handle disconnection
-  const unsubDisconnect = ws.on('disconnected', ({ code, reason }) => {
+  const unsubDisconnect = ws.on('disconnected', ({ code }) => {
+    if (ended) return;
+    terminalError = new ConnectionError(
+      'WebSocket disconnected before a terminal debate event',
+      undefined,
+      undefined,
+      { code }
+    );
     ended = true;
-    if (resolveNext) {
-      // Create a synthetic end event
-      resolveNext({
-        type: 'debate_end',
-        debate_id: debateId,
-        timestamp: new Date().toISOString(),
-        data: { reason: 'connection_closed', code, close_reason: reason },
-      });
-      resolveNext = null;
-    }
+    wake();
   });
 
-  // Connect to the WebSocket
-  await ws.connect(debateId);
-
-  try {
-    while (!ended) {
-      if (eventQueue.length > 0) {
-        yield eventQueue.shift()!;
-      } else {
-        const event = await new Promise<WebSocketEvent>((resolve, reject) => {
-          resolveNext = resolve;
-          rejectNext = reject;
-        });
-        yield event;
-      }
-    }
-  } finally {
-    // Cleanup
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
     unsubMessage();
     unsubError();
     unsubDisconnect();
+    wakeNext = null;
     ws.disconnect();
+  };
+
+  try {
+    // Setup failures need the same cleanup as iterator termination.
+    // A close-before-open need not reject the low-level connection promise.
+    await Promise.race([ws.connect(debateId), terminalSignal]);
+    while (true) {
+      if (eventQueue.length > 0) {
+        yield eventQueue.shift()!;
+      } else if (ended) {
+        if (terminalError) throw terminalError;
+        return;
+      } else {
+        await new Promise<void>((resolve) => {
+          wakeNext = resolve;
+        });
+      }
+    }
+  } finally {
+    cleanup();
   }
 }
 

--- a/sdk/typescript/src/websocket.ts
+++ b/sdk/typescript/src/websocket.ts
@@ -26,6 +26,9 @@ import { ConnectionError } from './errors';
 // Keep Node fallback local to this file without requiring global @types/node.
 declare const require: (moduleName: string) => unknown;
 
+// Keep native transport provenance internal; parser errors use the same public event.
+const transportErrors = new WeakSet<Error>();
+
 export type WebSocketState = 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
 
 export interface WebSocketOptions {
@@ -149,6 +152,7 @@ export class AragoraWebSocket {
 
         this.ws!.onerror = (_event) => {
           const error = new Error('WebSocket error');
+          transportErrors.add(error);
           this.emit('error', error);
           if (this.state === 'connecting') {
             reject(error);
@@ -393,6 +397,8 @@ function getEventDebateId(event: WebSocketEvent): string | undefined {
 
 // Transient RFC WebSocket closes plus Aragora's application rate-limit close.
 const RETRYABLE_WEBSOCKET_CLOSE_CODES = new Set([1001, 1006, 1011, 1012, 1013, 4029]);
+// Fixed stream contract: allow a subsequent close to supply diagnostics, but never hang.
+const CLOSE_OBSERVATION_TIMEOUT_MS = 1000;
 
 /**
  * Create an async iterable stream for debate events.
@@ -401,6 +407,9 @@ const RETRYABLE_WEBSOCKET_CLOSE_CODES = new Set([1001, 1006, 1011, 1012, 1013, 4
  * The stream handles connection and cleanup, draining accepted events before ending.
  * A disconnect without a server terminal event raises ConnectionError after draining;
  * it does not imply debate completion or resume this iterator on reconnection.
+ * A native transport error allows up to 1,000 ms for authoritative close details.
+ * Without close details, the error has no close code and is not retryable. Parsing
+ * errors fail immediately. Repeated transport errors do not extend the window.
  *
  * @param config - Aragora configuration (baseUrl, apiKey, etc.)
  * @param options - Stream options including optional debateId filter
@@ -436,19 +445,28 @@ export async function* streamDebate(
   config: AragoraConfig,
   options: StreamOptions = {}
 ): AsyncGenerator<WebSocketEvent, void, unknown> {
-  const ws = new AragoraWebSocket(config, options);
+  const ws = new AragoraWebSocket(config, { ...options, autoReconnect: false });
   const eventQueue: WebSocketEvent[] = [];
   let wakeNext: (() => void) | null = null;
   let ended = false;
   let terminalError: Error | null = null;
+  let closeObservationTimer: ReturnType<typeof setTimeout> | null = null;
   let signalEnd: () => void;
   const terminalSignal = new Promise<void>((resolve) => {
     signalEnd = resolve;
   });
   const { debateId } = options;
 
+  const clearCloseObservation = () => {
+    if (closeObservationTimer !== null) {
+      clearTimeout(closeObservationTimer);
+      closeObservationTimer = null;
+    }
+  };
+
   const wake = () => {
     if (ended) {
+      clearCloseObservation();
       signalEnd();
       // Let connect's onerror finish rejecting before disconnect changes its state.
       // Cleanup must not depend on when a paused consumer requests another event.
@@ -492,12 +510,24 @@ export async function* streamDebate(
   // Handle errors
   const unsubError = ws.on('error', (error) => {
     if (ended) return;
-    // A transport error commonly precedes close; type it immediately rather than
-    // waiting for a close callback that cleanup may already have detached.
-    // Low-level parse errors can contain raw frames, so do not copy their text.
-    terminalError = error instanceof ConnectionError
-      ? error
-      : new ConnectionError('WebSocket stream failed');
+    if (transportErrors.has(error)) {
+      if (closeObservationTimer === null) {
+        closeObservationTimer = setTimeout(() => {
+          if (ended) return;
+          terminalError = new ConnectionError(
+            'WebSocket stream failed without close details',
+            undefined, undefined, undefined, false
+          );
+          ended = true;
+          wake();
+        }, CLOSE_OBSERVATION_TIMEOUT_MS);
+      }
+      return;
+    }
+    // Parser errors need no close callback and can contain raw frames. Never copy text.
+    terminalError = new ConnectionError(
+      'WebSocket stream failed', undefined, undefined, undefined, false
+    );
     ended = true;
     wake();
   });
@@ -520,6 +550,7 @@ export async function* streamDebate(
   const cleanup = () => {
     if (cleaned) return;
     cleaned = true;
+    clearCloseObservation();
     unsubMessage();
     unsubError();
     unsubDisconnect();
@@ -530,7 +561,13 @@ export async function* streamDebate(
   try {
     // Setup failures need the same cleanup as iterator termination.
     // A close-before-open need not reject the low-level connection promise.
-    await Promise.race([ws.connect(debateId), terminalSignal]);
+    const connected = ws.connect(debateId).catch((error: unknown) => {
+      // The marked error already started close observation; connect rejection must
+      // not finalize the iterator before the authoritative close or bounded fallback.
+      if (error instanceof Error && transportErrors.has(error)) return terminalSignal;
+      throw error;
+    });
+    await Promise.race([connected, terminalSignal]);
     while (true) {
       if (eventQueue.length > 0) {
         yield eventQueue.shift()!;


### PR DESCRIPTION
## Summary

Reliable SDK Consumption Batch 1: preserve accepted TypeScript stream events and report interrupted transport truthfully.

Current exact head: `1418b449fcb61d43f18068ca72c4a65a9ea67580`.
The latest user-authorized bounded repair preserves authoritative close diagnostics after a native transport error. Six cumulative files, 555 additions / 62 deletions (617 changed lines), below the explicitly approved 700-line cap. This repair changes only websocket.ts, its existing focused tests, and the existing streaming sections in TypeScript breaking changes and Quickstart; errors.ts and errors.test.ts are unchanged from e1838f959b77de6ff6db4a37c8424943972f7ccf.

- Drain accepted events FIFO; only a genuine server terminal event can signal debate completion.
- An internal marker distinguishes native transport errors from parsing failures without adding any public exception, event or configuration API.
- First native error opens one fixed 1,000 ms close-observation window; repeated errors never extend it.
- A close before finalization exposes sanitized WS_CLOSE_<number> via code/errorCode and numeric responseBody.code. Only 1001, 1006, 1011, 1012, 1013 and 4029 are retryable.
- No-close expiry is sanitized, non-retryable and has no fabricated close code. Parsing errors fail immediately and non-retryably. Late events cannot revise a finalized outcome.
- Connecting native-error rejection cannot bypass observation. Genuine terminal events accepted before finalization win; eager idempotent cleanup clears timers/listeners and disconnects without waiting for a later consumer pull.
- Iterator reconnection is disabled; standalone callback-client reconnect policy is unchanged. Reconnection never guarantees replay.
- The cumulative optional fifth ConnectionError.retryable argument defaults true, preserving existing HTTP caller behavior.

No dependencies, workflows, server behavior, endpoints, governance or operational artifacts changed. Intentional public failure semantics remain Tier 3; no downgrade is requested.

## Validation

- Baseline-red contract tests: 32 fail / 39 pass before this implementation.
- Focused SDK tests: 183 pass, zero failures/skips.
- Full SDK: 1761 pass, one unchanged baseline failure, zero skips. parity-compat-routes.test.ts:51 expects /api/debates/stats/agents while unchanged implementation uses /api/v1/debates/stats/agents.
- Four mutants killed and byte-restored: immediate error finalization (30 failures), discarded close code (42), blanket retryability (23), missing observation-timer cleanup (28). Restored focused suite passes.
- Source and focused-test strict typechecks pass. Source lint has zero errors / 78 baseline warnings; focused-test lint is clean.
- CJS, ESM and declarations build. Isolated installed tarball SHA256: d8cebc3fa3eb67066736955c48e86a92857376043046e460a837144cf1cd6768.
- Installed CJS/ESM acceptance: 114 cases (14 existing lifecycle, 38 close classification, 62 new observation cases) plus two actual streaming documentation examples, all pass with deterministic fake sockets. These establish SDK behavior, not real-browser incidence.
- Version alignment, SDK parity/budget, namespace/cross-SDK parity, generated OpenAPI enrichment, SDK contract baseline and route validation pass with zero new drift.
- Broad make ci-required is NOT green: Ruff passes, then unchanged Python mypy debt produces 1758 errors in 466 files. Later Make gates were run separately and pass; no gate or test was weakened.
- Commit/push hooks and automation publication preflight pass. All new-head remote checks are terminal:29success/21skipped/1failure(quorum). Five non-quorum required checks pass; old-head checks are not reused.

## Review provenance and authority

Historical initial review found error-before-close bypassing ConnectionError; repaired at 4120f07bd6. The later Claude review found permanent-close retry classification/code access and migration guidance P2s; explicitly repaired at e1838f959b77de6ff6db4a37c8424943972f7ccf. Its independent non-countable terminal review found no new in-scope P0-P3.

The subsequent e183 exact-head prepare-only pass had Claude PASS with seven P3 advisories and OpenAI CHANGES-REQUESTED with a P2: error-before-close loses authoritative close diagnostics and defaults to retryable. Prepared support was 1/2, posted 0; there was no supportive quorum. Claude reported Vitest execution permission denial, so its dogfood marker did not prove those tests ran. Raw dissent remains preserved unchanged; the new repair does not erase or reuse it.

The user explicitly authorized the fixed-window repair above, one commit/push, and ONE fresh independent non-countable review of this new exact head. That single fresh review is complete at this exact head, with no new in-scope P0-P3. The reviewer independently reran183focused tests, the full1761-pass/one-baseline-failure suite, source/test lint and typechecks, byte-identical fresh builds,114installed cases plus2actual examples, and140additional deterministic boundary probes. Mutation and repository-gate receipts were inspected, not independently rerun. The branch remains frozen; lease and reviewer capacity are released. Any P0-P2 parks this head immediately, with no additional repair loop. This clean review provides a readiness packet only, not landing authority. No new countable evidence, posting, settlement, merge, automatic rebase or main merge is authorized. Subsequent Tier-3 exact-head OWNER gates require separate authorization.

PR #10015 stays parked and untouched. The wider HTTP campaign remains blocked until #10014 subsequently lands. Inherited pending-next return/throw cancellation and unrelated-debate low-level error routing remain outside this unit; no P3 cleanup.

Safe because: the bounded observation contract replaces competing error/close finalization with one outcome, preserves buffered work and exact close diagnostics, and is tested across connecting, waiting, paused, completion, parsing and cleanup paths. Existing HTTP defaults and standalone reconnect remain unchanged.
