### PR TITLE
feat(policy): add data-only operator grant verification

### DIFF
--- a/aragora/policy/operator_grant.py
+++ b/aragora/policy/operator_grant.py
@@ -1,0 +1,338 @@
+"""Opt-in verification of operator-grant *data*, never action authorization.
+
+No signer, key discovery, storage, network, legacy conversion, or live caller.
+Trusted observations must come from a separate trusted caller, not the grant.
+See docs/governance/OPERATOR_GRANT_VERIFICATION.md for the closed wire contract.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Any
+
+from aragora.storage.receipt_signing import Ed25519Signer
+
+SCHEMA_VERSION = "aragora-operator-grant/1.0"
+DOMAIN = b"aragora/operator-grant/v1\n"
+MAX_BYTES = 65_536
+MAX_OBSERVATION_AGE = timedelta(seconds=60)
+ACTION_NAMES = frozenset(
+    {"branch_write", "validate", "draft_publish", "ready", "evidence_apply", "protected_squash"}
+)
+HARD_DENIALS = frozenset(
+    {
+        "authority_change",
+        "grant_issue",
+        "grant_renew",
+        "grant_revoke",
+        "subdelegate",
+        "admin_merge",
+        "force_push",
+        "delete",
+        "deploy",
+        "credentials",
+        "workflow_change",
+        "schedule_change",
+        "paid_inference",
+    }
+)
+CONTEXT_FIELDS = frozenset(
+    {
+        "grant_id",
+        "grant_version",
+        "repository_id",
+        "repository",
+        "operator",
+        "delegate",
+        "campaign_id",
+        "goal_digest",
+        "acceptance_digest",
+        "policy_version",
+        "policy_digest",
+        "enforcement_digest",
+        "key_id",
+        "trust_version",
+        "revocation_source",
+    }
+)
+_FIELDS = CONTEXT_FIELDS | {
+    "schema_version",
+    "approval_ref",
+    "approval_digest",
+    "issued_at",
+    "not_before",
+    "expires_at",
+    "actions",
+    "denied_actions",
+    "scope",
+    "contract_ids",
+    "validation_commands",
+    "review_requirements",
+    "budget",
+    "can_subdelegate",
+}
+
+
+class VerificationCode(str, Enum):
+    VERIFIED = "verified_data_only"
+    MALFORMED = "malformed_grant"
+    CONTEXT_MISMATCH = "context_mismatch"
+    INVALID_TIME = "invalid_time"
+    UNTRUSTED = "untrusted_key_or_observation"
+    REVOKED = "revoked"
+    INVALID_SIGNATURE = "invalid_signature"
+    CRYPTO_UNAVAILABLE = "crypto_unavailable"
+
+
+class GrantValidationError(ValueError):
+    """Invalid closed-schema payload; also used by offline payload encoders."""
+
+
+@dataclass(frozen=True)
+class TrustedKey:
+    operator: str
+    public_key: bytes
+    trust_version: int
+    revoked: bool
+    observed_at: datetime
+    valid_until: datetime
+
+
+@dataclass(frozen=True)
+class RevocationObservation:
+    source: str
+    grant_id: str
+    grant_version: int
+    revoked: bool
+    observed_at: datetime
+    valid_until: datetime
+
+
+@dataclass(frozen=True)
+class VerifiedGrant:
+    """Immutable signed bytes, not a reusable authorization decision."""
+
+    canonical_payload: bytes
+    payload_sha256: str
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    code: VerificationCode
+    grant: VerifiedGrant | None = None
+
+
+def _require(condition: bool) -> None:
+    if not condition:
+        raise GrantValidationError("invalid operator-grant shape or constraint")
+
+
+def _fields(value: Any, fields: set[str] | frozenset[str]) -> None:
+    _require(type(value) is dict and value.keys() == fields)
+
+
+def _text(value: Any) -> None:
+    _require(type(value) is str and 0 < len(value) <= 2048)
+    _require(value == value.strip() and not any(ord(c) < 32 or ord(c) == 127 for c in value))
+    try:
+        value.encode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise GrantValidationError("invalid UTF-8 text") from exc
+
+
+def _integer(value: Any, low: int = 1, high: int = 2**53 - 1) -> None:
+    _require(type(value) is int and low <= value <= high)
+
+
+def _strings(value: Any, *, empty: bool = False) -> None:
+    _require(type(value) is list and (0 if empty else 1) <= len(value) <= 64)
+    for item in value:
+        _text(item)
+    _require(len(set(value)) == len(value))
+
+
+def _timestamp(value: Any) -> datetime:
+    _text(value)
+    _require(re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value) is not None)
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise GrantValidationError("invalid UTC timestamp") from exc
+
+
+def _validate_payload(p: dict[str, Any]) -> None:
+    _fields(p, _FIELDS)
+    for name, value in p.items():
+        if name not in {
+            "grant_version",
+            "repository_id",
+            "trust_version",
+            "actions",
+            "denied_actions",
+            "scope",
+            "contract_ids",
+            "validation_commands",
+            "review_requirements",
+            "budget",
+            "can_subdelegate",
+        }:
+            _text(value)
+        if name.endswith("_digest"):
+            _require(re.fullmatch(r"[0-9a-f]{64}", value) is not None)
+    _require(p["schema_version"] == SCHEMA_VERSION and p["can_subdelegate"] is False)
+    for name in ("grant_version", "repository_id", "trust_version"):
+        _integer(p[name])
+    _require(re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", p["repository"]) is not None)
+    for name in (
+        "actions",
+        "denied_actions",
+        "contract_ids",
+        "validation_commands",
+        "review_requirements",
+    ):
+        _strings(p[name])
+    _require(set(p["actions"]) <= ACTION_NAMES)
+    _require(HARD_DENIALS <= set(p["denied_actions"]))
+    _require(not set(p["actions"]) & set(p["denied_actions"]))
+    scope = p["scope"]
+    _fields(scope, {"branches", "paths", "denied_paths", "surfaces", "risk_classes", "tiers"})
+    for name in ("branches", "paths", "denied_paths", "surfaces", "risk_classes"):
+        _strings(scope[name], empty=name == "denied_paths")
+    for name in ("branches", "paths", "denied_paths"):
+        for path in scope[name]:
+            parsed = PurePosixPath(path)
+            _require(not parsed.is_absolute() and parsed.as_posix() == path)
+            _require(path != "." and ".." not in parsed.parts)
+            _require(not any(c in path for c in "\\:*?[]{}"))
+    _require(not set(scope["paths"]) & set(scope["denied_paths"]))
+    _require(type(scope["tiers"]) is list and 1 <= len(scope["tiers"]) <= 5)
+    for tier in scope["tiers"]:
+        _integer(tier, 0, 4)
+    _require(len(set(scope["tiers"])) == len(scope["tiers"]))
+    budget = p["budget"]
+    _fields(
+        budget,
+        {"active_prs", "merges", "attempts", "wall_seconds", "paid_microdollars", "subdelegates"},
+    )
+    for name, value in budget.items():
+        _integer(value, 0)
+    _require(budget["active_prs"] == 1 and 0 <= budget["merges"] <= 10)
+    _require(budget["attempts"] > 0 and 0 < budget["wall_seconds"] <= 7 * 86400)
+    _require(budget["paid_microdollars"] == 0 and budget["subdelegates"] == 0)
+    issued, start, end = (_timestamp(p[n]) for n in ("issued_at", "not_before", "expires_at"))
+    _require(issued <= start < end and (end - issued).total_seconds() <= budget["wall_seconds"])
+
+
+def canonical_grant_payload(payload: dict[str, Any]) -> bytes:
+    """Encode the closed schema for verification/offline test signing, without issuing it."""
+    _validate_payload(payload)
+    encoded = DOMAIN + json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+    _require(len(encoded) <= MAX_BYTES)
+    return encoded
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        _require(key not in result)
+        result[key] = value
+    return result
+
+
+def _utc(value: Any) -> bool:
+    return type(value) is datetime and value.tzinfo is UTC
+
+
+def _fresh(observed: Any, until: Any, now: datetime) -> bool:
+    return (
+        _utc(observed)
+        and _utc(until)
+        and observed <= now < until
+        and until - observed <= MAX_OBSERVATION_AGE
+    )
+
+
+def verify_operator_grant(
+    envelope: bytes,
+    *,
+    expected: Mapping[str, str | int],
+    trusted_keys: Mapping[str, TrustedKey] | None,
+    revocation: RevocationObservation | None,
+    now: datetime,
+) -> VerificationResult:
+    """Verify signed data against explicitly supplied, fresh trusted inputs.
+
+    VERIFIED does not approve the referenced commands, scopes, reviews, or actions.
+    No default/global trust or clock is read; no mutations can be performed here.
+    """
+    invalid = VerificationResult
+    try:
+        _require(type(envelope) is bytes and len(envelope) <= MAX_BYTES)
+        outer = json.loads(envelope.decode("utf-8"), object_pairs_hook=_unique_object)
+        _fields(outer, {"payload", "signature"})
+        p = outer["payload"]
+        canonical = canonical_grant_payload(p)
+        _text(outer["signature"])
+        signature = base64.b64decode(outer["signature"], validate=True)
+        _require(len(signature) == 64)
+        _require(base64.b64encode(signature).decode("ascii") == outer["signature"])
+    except (ValueError, TypeError, RecursionError, binascii.Error):
+        return invalid(VerificationCode.MALFORMED)
+    if not isinstance(expected, Mapping) or set(expected) != CONTEXT_FIELDS:
+        return invalid(VerificationCode.CONTEXT_MISMATCH)
+    if any(type(expected[k]) is not type(p[k]) or expected[k] != p[k] for k in CONTEXT_FIELDS):
+        return invalid(VerificationCode.CONTEXT_MISMATCH)
+    if not _utc(now) or not (_timestamp(p["not_before"]) <= now < _timestamp(p["expires_at"])):
+        return invalid(VerificationCode.INVALID_TIME)
+    if not isinstance(trusted_keys, Mapping):
+        return invalid(VerificationCode.UNTRUSTED)
+    key = trusted_keys.get(p["key_id"])
+    if (
+        type(key) is not TrustedKey
+        or key.operator != p["operator"]
+        or type(key.trust_version) is not int
+        or key.trust_version != p["trust_version"]
+        or type(key.public_key) is not bytes
+        or len(key.public_key) != 32
+        or type(key.revoked) is not bool
+        or not _fresh(key.observed_at, key.valid_until, now)
+    ):
+        return invalid(VerificationCode.UNTRUSTED)
+    if (
+        type(revocation) is not RevocationObservation
+        or revocation.source != p["revocation_source"]
+        or revocation.grant_id != p["grant_id"]
+        or type(revocation.grant_version) is not int
+        or revocation.grant_version != p["grant_version"]
+        or type(revocation.revoked) is not bool
+        or not _fresh(revocation.observed_at, revocation.valid_until, now)
+    ):
+        return invalid(VerificationCode.UNTRUSTED)
+    if key.revoked or revocation.revoked:
+        return invalid(VerificationCode.REVOKED)
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        verifier = Ed25519Signer(
+            public_key=Ed25519PublicKey.from_public_bytes(key.public_key), key_id=p["key_id"]
+        )
+        if not verifier.verify(canonical, signature):
+            return invalid(VerificationCode.INVALID_SIGNATURE)
+    except (ImportError, RuntimeError):
+        return invalid(VerificationCode.CRYPTO_UNAVAILABLE)
+    except (ValueError, TypeError):
+        return invalid(VerificationCode.INVALID_SIGNATURE)
+    return VerificationResult(
+        VerificationCode.VERIFIED, VerifiedGrant(canonical, hashlib.sha256(canonical).hexdigest())
+    )

--- a/docs/governance/OPERATOR_GRANT_VERIFICATION.md
+++ b/docs/governance/OPERATOR_GRANT_VERIFICATION.md
@@ -1,0 +1,49 @@
+# Operator Grant Verification: Phase 2A
+
+**Data verification only; no live authority or integration.** Authorized after
+[design #10022](https://github.com/synaptent/aragora/pull/10022); not pilot activation.
+Import `canonical_grant_payload` and `verify_operator_grant` directly from
+`aragora.policy.operator_grant`. No CLI, runner, policy engine, flag or merge caller is wired.
+
+## Closed Wire Contract
+
+At most 65,536 UTF-8 bytes: exactly `payload` and `signature`. Signature: canonical padded
+base64, 64 Ed25519 bytes. Schema: `aragora-operator-grant/1.0`; unsigned v0.1 records reject,
+without changing v0.1. See [the fixture](../../tests/policy/test_operator_grant.py) for all fields.
+Required identity pins cover grant/version, repo ID/name, operator/delegate, campaign,
+goal/acceptance/policy/enforcement digests, key/trust versions and revocation source.
+Approval event reference/digest, UTC times, explicit actions/denials/scopes, contracts,
+validation commands, review requirements, and integer budgets are mandatory.
+Pilot ceilings: one active PR, ten merges, seven days, finite positive attempts, zero
+additional paid microdollars/subdelegates; `can_subdelegate` must be boolean false.
+
+Signing bytes: `aragora/operator-grant/v1\n` plus compact sorted-key JSON, UTF-8 without
+ASCII escaping. Keys are fixed ASCII; arrays retain order; Unicode is not normalized.
+No floats, coercion, duplicate/unknown keys, NaN/Infinity or lone surrogates. This is
+schema-specific encoding, not general RFC 8785. Result SHA-256 includes the domain prefix.
+Scope paths/branches are explicit normalized relative names, not globs. Empty permitted
+scope rejects; lists are bounded and unique. Filesystem and semantic scope are not evaluated.
+
+## Trusted Inputs and Results
+
+`expected` must contain exactly every `CONTEXT_FIELDS` key with matching values/types.
+Derive it from trusted request context, never from the untrusted grant. Supply pinned
+raw 32-byte public keys via `trusted_keys: Mapping[str, TrustedKey]`, one exact-grant
+`RevocationObservation`, and explicit `now`; no global trust, clock or network discovery.
+Observations bind issuer/trust version or source/grant version, real boolean revocation
+state, and UTC `datetime` values using `datetime.UTC`. Require `observed_at <= now < valid_until`
+and a validity window at most 60 seconds. Missing, stale, future, revoked or mismatched data rejects.
+These observations are **not authenticated here**: a future trusted adapter must establish
+provenance/custody. Workers must not choose trust roots or revocation state. The existing
+Ed25519 backend is public-key-only; no HMAC default, secret reads, or generated operator keys.
+
+`VerificationResult.code` is a typed reason; rejection has no `grant`. `verified_data_only`
+returns immutable signed bytes/digest, not an action capability or human settlement.
+It does not prove tests/reviews exist and must not be cached as future permission.
+No signer, grant issuer, transaction store, live receipt, or external mutation is implemented.
+Atomic budgets, authenticated observations, key custody, full diff/symlink/rename/semantic
+scope, exact-head/check/owner/review gates and packet/steward/executor parity remain future work.
+Coordinate #9880's landed interface; do not adopt it. Human implementation/merge/activation
+gates remain intact. Tests use ephemeral keys, no real credentials or grants.
+
+Run `python3 -m pytest tests/policy/test_operator_grant.py tests/policy/test_delegation_contract.py tests/policy/test_predicate_oracle.py -q`.

--- a/tests/policy/test_operator_grant.py
+++ b/tests/policy/test_operator_grant.py
@@ -1,0 +1,411 @@
+"""Phase 2A data verification: test keys only, no live authorization or I/O."""
+
+import base64
+import copy
+import hashlib
+import json
+from dataclasses import FrozenInstanceError, replace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from aragora.policy import operator_grant as g
+
+NOW = datetime(2026, 9, 7, 12, tzinfo=UTC)
+DEFAULT_WIRE = object()
+
+
+@pytest.fixture
+def state():
+    private = Ed25519PrivateKey.generate()
+    public = private.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    payload = {
+        "schema_version": g.SCHEMA_VERSION,
+        "grant_id": "test-grant",
+        "grant_version": 1,
+        "repository_id": 123,
+        "repository": "example/test-only",
+        "operator": "test-operator",
+        "delegate": "test-session",
+        "campaign_id": "test-campaign",
+        "goal_digest": "a" * 64,
+        "acceptance_digest": "b" * 64,
+        "policy_version": "test-policy-v1",
+        "policy_digest": "c" * 64,
+        "enforcement_digest": "d" * 64,
+        "key_id": "test-key",
+        "trust_version": 1,
+        "revocation_source": "test-only-snapshot",
+        "approval_ref": "test-event",
+        "approval_digest": "e" * 64,
+        "issued_at": "2026-09-07T11:59:00Z",
+        "not_before": "2026-09-07T12:00:00Z",
+        "expires_at": "2026-09-08T11:59:00Z",
+        "actions": ["validate"],
+        "denied_actions": sorted(g.HARD_DENIALS),
+        "scope": {
+            "branches": ["codex/test"],
+            "paths": ["tests/test_example.py"],
+            "denied_paths": [".github/workflows/test.yml"],
+            "surfaces": ["test-only"],
+            "risk_classes": ["test-only"],
+            "tiers": [0],
+        },
+        "contract_ids": ["TEST-01"],
+        "validation_commands": ["pytest tests/test_example.py"],
+        "review_requirements": ["current-landed-policy"],
+        "can_subdelegate": False,
+        "budget": {
+            "active_prs": 1,
+            "merges": 10,
+            "attempts": 2,
+            "wall_seconds": 86400,
+            "paid_microdollars": 0,
+            "subdelegates": 0,
+        },
+    }
+    return {
+        "payload": payload,
+        "private": private,
+        "expected": {k: payload[k] for k in g.CONTEXT_FIELDS},
+        "trusted_keys": {
+            "test-key": g.TrustedKey(
+                "test-operator", public, 1, False, NOW, NOW + timedelta(seconds=60)
+            )
+        },
+        "revocation": g.RevocationObservation(
+            "test-only-snapshot", "test-grant", 1, False, NOW, NOW + timedelta(seconds=60)
+        ),
+    }
+
+
+def wire(state, payload=None, domain=g.DOMAIN):
+    # Encode independently of the production validator so malformed shapes reach it.
+    p = state["payload"] if payload is None else payload
+    data = domain + json.dumps(p, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8", errors="surrogatepass"
+    )
+    signature = base64.b64encode(state["private"].sign(data)).decode("ascii")
+    return json.dumps({"payload": p, "signature": signature}).encode("utf-8")
+
+
+def verify(state, data=DEFAULT_WIRE, **overrides):
+    args = {k: state[k] for k in ("expected", "trusted_keys", "revocation")}
+    args["now"] = NOW
+    args.update(overrides)
+    return g.verify_operator_grant(wire(state) if data is DEFAULT_WIRE else data, **args)
+
+
+def denied(result, code):
+    assert result.code is code
+    assert result.grant is None
+
+
+def test_verified_data_is_immutable_and_not_authority(state):
+    result = verify(state)
+    assert result.code is g.VerificationCode.VERIFIED
+    canonical = g.canonical_grant_payload(state["payload"])
+    assert result.grant.canonical_payload == canonical
+    assert result.grant.payload_sha256 == hashlib.sha256(canonical).hexdigest()
+    assert not hasattr(result, "allowed") and not hasattr(result, "human_preapproval_recorded")
+    with pytest.raises(FrozenInstanceError):
+        result.grant.canonical_payload = b"changed"
+    state["payload"]["actions"].append("ready")
+    assert result.grant.canonical_payload == canonical
+
+
+def test_canonical_encoding_order_unicode_and_wire_format(state):
+    p = state["payload"]
+    p["approval_ref"] = "test-event-\u00e9"
+    assert verify(state).code is g.VerificationCode.VERIFIED
+    first = g.canonical_grant_payload(p)
+    assert first == g.canonical_grant_payload(dict(reversed(list(p.items()))))
+    assert b"\xc3\xa9" in first and b"\\u00e9" not in first
+    p["approval_ref"] = "test-event-e\u0301"
+    assert first != g.canonical_grant_payload(p)  # No silent Unicode normalization.
+    compact = json.dumps(json.loads(wire(state)), separators=(",", ":")).encode()
+    assert verify(state, compact).code is g.VerificationCode.VERIFIED
+
+
+@pytest.mark.parametrize("field", sorted(g.CONTEXT_FIELDS))
+def test_every_context_pin_is_required_and_exact(state, field):
+    expected = dict(state["expected"])
+    expected.pop(field)
+    denied(verify(state, expected=expected), g.VerificationCode.CONTEXT_MISMATCH)
+    expected = dict(state["expected"])
+    expected[field] = 2 if type(expected[field]) is int else "different"
+    denied(verify(state, expected=expected), g.VerificationCode.CONTEXT_MISMATCH)
+
+
+@pytest.mark.parametrize("expected", [None, [], {}, {"grant_version": True}])
+def test_unavailable_context_does_not_authorize(state, expected):
+    denied(verify(state, expected=expected), g.VerificationCode.CONTEXT_MISMATCH)
+
+
+def test_context_bool_does_not_match_integer_and_signed_wrong_repo_rejects(state):
+    expected = {**state["expected"], "grant_version": True}
+    denied(verify(state, expected=expected), g.VerificationCode.CONTEXT_MISMATCH)
+    p = {**state["payload"], "repository": "different/repo"}
+    denied(verify(state, wire(state, p)), g.VerificationCode.CONTEXT_MISMATCH)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", "aragora-delegation-contract/0.1"),
+        ("operator", ""),
+        ("delegate", 1),
+        ("goal_digest", "z" * 64),
+        ("policy_digest", "A" * 64),
+        ("repository_id", True),
+        ("grant_version", 0),
+        ("trust_version", "1"),
+        ("can_subdelegate", "false"),
+        ("can_subdelegate", 0),
+        ("can_subdelegate", True),
+        ("approval_ref", "quoted\nreply"),
+        ("approval_ref", "\ud800"),
+        ("actions", []),
+        ("actions", ["admin_merge"]),
+        ("actions", ["validate", "validate"]),
+        ("actions", ["*"]),
+        ("denied_actions", []),
+        ("contract_ids", []),
+        ("validation_commands", []),
+        ("review_requirements", None),
+        ("issued_at", "2026-02-30T00:00:00Z"),
+        ("not_before", "2026-09-07T12:00:00+00:00"),
+        ("not_before", "2026-09-07T11:58:00Z"),
+        ("expires_at", "2026-09-09T00:00:00Z"),
+        ("expires_at", "2026-09-07T12:00:00Z"),
+        ("signature", "unexpected-payload-field"),
+    ],
+)
+def test_signed_malformed_payloads_reject(state, field, value):
+    p = {**state["payload"], field: value}
+    denied(verify(state, wire(state, p)), g.VerificationCode.MALFORMED)
+    with pytest.raises(g.GrantValidationError):
+        g.canonical_grant_payload(p)
+
+
+@pytest.mark.parametrize("field", list(g.CONTEXT_FIELDS) + ["scope", "budget", "approval_digest"])
+def test_missing_payload_fields_reject(state, field):
+    p = dict(state["payload"])
+    p.pop(field)
+    denied(verify(state, wire(state, p)), g.VerificationCode.MALFORMED)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("paths", []),
+        ("branches", []),
+        ("surfaces", []),
+        ("risk_classes", []),
+        ("paths", ["../outside.py"]),
+        ("paths", ["/tmp/outside.py"]),
+        ("paths", ["a/./b"]),
+        ("paths", ["a//b"]),
+        ("paths", ["a\\b"]),
+        ("paths", ["a/*"]),
+        ("paths", ["."]),
+        ("paths", [".github/workflows/test.yml"]),
+        ("tiers", [True]),
+        ("tiers", [5]),
+        ("tiers", []),
+        ("tiers", [0, 0]),
+        ("extra", "unknown"),
+    ],
+)
+def test_explicit_scope_required(state, field, value):
+    p = copy.deepcopy(state["payload"])
+    p["scope"][field] = value
+    denied(verify(state, wire(state, p)), g.VerificationCode.MALFORMED)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("active_prs", 2),
+        ("active_prs", True),
+        ("merges", 11),
+        ("merges", -1),
+        ("attempts", 0),
+        ("attempts", 2**53),
+        ("attempts", 1.5),
+        ("wall_seconds", 604801),
+        ("wall_seconds", 0),
+        ("subdelegates", 1),
+        ("paid_microdollars", 1),
+        ("paid_microdollars", False),
+        ("merges", float("inf")),
+        ("merges", float("nan")),
+    ],
+)
+def test_bounded_integer_budgets(state, field, value):
+    p = copy.deepcopy(state["payload"])
+    p["budget"][field] = value
+    denied(verify(state, wire(state, p)), g.VerificationCode.MALFORMED)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"",
+        b"null",
+        b"[]",
+        b"{}",
+        b"not json",
+        b'"approve"',
+        b"```json\n{}\n```",
+        b"\xff",
+        b" " * (g.MAX_BYTES + 1),
+        b'{"payload":{},"payload":{},"signature":"a"}',
+        b'{"payload":{"x":1,"x":2},"signature":"a"}',
+        b"[" * 1200 + b"]" * 1200,
+        b'{"contract_id":"legacy","signature":null}',
+    ],
+)
+def test_invalid_envelopes_and_legacy_records(state, data):
+    denied(verify(state, data), g.VerificationCode.MALFORMED)
+
+
+def test_payload_limit_and_noncanonical_signature(state):
+    p = copy.deepcopy(state["payload"])
+    p["validation_commands"] = ["x" * 2044 + f"{i:04}" for i in range(64)]
+    with pytest.raises(g.GrantValidationError):
+        g.canonical_grant_payload(p)
+    denied(verify(state, wire(state, p)), g.VerificationCode.MALFORMED)
+    outer = json.loads(wire(state))
+    signature = outer["signature"]
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    outer["signature"] = signature[:-3] + alphabet[alphabet.index(signature[-3]) + 1] + "=="
+    denied(verify(state, json.dumps(outer).encode()), g.VerificationCode.MALFORMED)
+
+
+@pytest.mark.parametrize("data", ["{}", None, {}, bytearray(b"{}")])
+def test_wrong_wire_type(state, data):
+    denied(verify(state, data), g.VerificationCode.MALFORMED)
+
+
+def test_signed_tampering_domain_and_wrong_key(state):
+    outer = json.loads(wire(state))
+    outer["payload"]["approval_ref"] = "tampered"
+    denied(verify(state, json.dumps(outer).encode()), g.VerificationCode.INVALID_SIGNATURE)
+    denied(
+        verify(state, wire(state, domain=b"other-domain\n")), g.VerificationCode.INVALID_SIGNATURE
+    )
+    other = {**state, "private": Ed25519PrivateKey.generate()}
+    denied(verify(state, wire(other)), g.VerificationCode.INVALID_SIGNATURE)
+    outer = json.loads(wire(state))
+    outer["signature"] = base64.b64encode(bytes(64)).decode()
+    denied(verify(state, json.dumps(outer).encode()), g.VerificationCode.INVALID_SIGNATURE)
+
+
+@pytest.mark.parametrize("signature", [None, "!", "YQ==", "\u00e9", "AA==\n"])
+def test_malformed_signatures(state, signature):
+    outer = json.loads(wire(state))
+    outer["signature"] = signature
+    denied(verify(state, json.dumps(outer).encode()), g.VerificationCode.MALFORMED)
+
+
+@pytest.mark.parametrize(
+    "now",
+    [
+        NOW - timedelta(seconds=1),
+        NOW + timedelta(days=1),
+        None,
+        NOW.replace(tzinfo=None),
+        "2026-09-07T12:00:00Z",
+    ],
+)
+def test_time_boundary_and_unavailable_clock(state, now):
+    denied(verify(state, now=now), g.VerificationCode.INVALID_TIME)
+
+
+@pytest.mark.parametrize("keys", [None, {}, [], {"test-key": {}}, {"test-key": None}])
+def test_no_implicit_trust(state, keys):
+    denied(verify(state, trusted_keys=keys), g.VerificationCode.UNTRUSTED)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("operator", "other"),
+        ("trust_version", True),
+        ("trust_version", 2),
+        ("public_key", b"bad"),
+        ("public_key", "not bytes"),
+        ("revoked", "false"),
+        ("revoked", 0),
+        ("observed_at", None),
+        ("valid_until", NOW),
+        ("observed_at", NOW + timedelta(seconds=1)),
+        ("observed_at", NOW - timedelta(seconds=61)),
+        ("valid_until", NOW + timedelta(seconds=61)),
+    ],
+)
+def test_malformed_stale_or_wrong_trust(state, field, value):
+    key = replace(state["trusted_keys"]["test-key"], **{field: value})
+    denied(verify(state, trusted_keys={"test-key": key}), g.VerificationCode.UNTRUSTED)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("source", "other"),
+        ("grant_id", "other"),
+        ("grant_version", 2),
+        ("grant_version", True),
+        ("revoked", "false"),
+        ("revoked", 0),
+        ("observed_at", None),
+        ("valid_until", NOW),
+        ("observed_at", NOW + timedelta(seconds=1)),
+        ("observed_at", NOW - timedelta(seconds=61)),
+    ],
+)
+def test_revocation_is_fresh_exact_and_boolean(state, field, value):
+    observation = replace(state["revocation"], **{field: value})
+    denied(verify(state, revocation=observation), g.VerificationCode.UNTRUSTED)
+
+
+def test_revoked_and_missing_observations(state):
+    denied(verify(state, revocation=None), g.VerificationCode.UNTRUSTED)
+    denied(verify(state, revocation={}), g.VerificationCode.UNTRUSTED)
+    denied(
+        verify(state, revocation=replace(state["revocation"], revoked=True)),
+        g.VerificationCode.REVOKED,
+    )
+    key = replace(state["trusted_keys"]["test-key"], revoked=True)
+    denied(verify(state, trusted_keys={"test-key": key}), g.VerificationCode.REVOKED)
+
+
+def test_crypto_unavailable_fails_closed(state, monkeypatch):
+    def unavailable(**kwargs):
+        raise ImportError("test: no cryptography")
+
+    monkeypatch.setattr(g, "Ed25519Signer", unavailable)
+    denied(verify(state), g.VerificationCode.CRYPTO_UNAVAILABLE)
+
+
+def test_verifier_only_cannot_sign_and_does_no_io(state, monkeypatch):
+    verifier = g.Ed25519Signer(public_key=state["private"].public_key(), key_id="test-key")
+    with pytest.raises(ValueError, match="Private key required"):
+        verifier.sign(b"test")
+    data = wire(state)
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("verification attempted I/O")
+
+    monkeypatch.setattr("builtins.open", forbidden)
+    monkeypatch.setattr("socket.socket", forbidden)
+    monkeypatch.setattr("subprocess.Popen", forbidden)
+    monkeypatch.setattr("pathlib.Path.write_text", forbidden)
+    monkeypatch.setattr("pathlib.Path.write_bytes", forbidden)
+    assert verify(state, data).code is g.VerificationCode.VERIFIED
+    denied(verify(state, b"quoted approval"), g.VerificationCode.MALFORMED)


### PR DESCRIPTION
## Scope and Authorization

Phase 2A of the design in #10022, pinned to `ae57cf28e1fbd157b0889570a3f61f35c0e48291`.
The operator approved that design and then explicitly authorized this bounded implementation preparation in the originating Codex task. This description is not an authenticated grant, GitHub approval, human-settlement receipt, or authorization to merge or activate delegation.

**Treat as Tier 4 preparation. Draft only.** No reviewer collection or evidence posting was performed. Independent review and separate exact-head human acceptance remain required before merge; actual key custody, policy integration and pilot activation remain separate decisions.

## Changes

- Add an opt-in, data-only verifier beside the unchanged v0.1 delegation contract. Reuse the existing Ed25519 public-key verifier without changing the receipt-signing module.
- Specify a bounded closed schema and domain-separated, deterministic UTF-8 signing bytes. Reject duplicate/unknown fields, coercion, unsigned legacy inputs, malformed scopes, bad timestamps, invalid signatures and noncanonical signature encoding.
- Require caller-supplied exact context pins and explicit fresh key/revocation observations. Missing, stale, revoked or mismatched inputs reject. Success returns immutable verified bytes and a digest, never action permission or human preapproval.
- Add deterministic ephemeral-key regression tests and one usage/status note. Exactly three files, 798 added lines; no new dependency and no live caller.

## Deliberately Not Implemented

No real operator keys/grants, signing service, network/store discovery, trust-root installation, atomic budget store, authenticated observation adapter, settlement records, live policy registration, action executor, CI/workflow change, or activation. The injected observations are not authenticated by this module; a future trusted adapter must establish their provenance. Filesystem/semantic scope matching and exact-head/check/owner/review gates are not claimed here.

#9880's interface work remains with its owner. Receipt, SDK, installation, reviewer transport, merge/evidence/settlement tooling, refill settings, schedules, and the approved #10022 proposal bytes are untouched.

## Validation

At implementation head `d4b6affb9bbbdec77703f588d144a0ae85d053b2` on main base `ebe1bfd262f3c9f942679a0a6e2da24e3bd71534`:

- `env ARAGORA_USE_SECRETS_MANAGER=false python3 -m pytest -q tests/policy/test_operator_grant.py tests/policy/test_delegation_contract.py tests/policy/test_predicate_oracle.py`: **221 passed**, 7 existing deprecation warnings.
- `python3 -m ruff check aragora/policy/operator_grant.py tests/policy/test_operator_grant.py`: passed.
- `python3 -m mypy --follow-imports=silent --ignore-missing-imports aragora/policy/operator_grant.py`: passed.
- Scoped documentation-link check, `git diff --check`, and `git diff --cached --check`: passed.
- `bash scripts/automation_pr_preflight.sh --json origin/main HEAD`: `status=ok`, no forbidden files, source paired with tests.
- Normal commit and push hooks passed without bypass, including Ruff, mypy, gitleaks, portability and receipts/verifier boundary checks.
- Tracked-caller scan found only the verifier definition and its test caller. Tests trap file/network/process I/O during verification and confirm public-key-only objects cannot sign.

An initial test-helper bug that substituted a valid envelope for an explicit `None` input was corrected; the final suite tests the actual malformed input. No production validation was weakened.

## Next Gate

Review this foundation's closed schema and trust-input boundary before planning the next batch. This PR does not complete the delegation system or the ten-contract concurrent-debates campaign. No merge, evidence, real grant, or pilot activation is requested by this draft publication.
