### PR TITLE
ci(monitor): park the 30-minute production probes until a canary exists [Tier 4]

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,9 +1,14 @@
 name: Uptime Monitor
 
 on:
-  schedule:
-    # Run every 30 minutes (reduced from 5 min to save Actions minutes)
-    - cron: '*/30 * * * *'
+  # Scheduled probes are PARKED (operator decision 2026-09-07, #9391 / #9966
+  # metric 7): api.aragora.ai has had no production origin since AWS was retired
+  # on 2026-08-19, so every 30-minute run failed by construction (~100 red runs a
+  # day). Re-enable the schedule in the same PR that lands the provider-neutral
+  # canary (#9851 / #9882) and restores a 200 on /readyz. Manual dispatch still
+  # works for a one-off probe.
+  # schedule:
+  #   - cron: '*/30 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,8 +1,14 @@
 name: Production Smoke Test
 
 on:
-  schedule:
-    - cron: '*/30 * * * *'  # Every 30 minutes
+  # Scheduled probes are PARKED (operator decision 2026-09-07, #9391 / #9966
+  # metric 7): api.aragora.ai has had no production origin since AWS was retired
+  # on 2026-08-19, so every 30-minute run failed by construction (~100 red runs a
+  # day). Re-enable the schedule in the same PR that lands the provider-neutral
+  # canary (#9851 / #9882) and restores a 200 on /readyz. Manual dispatch still
+  # works for a one-off probe.
+  # schedule:
+  #   - cron: '*/30 * * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Comments out the `schedule` trigger in `monitor.yml` (Uptime Monitor) and `production-smoke.yml` (Production Smoke Test). Both have probed `https://api.aragora.ai` every 30 minutes and failed on every run since 2026-07-16; the AWS origin was retired by operator decision on 2026-08-19 (#9391), so there is no target to probe and the ~100 red runs a day are noise.
- `workflow_dispatch` stays, every step is unchanged, and the cron lines are left commented so the PR that lands the provider-neutral canary (#9851 / #9882) restores the schedule by uncommenting two lines.
- Mission #9966 metric 7 (hosted `/readyz` → 200) is recorded as parked on the epic alongside this change.

## Type of Change

- [x] Refactoring (no functional changes) — CI scheduling only

## Related Issues

Related to #9391, #9966 (metric 7), #9800.

## Checklist

### Before Submitting

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project's code style (YAML validated with PyYAML; both workflows parse, `schedule` absent, `workflow_dispatch` present)
- [ ] I have added tests that prove my fix/feature works (not applicable, workflow trigger only)
- [x] All new and existing tests pass (no code touched)
- [x] I have updated documentation if needed (rationale recorded in the workflow comment and on #9966)
- [x] My commit messages follow conventional commit format

### Code Quality

- [x] No hardcoded secrets or credentials

## Test Plan

```bash
python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in ('.github/workflows/monitor.yml','.github/workflows/production-smoke.yml')]; print('ok')"
git ls-files .github/workflows | grep -E '\.yml$' | wc -l   # 97, unchanged (guardrail ceiling)
```

## Additional Notes

Tier 4 (workflow file), operator settlement required. Operator decision 2026-09-07: park the monitors now, queue the migration PRs (#9846, #9848, #9849, #9854, #9851, #9853, #9882, #9883) for a dedicated settlement session. `status-page.yml` also targets `api.aragora.ai` on a nightly schedule and is left untouched here; it is a deployment, not a probe, and was not part of the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt)_