### PR TITLE
fix(validation): allow dotted model versions in SAFE_AGENT_PATTERN [Tier 2]

### DIFF
--- a/aragora/server/validation/entities.py
+++ b/aragora/server/validation/entities.py
@@ -12,7 +12,12 @@ import re
 SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 SAFE_ID_PATTERN_WITH_DOTS = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
 SAFE_SLUG_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
-SAFE_AGENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,32}$")
+# Agent names may carry dotted model versions ("gemini-3.1-pro-preview",
+# "claude-fable-5.1", "qwen3.8-2.4t-a95b"), so "." is allowed after the first
+# character. "/" is never allowed: these are single path segments, and the
+# provider prefix of a slug ("anthropic/...") is not part of an agent name.
+# A leading "." is rejected so "." / ".." can never validate (#9994).
+SAFE_AGENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-][a-zA-Z0-9._-]{0,31}$")
 
 # Plugin manifest patterns (stricter for submission)
 SAFE_PLUGIN_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]{0,62}[a-z0-9]?$")  # 1-64 chars, lowercase

--- a/tests/handlers/agents/test_config.py
+++ b/tests/handlers/agents/test_config.py
@@ -1139,12 +1139,16 @@ class TestHandleConfigEndpoint:
             assert _status(result) == 400
 
     def test_config_name_with_dots(self, handler):
-        """Rejects config names with dots."""
+        """Accepts dotted model-version names (#9994); rejects a leading dot and slashes."""
         with patch(
             "aragora.server.handlers.agents.config.get_config_loader",
             return_value=MagicMock(),
         ):
-            result = handler._handle_config_endpoint("/api/agents/configs/my.agent", {})
+            result = handler._handle_config_endpoint("/api/agents/configs/gemini-3.1-pro", {})
+            assert _status(result) == 200
+            result = handler._handle_config_endpoint("/api/agents/configs/.my-agent", {})
+            assert _status(result) == 400
+            result = handler._handle_config_endpoint("/api/agents/configs/..", {})
             assert _status(result) == 400
 
     def test_config_name_with_spaces(self, handler):

--- a/tests/handlers/agents/test_relationships.py
+++ b/tests/handlers/agents/test_relationships.py
@@ -509,10 +509,19 @@ class TestHandlePairwise:
 class TestInputValidation:
     """Tests for input validation on agent names."""
 
-    def test_invalid_agent_name_with_dots_returns_400(self, handler, mock_http_handler):
-        """Agent name containing dots fails validation."""
-        result = handler.handle("/api/v1/agents/bad.name/relationships", {}, mock_http_handler)
+    def test_dotted_agent_name_is_valid(self, handler, mock_http_handler):
+        """Dotted model-version names are valid agent names (#9994)."""
+        result = handler.handle(
+            "/api/v1/agents/claude-fable-5.1/relationships", {}, mock_http_handler
+        )
+        assert _status(result) == 200
+
+    def test_leading_dot_agent_name_returns_400(self, handler, mock_http_handler):
+        """A dot-led token can never be an agent name (guards '.' and '..')."""
+        result = handler.handle("/api/v1/agents/.bad/relationships", {}, mock_http_handler)
         assert _status(result) == 400
+        result = handler.handle("/api/v1/agents/../relationships", {}, mock_http_handler)
+        assert _status(result) != 200
 
     def test_agent_name_with_special_chars(self, handler, mock_http_handler):
         result = handler.handle("/api/v1/agents/bad%3Cscript/relationships", {}, mock_http_handler)

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -1034,11 +1034,21 @@ class TestPathParameterInjection:
             "agent_1",
             "CodexModel",
             "gemini-pro",
+            "gemini-3.1-pro-preview",  # dotted model version (#9994)
+            "claude-fable-5.1",
         ]
 
         for name in valid_names:
             is_valid, error = validate_agent_name(name)
             assert is_valid is True, f"Should accept: {name} (got: {error})"
+
+    def test_agent_name_slash_and_leading_dot_rejected(self):
+        """Provider-qualified slugs and dot-led tokens are not valid agent path segments."""
+        from aragora.server.handlers.base import validate_agent_name
+
+        for name in ["anthropic/claude-fable-5.1", ".hidden", "..", "../claude"]:
+            is_valid, _ = validate_agent_name(name)
+            assert is_valid is False, f"Should reject: {name}"
 
     def test_empty_values_rejected(self):
         """Empty values should be rejected."""

--- a/tests/server/test_validation.py
+++ b/tests/server/test_validation.py
@@ -666,11 +666,32 @@ class TestPatterns:
             "gemini-pro",
             "gpt_4",
             "agent123",
+            # dotted frontier model ids (#9994)
+            "gemini-3.1-pro-preview",
+            "claude-fable-5.1",
+            "qwen3.8-2.4t-a95b",
         ],
     )
     def test_safe_agent_pattern_valid(self, agent: str):
         """Test valid agent names match pattern."""
         assert SAFE_AGENT_PATTERN.match(agent), f"{agent} should match"
+
+    @pytest.mark.parametrize(
+        "agent",
+        [
+            "anthropic/claude-fable-5.1",  # provider-qualified slug: "/" is a path separator
+            "x-ai/grok-4.6",
+            ".hidden",  # leading dot
+            ".",
+            "..",
+            "../etc",
+            "claude fable",  # whitespace
+            "",
+        ],
+    )
+    def test_safe_agent_pattern_rejects_separators_and_leading_dot(self, agent: str):
+        """Dots are allowed inside a name, never as a path token; slashes never."""
+        assert not SAFE_AGENT_PATTERN.match(agent), f"{agent!r} should not match"
 
     @pytest.mark.parametrize(
         "agent,expected_match",


### PR DESCRIPTION
## Summary

- Frontier model ids carry dots (`gemini-3.1-pro-preview`, `claude-fable-5.1`, `qwen3.8-2.4t-a95b`), so agent names derived from them failed every path segment validated with `SAFE_AGENT_PATTERN` (agents, calibration, config, feedback, relationships, introspection, persona and social handlers).
- Decision encoded in the pattern and its comment, per the #9994 acceptance: `.` allowed after the first character; a leading `.` rejected so `.` and `..` can never validate; `/` never allowed (single path segments; a provider prefix is not part of an agent name). Pattern stays anchored and bounded at 32 chars and mirrors the existing `SAFE_ID_PATTERN_WITH_DOTS` convention.
- Tests: dotted ids added to the valid sets; new rejection cases for slash-qualified slugs, leading dot, `.`, `..`, `../etc`, whitespace, empty. Two handler tests that encoded the old no-dots rule now assert acceptance of a dotted name and rejection of a dot-led token.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Closes #9994. Surfaced by the frontier model refresh (#9989).

## Checklist

### Before Submitting

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project's code style (`ruff check` / `ruff format --check` clean)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commit messages follow conventional commit format

### For Bug Fixes

- [x] Root cause is identified and explained
- [x] Test case added to prevent regression
- [x] Related edge cases considered (`.`/`..`/`../x` traversal tokens, provider-qualified slugs, whitespace)

## Test Plan

```bash
python -m pytest tests/server/test_validation.py tests/server/test_security.py \
  tests/handlers/test_handler_security.py tests/server/handlers/test_base.py tests/handlers/test_base.py \
  tests/handlers/agents tests/server/handlers/social/test_relationship.py tests/routing/test_routing.py -q
# 1598 passed
```

## Additional Notes

Tier 2 (security-adjacent input validation). The config-name endpoint passes the name to `get_config_loader().get_config(name)` (a lookup, not a filesystem path), and the first-character rule keeps `.`/`..` unreachable for any consumer that does build paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01STpDAUQBgyFcTdNaEwiUdt)_