### PR TITLE
fix(cli): refuse misleading receipt export fallbacks

### DIFF
--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -815,14 +815,23 @@ def cmd_receipt_export(args: argparse.Namespace) -> None:
                 content = receipt.to_csv()
             else:
                 content = receipt.to_json()
-        except (ImportError, AttributeError, KeyError, ValueError, TypeError):
-            # Fallback to simple formatter
+        except (ImportError, AttributeError, KeyError, ValueError, TypeError) as exc:
+            # A fallback must still produce the requested artifact format.
             if output_format == "html":
                 content = receipt_to_html(data)
             elif output_format in ("md", "markdown"):
                 content = receipt_to_markdown(data)
             else:
-                content = json.dumps(data, indent=2, default=str)
+                print(
+                    f"Error: Could not export receipt as {output_format.upper()}", file=sys.stderr
+                )
+                if output_format == "pdf" and isinstance(exc, ImportError):
+                    print(
+                        "PDF export requires weasyprint and its system dependencies; "
+                        "check that they are installed in this environment.",
+                        file=sys.stderr,
+                    )
+                sys.exit(1)
 
     if output_path:
         if isinstance(content, bytes):

--- a/tests/cli/test_receipt_export_failures.py
+++ b/tests/cli/test_receipt_export_failures.py
@@ -1,0 +1,213 @@
+"""Receipt export failures must not masquerade as another artifact format."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from aragora.cli.commands.receipt import cmd_receipt_export
+from aragora.cli.receipt_formatter import receipt_to_html, receipt_to_markdown
+from aragora.gauntlet.receipt_models import DecisionReceipt
+
+
+@pytest.fixture
+def receipt_path(tmp_path: Path) -> Path:
+    path = tmp_path / "receipt.json"
+    path.write_text(
+        json.dumps(
+            {
+                "receipt_id": "export-contract",
+                "gauntlet_id": "export-contract",
+                "timestamp": "2026-09-07T00:00:00Z",
+                "verdict": "PASS",
+                "confidence": 0.8,
+                "risk_summary": {"total": 0},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.mark.parametrize(
+    "output_format,method", [("pdf", "to_pdf"), ("sarif", "to_sarif_json"), ("csv", "to_csv")]
+)
+@pytest.mark.parametrize(
+    "error_type", [ImportError, AttributeError, KeyError, ValueError, TypeError]
+)
+@pytest.mark.parametrize("destination", ["stdout", "new", "existing"])
+def test_conversion_failure_never_outputs_native_json(
+    receipt_path: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    output_format: str,
+    method: str,
+    error_type: type[Exception],
+    destination: str,
+) -> None:
+    output = tmp_path / f"output.{output_format}"
+    if destination == "existing":
+        output.write_bytes(b"preserve existing artifact")
+    args = argparse.Namespace(
+        receipt=str(receipt_path),
+        format=output_format,
+        output=None if destination == "stdout" else str(output),
+    )
+
+    with patch.object(DecisionReceipt, method, side_effect=error_type("conversion failed")):
+        with pytest.raises(SystemExit) as exc:
+            cmd_receipt_export(args)
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert output_format.upper() in captured.err
+    assert "Error:" in captured.err
+    if destination == "existing":
+        assert output.read_bytes() == b"preserve existing artifact"
+    else:
+        assert not output.exists()
+
+
+def test_missing_pdf_dependency_is_actionable(
+    receipt_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with patch.dict("sys.modules", {"weasyprint": None}):
+        with pytest.raises(SystemExit) as exc:
+            cmd_receipt_export(
+                argparse.Namespace(receipt=str(receipt_path), format="pdf", output=None)
+            )
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "weasyprint" in captured.err
+
+
+def test_missing_pdf_dependency_fails_through_cli_process(
+    receipt_path: Path, tmp_path: Path
+) -> None:
+    output = tmp_path / "receipt.pdf"
+    output.write_bytes(b"preserve existing artifact")
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+        "ARAGORA_USE_SECRETS_MANAGER": "0",
+        "AWS_EC2_METADATA_DISABLED": "true",
+        "ARAGORA_SSRF_ALLOW_LOCALHOST": "false",
+        "ARAGORA_DATA_DIR": str(tmp_path / "data"),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.modules['weasyprint'] = None; "
+            "from aragora.cli.main import main; raise SystemExit(main())",
+            "receipt",
+            "export",
+            str(receipt_path),
+            "--format",
+            "pdf",
+            "--output",
+            str(output),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        timeout=30,
+    )
+    assert result.returncode == 1, result.stderr.decode()
+    assert result.stdout == b""
+    assert b"weasyprint" in result.stderr
+    assert b"Traceback" not in result.stderr
+    assert output.read_bytes() == b"preserve existing artifact"
+
+
+@pytest.mark.parametrize("output_format", ["sarif", "csv"])
+def test_successful_export_through_cli_process(
+    receipt_path: Path, tmp_path: Path, output_format: str
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "aragora.cli.main",
+            "receipt",
+            "export",
+            str(receipt_path),
+            "--format",
+            output_format,
+        ],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+            "ARAGORA_USE_SECRETS_MANAGER": "0",
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "ARAGORA_SSRF_ALLOW_LOCALHOST": "false",
+            "ARAGORA_DATA_DIR": str(tmp_path / "data"),
+        },
+        capture_output=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr.decode()
+    assert result.stderr == b""
+    if output_format == "sarif":
+        assert json.loads(result.stdout)["version"] == "2.1.0"
+    else:
+        assert result.stdout.startswith(b"Finding ID,Category,Severity,Title,")
+
+
+@pytest.mark.parametrize(
+    "output_format,method,content",
+    [
+        ("pdf", "to_pdf", b"%PDF-1.7\n"),
+        ("sarif", "to_sarif_json", '{"version":"2.1.0"}'),
+        ("csv", "to_csv", "title,severity\n"),
+    ],
+)
+@pytest.mark.parametrize("to_file", [False, True])
+def test_successful_export_preserves_format_bytes(
+    receipt_path: Path,
+    tmp_path: Path,
+    capfdbinary: pytest.CaptureFixture[bytes],
+    output_format: str,
+    method: str,
+    content: str | bytes,
+    to_file: bool,
+) -> None:
+    output = tmp_path / f"output.{output_format}"
+    args = argparse.Namespace(
+        receipt=str(receipt_path), format=output_format, output=str(output) if to_file else None
+    )
+    with patch.object(DecisionReceipt, method, return_value=content):
+        cmd_receipt_export(args)
+    expected = content if isinstance(content, bytes) else content.encode("utf-8")
+    captured = capfdbinary.readouterr()
+    assert captured.err == b""
+    if to_file:
+        assert output.read_bytes() == expected
+        assert captured.out == f"Exported to {output}\n".encode()
+    else:
+        assert captured.out == expected + (b"" if isinstance(content, bytes) else b"\n")
+
+
+@pytest.mark.parametrize("output_format", ["html", "md", "markdown"])
+def test_legacy_fallback_still_produces_requested_format(
+    receipt_path: Path, capsys: pytest.CaptureFixture[str], output_format: str
+) -> None:
+    data = json.loads(receipt_path.read_text(encoding="utf-8"))
+    expected = receipt_to_html(data) if output_format == "html" else receipt_to_markdown(data)
+    with patch.object(DecisionReceipt, "from_dict", side_effect=ValueError("legacy shape")):
+        cmd_receipt_export(
+            argparse.Namespace(receipt=str(receipt_path), format=output_format, output=None)
+        )
+    captured = capsys.readouterr()
+    assert captured.out == expected + "\n"
+    assert captured.err == ""


### PR DESCRIPTION
## Summary
- Fail with exit 1 when PDF, SARIF, or CSV conversion fails instead of emitting native JSON as a successful requested-format artifact.
- Preserve HTML/Markdown format-correct fallbacks and successful output bytes. Conversion failure leaves an existing destination unchanged and does not create a new one.
- Report missing PDF dependencies with an actionable diagnostic.

Receipt Consumer Reliability campaign, contract 1. Related outsider acceptance: #8858 (not fulfilled by these automated tests).

## Validation
- Baseline witnesses: 46 failures and 9 passing success/fallback cases on main `ebe1bfd262f3c9f942679a0a6e2da24e3bd71534` before the production fix.
- `uv sync --locked --extra dev --extra test` created the branch-local environment without dependency changes.
- `python -m pytest tests/cli/test_receipt_export_failures.py tests/cli/test_receipt_command.py tests/cli/test_receipt_roundtrip.py -q`: 75 passed, including real CLI subprocess failure/success paths.
- Ruff and changed-file mypy: passed for both files.
- `python scripts/report_code_quality.py --check`: passed; broad catches remain 900/900.
- Automation publication preflight, `git diff --check`, and normal commit hooks: passed.

## Boundaries And Rollback
Two files only; 15-line production diff plus focused regressions. No schema, signing, verification algorithm, dependency, workflow, or exporter-internal changes. No changes to #9903 or peer-owned work. Broader input/inspection/filesystem error handling and installed offline acceptance remain future campaign contracts.

Revert this commit to restore prior CLI conversion behavior. Draft pending exact-head CI and independent governed review; no model evidence has been collected or posted.
