### PR TITLE
fix(sdk): preserve Python debate pagination results and metadata

### DIFF
--- a/sdk/python/aragora_sdk/namespaces/debates.py
+++ b/sdk/python/aragora_sdk/namespaces/debates.py
@@ -129,7 +129,9 @@ class DebatesAPI:
         if status:
             params["status"] = status
 
-        return SyncPaginator(self._client, "/api/v1/debates", params, page_size)
+        return SyncPaginator(
+            self._client, "/api/v1/debates", params, page_size, items_key="debates"
+        )
 
     def get_messages(self, debate_id: str) -> dict[str, Any]:
         """
@@ -1250,7 +1252,9 @@ class AsyncDebatesAPI:
         if status:
             params["status"] = status
 
-        return AsyncPaginator(self._client, "/api/v1/debates", params, page_size)
+        return AsyncPaginator(
+            self._client, "/api/v1/debates", params, page_size, items_key="debates"
+        )
 
     async def stream(self, debate_id: str) -> AsyncIterator[WebSocketEvent]:
         """

--- a/sdk/python/aragora_sdk/pagination.py
+++ b/sdk/python/aragora_sdk/pagination.py
@@ -28,14 +28,19 @@ def _named_page(
     total = response.get("total")
     if total is not None and (type(total) is not int or total < 0):
         raise AragoraError("Invalid pagination response: expected non-negative total")
+    next_offset = offset + len(items)
+    if total is not None and (next_offset > total or (not items and next_offset < total)):
+        raise AragoraError("Invalid pagination response: inconsistent total")
     if "has_more" in response:
         has_more = response["has_more"]
         if not isinstance(has_more, bool) or (has_more and not items):
             raise AragoraError("Invalid pagination response: inconsistent has_more")
+        if total is not None and has_more != (next_offset < total):
+            raise AragoraError("Invalid pagination response: inconsistent has_more")
         # Servers may clamp the requested limit; a short page can still continue.
         exhausted = not has_more
     elif total is not None:
-        exhausted = not items or offset + len(items) >= total
+        exhausted = next_offset >= total
     else:
         exhausted = len(items) < page_size
     return items, total, exhausted

--- a/sdk/python/aragora_sdk/pagination.py
+++ b/sdk/python/aragora_sdk/pagination.py
@@ -10,8 +10,35 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator
 from typing import TYPE_CHECKING, Any
 
+from .exceptions import AragoraError
+
 if TYPE_CHECKING:
     from .client import AragoraAsyncClient, AragoraClient
+
+
+def _named_page(
+    response: Any, items_key: str, offset: int, page_size: int
+) -> tuple[list[dict[str, Any]], int | None, bool]:
+    """Validate an opted-in endpoint envelope before changing iterator state."""
+    if not isinstance(response, dict) or not isinstance(response.get(items_key), list):
+        raise AragoraError("Invalid pagination response: expected named item list")
+    items = response[items_key]
+    if any(not isinstance(item, dict) for item in items):
+        raise AragoraError("Invalid pagination response: expected object items")
+    total = response.get("total")
+    if total is not None and (type(total) is not int or total < 0):
+        raise AragoraError("Invalid pagination response: expected non-negative total")
+    if "has_more" in response:
+        has_more = response["has_more"]
+        if not isinstance(has_more, bool) or (has_more and not items):
+            raise AragoraError("Invalid pagination response: inconsistent has_more")
+        # Servers may clamp the requested limit; a short page can still continue.
+        exhausted = not has_more
+    elif total is not None:
+        exhausted = not items or offset + len(items) >= total
+    else:
+        exhausted = len(items) < page_size
+    return items, total, exhausted
 
 
 class SyncPaginator(Iterator[dict[str, Any]]):
@@ -31,6 +58,8 @@ class SyncPaginator(Iterator[dict[str, Any]]):
         path: str,
         params: dict[str, Any] | None = None,
         page_size: int = 20,
+        *,
+        items_key: str | None = None,
     ) -> None:
         """Initialize the paginator.
 
@@ -39,7 +68,12 @@ class SyncPaginator(Iterator[dict[str, Any]]):
             path: The API endpoint path.
             params: Additional query parameters to include in requests.
             page_size: Number of items to fetch per page.
+            items_key: Opt into a named object-list envelope with validated metadata.
+                Omit to retain the generic items/data/raw-list response formats.
         """
+        if items_key is not None and (type(page_size) is not int or page_size <= 0):
+            raise AragoraError("Pagination page_size must be a positive integer")
+        self._items_key = items_key
         self._client = client
         self._path = path
         self._params = params or {}
@@ -69,6 +103,16 @@ class SyncPaginator(Iterator[dict[str, Any]]):
             "offset": self._offset,
         }
         response = self._client.request("GET", self._path, params=params)
+
+        if self._items_key is not None:
+            page, total, exhausted = _named_page(
+                response, self._items_key, self._offset, self._page_size
+            )
+            self._buffer.extend(page)
+            self._offset += len(page)
+            self._total = total
+            self._exhausted = exhausted
+            return
 
         # Handle different response formats
         if isinstance(response, dict):
@@ -113,6 +157,8 @@ class AsyncPaginator(AsyncIterator[dict[str, Any]]):
         path: str,
         params: dict[str, Any] | None = None,
         page_size: int = 20,
+        *,
+        items_key: str | None = None,
     ) -> None:
         """Initialize the paginator.
 
@@ -121,7 +167,12 @@ class AsyncPaginator(AsyncIterator[dict[str, Any]]):
             path: The API endpoint path.
             params: Additional query parameters to include in requests.
             page_size: Number of items to fetch per page.
+            items_key: Opt into a named object-list envelope with validated metadata.
+                Omit to retain the generic items/data/raw-list response formats.
         """
+        if items_key is not None and (type(page_size) is not int or page_size <= 0):
+            raise AragoraError("Pagination page_size must be a positive integer")
+        self._items_key = items_key
         self._client = client
         self._path = path
         self._params = params or {}
@@ -151,6 +202,16 @@ class AsyncPaginator(AsyncIterator[dict[str, Any]]):
             "offset": self._offset,
         }
         response = await self._client.request("GET", self._path, params=params)
+
+        if self._items_key is not None:
+            page, total, exhausted = _named_page(
+                response, self._items_key, self._offset, self._page_size
+            )
+            self._buffer.extend(page)
+            self._offset += len(page)
+            self._total = total
+            self._exhausted = exhausted
+            return
 
         # Handle different response formats
         if isinstance(response, dict):

--- a/sdk/python/tests/test_debate_pagination.py
+++ b/sdk/python/tests/test_debate_pagination.py
@@ -84,6 +84,51 @@ async def test_total_without_has_more_retains_short_page_remainder(client_api: A
 @pytest.mark.parametrize(
     "page",
     [
+        {"debates": [], "total": 2},
+        {"debates": [], "total": 2, "has_more": False},
+        {"debates": [{"id": "private-payload"}], "total": 2, "has_more": False},
+        {"debates": [{"id": "private-payload"}], "total": 1, "has_more": True},
+        {"debates": [{"id": "private-payload"}], "total": 0},
+    ],
+)
+async def test_contradictory_metadata_fails_before_page_state_changes(
+    client_api: Any, page: Any
+) -> None:
+    client, api = client_api
+    client.request.return_value = page
+    paginator = api.list_all()
+    with pytest.raises(AragoraError) as error:
+        await pull(paginator)
+    assert "private-payload" not in str(error.value)
+    assert error.value.response_body is None
+    assert paginator.total is None
+    assert paginator._offset == 0
+    assert not paginator._buffer
+    assert not paginator._exhausted
+
+
+@pytest.mark.parametrize("metadata", [{}, {"has_more": False}])
+async def test_contradictory_later_page_preserves_delivered_work_and_offset(
+    client_api: Any, metadata: Any
+) -> None:
+    client, api = client_api
+    client.request.side_effect = [
+        {"debates": [{"id": "a"}], "total": 2, "has_more": True},
+        {"debates": [], "total": 2, **metadata},
+        {"debates": [{"id": "b"}], "total": 2, "has_more": False},
+    ]
+    paginator = api.list_all()
+    assert await pull(paginator) == {"id": "a"}
+    with pytest.raises(AragoraError):
+        await pull(paginator)
+    assert paginator.total == 2
+    assert await collect(paginator) == [{"id": "b"}]
+    assert [c.kwargs["params"]["offset"] for c in client.request.call_args_list] == [0, 1, 1]
+
+
+@pytest.mark.parametrize(
+    "page",
+    [
         {"debates": [], "total": 0, "has_more": False},
         {"debates": []},
     ],

--- a/sdk/python/tests/test_debate_pagination.py
+++ b/sdk/python/tests/test_debate_pagination.py
@@ -1,0 +1,184 @@
+"""Debate pagination contracts from CrudOperationsMixin._list_debates envelopes."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aragora_sdk.exceptions import AragoraError, ConnectionError
+from aragora_sdk.namespaces.debates import AsyncDebatesAPI, DebatesAPI
+from aragora_sdk.pagination import AsyncPaginator, SyncPaginator
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(params=[False, True], ids=["sync", "async"])
+def client_api(request: Any) -> tuple[Any, Any]:
+    client = MagicMock()
+    if request.param:
+        client.request = AsyncMock()
+        return client, AsyncDebatesAPI(client)
+    return client, DebatesAPI(client)
+
+
+async def pull(paginator: Any) -> dict[str, Any]:
+    return await paginator.__anext__() if isinstance(paginator, AsyncPaginator) else next(paginator)
+
+
+async def collect(paginator: Any) -> list[dict[str, Any]]:
+    if isinstance(paginator, AsyncPaginator):
+        return [item async for item in paginator]
+    return list(paginator)
+
+
+async def test_server_envelope_preserves_items_metadata_and_filters(client_api: Any) -> None:
+    client, api = client_api
+    items = [{"id": "a", "status": "failed", "agent_failures": [{"phase": "vote"}]}, {"id": "b"}]
+    client.request.side_effect = [
+        {"debates": items, "count": 2, "total": 3, "has_more": True, "offset": 0, "limit": 2},
+        {
+            "debates": [{"id": "c"}],
+            "count": 1,
+            "total": 3,
+            "has_more": False,
+            "offset": 2,
+            "limit": 2,
+        },
+    ]
+    paginator = api.list_all(status="completed", page_size=2)
+    assert await collect(paginator) == [*items, {"id": "c"}]
+    assert paginator.total == 3
+    assert [c.kwargs["params"] for c in client.request.call_args_list] == [
+        {"status": "completed", "limit": 2, "offset": 0},
+        {"status": "completed", "limit": 2, "offset": 2},
+    ]
+    assert all(c.args == ("GET", "/api/v1/debates") for c in client.request.call_args_list)
+    assert await collect(paginator) == []
+    assert client.request.call_count == 2
+
+
+async def test_server_clamped_short_page_does_not_lose_remainder(client_api: Any) -> None:
+    client, api = client_api
+    # DebatesHandler clamps limit to 100 even when the caller asks for 200.
+    first = [{"id": str(i)} for i in range(100)]
+    client.request.side_effect = [
+        {"debates": first, "total": 101, "has_more": True, "limit": 100, "offset": 0},
+        {"debates": [{"id": "100"}], "total": 101, "has_more": False, "limit": 100, "offset": 100},
+    ]
+    assert len(await collect(api.list_all(page_size=200))) == 101
+    assert [c.kwargs["params"]["offset"] for c in client.request.call_args_list] == [0, 100]
+
+
+async def test_total_without_has_more_retains_short_page_remainder(client_api: Any) -> None:
+    client, api = client_api
+    client.request.side_effect = [
+        {"debates": [{"id": "a"}], "total": 2},
+        {"debates": [{"id": "b"}], "total": 2},
+    ]
+    assert await collect(api.list_all(page_size=20)) == [{"id": "a"}, {"id": "b"}]
+    assert client.request.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "page",
+    [
+        {"debates": [], "total": 0, "has_more": False},
+        {"debates": []},
+    ],
+)
+async def test_genuine_empty_page_terminates(client_api: Any, page: Any) -> None:
+    client, api = client_api
+    client.request.return_value = page
+    assert await collect(api.list_all()) == []
+    assert client.request.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "page",
+    [
+        {"debates": [{"id": "a"}], "total": 1},
+        {"debates": [{"id": "a"}], "has_more": False},
+        {"debates": [{"id": "a"}]},
+    ],
+)
+async def test_legacy_metadata_is_optional(client_api: Any, page: Any) -> None:
+    client, api = client_api
+    client.request.return_value = page
+    assert await collect(api.list_all()) == [{"id": "a"}]
+    assert client.request.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "page",
+    [
+        None,
+        "private-payload",
+        [],
+        {},
+        {"items": []},
+        {"data": []},
+        {"debates": None},
+        {"debates": "private-payload"},
+        {"debates": {"id": "a"}},
+        {"debates": [None]},
+        {"debates": ["private-payload"]},
+        {"debates": [], "total": "2"},
+        {"debates": [], "total": True},
+        {"debates": [], "total": -1},
+        {"debates": [], "has_more": "false"},
+        {"debates": [], "has_more": True},
+    ],
+)
+async def test_invalid_envelope_is_typed_failure_not_empty_success(
+    client_api: Any, page: Any
+) -> None:
+    client, api = client_api
+    client.request.return_value = page
+    with pytest.raises(AragoraError) as error:
+        await collect(api.list_all())
+    assert "private-payload" not in str(error.value)
+    assert error.value.response_body is None
+    assert client.request.call_count == 1
+
+
+async def test_later_bad_page_preserves_already_delivered_work(client_api: Any) -> None:
+    client, api = client_api
+    client.request.side_effect = [
+        {"debates": [{"id": "a"}], "has_more": True},
+        {"items": [{"id": "wrong-envelope"}]},
+    ]
+    paginator = api.list_all(page_size=1)
+    assert await pull(paginator) == {"id": "a"}
+    with pytest.raises(AragoraError):
+        await pull(paginator)
+
+
+async def test_transport_error_identity_is_preserved(client_api: Any) -> None:
+    client, api = client_api
+    failure = ConnectionError("offline")
+    client.request.side_effect = failure
+    with pytest.raises(ConnectionError) as error:
+        await collect(api.list_all())
+    assert error.value is failure
+
+
+@pytest.mark.parametrize("page_size", [0, -1, True, 1.5])
+async def test_invalid_page_size_fails_before_request(client_api: Any, page_size: Any) -> None:
+    client, api = client_api
+    with pytest.raises(AragoraError):
+        api.list_all(page_size=page_size)
+    client.request.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "response", [[{"id": "a"}], {"items": [{"id": "a"}]}, {"data": [{"id": "a"}]}]
+)
+async def test_generic_paginator_compatibility(client_api: Any, response: Any) -> None:
+    client, api = client_api
+    client.request.return_value = response
+    paginator = (AsyncPaginator if isinstance(api, AsyncDebatesAPI) else SyncPaginator)(
+        client, "/items"
+    )
+    assert await collect(paginator) == [{"id": "a"}]


### PR DESCRIPTION
## Summary

**PARKED at d43ed663b013b99d9383a6ef9e66a4e8a557911d — terminal non-countable review found a remaining P2; repair budget exhausted. Do not mark ready, collect evidence, settle or merge.**

Remaining blocker: after a page declares total=2/has_more=true with item a, a later {debates:[]} page omitting metadata returns [a] successfully and clears total to None. Same-category short-page variants also lose the known remaining total. Reproduced independently with both installed public clients. The initial same-page contradiction repair is correct, but cross-page metadata preservation is incomplete. No further repair or review is authorized by this campaign.

Reliable SDK Consumption campaign, Batch 2: repair Python debate pagination without changing the server or generic paginator defaults.

- Opt synchronous/asynchronous debate list_all into the server's actual debates envelope; preserve full item dictionaries and total.
- Honor has_more and total when deciding exhaustion. The server caps limit at 100, so a requested larger page can be short without being final.
- Raise existing AragoraError for incompatible named envelopes, invalid item lists/metadata and non-positive page sizes, without exposing raw payloads.
- Keep existing generic items/data/raw-list paginator compatibility. No new endpoint, reconnect/cursor redesign, dependencies, workflows, governance or operational artifacts.

Scope: three files, 301 insertions/2 deletions after the single bounded repair. Existing generic agents/knowledge consumers are unchanged. Batch 1 #10014 remains separately frozen; this branch starts from fresh main, not its branch.

## Validation

- Baseline reproduced from source and a clean installed wheel: both clients return [] for two valid debates while reporting total=2. Initial 64 regression cases had 52 baseline failures; two additional metadata cases are mutation-covered.
- 80 new deterministic sync/async cases; 135 focused tests pass, zero skips. All 14 new contradictory-metadata cases failed on the initial reviewed head and pass after repair.
- Full Python SDK suite: 1459 passed, zero failures/skips (7 warnings).
- Seven defect mutants killed: dropped items, premature short-page exhaustion, silently empty malformed envelope, discarded total, ignored remaining total, accepted empty remaining-total page, contradictory has_more. All restored before commit.
- Ruff format/lint and changed-file strict mypy (follow-imports=silent): pass.
- Wheel built and installed in a fresh isolated Python 3.11 consumer; 14 full-client/mock-HTTP cases pass, zero skips or network requests. Covers clamped multi-page delivery, empty results, malformed responses, contradictory exhaustion and typed authentication errors. Wheel SHA256: 365b45771422e502a03e34ad83548fcac7fe35379ca48a6fe5e7ef9c641f2f81.
- Version alignment, strict SDK/namespace/cross-SDK parity, generated OpenAPI contract baseline and route validation pass.
- Broad make ci-required is NOT green: Ruff passed; unchanged root Python mypy baseline fails with 1758 errors across 466 files (4317 checked), stopping that Makefile sequence. Remaining relevant gates were run independently and passed; actual protected remote checks still govern readiness.

## Review and landing

Initial independent non-countable review of c68f3f42905c9100ce1b569d4c72629cc9de665e found one P2: contradictory total/has_more could silently report partial results as complete. The single permitted repair rejects inconsistent same-page metadata before committing page state. Fresh independent terminal review at d43ed663b013b99d9383a6ef9e66a4e8a557911d found the remaining cross-page P2 above; no other P0/P1/P3. Reviewer independently passed 135 focused/1459 full tests, Ruff/mypy and14 installed cases; green tests do not resolve the untested defect. Exact head is parked, not ready. No countable evidence, settlement or merge. Normal protected landing only, never admin merge; no further repair budget.

Safe because: only debates explicitly opts into validated named-envelope parsing; shared generic defaults retain their prior behavior, public signatures remain backward-compatible, no server records are transformed, and sync/async public installed clients are directly exercised.
