### PR TITLE
fix(cli): catch asyncio.TimeoutError in the live quickstart debate on Python 3.10 [Tier 1]

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -1164,7 +1164,7 @@ async def _run_live_debate(
     run_task = asyncio.create_task(arena.run())
     try:
         result = await asyncio.wait_for(run_task, timeout=_LIVE_DEBATE_TIMEOUT_SECONDS)
-    except TimeoutError as exc:
+    except (asyncio.TimeoutError, TimeoutError) as exc:  # noqa: UP041 - distinct classes on 3.10
         run_task.cancel()
         with contextlib.suppress(asyncio.CancelledError, RuntimeError):
             await run_task


### PR DESCRIPTION
## Summary

- `_run_live_debate` bounded `asyncio.wait_for` with `except TimeoutError`. On Python 3.11+ `asyncio.TimeoutError` is an alias of the builtin, but on 3.10 (the package's declared floor, `requires-python >= 3.10`) it is a distinct class, so a timed-out live debate escaped the clean "Live debate timed out after Ns" path and surfaced as an unhandled `asyncio.TimeoutError`.
- One-line change: catch both classes (`# noqa: UP041` because they are distinct on 3.10).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Related to #10010 (whose release-to-production diagnostic on #9966 surfaced this as the residual 3.10 failure) and to the Python 3.10 quickstart support it carries.

## Checklist

### Before Submitting

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project's code style (`ruff check` / `ruff format --check` clean)
- [x] I have added tests that prove my fix/feature works (the existing `test_run_live_debate_times_out_cleanly` is the regression test; it fails on 3.10 before and passes after)
- [x] All new and existing tests pass (see Test Plan for the 3.10 caveat)
- [x] My commit messages follow conventional commit format

### For Bug Fixes

- [x] Root cause is identified and explained
- [x] Test case added to prevent regression (existing test now exercises the 3.10 path)
- [x] Related edge cases considered (the `except (OSError, TimeoutError, ConnectionError)` at the TLS probe is a synchronous socket path and is unaffected)

## Test Plan

```bash
# Python 3.10.20 (uv venv, editable install)
python -m pytest tests/cli/test_quickstart.py -q
# origin/main: 17 failed / 59 passed
# this head:   16 failed / 60 passed  -- the one test that flips is
#   TestCmdQuickstart::test_run_live_debate_times_out_cleanly; no test newly fails.
# The remaining 16 are a separate pre-existing 3.10 gap (asyncio.Runner is
# 3.11+; quickstart.py:139) that #10010 "support Python 3.10 quickstart" addresses.

# Python 3.11.15
python -m pytest tests/cli/test_quickstart.py -q   # 76 passed
```

## Additional Notes

Tier 1. Touches the same file as #10010; whichever lands second takes a trivial merge. No behaviour change on 3.11+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt)_