### PR TITLE
ci(contract-drift): make the program-trajectory job informational during paydown [Tier 4]

### DIFF
--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -178,6 +178,15 @@ jobs:
     name: contract-drift-program-trajectory
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || !inputs.historical_backfill)
     runs-on: ubuntu-latest
+    # INFORMATIONAL while the Receipt-First paydown (#9966 row 10) catches up
+    # to the date-driven target: the strict --mode program check fails on
+    # every push to main (398 active units on 2026-09-06 vs a target of 75 and
+    # shrinking), so the red X carried no information. The step still runs in
+    # --strict mode and still uploads the trajectory artifact; only the job
+    # conclusion is decoupled. Re-tighten (remove continue-on-error) in the
+    # same PR that brings total_items at or below max_open_items on main.
+    # Operator decision 2026-09-07.
+    continue-on-error: true
     env: {SOURCE_SHA: "${{ github.event_name == 'push' && github.event.after || github.sha }}"}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the `program-trajectory` job in `contract-drift-governance.yml`. The job runs `check_contract_drift_ratchet.py --mode program --strict` against a date-driven target (75 open units on 2026-09-04, shrinking daily) while `main` carries 398 active units (339 after #9979, 288 after #10013), so it has failed on every push to `main` and will for weeks even with paydown batches landing. A check that is red by construction conveys nothing.
- The step still runs strict and still uploads `contract-drift-program-trajectory-<sha>.json`; only the job conclusion is decoupled. The re-tighten condition (`total_items <= max_open_items` on `main`) is recorded in the workflow comment.
- No target re-anchoring: the mission's row-10 rule ("never re-anchor") is respected.

## Type of Change

- [x] Refactoring (no functional changes) — CI job conclusion only

## Related Issues

Related to #9966 (exit metric row 10).

## Checklist

### Before Submitting

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project's code style (YAML validated with PyYAML; `jobs.program-trajectory.continue-on-error == true`)
- [ ] I have added tests that prove my fix/feature works (not applicable)
- [x] All new and existing tests pass (no code touched)
- [x] I have updated documentation if needed (rationale in the workflow comment)
- [x] My commit messages follow conventional commit format

### Code Quality

- [x] No hardcoded secrets or credentials

## Test Plan

```bash
python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/contract-drift-governance.yml')); assert d['jobs']['program-trajectory']['continue-on-error'] is True; print('ok')"
```

## Additional Notes

Tier 4 (workflow file), operator settlement required. Operator decision 2026-09-07: informational until paydown catches up. Per-PR delta enforcement (`contract-drift-pr-delta`) is untouched and still fails a PR that adds drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt)_