### PR TITLE
[AGT-02] A2A agent registration bridge — in-process store + typed record

### DIFF
--- a/aragora/protocols/a2a/registration.py
+++ b/aragora/protocols/a2a/registration.py
@@ -89,11 +89,7 @@ class AgentRegistrationRecord:
         if not isinstance(raw_caps, list):
             raise RegistrationError("capabilities must be a list")
         raw_ts = data.get("registered_at")
-        ts = (
-            datetime.fromisoformat(str(raw_ts))
-            if raw_ts
-            else datetime.now(tz=UTC)
-        )
+        ts = datetime.fromisoformat(str(raw_ts)) if raw_ts else datetime.now(tz=UTC)
         return cls(
             agent_id=str(data["agent_id"]),
             capabilities=frozenset(str(c) for c in raw_caps),
@@ -119,8 +115,7 @@ class RegistrationStore:
     def put(self, record: AgentRegistrationRecord, *, overwrite: bool = False) -> None:
         if record.agent_id in self._records and not overwrite:
             raise RegistrationError(
-                f"Agent '{record.agent_id}' is already registered. "
-                "Pass overwrite=True to replace."
+                f"Agent '{record.agent_id}' is already registered. Pass overwrite=True to replace."
             )
         self._records[record.agent_id] = record
 
@@ -166,8 +161,7 @@ def register_agent(
         raise RegistrationError("At least one capability is required.")
 
     cap_strings: frozenset[str] = frozenset(
-        c.value if isinstance(c, AgentCapability) else str(c)
-        for c in capabilities
+        c.value if isinstance(c, AgentCapability) else str(c) for c in capabilities
     )
     record = AgentRegistrationRecord(
         agent_id=agent_id.strip(),

--- a/aragora/protocols/a2a/registration.py
+++ b/aragora/protocols/a2a/registration.py
@@ -1,0 +1,195 @@
+"""A2A agent registration bridge — AGT-02 / #6063 sub-deliverable 4.
+
+Agents register themselves with a stable ``agent_id``, a set of
+:class:`AgentCapability` strings, an optional Ed25519 ``public_key``, and an
+optional ``endpoint_url``.  The resulting :class:`AgentRegistrationRecord` can
+be held in the lightweight in-process :class:`RegistrationStore` (useful in
+tests and single-process deployments) or handed off to the identity-contract
+layer (``aragora/blockchain/contracts/identity.py``) once that wiring lands in
+a follow-up slice.
+
+Gate: ``ARAGORA_A2A_REGISTRATION_ENABLED`` (default **off**).  The dataclasses
+and the store are always importable and safe to construct; only
+:func:`register_agent` and :func:`lookup_agent` check the flag, so callers
+that just need typed objects are never blocked.
+
+Out of scope:
+- Persistence beyond process lifetime (follow-up: identity-contract bridge).
+- HTTP routes for registration (follow-up: server endpoint slice).
+- Reputation read/write (AGT-05 track).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Sequence
+
+from aragora.protocols.a2a.types import AgentCapability
+
+__all__ = [
+    "registration_enabled",
+    "RegistrationError",
+    "AgentRegistrationRecord",
+    "RegistrationStore",
+    "register_agent",
+    "lookup_agent",
+]
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+_default_store: RegistrationStore | None = None
+
+
+def registration_enabled() -> bool:
+    raw = os.environ.get("ARAGORA_A2A_REGISTRATION_ENABLED", "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _require_enabled() -> None:
+    if not registration_enabled():
+        raise RegistrationError(
+            "Set ARAGORA_A2A_REGISTRATION_ENABLED=1 to enable A2A registration."
+        )
+
+
+class RegistrationError(RuntimeError):
+    """Raised when registration is called while the feature gate is off,
+    or when a conflict or lookup failure occurs."""
+
+
+@dataclass(frozen=True)
+class AgentRegistrationRecord:
+    """Immutable snapshot of a registered agent's identity and capabilities.
+
+    ``public_key`` is an opaque string (base64-encoded Ed25519 or similar);
+    the cryptographic verification bridge lands in a follow-up PR once the
+    identity-contract wiring is ready.
+    """
+
+    agent_id: str
+    capabilities: frozenset[str]
+    public_key: str | None
+    endpoint_url: str | None
+    registered_at: datetime
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "agent_id": self.agent_id,
+            "capabilities": sorted(self.capabilities),
+            "public_key": self.public_key,
+            "endpoint_url": self.endpoint_url,
+            "registered_at": self.registered_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "AgentRegistrationRecord":
+        raw_caps = data.get("capabilities", [])
+        if not isinstance(raw_caps, list):
+            raise RegistrationError("capabilities must be a list")
+        raw_ts = data.get("registered_at")
+        ts = (
+            datetime.fromisoformat(str(raw_ts))
+            if raw_ts
+            else datetime.now(tz=UTC)
+        )
+        return cls(
+            agent_id=str(data["agent_id"]),
+            capabilities=frozenset(str(c) for c in raw_caps),
+            public_key=str(data["public_key"]) if data.get("public_key") else None,
+            endpoint_url=str(data["endpoint_url"]) if data.get("endpoint_url") else None,
+            registered_at=ts,
+        )
+
+
+@dataclass
+class RegistrationStore:
+    """Thread-unsafe in-process registry for agent registrations.
+
+    Suitable for unit tests and single-process evaluation.  Multi-process or
+    persistent deployments should route through the identity-contract bridge
+    (out of scope for this slice).
+    """
+
+    _records: dict[str, AgentRegistrationRecord] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def put(self, record: AgentRegistrationRecord, *, overwrite: bool = False) -> None:
+        if record.agent_id in self._records and not overwrite:
+            raise RegistrationError(
+                f"Agent '{record.agent_id}' is already registered. "
+                "Pass overwrite=True to replace."
+            )
+        self._records[record.agent_id] = record
+
+    def get(self, agent_id: str) -> AgentRegistrationRecord | None:
+        return self._records.get(agent_id)
+
+    def all(self) -> list[AgentRegistrationRecord]:
+        return list(self._records.values())
+
+    def remove(self, agent_id: str) -> bool:
+        return self._records.pop(agent_id, None) is not None
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+
+def _get_default_store() -> RegistrationStore:
+    global _default_store
+    if _default_store is None:
+        _default_store = RegistrationStore()
+    return _default_store
+
+
+def register_agent(
+    agent_id: str,
+    capabilities: Sequence[str | AgentCapability],
+    *,
+    public_key: str | None = None,
+    endpoint_url: str | None = None,
+    store: RegistrationStore | None = None,
+    overwrite: bool = False,
+    registered_at: datetime | None = None,
+) -> AgentRegistrationRecord:
+    """Register an agent, returning the persisted :class:`AgentRegistrationRecord`.
+
+    Raises :class:`RegistrationError` if the gate is off or if ``agent_id`` is
+    already present in the store and ``overwrite`` is False.
+    """
+    _require_enabled()
+    if not agent_id or not agent_id.strip():
+        raise RegistrationError("agent_id must be a non-empty string.")
+    if not capabilities:
+        raise RegistrationError("At least one capability is required.")
+
+    cap_strings: frozenset[str] = frozenset(
+        c.value if isinstance(c, AgentCapability) else str(c)
+        for c in capabilities
+    )
+    record = AgentRegistrationRecord(
+        agent_id=agent_id.strip(),
+        capabilities=cap_strings,
+        public_key=public_key,
+        endpoint_url=endpoint_url,
+        registered_at=registered_at or datetime.now(tz=UTC),
+    )
+    target = store if store is not None else _get_default_store()
+    target.put(record, overwrite=overwrite)
+    return record
+
+
+def lookup_agent(
+    agent_id: str,
+    *,
+    store: RegistrationStore | None = None,
+) -> AgentRegistrationRecord | None:
+    """Return the :class:`AgentRegistrationRecord` for *agent_id*, or None.
+
+    Raises :class:`RegistrationError` if the gate is off.
+    """
+    _require_enabled()
+    target = store if store is not None else _get_default_store()
+    return target.get(agent_id)

--- a/aragora/protocols/a2a/registration.py
+++ b/aragora/protocols/a2a/registration.py
@@ -85,16 +85,48 @@ class AgentRegistrationRecord:
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> "AgentRegistrationRecord":
+        """Rebuild a record from :meth:`to_dict` output.
+
+        Persisted records are untrusted input: every field is validated and a
+        malformed record raises :class:`RegistrationError` instead of yielding
+        a half-formed identity.
+        """
+        if not isinstance(data, dict):
+            raise RegistrationError("record must be a mapping")
+
+        raw_id = data.get("agent_id")
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            raise RegistrationError("agent_id must be a non-empty string")
+
         raw_caps = data.get("capabilities", [])
         if not isinstance(raw_caps, list):
             raise RegistrationError("capabilities must be a list")
+        if not raw_caps or not all(isinstance(c, str) and c.strip() for c in raw_caps):
+            raise RegistrationError("capabilities must be a non-empty list of non-empty strings")
+
         raw_ts = data.get("registered_at")
-        ts = datetime.fromisoformat(str(raw_ts)) if raw_ts else datetime.now(tz=UTC)
+        if not isinstance(raw_ts, str) or not raw_ts.strip():
+            raise RegistrationError("registered_at must be an ISO-8601 string")
+        try:
+            ts = datetime.fromisoformat(raw_ts)
+        except ValueError as exc:
+            raise RegistrationError(f"registered_at is not ISO-8601: {raw_ts!r}") from exc
+        if ts.tzinfo is None or ts.utcoffset() is None:
+            raise RegistrationError("registered_at must be timezone-aware")
+
+        def _optional_str(key: str) -> str | None:
+            value = data.get(key)
+            if value is None:
+                return None
+            if not isinstance(value, str) or not value.strip():
+                raise RegistrationError(f"{key} must be a non-empty string or null")
+            return value
+
         return cls(
-            agent_id=str(data["agent_id"]),
-            capabilities=frozenset(str(c) for c in raw_caps),
-            public_key=str(data["public_key"]) if data.get("public_key") else None,
-            endpoint_url=str(data["endpoint_url"]) if data.get("endpoint_url") else None,
+            agent_id=raw_id.strip(),
+            capabilities=frozenset(c.strip() for c in raw_caps),
+            public_key=_optional_str("public_key"),
+            endpoint_url=_optional_str("endpoint_url"),
             registered_at=ts,
         )
 

--- a/tests/protocols/a2a/test_registration.py
+++ b/tests/protocols/a2a/test_registration.py
@@ -1,0 +1,254 @@
+"""Tests for aragora.protocols.a2a.registration (AGT-02 sub-deliverable 4)."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+
+from aragora.protocols.a2a.registration import (
+    AgentRegistrationRecord,
+    RegistrationError,
+    RegistrationStore,
+    lookup_agent,
+    register_agent,
+    registration_enabled,
+)
+from aragora.protocols.a2a.types import AgentCapability
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _store() -> RegistrationStore:
+    return RegistrationStore()
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+class TestFlagGate:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_A2A_REGISTRATION_ENABLED", raising=False)
+        assert registration_enabled() is False
+
+    def test_enabled_with_1(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_A2A_REGISTRATION_ENABLED", "1")
+        assert registration_enabled() is True
+
+    def test_enabled_with_true(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_A2A_REGISTRATION_ENABLED", "true")
+        assert registration_enabled() is True
+
+    def test_enabled_with_yes(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_A2A_REGISTRATION_ENABLED", "yes")
+        assert registration_enabled() is True
+
+    def test_register_raises_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_A2A_REGISTRATION_ENABLED", raising=False)
+        with pytest.raises(RegistrationError, match="ARAGORA_A2A_REGISTRATION_ENABLED"):
+            register_agent("agent-x", ["debate"], store=_store())
+
+    def test_lookup_raises_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_A2A_REGISTRATION_ENABLED", raising=False)
+        with pytest.raises(RegistrationError):
+            lookup_agent("agent-x", store=_store())
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+class TestRegisterAgent:
+    @pytest.fixture(autouse=True)
+    def enable(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_A2A_REGISTRATION_ENABLED", "1")
+
+    def test_basic_registration(self):
+        store = _store()
+        rec = register_agent("agent-1", ["debate", "critique"], store=store)
+        assert rec.agent_id == "agent-1"
+        assert "debate" in rec.capabilities
+        assert "critique" in rec.capabilities
+        assert rec.public_key is None
+        assert rec.endpoint_url is None
+
+    def test_with_public_key_and_endpoint(self):
+        store = _store()
+        rec = register_agent(
+            "agent-2",
+            [AgentCapability.AUDIT],
+            public_key="base64keyhere==",
+            endpoint_url="https://agent-2.example.com/a2a",
+            store=store,
+        )
+        assert rec.public_key == "base64keyhere=="
+        assert rec.endpoint_url == "https://agent-2.example.com/a2a"
+
+    def test_capability_enum_coercion(self):
+        store = _store()
+        rec = register_agent(
+            "agent-3",
+            [AgentCapability.DEBATE, AgentCapability.CONSENSUS],
+            store=store,
+        )
+        assert "debate" in rec.capabilities
+        assert "consensus" in rec.capabilities
+
+    def test_record_in_store_after_register(self):
+        store = _store()
+        register_agent("agent-4", ["synthesis"], store=store)
+        assert len(store) == 1
+        assert store.get("agent-4") is not None
+
+    def test_duplicate_raises_by_default(self):
+        store = _store()
+        register_agent("agent-5", ["audit"], store=store)
+        with pytest.raises(RegistrationError, match="already registered"):
+            register_agent("agent-5", ["audit"], store=store)
+
+    def test_duplicate_allowed_with_overwrite(self):
+        store = _store()
+        register_agent("agent-6", ["audit"], store=store)
+        rec2 = register_agent("agent-6", ["debate"], store=store, overwrite=True)
+        assert "debate" in rec2.capabilities
+        assert len(store) == 1
+
+    def test_empty_agent_id_raises(self):
+        store = _store()
+        with pytest.raises(RegistrationError, match="non-empty"):
+            register_agent("", ["debate"], store=store)
+
+    def test_whitespace_agent_id_raises(self):
+        store = _store()
+        with pytest.raises(RegistrationError, match="non-empty"):
+            register_agent("   ", ["debate"], store=store)
+
+    def test_no_capabilities_raises(self):
+        store = _store()
+        with pytest.raises(RegistrationError, match="capability"):
+            register_agent("agent-7", [], store=store)
+
+    def test_registered_at_is_utc_aware(self):
+        store = _store()
+        rec = register_agent("agent-8", ["debate"], store=store)
+        assert rec.registered_at.tzinfo is not None
+
+    def test_custom_registered_at(self):
+        store = _store()
+        ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        rec = register_agent("agent-9", ["debate"], store=store, registered_at=ts)
+        assert rec.registered_at == ts
+
+    def test_agent_id_whitespace_stripped(self):
+        store = _store()
+        rec = register_agent("  agent-10  ", ["debate"], store=store)
+        assert rec.agent_id == "agent-10"
+
+
+# ---------------------------------------------------------------------------
+# Lookup
+# ---------------------------------------------------------------------------
+
+class TestLookupAgent:
+    @pytest.fixture(autouse=True)
+    def enable(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_A2A_REGISTRATION_ENABLED", "1")
+
+    def test_lookup_returns_record(self):
+        store = _store()
+        register_agent("agent-a", ["debate"], store=store)
+        rec = lookup_agent("agent-a", store=store)
+        assert rec is not None
+        assert rec.agent_id == "agent-a"
+
+    def test_lookup_missing_returns_none(self):
+        store = _store()
+        assert lookup_agent("unknown", store=store) is None
+
+
+# ---------------------------------------------------------------------------
+# RegistrationStore
+# ---------------------------------------------------------------------------
+
+class TestRegistrationStore:
+    def test_put_and_get(self):
+        store = _store()
+        rec = AgentRegistrationRecord(
+            agent_id="x",
+            capabilities=frozenset(["debate"]),
+            public_key=None,
+            endpoint_url=None,
+            registered_at=datetime.now(tz=UTC),
+        )
+        store.put(rec)
+        assert store.get("x") is rec
+
+    def test_len(self):
+        store = _store()
+        assert len(store) == 0
+        store.put(
+            AgentRegistrationRecord("y", frozenset(["audit"]), None, None, datetime.now(tz=UTC))
+        )
+        assert len(store) == 1
+
+    def test_remove(self):
+        store = _store()
+        rec = AgentRegistrationRecord("z", frozenset(["debate"]), None, None, datetime.now(tz=UTC))
+        store.put(rec)
+        assert store.remove("z") is True
+        assert store.get("z") is None
+
+    def test_remove_missing_returns_false(self):
+        store = _store()
+        assert store.remove("nope") is False
+
+    def test_all(self):
+        store = _store()
+        r1 = AgentRegistrationRecord("a1", frozenset(["debate"]), None, None, datetime.now(tz=UTC))
+        r2 = AgentRegistrationRecord("a2", frozenset(["audit"]), None, None, datetime.now(tz=UTC))
+        store.put(r1)
+        store.put(r2)
+        assert set(r.agent_id for r in store.all()) == {"a1", "a2"}
+
+
+# ---------------------------------------------------------------------------
+# AgentRegistrationRecord serialization
+# ---------------------------------------------------------------------------
+
+class TestSerialization:
+    def test_to_dict_round_trip(self):
+        rec = AgentRegistrationRecord(
+            agent_id="ser-1",
+            capabilities=frozenset(["debate", "critique"]),
+            public_key="pk123",
+            endpoint_url="https://example.com",
+            registered_at=datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        d = rec.to_dict()
+        assert d["agent_id"] == "ser-1"
+        assert sorted(d["capabilities"]) == ["critique", "debate"]
+        assert d["public_key"] == "pk123"
+        assert d["endpoint_url"] == "https://example.com"
+
+    def test_from_dict(self):
+        d = {
+            "agent_id": "ser-2",
+            "capabilities": ["audit"],
+            "public_key": None,
+            "endpoint_url": None,
+            "registered_at": "2026-06-01T00:00:00+00:00",
+        }
+        rec = AgentRegistrationRecord.from_dict(d)
+        assert rec.agent_id == "ser-2"
+        assert "audit" in rec.capabilities
+
+    def test_from_dict_bad_capabilities_raises(self):
+        with pytest.raises(RegistrationError, match="capabilities must be a list"):
+            AgentRegistrationRecord.from_dict({
+                "agent_id": "bad",
+                "capabilities": "not-a-list",
+            })

--- a/tests/protocols/a2a/test_registration.py
+++ b/tests/protocols/a2a/test_registration.py
@@ -22,6 +22,7 @@ from aragora.protocols.a2a.types import AgentCapability
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _store() -> RegistrationStore:
     return RegistrationStore()
 
@@ -29,6 +30,7 @@ def _store() -> RegistrationStore:
 # ---------------------------------------------------------------------------
 # Flag gate
 # ---------------------------------------------------------------------------
+
 
 class TestFlagGate:
     def test_disabled_by_default(self, monkeypatch):
@@ -61,6 +63,7 @@ class TestFlagGate:
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
+
 
 class TestRegisterAgent:
     @pytest.fixture(autouse=True)
@@ -153,6 +156,7 @@ class TestRegisterAgent:
 # Lookup
 # ---------------------------------------------------------------------------
 
+
 class TestLookupAgent:
     @pytest.fixture(autouse=True)
     def enable(self, monkeypatch):
@@ -173,6 +177,7 @@ class TestLookupAgent:
 # ---------------------------------------------------------------------------
 # RegistrationStore
 # ---------------------------------------------------------------------------
+
 
 class TestRegistrationStore:
     def test_put_and_get(self):
@@ -219,6 +224,7 @@ class TestRegistrationStore:
 # AgentRegistrationRecord serialization
 # ---------------------------------------------------------------------------
 
+
 class TestSerialization:
     def test_to_dict_round_trip(self):
         rec = AgentRegistrationRecord(
@@ -248,7 +254,9 @@ class TestSerialization:
 
     def test_from_dict_bad_capabilities_raises(self):
         with pytest.raises(RegistrationError, match="capabilities must be a list"):
-            AgentRegistrationRecord.from_dict({
-                "agent_id": "bad",
-                "capabilities": "not-a-list",
-            })
+            AgentRegistrationRecord.from_dict(
+                {
+                    "agent_id": "bad",
+                    "capabilities": "not-a-list",
+                }
+            )

--- a/tests/protocols/a2a/test_registration.py
+++ b/tests/protocols/a2a/test_registration.py
@@ -260,3 +260,69 @@ class TestSerialization:
                     "capabilities": "not-a-list",
                 }
             )
+
+
+class TestFromDictValidation:
+    """Persisted records are untrusted; malformed ones must be rejected, not coerced."""
+
+    @staticmethod
+    def _valid() -> dict[str, object]:
+        return {
+            "agent_id": "val-1",
+            "capabilities": ["debate"],
+            "public_key": None,
+            "endpoint_url": None,
+            "registered_at": "2026-06-01T00:00:00+00:00",
+        }
+
+    def test_valid_record_round_trips(self):
+        rec = AgentRegistrationRecord.from_dict(self._valid())
+        assert rec.agent_id == "val-1"
+        assert rec.capabilities == frozenset({"debate"})
+        assert rec.registered_at.tzinfo is not None
+        assert AgentRegistrationRecord.from_dict(rec.to_dict()) == rec
+
+    @pytest.mark.parametrize("bad_id", [None, "", "   ", 42])
+    def test_bad_agent_id_raises(self, bad_id):
+        d = self._valid()
+        d["agent_id"] = bad_id
+        with pytest.raises(RegistrationError, match="agent_id"):
+            AgentRegistrationRecord.from_dict(d)
+
+    def test_missing_agent_id_raises(self):
+        d = self._valid()
+        del d["agent_id"]
+        with pytest.raises(RegistrationError, match="agent_id"):
+            AgentRegistrationRecord.from_dict(d)
+
+    @pytest.mark.parametrize("bad_caps", [[], [""], ["debate", "  "], [1], ["debate", None]])
+    def test_bad_capabilities_raise(self, bad_caps):
+        d = self._valid()
+        d["capabilities"] = bad_caps
+        with pytest.raises(RegistrationError, match="capabilities"):
+            AgentRegistrationRecord.from_dict(d)
+
+    @pytest.mark.parametrize("bad_ts", [None, "", "not-a-date", 1717200000, "2026-06-01T00:00:00"])
+    def test_bad_registered_at_raises(self, bad_ts):
+        d = self._valid()
+        d["registered_at"] = bad_ts
+        with pytest.raises(RegistrationError, match="registered_at"):
+            AgentRegistrationRecord.from_dict(d)
+
+    def test_missing_registered_at_raises(self):
+        d = self._valid()
+        del d["registered_at"]
+        with pytest.raises(RegistrationError, match="registered_at"):
+            AgentRegistrationRecord.from_dict(d)
+
+    @pytest.mark.parametrize("key", ["public_key", "endpoint_url"])
+    @pytest.mark.parametrize("bad", ["", "  ", 7, {"k": "v"}])
+    def test_bad_optional_strings_raise(self, key, bad):
+        d = self._valid()
+        d[key] = bad
+        with pytest.raises(RegistrationError, match=key):
+            AgentRegistrationRecord.from_dict(d)
+
+    def test_non_mapping_raises(self):
+        with pytest.raises(RegistrationError, match="mapping"):
+            AgentRegistrationRecord.from_dict(["agent_id"])  # type: ignore[arg-type]


### PR DESCRIPTION
## Slice

Adds `aragora/protocols/a2a/registration.py`: a flag-gated A2A agent registration bridge with `AgentRegistrationRecord` (immutable, JSON-serialisable), `RegistrationStore` (in-process, zero deps), and the `register_agent` / `lookup_agent` public functions. This is sub-deliverable 4 of AGT-02 (A2A consumer surface), complementing the already-merged capability-discovery (sub-3) and receipts (sub-2) modules.

## Gating

- Default: **OFF** (flag: `ARAGORA_A2A_REGISTRATION_ENABLED`)
- Live queue effect: **none** — all logic is side-effect-free; nothing auto-registers or auto-publishes
- Advances: AGT-02 (A2A consumer surface) — registration sub-deliverable, as specified in `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` §AGT-02

## Tests

- `TestFlagGate` (6 tests) — gate off by default; register/lookup raise when disabled; truthy values `"1"`, `"true"`, `"yes"` enable
- `TestRegisterAgent` (12 tests) — basic registration, public key + endpoint URL, `AgentCapability` enum coercion, store persistence, duplicate rejection + overwrite, empty/whitespace agent-id rejection, empty capabilities rejection, UTC-aware timestamp, custom timestamp, whitespace stripping
- `TestLookupAgent` (2 tests) — returns record; returns None for unknown id
- `TestRegistrationStore` (5 tests) — put/get, len, remove, remove-missing, all()
- `TestSerialization` (3 tests) — `to_dict` shape, `from_dict` round-trip, bad capabilities raises

## Validation

- `pytest tests/protocols/a2a/test_registration.py --noconftest` — **28 passed**
- `ruff check aragora/protocols/a2a/registration.py tests/protocols/a2a/test_registration.py` — **clean**
- `mypy aragora/protocols/a2a/registration.py --ignore-missing-imports` — **clean**

## Out of scope

- HTTP server endpoint for `/a2a/register` (follow-up: server-endpoint slice, requires pydantic settings in place)
- Persistence to `aragora/blockchain/contracts/identity.py` (follow-up: identity-contract bridge once that slice is gated in)
- Reputation read/write surfaces (AGT-05 track)

---
_Generated by [Claude Code](https://claude.ai/code/session_015wPan2tEYPH4LBQrSJTcJ7)_