### PR TITLE
feat(swarm): add non-counting advisory summaries [Tier 2]

### DIFF
--- a/aragora/swarm/advisory_dissent.py
+++ b/aragora/swarm/advisory_dissent.py
@@ -106,7 +106,7 @@ def compose_advisory_dissent_summary(outcome: CollectOutcome | dict, *, head_sha
     summary += " Severity labels only; not a merge decision."
     flags = [item.get("severity_gated") for item in items]
     if any(flag is False for flag in flags):
-        regime = "severity-gated dissent OFF; a P2 finding blocks the merge gate by default."
+        regime = "severity-gated dissent OFF; a changes-requested verdict blocks the merge gate whatever its findings."
     elif all(flag is True for flag in flags):
         regime = "severity-gated dissent ON; P2/P3 findings are advisory to the merge gate."
     else:

--- a/aragora/swarm/advisory_dissent.py
+++ b/aragora/swarm/advisory_dissent.py
@@ -1,0 +1,204 @@
+"""Human-readable collection summaries, separate from countable evidence.
+
+The composer accepts a CollectOutcome or its dry-run JSON dictionary unchanged.
+An explicit head may differ from the artifact head for offline rendering; posting
+requires the body's marker to match the supplied head. Calls for a head are
+serialized by the caller (GitHub issue comments have no atomic upsert).
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from aragora.swarm.quorum_evidence import (
+    CollectOutcome,
+    _neutralize_reviewer_text,
+    canonical_family,
+    has_blocking_finding_or_label,
+    merge_quorum_io,
+)
+
+_TOKENS = re.compile(
+    r"dogfood|adversarial|cross-author|recheck|codex review|claude review|"
+    r"grok independent|gemini independent|independent semantic review|"
+    r"independent model review|model-family semantic signal",
+    re.I,
+)
+_PRIORITY = re.compile(r"\[P([0-3])\]", re.I)
+_FINDING = re.compile(r"^\[(P[0-3])\](?:\*\*)?(?:\s|$|[:.;—–-])(.*)", re.I)
+_BODY_LIMIT = 60000
+_EXCERPT_LIMIT = 8000
+_TRUNCATED = "[truncated]"
+
+
+@dataclass(frozen=True)
+class AdvisoryPostResult:
+    posted: bool
+    comment_url: str | None
+    reason: str | None
+    edited: bool
+
+
+def _marker(head_sha: str) -> str:
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha):
+        raise ValueError("advisory summary requires a full head SHA")
+    return f"<!-- aragora-advisory-summary head={head_sha} -->"
+
+
+def _clip(text: str, limit: int) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= limit:
+        return text
+    return encoded[: limit - len(_TRUNCATED)].decode("utf-8", errors="ignore") + _TRUNCATED
+
+
+def _safe_text(value: Any, *, inline: bool = False) -> str:
+    text = _neutralize_reviewer_text(str(value))
+    text = html.escape(" ".join(text.split()) if inline else text, quote=False)
+    # Entities preserve readable words without activating substring recognisers.
+    while _TOKENS.search(text):
+        text = _TOKENS.sub(lambda m: f"{m[0][0]}&#{ord(m[0][1])};{m[0][2:]}", text)
+    text = _PRIORITY.sub(r"(P\1)", text)
+    return re.sub(
+        r"((?:model family|reviewer harness|transport grounding|reviewer)\s*):",
+        r"\1&#58;",
+        text,
+        flags=re.I,
+    )
+
+
+def _findings(body: str) -> list[tuple[str, str]]:
+    findings: list[tuple[str, str]] = []
+    in_fence = False
+    for raw in body.splitlines():
+        line = raw.strip()
+        if re.fullmatch(r"(?:`{3,}|~{3,})(?:[\w.+-]+)?", line):
+            in_fence = not in_fence
+            continue
+        if in_fence or line.startswith(">") or raw.startswith(("    ", "\t")):
+            continue
+        line = re.sub(r"^(?:[#\-*+\s]+|\d+[.)]\s+)+", "", line)
+        match = _FINDING.match(line)
+        if match:
+            severity, detail = match[1].upper(), match[2].lstrip(" :.;—–-")
+            # Reuse the library's absence-declaration rules at every priority.
+            if has_blocking_finding_or_label(f"[P1] {detail}"):
+                findings.append((severity, detail))
+    return findings
+
+
+def compose_advisory_dissent_summary(outcome: CollectOutcome | dict, *, head_sha: str) -> str:
+    """Render all families and findings without emitting an evidence identity."""
+    data = outcome.to_dict() if isinstance(outcome, CollectOutcome) else outcome
+    items = data.get("items") or []
+    if not items:
+        return ""
+    marker = _marker(head_sha)
+    families = []
+    findings: list[tuple[str, str, str]] = []
+    for item in items:
+        family = canonical_family(str(item.get("family") or "unknown"))
+        family = (
+            family if re.fullmatch(r"[a-z]+", family) and not _TOKENS.search(family) else "unknown"
+        )
+        families.append(family)
+        findings.extend((sev, family, text) for sev, text in _findings(item.get("body") or ""))
+    findings.sort(key=lambda finding: finding[0])
+    blocking = sum(sev in {"P0", "P1"} for sev, _, _ in findings)
+    summary = (
+        f"Summary: {blocking} blocking and {len(findings) - blocking} advisory findings."
+        if blocking
+        else f"Summary: {len(findings)} advisory findings."
+    )
+    lines = [marker, "", "## Collection summary", "", summary, "", "### Family outcomes"]
+    for family, item in zip(families, items):
+        verdict = str(item.get("verdict") or "unknown")
+        verdict = verdict if verdict in {"pass", "changes_requested", "unknown"} else "unknown"
+        lines.append(f"- {family}: {verdict}")
+    lines.extend(
+        [
+            "",
+            "### Adjudication",
+            "",
+            "> " + _clip(_safe_text(data.get("adjudication") or "none", inline=True), 2000),
+            "",
+            "### Collection action",
+            "",
+            "> " + _clip(_safe_text(data.get("action", "prepare"), inline=True), 200),
+            "> " + _clip(_safe_text(data.get("action_reason", ""), inline=True), 2000),
+            "",
+            "### Findings",
+            "",
+        ]
+    )
+    prefixes = [
+        f"- [{sev}] {family} ({'blocking' if sev in {'P0', 'P1'} else 'advisory'}): "
+        for sev, family, _ in findings
+    ]
+    fixed = len(("\n".join(lines) + "\n" + "\n".join(prefixes)).encode())
+    detail_limit = (45000 - fixed) // max(1, len(findings))
+    if detail_limit < len(_TRUNCATED):
+        raise ValueError("too many findings for one advisory summary")
+    for prefix, (_, _, detail) in zip(prefixes, findings):
+        lines.append(prefix + _clip(_safe_text(detail, inline=True), detail_limit))
+    if not findings:
+        lines.append("No severity-tagged findings.")
+    body = "\n".join(lines)
+    for index, item in enumerate(items):
+        heading = f"\n\n### Output {index + 1}\n\n"
+        remaining = _BODY_LIMIT - len(body.encode()) - len(heading)
+        budget = min(_EXCERPT_LIMIT - 2, remaining)
+        if budget < 2 + len(_TRUNCATED):
+            break
+        text = _safe_text(item.get("body") or "")
+        quoted = "\n".join("> " + line for line in text.splitlines())
+        body += heading + _clip(quoted, budget)
+    return body
+
+
+def post_advisory_summary(repo: str, pr: int, body: str, *, head_sha: str) -> AdvisoryPostResult:
+    """Edit the same-head summary or create one; never mutate gate state."""
+    if not body.strip():
+        return AdvisoryPostResult(False, None, "items: []; no reviewer output", False)
+    try:
+        marker = _marker(head_sha)
+        if body.splitlines()[0] != marker or len(body.encode()) > _BODY_LIMIT:
+            raise ValueError("invalid advisory summary body")
+        if not re.fullmatch(r"[\w.-]+/[\w.-]+", repo) or pr <= 0:
+            raise ValueError("invalid advisory summary target")
+        env = merge_quorum_io.aragora_env()
+        endpoint = f"repos/{repo}/issues/{pr}/comments"
+        result = merge_quorum_io.run(
+            ["gh", "api", endpoint + "?per_page=100", "--paginate", "--slurp"],
+            env=env,
+            timeout=60,
+        )
+        if result.returncode:
+            raise RuntimeError("could not read existing comments")
+        pages = json.loads(result.stdout)
+        comments = [comment for page in pages for comment in page]
+        existing = next(
+            (c for c in comments if str(c.get("body") or "").split("\n", 1)[0] == marker),
+            None,
+        )
+        if existing is not None:
+            endpoint = f"repos/{repo}/issues/comments/{int(existing['id'])}"
+        result = merge_quorum_io.run(
+            ["gh", "api", "--method", "PATCH" if existing else "POST", endpoint, "--input", "-"],
+            env=env,
+            timeout=60,
+            input_text=json.dumps({"body": body}),
+        )
+        if result.returncode:
+            raise RuntimeError("could not deliver advisory summary")
+        url = json.loads(result.stdout)["html_url"]
+        return AdvisoryPostResult(True, url, None, existing is not None)
+    except Exception as exc:
+        # Do not copy subprocess stderr (which may contain credentials) into JSON.
+        return AdvisoryPostResult(
+            False, None, f"advisory delivery failed ({type(exc).__name__})", False
+        )

--- a/aragora/swarm/advisory_dissent.py
+++ b/aragora/swarm/advisory_dissent.py
@@ -15,11 +15,11 @@ import subprocess
 from dataclasses import dataclass
 from typing import Any
 
+from aragora.cli.commands.review_queue_comment_verdicts import extract_finding_lines
 from aragora.swarm.quorum_evidence import (
     CollectOutcome,
     _neutralize_reviewer_text,
     canonical_family,
-    has_blocking_finding_or_label,
     merge_quorum_io,
 )
 
@@ -30,7 +30,6 @@ _TOKENS = re.compile(
     re.I,
 )
 _PRIORITY = re.compile(r"\[P([0-3])\]", re.I)
-_FINDING = re.compile(r"^\[(P[0-3])\](?:\*\*)?(?:\s|$|[:.;—–-])(.*)", re.I)
 _BODY_LIMIT = 60000
 _EXCERPT_LIMIT = 8000
 _TRUNCATED = "[truncated]"
@@ -65,7 +64,7 @@ def _safe_text(value: Any, *, inline: bool = False) -> str:
         text = _TOKENS.sub(lambda m: f"{m[0][0]}&#{ord(m[0][1])};{m[0][2:]}", text)
     text = _PRIORITY.sub(r"(P\1)", text)
     return re.sub(
-        r"((?:model family|reviewer harness|transport grounding|reviewer)\s*):",
+        r"((?:model family|reviewer harness|transport grounding|reviewer)[\s*_]*):",
         r"\1&#58;",
         text,
         flags=re.I,
@@ -74,21 +73,10 @@ def _safe_text(value: Any, *, inline: bool = False) -> str:
 
 def _findings(body: str) -> list[tuple[str, str]]:
     findings: list[tuple[str, str]] = []
-    in_fence = False
-    for raw in body.splitlines():
-        line = raw.strip()
-        if re.fullmatch(r"(?:`{3,}|~{3,})(?:[\w.+-]+)?", line):
-            in_fence = not in_fence
-            continue
-        if in_fence or line.startswith(">") or raw.startswith(("    ", "\t")):
-            continue
-        line = re.sub(r"^(?:[#\-*+\s]+|\d+[.)]\s+)+", "", line)
-        match = _FINDING.match(line)
+    for line in extract_finding_lines(body):
+        match = re.match(r"\[(P[0-3])\]\s*(.*)", line)
         if match:
-            severity, detail = match[1].upper(), match[2].lstrip(" :.;—–-")
-            # Reuse the library's absence-declaration rules at every priority.
-            if has_blocking_finding_or_label(f"[P1] {detail}"):
-                findings.append((severity, detail))
+            findings.append((match[1], match[2].strip()))
     return findings
 
 
@@ -115,7 +103,24 @@ def compose_advisory_dissent_summary(outcome: CollectOutcome | dict, *, head_sha
         if blocking
         else f"Summary: {len(findings)} advisory findings."
     )
-    lines = [marker, "", "## Collection summary", "", summary, "", "### Family outcomes"]
+    summary += " Severity labels only; not a merge decision."
+    flags = [item.get("severity_gated") for item in items]
+    if any(flag is False for flag in flags):
+        regime = "severity-gated dissent OFF; a P2 finding blocks the merge gate by default."
+    elif all(flag is True for flag in flags):
+        regime = "severity-gated dissent ON; P2/P3 findings are advisory to the merge gate."
+    else:
+        regime = "unknown (outcome carries no severity_gated field)."
+    lines = [
+        marker,
+        "",
+        "## Collection summary",
+        "",
+        summary,
+        f"Gate regime: {regime}",
+        "",
+        "### Family outcomes",
+    ]
     for family, item in zip(families, items):
         verdict = str(item.get("verdict") or "unknown")
         verdict = verdict if verdict in {"pass", "changes_requested", "unknown"} else "unknown"

--- a/aragora/swarm/advisory_dissent.py
+++ b/aragora/swarm/advisory_dissent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import html
 import json
 import re
+import subprocess
 from dataclasses import dataclass
 from typing import Any
 
@@ -182,7 +183,11 @@ def post_advisory_summary(repo: str, pr: int, body: str, *, head_sha: str) -> Ad
         pages = json.loads(result.stdout)
         comments = [comment for page in pages for comment in page]
         existing = next(
-            (c for c in comments if str(c.get("body") or "").split("\n", 1)[0] == marker),
+            (
+                c
+                for c in comments
+                if str(c.get("body") or "").split("\n", 1)[0].rstrip("\r") == marker
+            ),
             None,
         )
         if existing is not None:
@@ -197,7 +202,14 @@ def post_advisory_summary(repo: str, pr: int, body: str, *, head_sha: str) -> Ad
             raise RuntimeError("could not deliver advisory summary")
         url = json.loads(result.stdout)["html_url"]
         return AdvisoryPostResult(True, url, None, existing is not None)
-    except Exception as exc:
+    except (
+        OSError,
+        subprocess.SubprocessError,
+        RuntimeError,
+        ValueError,
+        TypeError,
+        KeyError,
+    ) as exc:
         # Do not copy subprocess stderr (which may contain credentials) into JSON.
         return AdvisoryPostResult(
             False, None, f"advisory delivery failed ({type(exc).__name__})", False

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -138,7 +138,12 @@ def main(argv: list[str] | None = None) -> int:
         reviewer_timeout_seconds=args.reviewer_timeout,
         overall_timeout_seconds=args.overall_timeout,
     )
-    outcome = json.loads("\n".join(captured))
+    try:
+        outcome = json.loads("\n".join(captured))
+        if not isinstance(outcome, dict):
+            raise ValueError("expected an object")
+    except ValueError:
+        outcome = {"error": "collection outcome was not a JSON object"}
     outcome.update(
         advisory_posted=False,
         advisory_comment_url=None,
@@ -146,8 +151,25 @@ def main(argv: list[str] | None = None) -> int:
         advisory_edited=False,
     )
     if args.post_advisory_summary:
+        skip_reason = None
         if not outcome.get("items"):
-            outcome["advisory_reason"] = "items: []; no reviewer output"
+            skip_reason = "items: []; no reviewer output"
+        elif args.prepared_json:
+            try:
+                prepared = json.loads(args.prepared_json.read_text())
+                prepared_head = prepared.get("head_sha") if isinstance(prepared, dict) else None
+                if not isinstance(prepared_head, str):
+                    raise ValueError("missing prepared head")
+                live_head = str(outcome.get("head_sha") or "")
+                if prepared_head != live_head:
+                    skip_reason = (
+                        f"prepared head {prepared_head[:7]} differs from live head "
+                        f"{live_head[:7]}; not summarised"
+                    )
+            except (OSError, ValueError):
+                skip_reason = "prepared artifact unreadable; not summarised"
+        if skip_reason:
+            outcome["advisory_reason"] = skip_reason
         else:
             try:
                 from aragora.swarm.advisory_dissent import (

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -14,6 +14,8 @@ Two safety invariants (enforced in :mod:`aragora.swarm.quorum_evidence`):
   operator and never post.
 
 Defaults to a dry run (prepares + lints, prints, posts nothing).
+``--post-advisory-summary`` separately opts into a non-counting summary comment,
+including on draft and Tier 3-4 PRs; it does not opt into evidence posting.
 
 Examples
 --------
@@ -27,6 +29,7 @@ Examples
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -64,7 +67,12 @@ def _hydrate_provider_secrets() -> None:
 
 def main(argv: list[str] | None = None) -> int:
     _hydrate_provider_secrets()
-    from aragora.swarm.quorum_evidence import DEFAULT_FAMILIES, run_collect_cli
+    from aragora.swarm.quorum_evidence import (
+        DEFAULT_FAMILIES,
+        _render_outcome,
+        collect_outcome_from_dict,
+        run_collect_cli,
+    )
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", required=True, help="owner/name of the target repo")
@@ -109,19 +117,70 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument("--json", dest="json_output", action="store_true", help="Output as JSON")
+    parser.add_argument(
+        "--post-advisory-summary",
+        action="store_true",
+        help="Post a non-counting summary, editing the existing comment for this head.",
+    )
     args = parser.parse_args(argv)
 
-    return run_collect_cli(
+    captured: list[str] = []
+    exit_code = run_collect_cli(
         repo=args.repo,
         pr=args.pr,
         families=args.reviewers,
         author=args.author,
         apply=args.apply,
-        json_output=args.json_output,
+        json_output=True,
+        printer=captured.append,
         prepared_json=args.prepared_json,
         reviewer_timeout_seconds=args.reviewer_timeout,
         overall_timeout_seconds=args.overall_timeout,
     )
+    outcome = json.loads("\n".join(captured))
+    outcome.update(
+        advisory_posted=False,
+        advisory_comment_url=None,
+        advisory_reason="--post-advisory-summary not enabled",
+        advisory_edited=False,
+    )
+    if args.post_advisory_summary:
+        if not outcome.get("items"):
+            outcome["advisory_reason"] = "items: []; no reviewer output"
+        else:
+            try:
+                from aragora.swarm.advisory_dissent import (
+                    compose_advisory_dissent_summary,
+                    post_advisory_summary,
+                )
+
+                head_sha = outcome["head_sha"]
+                body = compose_advisory_dissent_summary(outcome, head_sha=head_sha)
+                result = post_advisory_summary(args.repo, args.pr, body, head_sha=head_sha)
+                outcome.update(
+                    advisory_posted=result.posted,
+                    advisory_comment_url=result.comment_url,
+                    advisory_reason=result.reason,
+                    advisory_edited=result.edited,
+                )
+            except Exception as exc:
+                outcome["advisory_reason"] = f"advisory summary failed ({type(exc).__name__})"
+    if args.json_output:
+        print(json.dumps(outcome, indent=2))
+    else:
+        print(
+            f"error: {outcome['error']}"
+            if "error" in outcome
+            else _render_outcome(collect_outcome_from_dict(outcome))
+        )
+        for key in (
+            "advisory_posted",
+            "advisory_comment_url",
+            "advisory_reason",
+            "advisory_edited",
+        ):
+            print(f"  {key}: {outcome[key]}")
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -69,6 +69,7 @@ def main(argv: list[str] | None = None) -> int:
     _hydrate_provider_secrets()
     from aragora.swarm.quorum_evidence import (
         DEFAULT_FAMILIES,
+        CollectPreflightTransportError,
         _render_outcome,
         collect_outcome_from_dict,
         run_collect_cli,
@@ -168,8 +169,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.json_output:
         print(json.dumps(outcome, indent=2))
     else:
+        error = outcome.get("error")
+        if outcome.get("transport_blocked"):
+            error = CollectPreflightTransportError(
+                repo=outcome["repo"],
+                pr=outcome["pr_number"],
+                phase=outcome["phase"],
+                error=RuntimeError(str(error)),
+                attempts=outcome["attempts"],
+            )
         print(
-            f"error: {outcome['error']}"
+            f"error: {error}"
             if "error" in outcome
             else _render_outcome(collect_outcome_from_dict(outcome))
         )

--- a/tests/scripts/test_collect_quorum_evidence.py
+++ b/tests/scripts/test_collect_quorum_evidence.py
@@ -138,6 +138,22 @@ def test_collect_failure_payload(collected, capsys):
     poster.assert_not_called()
 
 
+def test_transport_failure_keeps_text_context(collected, capsys):
+    data, _, poster = collected
+    error = quorum.CollectPreflightTransportError(
+        repo="synaptent/aragora",
+        pr=123,
+        phase="fetch_pr_context",
+        error=RuntimeError("network unavailable"),
+        attempts=3,
+    )
+    data.clear()
+    data.update(error.to_dict())
+    assert cli.main(ARGS) == 2
+    assert capsys.readouterr().out.splitlines()[0] == f"error: {error}"
+    poster.assert_not_called()
+
+
 def test_help_lists_existing_and_new_flags(collected, capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])

--- a/tests/scripts/test_collect_quorum_evidence.py
+++ b/tests/scripts/test_collect_quorum_evidence.py
@@ -1,0 +1,158 @@
+"""The wrapper adds advisory delivery without changing collection semantics."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from aragora.swarm import advisory_dissent as adv
+from aragora.swarm import quorum_evidence as quorum
+from scripts import collect_quorum_evidence as cli
+
+
+@pytest.fixture
+def collected(monkeypatch):
+    data = quorum.CollectOutcome(
+        repo="synaptent/aragora",
+        pr=123,
+        head_sha="a" * 40,
+        head_committed_at="",
+        tier=2,
+        action="prepare",
+        action_reason="dry run",
+        items=[
+            quorum.EvidenceItem(
+                family="claude",
+                body="- [P3] Minor",
+                verdict="pass",
+                would_count=True,
+            )
+        ],
+    ).to_dict()
+
+    def run(**kwargs):
+        assert kwargs["json_output"] is True
+        kwargs["printer"](json.dumps(data))
+        return 2
+
+    collector = Mock(side_effect=run)
+    poster = Mock(
+        return_value=adv.AdvisoryPostResult(
+            posted=True,
+            comment_url="https://example.test/comment",
+            reason=None,
+            edited=False,
+        )
+    )
+    monkeypatch.setattr(cli, "_hydrate_provider_secrets", lambda: None)
+    monkeypatch.setattr(quorum, "run_collect_cli", collector)
+    monkeypatch.setattr(adv, "post_advisory_summary", poster)
+    return data, collector, poster
+
+
+ARGS = ["--repo", "synaptent/aragora", "--pr", "123"]
+
+
+def test_default_off_json_keys(collected, capsys):
+    _, _, poster = collected
+    assert cli.main(ARGS + ["--json"]) == 2
+    data = json.loads(capsys.readouterr().out)
+    assert data["advisory_posted"] is False
+    assert data["advisory_comment_url"] is None and data["advisory_reason"]
+    poster.assert_not_called()
+
+
+@pytest.mark.parametrize("prepared", [False, True])
+def test_flag_plumbing_fresh_and_prepared(collected, capsys, prepared):
+    original, collector, poster = collected
+    flags = ["--prepared-json", "/tmp/prepared.json"] if prepared else []
+    assert (
+        cli.main(
+            ARGS
+            + flags
+            + [
+                "--post-advisory-summary",
+                "--json",
+                "--apply",
+                "--author",
+                "x",
+                "--reviewers",
+                "claude",
+                "openai",
+                "--reviewer-timeout",
+                "30",
+                "--overall-timeout",
+                "60",
+            ]
+        )
+        == 2
+    )
+    data = json.loads(capsys.readouterr().out)
+    assert data["advisory_posted"] is True and data["advisory_reason"] is None
+    assert data["advisory_comment_url"] == "https://example.test/comment"
+    assert all(data[key] == value for key, value in original.items())
+    kwargs = collector.call_args.kwargs
+    assert kwargs["prepared_json"] == (Path("/tmp/prepared.json") if prepared else None)
+    assert kwargs["families"] == ["claude", "openai"] and kwargs["author"] == "x"
+    assert kwargs["apply"] is True
+    assert kwargs["reviewer_timeout_seconds"] == 30 and kwargs["overall_timeout_seconds"] == 60
+    poster.assert_called_once()
+    assert poster.call_args.kwargs["head_sha"] == original["head_sha"]
+
+
+def test_empty_items_never_calls_poster(collected, capsys):
+    data, _, poster = collected
+    data["items"] = []
+    assert cli.main(ARGS + ["--post-advisory-summary", "--json"]) == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["advisory_posted"] is False and "items: []" in output["advisory_reason"]
+    poster.assert_not_called()
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_posting_failure_preserves_exit_code(collected, capsys, raises):
+    _, _, poster = collected
+    if raises:
+        poster.side_effect = RuntimeError("delivery failed")
+    else:
+        poster.return_value = adv.AdvisoryPostResult(False, None, "delivery failed", False)
+    assert cli.main(ARGS + ["--post-advisory-summary", "--json"]) == 2
+    data = json.loads(capsys.readouterr().out)
+    assert data["advisory_posted"] is False and data["advisory_reason"]
+
+
+def test_text_output_keeps_collection_and_advisory_fields(collected, capsys):
+    assert cli.main(ARGS) == 2
+    text = capsys.readouterr().out
+    assert "action: prepare (dry run)" in text
+    assert "advisory_posted: False" in text and "advisory_reason:" in text
+
+
+def test_collect_failure_payload(collected, capsys):
+    data, _, poster = collected
+    data.clear()
+    data.update(mode="collect_evidence", error="preflight failed")
+    assert cli.main(ARGS + ["--post-advisory-summary"]) == 2
+    assert "error: preflight failed" in capsys.readouterr().out
+    poster.assert_not_called()
+
+
+def test_help_lists_existing_and_new_flags(collected, capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--help"])
+    assert exc.value.code == 0
+    help_text = capsys.readouterr().out
+    for flag in (
+        "--repo",
+        "--pr",
+        "--reviewers",
+        "--author",
+        "--apply",
+        "--reviewer-timeout",
+        "--overall-timeout",
+        "--prepared-json",
+        "--json",
+        "--post-advisory-summary",
+    ):
+        assert flag in help_text

--- a/tests/scripts/test_collect_quorum_evidence.py
+++ b/tests/scripts/test_collect_quorum_evidence.py
@@ -1,7 +1,6 @@
 """The wrapper adds advisory delivery without changing collection semantics."""
 
 import json
-from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -27,6 +26,7 @@ def collected(monkeypatch):
                 body="- [P3] Minor",
                 verdict="pass",
                 would_count=True,
+                severity_gated=True,
             )
         ],
     ).to_dict()
@@ -64,9 +64,11 @@ def test_default_off_json_keys(collected, capsys):
 
 
 @pytest.mark.parametrize("prepared", [False, True])
-def test_flag_plumbing_fresh_and_prepared(collected, capsys, prepared):
+def test_flag_plumbing_fresh_and_prepared(collected, capsys, prepared, tmp_path):
     original, collector, poster = collected
-    flags = ["--prepared-json", "/tmp/prepared.json"] if prepared else []
+    path = tmp_path / "prepared.json"
+    path.write_text(json.dumps(original))
+    flags = ["--prepared-json", str(path)] if prepared else []
     assert (
         cli.main(
             ARGS
@@ -93,12 +95,32 @@ def test_flag_plumbing_fresh_and_prepared(collected, capsys, prepared):
     assert data["advisory_comment_url"] == "https://example.test/comment"
     assert all(data[key] == value for key, value in original.items())
     kwargs = collector.call_args.kwargs
-    assert kwargs["prepared_json"] == (Path("/tmp/prepared.json") if prepared else None)
+    assert kwargs["prepared_json"] == (path if prepared else None)
     assert kwargs["families"] == ["claude", "openai"] and kwargs["author"] == "x"
     assert kwargs["apply"] is True
     assert kwargs["reviewer_timeout_seconds"] == 30 and kwargs["overall_timeout_seconds"] == 60
     poster.assert_called_once()
     assert poster.call_args.kwargs["head_sha"] == original["head_sha"]
+
+
+@pytest.mark.parametrize("artifact", ["stale", "missing", "malformed", "[]", "null", "{}"])
+def test_prepared_json_stale_head_not_summarised(collected, capsys, tmp_path, artifact):
+    data, _, poster = collected
+    path = tmp_path / "prepared.json"
+    if artifact != "missing":
+        path.write_text(
+            json.dumps(dict(data, head_sha="b" * 40)) if artifact == "stale" else artifact
+        )
+    assert cli.main(ARGS + ["--prepared-json", str(path), "--post-advisory-summary", "--json"]) == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["advisory_posted"] is False
+    reason = output["advisory_reason"]
+    assert reason == (
+        "prepared head bbbbbbb differs from live head aaaaaaa; not summarised"
+        if artifact == "stale"
+        else "prepared artifact unreadable; not summarised"
+    )
+    poster.assert_not_called()
 
 
 def test_empty_items_never_calls_poster(collected, capsys):
@@ -135,6 +157,23 @@ def test_collect_failure_payload(collected, capsys):
     data.update(mode="collect_evidence", error="preflight failed")
     assert cli.main(ARGS + ["--post-advisory-summary"]) == 2
     assert "error: preflight failed" in capsys.readouterr().out
+    poster.assert_not_called()
+
+
+@pytest.mark.parametrize("payload", ["", "diagnostic text", "[]", "null"])
+def test_malformed_capture_failure_preserves_exit(collected, capsys, payload):
+    _, collector, poster = collected
+
+    def run(**kwargs):
+        if payload:
+            kwargs["printer"](payload)
+        return 2
+
+    collector.side_effect = run
+    assert cli.main(ARGS + ["--post-advisory-summary", "--json"]) == 2
+    data = json.loads(capsys.readouterr().out)
+    assert data["error"] == "collection outcome was not a JSON object"
+    assert data["advisory_posted"] is False
     poster.assert_not_called()
 
 

--- a/tests/swarm/test_advisory_dissent.py
+++ b/tests/swarm/test_advisory_dissent.py
@@ -143,8 +143,9 @@ def fake_github(monkeypatch, comments):
     return mock
 
 
-def test_idempotent_same_head_edits(monkeypatch):
-    mock = fake_github(monkeypatch, [{"id": 7, "body": MARKER + "\nold"}])
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_idempotent_same_head_edits(monkeypatch, newline):
+    mock = fake_github(monkeypatch, [{"id": 7, "body": MARKER + newline + "old"}])
     result = adv.post_advisory_summary(
         "synaptent/aragora",
         123,

--- a/tests/swarm/test_advisory_dissent.py
+++ b/tests/swarm/test_advisory_dissent.py
@@ -159,7 +159,7 @@ def test_findings_mirror_gate_reader(raw):
         ([True, True], "severity-gated dissent ON; P2/P3 findings are advisory to the merge gate."),
         (
             [True, False],
-            "severity-gated dissent OFF; a P2 finding blocks the merge gate by default.",
+            "severity-gated dissent OFF; a changes-requested verdict blocks the merge gate whatever its findings.",
         ),
         ([None, None], "unknown (outcome carries no severity_gated field)."),
     ],

--- a/tests/swarm/test_advisory_dissent.py
+++ b/tests/swarm/test_advisory_dissent.py
@@ -1,0 +1,181 @@
+"""Advisory summaries are visible to people, never quorum evidence."""
+
+import json
+import re
+from unittest.mock import Mock
+
+import pytest
+
+from aragora.swarm import advisory_dissent as adv
+from aragora.swarm.quorum_evidence import CollectOutcome, EvidenceItem
+
+HEAD = "a" * 40
+MARKER = f"<!-- aragora-advisory-summary head={HEAD} -->"
+TOKENS = (
+    "dogfood|adversarial|cross-author|recheck|codex review|claude review|"
+    "grok independent|gemini independent|independent semantic review|"
+    "independent model review|model-family semantic signal"
+)
+
+
+def outcome(body="- [P3] Keep the log", family="claude", verdict="pass"):
+    return CollectOutcome(
+        repo="synaptent/aragora",
+        pr=123,
+        head_sha=HEAD,
+        head_committed_at="",
+        tier=2,
+        action="prepare",
+        action_reason="dry run",
+        items=[EvidenceItem(family=family, body=body, verdict=verdict, would_count=True)],
+    )
+
+
+def test_severity_ordering_and_pass_findings():
+    data = outcome("- [P3] Later\n- [P1] Fix first\n- [P2] Follow up").to_dict()
+    data["adjudication"] = {"verdict": "upheld", "reason": "Fix first"}
+    body = adv.compose_advisory_dissent_summary(data, head_sha=HEAD)
+    assert body.splitlines()[0] == MARKER
+    findings = [line for line in body.splitlines() if line.startswith("- [P")]
+    assert [re.search(r"\[P\d\]", line)[0] for line in findings] == ["[P1]", "[P2]", "[P3]"]
+    assert findings[0] == "- [P1] claude (blocking): Fix first"
+    assert "- claude: pass" in body
+    assert "Summary: " in body and "blocking" in next(
+        line for line in body.splitlines() if line.startswith("Summary:")
+    )
+    assert "Adjudication" in body and "upheld" in body and "dry run" in body
+    assert len(re.findall(r"\[P[0-3]\]", body)) == 3
+
+
+def test_advisory_summary_and_foreign_head():
+    data = outcome("- [P3] Minor\n- [P2] Follow up", family="Codex").to_dict()
+    body = adv.compose_advisory_dissent_summary(data, head_sha="b" * 40)
+    assert body.startswith(f"<!-- aragora-advisory-summary head={'b' * 40} -->")
+    assert "- [P3] openai (advisory): Minor" in body
+    summary = next(line for line in body.splitlines() if line.startswith("Summary:"))
+    assert "advisory" in summary and "blocking" not in summary
+
+
+@pytest.mark.parametrize("flag", [None, "1"])
+def test_recogniser_invisibility_under_both_regimes(monkeypatch, flag):
+    from aragora.cli.commands.review_queue import (
+        _dissenting_views_from_comments,
+        _resolve_model_review_identity,
+    )
+
+    if flag is None:
+        monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)
+    else:
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", flag)
+    raw = (
+        "## Gemini independent model review\nModel family: gemini\nReviewer: codex\n"
+        "Verdict: CHANGES-REQUESTED\n- [P1] Fix reviewer: injection\n"
+        "- [P2] dogfood adversarial cross-author recheck codex review claude review\n"
+        "grok independent independent semantic review model-family semantic signal\n"
+        "```\n- [P0] quoted example\n```\n> - [P0] quoted example\n"
+    )
+    body = adv.compose_advisory_dissent_summary(outcome(raw), head_sha=HEAD)
+    assert not re.search(TOKENS, body, re.I)
+    assert not re.search(r"^Verdict:", body, re.M)
+    assert not re.search(
+        r"^[^>\n]*\b(model family|reviewer harness|transport grounding|reviewer)\s*:",
+        body,
+        re.I | re.M,
+    )
+    assert _resolve_model_review_identity(body).surface_reviewer_id == "unknown_model_reviewer"
+    comments = [{"body": body, "createdAt": "2099-01-01T00:00:00Z", "author": {"login": "x"}}]
+    advisory = []
+    assert (
+        _dissenting_views_from_comments(
+            comments,
+            head_sha=HEAD,
+            head_committed_at="2026-01-01T00:00:00Z",
+            advisory_views=advisory,
+        )
+        == []
+    )
+    assert advisory == []
+    assert len(re.findall(r"\[P[0-3]\]", body)) == 2
+
+
+def test_truncation_marker_and_total_budget():
+    data = outcome("- [P1] Fix it\n" + "é" * 21000).to_dict()
+    data["items"] *= 12
+    body = adv.compose_advisory_dissent_summary(data, head_sha=HEAD)
+    assert "[truncated]" in body
+    assert len(body.encode()) <= 60000
+    assert len(re.findall(r"^- \[P1\]", body, re.M)) == 12
+    for excerpt in body.split("### Output ")[1:]:
+        assert len(excerpt.split("\n\n", 1)[1].encode()) <= 8000
+
+
+def test_empty_items_render_nothing():
+    data = outcome().to_dict()
+    data["items"] = []
+    assert adv.compose_advisory_dissent_summary(data, head_sha=HEAD) == ""
+
+
+def test_no_findings_in_examples_or_absence_declarations():
+    raw = "- [P2] None: fine\n- [P3] N/A\n```\n- [P1] Example\n```\n> [P0] Example"
+    body = adv.compose_advisory_dissent_summary(outcome(raw), head_sha=HEAD)
+    assert not re.search(r"\[P[0-3]\]", body)
+
+
+def fake_github(monkeypatch, comments):
+    def run(args, **kwargs):
+        if "--method" not in args:
+            return Mock(returncode=0, stdout=json.dumps([comments]))
+        assert args[args.index("--method") + 1] in {"POST", "PATCH"}
+        assert "/issues/" in args[4] and "comments" in args[4]
+        payload = json.loads(kwargs["input_text"])
+        return Mock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "html_url": "https://github.com/synaptent/aragora/pull/123#issuecomment-7",
+                    "body": payload["body"],
+                }
+            ),
+        )
+
+    mock = Mock(side_effect=run)
+    monkeypatch.setattr(adv.merge_quorum_io, "run", mock)
+    return mock
+
+
+def test_idempotent_same_head_edits(monkeypatch):
+    mock = fake_github(monkeypatch, [{"id": 7, "body": MARKER + "\nold"}])
+    result = adv.post_advisory_summary(
+        "synaptent/aragora",
+        123,
+        MARKER + "\nnew",
+        head_sha=HEAD,
+    )
+    assert result.posted and result.edited and result.reason is None
+    assert result.comment_url.endswith("issuecomment-7")
+    assert "PATCH" in mock.call_args.args[0]
+    assert "repos/synaptent/aragora/issues/comments/7" in mock.call_args.args[0]
+
+
+def test_new_head_creates_comment(monkeypatch):
+    mock = fake_github(monkeypatch, [{"id": 7, "body": MARKER + "\nold"}])
+    new_head = "b" * 40
+    body = adv.compose_advisory_dissent_summary(outcome(), head_sha=new_head)
+    result = adv.post_advisory_summary("synaptent/aragora", 123, body, head_sha=new_head)
+    assert result.posted and not result.edited
+    assert "POST" in mock.call_args.args[0]
+
+
+def test_empty_body_never_calls_github(monkeypatch):
+    mock = fake_github(monkeypatch, [])
+    result = adv.post_advisory_summary("synaptent/aragora", 123, "", head_sha=HEAD)
+    assert not result.posted and "items: []" in result.reason
+    mock.assert_not_called()
+
+
+def test_read_failure_never_creates_duplicate(monkeypatch):
+    mock = Mock(return_value=Mock(returncode=1, stdout="", stderr="transport failure"))
+    monkeypatch.setattr(adv.merge_quorum_io, "run", mock)
+    result = adv.post_advisory_summary("synaptent/aragora", 123, MARKER, head_sha=HEAD)
+    assert not result.posted and result.reason
+    assert mock.call_count == 1

--- a/tests/swarm/test_advisory_dissent.py
+++ b/tests/swarm/test_advisory_dissent.py
@@ -1,13 +1,17 @@
 """Advisory summaries are visible to people, never quorum evidence."""
 
+import ast
 import json
 import re
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
 from aragora.swarm import advisory_dissent as adv
 from aragora.swarm.quorum_evidence import CollectOutcome, EvidenceItem
+from aragora.cli.commands import review_queue
+from aragora.cli.commands.review_queue_comment_verdicts import extract_finding_lines
 
 HEAD = "a" * 40
 MARKER = f"<!-- aragora-advisory-summary head={HEAD} -->"
@@ -27,7 +31,11 @@ def outcome(body="- [P3] Keep the log", family="claude", verdict="pass"):
         tier=2,
         action="prepare",
         action_reason="dry run",
-        items=[EvidenceItem(family=family, body=body, verdict=verdict, would_count=True)],
+        items=[
+            EvidenceItem(
+                family=family, body=body, verdict=verdict, would_count=True, severity_gated=True
+            )
+        ],
     )
 
 
@@ -54,6 +62,7 @@ def test_advisory_summary_and_foreign_head():
     assert "- [P3] openai (advisory): Minor" in body
     summary = next(line for line in body.splitlines() if line.startswith("Summary:"))
     assert "advisory" in summary and "blocking" not in summary
+    assert "Severity labels only; not a merge decision." in summary
 
 
 @pytest.mark.parametrize("flag", [None, "1"])
@@ -74,7 +83,10 @@ def test_recogniser_invisibility_under_both_regimes(monkeypatch, flag):
         "grok independent independent semantic review model-family semantic signal\n"
         "```\n- [P0] quoted example\n```\n> - [P0] quoted example\n"
     )
-    body = adv.compose_advisory_dissent_summary(outcome(raw), head_sha=HEAD)
+    data = outcome(raw).to_dict()
+    data["items"][0]["severity_gated"] = False
+    body = adv.compose_advisory_dissent_summary(data, head_sha=HEAD)
+    assert "&#58;" in adv._safe_text("Reviewer**: codex", inline=True)
     assert not re.search(TOKENS, body, re.I)
     assert not re.search(r"^Verdict:", body, re.M)
     assert not re.search(
@@ -119,6 +131,63 @@ def test_no_findings_in_examples_or_absence_declarations():
     raw = "- [P2] None: fine\n- [P3] N/A\n```\n- [P1] Example\n```\n> [P0] Example"
     body = adv.compose_advisory_dissent_summary(outcome(raw), head_sha=HEAD)
     assert not re.search(r"\[P[0-3]\]", body)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "- [P3] Later\n- [P1] Fix first\n- [P2] Follow up",
+        "- **[P2]** Bold\n1. [p3] lower\n- [P1]: colon form",
+        "- [P2] None: fine\n- [P3] N/A\n```\n- [P1] Example\n```\n> [P0] Example",
+        "````python title=x\n- [P0] Example\n```\n````\n- [P3] Real finding",
+    ],
+)
+def test_findings_mirror_gate_reader(raw):
+    body = adv.compose_advisory_dissent_summary(outcome(raw), head_sha=HEAD)
+    findings = [line for line in body.splitlines() if line.startswith("- [P")]
+    expected = []
+    for line in sorted(extract_finding_lines(raw), key=lambda line: line[1:3]):
+        match = re.match(r"\[(P[0-3])\]\s*(.*)", line)
+        label = "blocking" if match[1] in {"P0", "P1"} else "advisory"
+        expected.append(f"- [{match[1]}] claude ({label}): {match[2].strip()}")
+    assert findings == expected
+
+
+@pytest.mark.parametrize(
+    "flags,disclosure",
+    [
+        ([True, True], "severity-gated dissent ON; P2/P3 findings are advisory to the merge gate."),
+        (
+            [True, False],
+            "severity-gated dissent OFF; a P2 finding blocks the merge gate by default.",
+        ),
+        ([None, None], "unknown (outcome carries no severity_gated field)."),
+    ],
+)
+def test_gate_regime_line_from_items(flags, disclosure):
+    data = outcome("- [P2] Follow up").to_dict()
+    data["items"] = [dict(data["items"][0], severity_gated=flag) for flag in flags]
+    for item in data["items"]:
+        if item["severity_gated"] is None:
+            del item["severity_gated"]
+    body = adv.compose_advisory_dissent_summary(data, head_sha=HEAD)
+    lines = body.splitlines()
+    index = next(i for i, line in enumerate(lines) if line.startswith("Summary:"))
+    assert lines[index + 1] == f"Gate regime: {disclosure}"
+    assert sum(line.startswith("Gate regime: ") for line in lines) == 1
+    assert "- [P2] claude (advisory): Follow up" in lines
+
+
+def test_recogniser_tokens_cover_review_queue_literals():
+    tree = ast.parse(Path(review_queue.__file__).read_text())
+    groups = [
+        [elt.value for elt in node.elts if isinstance(elt, ast.Constant)]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Tuple, ast.List, ast.Set))
+    ]
+    groups = [group for group in groups if "independent model review" in group]
+    assert len(groups) >= 3
+    assert all(adv._TOKENS.fullmatch(value) for group in groups for value in group)
 
 
 def fake_github(monkeypatch, comments):


### PR DESCRIPTION
## Summary

- Add `aragora/swarm/advisory_dissent.py` and `--post-advisory-summary` in the thin collector wrapper together. Default remains off.
- Preserve each family's verdict and findings, including findings on PASS outputs. Show severity ordering, adjudication, action and reason separately from countable evidence.
- Edit the same-head marker comment on repeat delivery; never set a status, label or GitHub review. Delivery failures preserve the collection exit code.

## Exit metric moved

Receipt-First epic #9966, row 6: adds the dissent visibility mechanism for prepared collections. The scoreboard's post-M2 counting rule follows in its separately assigned feature.

## Test commands

- `python3 -m pytest tests/swarm/test_advisory_dissent.py tests/scripts/test_collect_quorum_evidence.py tests/swarm/test_quorum_evidence.py -q -p no:cacheprovider`: 400 passed (380 unchanged library tests, 20 new cases).
- `bash "$MISSION_DIR/bin/gate.sh" lint|typecheck|contracts|guardrails|test` (each section separately): all GATE PASSED; curated suite 3931 passed, 3 skipped; publish-shadow 104 passed, 2 skipped; mypy 1744 unchanged.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed.
- Real `research/quorum-dryrun-9949.json`, rendered unchanged with foreign `head_sha="a"*40`: exactly five advisory findings (four claude P3 on PASS, one openai P2), 7248 bytes; real identity/dissent parsers ignore it with the severity flag both on and unset.
- Empty items render `''` and are not posted. The implementation does not re-export the composer from `aragora.swarm`; neither protected quorum file changes.

## Reviewed design tradeoffs

No new dependency. Only the existing quorum-evidence library is imported by the module. Display-only finding extraction rejects fenced/quoted examples and reuses the library's absence-declaration rules. HTML entities preserve recogniser phrases visually without leaving raw trigger substrings. Priority tokens appear only in finding lines, not duplicated in quoted excerpts.

The body cap is 60000 UTF-8 bytes (also bounds characters); excerpts are at most 8000 bytes with literal `[truncated]`. All verdicts/findings precede optional excerpts; if even their structural skeleton cannot fit, composition fails rather than silently dropping findings. Foreign-head rendering is offline-only use; wrapper delivery uses the collector's resolved head.

**Collection 1 (2026-09-07, head 490c74d4): CI ratchet repair and the six advisory findings.**

- CI: the required `lint` check failed at `Enforce code quality ratchet` (`except Exception: 901 > 900`). The delivery handler now catches `(OSError, subprocess.SubprocessError, RuntimeError, ValueError, TypeError, KeyError)`, covering subprocess/OS failures, JSON decoding, comment id/URL lookups and its explicit errors. No ratchet limit changed.
- REPAIRED in head 20c3d4e2949e381b2c43debeb65ed77b2b509eab: CRLF-safe same-head marker matching, and the text-mode `error:` line retaining transport phase/attempt context. Regression tests cover both.
- ANSWERED, not changed: `collect_outcome_from_dict` drops `orchestration_timeout`, `timed_out_families`, and `overall_timeout_seconds`. `_render_outcome` prints none of them, so today's text output is identical, verified on the collection-1 JSON. The round trip lives in the Tier-4 `aragora/swarm/quorum_evidence.py`, which this PR never touches; a future renderer change must extend `collect_outcome_from_dict` in the same library PR.
- ANSWERED, not changed: `_safe_text` emits `&gt; ` for a neutralised heading/disclosure line inside a finding. This is cosmetic and deliberate: the entity is the neutralisation layer. It appears only when a reviewer's finding text itself starts with a heading marker or disclosure label, an injection attempt. Recogniser invisibility is tested with the severity gate both enabled and unset.
- ANSWERED, not changed: same-head lookup matches the full 40-hex head marker without an author filter. A spoofed marker comment from another account can only produce PATCH 403 (`advisory delivery failed (RuntimeError)`, collection exit code unchanged) or an overwrite of that spoof, neither harmful to genuine evidence. An author filter would add a `gh api user` call per run.
- ANSWERED, not changed: roughly 1200+ tagged findings can make composition raise rather than silently drop findings, as the structural-skeleton tradeoff above states. The wrapper isolates this as `advisory summary failed (ValueError)` without changing the collection exit code.

Repair verification: both feature suites now have 22 passing cases; ruff check/format are clean and the code-quality ratchet passes at `except_exception 900 (limit: 900)`. The original test counts above describe the initial head.

**Collection 2 (2026-09-07, head 20c3d4e2): gate-mirror findings, regime disclosure, fail-closed wrapper.**

The initial implementation and verification paragraphs above are preserved as history. This entry supersedes the initial import/extraction description: the module now also imports the gate's own `extract_finding_lines` reader, rather than maintaining a second parser.

- REPAIRED in head 8e2dc5ede2be147b323290872b0ae6475cbeb369 (A): findings come directly from `aragora.cli.commands.review_queue_comment_verdicts.extract_finding_lines`. The summary shares the gate's fence-info-string limitation by design: a fence info string containing spaces can expose an example finding to both. This avoids hiding a finding that the gate reads. Real fixture counts match one-to-one: 9949 = 4+1, 490c74d4 = 6+0, 20c3d4e2 = 6+1.
- REPAIRED in head 8e2dc5ede2be147b323290872b0ae6475cbeb369 (B): finding labels remain severity-level per the mission contract, P0/P1 blocking and P2/P3 advisory. The items' `severity_gated` fields supply a separate ON/OFF/unknown regime disclosure immediately after `Summary:`, never the environment. The summary explicitly says `Severity labels only; not a merge decision.` OFF means a P2 finding blocks the merge gate by default, even though the severity-level label stays advisory.
- REPAIRED in head 8e2dc5ede2be147b323290872b0ae6475cbeb369 (C): malformed/non-object captured JSON fails closed, preserving the collector's exit code. Prepared artifacts with stale heads or unreadable content are never summarised under the live head; the stale reason names both short heads.
- REPAIRED in head 8e2dc5ede2be147b323290872b0ae6475cbeb369 (D): an AST regression checks every recogniser token in the three live literal groups in `review_queue.py`, without editing that protected file.
- REPAIRED in head 8e2dc5ede2be147b323290872b0ae6475cbeb369 (E): disclosure-label neutralisation covers decorations before the colon, including `Reviewer**:`.
- ANSWERED, not changed (see the Collection 1 entry): "same-head lookup matches the full 40-hex head marker without an author filter." Its failed PATCH is isolated and cannot change gate state; no extra user-identity request was added.
- ANSWERED, not changed (see the Collection 1 entry): "`_safe_text` emits `&gt; ` for a neutralised heading/disclosure line inside a finding." The entity remains the deliberate neutralisation layer.

Repair verification: red-first regression run 12 failed / 28 passed; repaired feature suites 40 passed. Every constructed evidence item explicitly sets its gate regime. Ruff format/check are clean; PR delta is 782 LOC across exactly the module, wrapper and both test files. Main #10011 was merged without rewriting branch history.

**Collection 3 (2026-09-07, head 8e2dc5ed): OFF regime wording repaired; mirror line and hardening deferred.**

This entry supersedes the historical OFF-regime wording in the Collection 2 entry; all earlier sections remain preserved.

- REPAIRED in head 74e4a501ab542d1dc40e5ca9063220e8c5525952: the OFF regime line now says a changes-requested verdict blocks the merge gate whatever its findings. Under OFF, `EvidenceItem.dissenting` returns True for any `changes_requested` verdict (`quorum_evidence.py:968-971`); a `[P2]` inside a PASS never blocks in any regime.
- ANSWERED, not changed (see the Collection 2 entry): regime-aware labels. Labels are severity-level by the mission contract (VAL-DISSENT-005), and the regime is disclosed on its own line.
- ANSWERED, not changed (see the Collection 1 entry): marker author filter / PATCH fallback.
- DEFERRED to the follow-up PR (mission feature `m2-advisory-dissent-hardening`, VAL-DISSENT-011), beyond this PR's 800-LOC cap (786 including this repair's four changed lines against the prior 782 budget): a `Merge-gate dissent: <families>.|none.|unknown (…)` line mirroring the outcome's own `dissenting_families` directly after `Gate regime:`; the text-mode rehydration guard; `merge_quorum_io._read_env()` for the comment-listing GET; entity-safe `_clip`.

Attempt-2 verification: the exact OFF-wording test failed first (1 failed, 2 passed), then both feature suites passed (40 passed). `test_recogniser_invisibility_under_both_regimes[None]` and `[1]` both passed. Ruff left both files unchanged and reported all checks passed. Only the module's OFF string and its test expectation changed; ON/unknown wording, labels, Summary, parser, clipping, neutralisation and delivery are unchanged. The net merge-base diff remains 782 LOC across the four feature paths, because the two replaced lines were already additions in this PR.

**Attempt-2 collection 1 (2026-09-07, head 74e4a501): clean two-family pass**

Claude and OpenAI both returned grounded PASS with `would_count: true`, action `prepare`, no dissenting families and no failures. Claude reported five P3 findings; OpenAI reported none. The preserved exact-head collection is reused, not rerolled.

- Marker-author/PATCH-fallback: answered in Collection 1; no author-filter change.
- Text-mode rehydration guard and entity-safe clipping: already deferred to `m2-advisory-dissent-hardening` (VAL-DISSENT-011).
- Private-helper imports: reviewed tradeoff, reusing existing gate/render helpers without adding public exports across this feature's protected-path boundary. Import and regression tests make a helper rename visible rather than silently ignored.
- Prepared/live-head comparison: retain the deliberate fail-closed advisory-delivery guard required by ruling 11, not remove it as cosmetic redundancy.

The [linked severity-label disposition](https://github.com/synaptent/aragora/issues/9966#issuecomment-5566038288) states **"answered, advisory, not a code defect"** and **"No relabelling and no author-filter change are to be made."** The corrected OFF wording is the Collection 3 wording above. Ruling 12's split remains: the mirror line and all three hardenings belong in the follow-up PR. The net diff is 782 of the binding 800-LOC cap, not 786; no cap or gate override is used. This clean collection requires neither another collection nor operator advisory settlement.

## Risks

GitHub comments do not provide an atomic upsert, so calls for a PR/head must be serialized. Comment-read failure fails closed instead of creating a possible duplicate. This flag deliberately publishes an advisory comment even on a draft or Tier 3-4 PR; it does not enable evidence posting or settlement.

The v0.2 receipt-bridge smoke is conditional on the separate M1 bridge being on main. No ODR, counting, recognition, settlement or workflow paths are changed. The inherited docs guardrail breach (1120 pages, external #9995) remains unchanged.



