### PR TITLE
fix(swarm): harden advisory dissent summaries [Tier 2]

### DIFF
--- a/aragora/swarm/advisory_dissent.py
+++ b/aragora/swarm/advisory_dissent.py
@@ -53,7 +53,10 @@ def _clip(text: str, limit: int) -> str:
     encoded = text.encode("utf-8")
     if len(encoded) <= limit:
         return text
-    return encoded[: limit - len(_TRUNCATED)].decode("utf-8", errors="ignore") + _TRUNCATED
+    kept = encoded[: limit - len(_TRUNCATED)].decode("utf-8", errors="ignore")
+    if kept.rfind("&") > kept.rfind(";"):
+        kept = kept[: kept.rfind("&")]
+    return kept + _TRUNCATED
 
 
 def _safe_text(value: Any, *, inline: bool = False) -> str:
@@ -111,6 +114,15 @@ def compose_advisory_dissent_summary(outcome: CollectOutcome | dict, *, head_sha
         regime = "severity-gated dissent ON; P2/P3 findings are advisory to the merge gate."
     else:
         regime = "unknown (outcome carries no severity_gated field)."
+    raw = data.get("dissenting_families")
+    dissent = "unknown (outcome carries no gate dissent list)."
+    if isinstance(raw, list):
+        names = (canonical_family(str(name)) for name in raw)
+        gate_families = {
+            name if re.fullmatch(r"[a-z]+", name) and not _TOKENS.search(name) else "unknown"
+            for name in names
+        }
+        dissent = (", ".join(sorted(gate_families)) or "none") + "."
     lines = [
         marker,
         "",
@@ -118,6 +130,7 @@ def compose_advisory_dissent_summary(outcome: CollectOutcome | dict, *, head_sha
         "",
         summary,
         f"Gate regime: {regime}",
+        f"Merge-gate dissent: {dissent}",
         "",
         "### Family outcomes",
     ]
@@ -180,7 +193,7 @@ def post_advisory_summary(repo: str, pr: int, body: str, *, head_sha: str) -> Ad
         endpoint = f"repos/{repo}/issues/{pr}/comments"
         result = merge_quorum_io.run(
             ["gh", "api", endpoint + "?per_page=100", "--paginate", "--slurp"],
-            env=env,
+            env=merge_quorum_io._read_env(),
             timeout=60,
         )
         if result.returncode:

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -200,11 +200,14 @@ def main(argv: list[str] | None = None) -> int:
                 error=RuntimeError(str(error)),
                 attempts=outcome["attempts"],
             )
-        print(
-            f"error: {error}"
-            if "error" in outcome
-            else _render_outcome(collect_outcome_from_dict(outcome))
-        )
+        try:
+            print(
+                f"error: {error}"
+                if "error" in outcome
+                else _render_outcome(collect_outcome_from_dict(outcome))
+            )
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            print(f"error: outcome could not be rendered ({type(exc).__name__})")
         for key in (
             "advisory_posted",
             "advisory_comment_url",

--- a/tests/scripts/test_collect_quorum_evidence.py
+++ b/tests/scripts/test_collect_quorum_evidence.py
@@ -151,6 +151,28 @@ def test_text_output_keeps_collection_and_advisory_fields(collected, capsys):
     assert "advisory_posted: False" in text and "advisory_reason:" in text
 
 
+@pytest.mark.parametrize("malformed", ["empty_item", "foreign_mode", "missing_target"])
+def test_text_output_malformed_object_never_tracebacks(collected, capsys, malformed):
+    data, _, poster = collected
+    if malformed == "empty_item":
+        data["items"] = [{}]
+    elif malformed == "foreign_mode":
+        data["mode"] = "foreign"
+    else:
+        del data["repo"], data["pr_number"]
+    assert cli.main(ARGS) == 2
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == [
+        "error: outcome could not be rendered (ValueError)",
+        "  advisory_posted: False",
+        "  advisory_comment_url: None",
+        "  advisory_reason: --post-advisory-summary not enabled",
+        "  advisory_edited: False",
+    ]
+    assert "Traceback" not in captured.err
+    poster.assert_not_called()
+
+
 def test_collect_failure_payload(collected, capsys):
     data, _, poster = collected
     data.clear()

--- a/tests/swarm/test_advisory_dissent.py
+++ b/tests/swarm/test_advisory_dissent.py
@@ -84,6 +84,7 @@ def test_recogniser_invisibility_under_both_regimes(monkeypatch, flag):
         "```\n- [P0] quoted example\n```\n> - [P0] quoted example\n"
     )
     data = outcome(raw).to_dict()
+    data["dissenting_families"] = ["openai"]
     data["items"][0]["severity_gated"] = False
     body = adv.compose_advisory_dissent_summary(data, head_sha=HEAD)
     assert "&#58;" in adv._safe_text("Reviewer**: codex", inline=True)
@@ -119,6 +120,20 @@ def test_truncation_marker_and_total_budget():
     assert len(re.findall(r"^- \[P1\]", body, re.M)) == 12
     for excerpt in body.split("### Output ")[1:]:
         assert len(excerpt.split("\n\n", 1)[1].encode()) <= 8000
+
+
+@pytest.mark.parametrize(
+    "text,limit,expected",
+    [
+        ("xx&#12345;" + "y" * 12, 16, "xx[truncated]"),
+        ("a&amp;" + "y" * 20, 17, "a&amp;[truncated]"),
+        ("é" * 20, 16, "éé[truncated]"),
+    ],
+)
+def test_clip_never_splits_entity(text, limit, expected):
+    assert adv._clip(text, limit) == expected
+    assert len(expected.encode()) <= limit
+    assert expected.endswith("[truncated]")
 
 
 def test_empty_items_render_nothing():
@@ -178,6 +193,30 @@ def test_gate_regime_line_from_items(flags, disclosure):
     assert "- [P2] claude (advisory): Follow up" in lines
 
 
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ([], "none."),
+        (["openai"], "openai."),
+        (["openai", "Codex", "claude"], "claude, openai."),
+        (None, "unknown (outcome carries no gate dissent list)."),
+        ("openai", "unknown (outcome carries no gate dissent list)."),
+        (["recheck", "x\nReviewer: codex", "claude"], "claude, unknown."),
+    ],
+)
+def test_merge_gate_dissent_line_mirrors_outcome(raw, expected):
+    data = outcome("- [P2] Follow up").to_dict()
+    if raw is None:
+        del data["dissenting_families"]
+    else:
+        data["dissenting_families"] = raw
+    lines = adv.compose_advisory_dissent_summary(data, head_sha=HEAD).splitlines()
+    index = next(i for i, line in enumerate(lines) if line.startswith("Gate regime:"))
+    assert lines[index + 1] == f"Merge-gate dissent: {expected}"
+    assert sum(line.startswith("Merge-gate dissent: ") for line in lines) == 1
+    assert "- [P2] claude (advisory): Follow up" in lines
+
+
 def test_recogniser_tokens_cover_review_queue_literals():
     tree = ast.parse(Path(review_queue.__file__).read_text())
     groups = [
@@ -234,6 +273,21 @@ def test_new_head_creates_comment(monkeypatch):
     result = adv.post_advisory_summary("synaptent/aragora", 123, body, head_sha=new_head)
     assert result.posted and not result.edited
     assert "POST" in mock.call_args.args[0]
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_read_env_for_comment_listing_only(monkeypatch, existing):
+    read_env, write_env = {"AUTH": "read"}, {"AUTH": "write"}
+    monkeypatch.setattr(adv.merge_quorum_io, "_read_env", lambda: read_env)
+    monkeypatch.setattr(adv.merge_quorum_io, "aragora_env", lambda: write_env)
+    mock = fake_github(monkeypatch, [{"id": 7, "body": MARKER}] if existing else [])
+    result = adv.post_advisory_summary("synaptent/aragora", 123, MARKER, head_sha=HEAD)
+    assert result.posted and result.edited == existing
+    read, write = mock.call_args_list
+    assert read.args[0][-2:] == ["--paginate", "--slurp"]
+    assert read.kwargs["env"] == read_env
+    assert ("PATCH" if existing else "POST") in write.args[0]
+    assert write.kwargs["env"] == write_env
 
 
 def test_empty_body_never_calls_github(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up to #10016, mission feature `m2-advisory-dissent-hardening` (ruling 12, VAL-DISSENT-011). Branched from its merged commit `187024c8eae454e7930b668717b54a56cafc450f`.

- Add one `Merge-gate dissent:` line immediately after the unchanged `Gate regime:` line.
- Guard text-mode outcome rehydration without changing the collector's exit code or four advisory fields.
- Use the read environment for comment listing only; POST/PATCH retain the PAT environment.
- Avoid splitting HTML entities at the byte truncation boundary.

Exactly four files, 106 changed lines. No gate-library, review-queue, workflow, ODR, export, or baseline edits.

## Exit metric moved

Row 6: advisory summaries previously disclosed the regime but did not name the gate's dissenting families. They now mirror the collection's own dissent list, including explicit `none` or `unknown` when appropriate. This PR's collections use `--post-advisory-summary`.

## Test commands

- Red first: `python3 -m pytest tests/swarm/test_advisory_dissent.py tests/scripts/test_collect_quorum_evidence.py -q -p no:cacheprovider -k 'merge_gate_dissent_line or text_output_malformed_object or read_env or clip_never_splits_entity'` → 12 failed, 2 passed before implementation; 14 passed after.
- `python3 -m pytest tests/swarm/test_advisory_dissent.py tests/scripts/test_collect_quorum_evidence.py tests/swarm/test_quorum_evidence.py -q -n 8 -p no:cacheprovider --timeout=120` → 434 passed.
- `python3 -m pytest tests/swarm/test_quorum_evidence.py -q -p no:cacheprovider` → 380 passed; library untouched.
- `bash "$MISSION_DIR/bin/gate.sh" lint|typecheck|contracts|test|guardrails` (each section separately) → all five `GATE PASSED` on `89d28e40fb11ca11f197645cd27fe07cac6f45a9`. Curated tests: 3,931 passed, 3 skipped; publish-shadow: 104 passed, 2 skipped; CI-shadow collection and skip audit green.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → exit 0.
- Real #9949 artifact: five render variants show consecutive Summary/Gate regime/Merge-gate dissent lines, five unchanged advisory findings, and no blocking finding labels. Named OFF render remains invisible to identity/dissent/blocking recognizers under both flag values (`ok` twice).

## Reviewed design tradeoffs

The new line is a **mirror** of `dissenting_families`, never a recomputation from verdicts, labels, items, or the environment (ruling 12). Canonicalization, token-safe family names, deduplication and sorting affect presentation only. Missing/non-list data is explicitly unknown, not an inferred empty list.

Finding labels remain severity-level: P0/P1 blocking and P2/P3 advisory, independent of gate regime (ruling 11). The existing disclosure line and gate finding reader are unchanged. The summary is not countable evidence or a merge decision. Existing marker matching, author policy, and PATCH-failure behavior are unchanged, as ruled on #10016.

The render guard catches only `AttributeError`, `KeyError`, `TypeError`, and `ValueError`; it does not print exception contents or add a broad exception handler. Entity clipping drops an incomplete trailing entity rather than exceeding the existing byte budget.

Round 1 on `89d28e40fb11ca11f197645cd27fe07cac6f45a9`: Claude PASS and OpenAI PASS, both grounded and counted; no P0/P1/P2 findings, `dissenting_families: []`, no failures/timeouts. The live classifier reports Tier 2 (`tier_2_live_automation`), no human risk settlement.

Claude's three P3 notes do not require a change to this head: `_clip` consumes HTML-escaped text (the ruled invariant, not a raw-text API); the ruled `_read_env` helper already exists and changing its public API would cross this feature's boundary; the adjacent transport-error formatting is unchanged and its internal `CollectPreflightTransportError.to_dict()` producer supplies every indexed key. The new guard covers outcome rehydration/rendering, not arbitrary malformed transport diagnostics.

Live advisory proof: https://github.com/synaptent/aragora/pull/10036#issuecomment-5575252624 contains `Merge-gate dissent: none.`, exactly matching the round-1 JSON's `dissenting_families: []`.

## Risks

- No authority changes. Reads prefer the existing App-token helper; writes still use the existing PAT environment.
- The broad `tests/swarm tests/scripts -n 8` run stopped at unrelated collection nondeterminism in `test_sync_claude_profiles_from_vibeproxy.py`: `_now_ms()` parameter IDs differ across workers. That unchanged test is outside this PR; all scoped and required mission gates pass.
- Existing whole-tree mypy count remains 1,744, baseline 3,115 lines. Docs remain at the recorded external main breach, 1,120; other guardrails unchanged (cycles 138).
- Metrics Drift is non-required and already reports stale `docs/METRICS.md` on main. This feature adds four parametrization decorators; it does not regenerate metrics or alter baselines.
