### PR TITLE
fix(review-queue): keep advisory settlement reachable in quorum job [Tier 4]

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2589,6 +2589,7 @@ def _build_packet(
             check_surfaces=check_surfaces,
         )
     required_pr_check_gate_satisfied = False
+    non_required_non_green_count = 0
     self_check_excluded = any(
         _is_current_merge_quorum_self_check(check)
         for check in _latest_status_check_rollup(pr.get("statusCheckRollup") or [])
@@ -2684,6 +2685,9 @@ def _build_packet(
             required_checks=required_pr_checks if required_available else None,
         )
         check_surfaces["pr_rollup"].update(rollup_required_diagnostics)
+        non_required_non_green_count = rollup_required_diagnostics.get(
+            "non_required_non_green_count", 0
+        )
 
         gate_blocked_reason = ""
         if not required_available:
@@ -2753,8 +2757,12 @@ def _build_packet(
                 "summary": checks_summary,
             }
             check_surfaces["diagnosis"] = (
-                "The PR check rollup includes non-required non-green checks, "
-                "but GitHub reports every branch-protection required check green; "
+                (
+                    "The PR check rollup includes non-required non-green checks, but "
+                    if non_required_non_green_count
+                    else ""
+                )
+                + "GitHub reports every effective branch-protection required check green; "
                 "merge-packet uses the required PR checks gate."
             )
             check_surfaces["remediation_prompt"] = (
@@ -2772,8 +2780,12 @@ def _build_packet(
                 "summary": checks_summary,
             }
             check_surfaces["diagnosis"] = (
-                "The PR check rollup includes non-required non-green checks, "
-                "and GitHub reports every non-quorum branch-protection required "
+                (
+                    "The PR check rollup includes non-required non-green checks, and "
+                    if non_required_non_green_count
+                    else ""
+                )
+                + "GitHub reports every non-quorum branch-protection required "
                 "check green; merge-packet leaves aragora-merge-quorum to the "
                 "model quorum evidence gate."
             )
@@ -2783,8 +2795,7 @@ def _build_packet(
             )
         elif gate_blocked_reason:
             check_surfaces["diagnosis"] = (
-                "The PR check rollup is non-green and merge-packet did not select "
-                f"the required PR checks gate: {gate_blocked_reason}"
+                f"merge-packet did not select the required PR checks gate: {gate_blocked_reason}"
             )
             check_surfaces["remediation_prompt"] = (
                 "Keep the PR blocked or authorize a bounded check-surface repair; "
@@ -2858,7 +2869,11 @@ def _build_packet(
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
     required_pr_check_surface = check_surfaces.get("required_pr_checks") or {}
-    if required_pr_check_gate_satisfied and required_pr_check_surface:
+    if (
+        required_pr_check_gate_satisfied
+        and required_pr_check_surface
+        and non_required_non_green_count
+    ):
         risk_flags.append(
             "non-required PR checks are non-green; "
             "effective gate uses branch-protection required checks"
@@ -2899,9 +2914,11 @@ def _build_packet(
     else:
         recommendation = "approve_candidate"
         if required_pr_check_gate_satisfied:
-            recommendation_reason = (
-                "branch-protection required checks green; non-required PR checks are non-green"
-            )
+            recommendation_reason = "branch-protection required checks green"
+            if non_required_non_green_count:
+                recommendation_reason += "; non-required PR checks are non-green"
+        elif required_pr_check_surface.get("gate_blocked_reason"):
+            recommendation_reason = required_pr_check_surface["gate_blocked_reason"]
         elif direct_check_fallback_satisfied and direct_summary.get("non_green_count", 0):
             recommendation_reason = (
                 "branch-protection required contexts green via direct check-run fallback; "

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2589,7 +2589,16 @@ def _build_packet(
             check_surfaces=check_surfaces,
         )
     required_pr_check_gate_satisfied = False
-    if not settlement_state_block and not checks_unavailable and (has_failures or has_pending):
+    self_check_excluded = any(
+        _is_current_merge_quorum_self_check(check)
+        for check in _latest_status_check_rollup(pr.get("statusCheckRollup") or [])
+        if isinstance(check, dict)
+    )
+    if (
+        not settlement_state_block
+        and not checks_unavailable
+        and (has_failures or has_pending or self_check_excluded)
+    ):
         required_surface = _fetch_required_pr_check_surface(number, repo_override)
         required_pr_checks = [
             item for item in required_surface.get("checks") or [] if isinstance(item, dict)

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -85,6 +85,8 @@ untouched. The settled verdict is a **distinct, auditable value**
 emits a `::notice::OPERATOR-SETTLED-OVER-ADVISORY` line naming the PR, head,
 tier, and validated families.
 
+Inside the enforcing job, the required-check surface is also fetched whenever its own quorum row was excluded from the rollup summary, keeping the valve reachable when every other check is green.
+
 ## What is preserved
 
 - `[P0]`/`[P1]` model dissent blocks the operator exactly as before.

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -87,6 +87,13 @@ tier, and validated families.
 
 Inside the enforcing job, the required-check surface is also fetched whenever its own quorum row was excluded from the rollup summary, keeping the valve reachable when every other check is green.
 
+Packet reporting claims non-required non-green checks only when the rollup's
+required-check membership classification identifies them. An unavailable required
+surface remains unknown, not a failed rollup. Raw pending self rows are preserved;
+the existing self-row exclusions still apply to summaries and diagnostic counts.
+Controlled in-job fixtures, including mocked settlement-creator checks, prove
+unit reachability only, not live CI execution or authorization.
+
 ## What is preserved
 
 - `[P0]`/`[P1]` model dissent blocks the operator exactly as before.

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -229,6 +229,162 @@ def test_build_packet_in_job_non_quorum_required_failure_keeps_valve_blocked(
     assert packet.model_review_quorum["verdict"] == "not_ready_for_settlement"
 
 
+@pytest.fixture(
+    params=[
+        "green",
+        "low_risk",
+        "unavailable",
+        "quorum_fail",
+        "quorum_pending",
+        "required_fail",
+        "required_pending",
+        "optional_fail",
+        "optional_pending",
+    ]
+)
+def reporting_case(request, in_job_advisory_inputs, monkeypatch, tmp_path):
+    """Unit evidence: mocked in-job env/settlement, never live CI or authorization."""
+    from aragora.cli.commands import review_queue as rq
+
+    case = request.param
+    pr, required = in_job_advisory_inputs
+    if case == "low_risk":
+        pr["files"] = [{"path": "docs/example.md"}]
+    if case == "unavailable":
+        monkeypatch.setattr(
+            rq,
+            "_fetch_required_pr_check_surface",
+            lambda *_args: {
+                "available": False,
+                "checks": [],
+                "error": "required surface transport unavailable",
+            },
+        )
+    if case.startswith("quorum_"):
+        # Required quorum rows are all excluded in-job. Exercise the external
+        # quorum-only branch without changing that detector or using the CLI flag.
+        monkeypatch.delenv("GITHUB_JOB")
+        row, required_row = pr["statusCheckRollup"][0], required[0]
+    elif case.startswith("required_"):
+        row, required_row = pr["statusCheckRollup"][1], required[1]
+    elif case.startswith("optional_"):
+        row, required_row = {"name": "optional-audit"}, {}
+        pr["statusCheckRollup"].append(row)
+    if case.endswith(("_fail", "_pending")):
+        pending = case.endswith("_pending")
+        row.update(
+            status="IN_PROGRESS" if pending else "COMPLETED",
+            conclusion="" if pending else "FAILURE",
+        )
+        required_row.update(row, bucket="pending" if pending else "fail")
+    packet = _build_packet("6283", repo_override="synaptent/aragora", review_queue_root=tmp_path)
+    return case, packet, pr, required
+
+
+def test_required_check_reporting_preserves_gate_results(reporting_case) -> None:
+    """Pin pre-cure machine outcomes independently of the reporting assertions."""
+    case, packet, pr, required_rows = reporting_case
+    required = packet.check_surfaces["required_pr_checks"]
+    quorum = packet.model_review_quorum
+    blocked = case in {"required_fail", "required_pending", "quorum_pending"}
+    unavailable = case == "unavailable"
+    expected_verdict = (
+        "not_ready_for_settlement"
+        if blocked
+        else "collect_model_quorum_before_merge"
+        if unavailable
+        else "advisory_settle"
+        if case == "low_risk"
+        else "operator_advisory_settlement"
+    )
+    assert quorum["verdict"] == expected_verdict
+    assert quorum["status"] == (
+        "repair_or_wait" if blocked else "needs_model_review_quorum" if unavailable else "satisfied"
+    )
+    assert quorum["admin_squash_allowed"] is (not blocked and not unavailable)
+    assert quorum["tier"] == (0 if case == "low_risk" else 3)
+    assert required["advisory_settle_surface_clear"] is (not blocked and not unavailable)
+    assert required["gate_selected"] is (not blocked and not unavailable)
+    assert required["quorum_only_failure"] is (case == "quorum_fail")
+    assert required["effective_total"] == (
+        0 if unavailable else 6 if case.startswith("quorum_") else 5
+    )
+    assert required["ignored_current_merge_quorum_self_check_count"] == (
+        0 if unavailable or case.startswith("quorum_") else 1
+    )
+    assert required["ignored_by_ignore_own_quorum_flag_count"] == 0
+    assert packet.machine_recommendation == (
+        "repair_first"
+        if case in {"quorum_fail", "required_fail"}
+        else "needs_human_attention"
+        if blocked
+        else "approve_candidate"
+    )
+    assert packet.check_surfaces.get("effective_gate", {}).get("source") == (
+        "required_pr_checks" if not blocked and not unavailable else None
+    )
+    # The raw rows stay pending even though the existing detector excludes the
+    # current self row from both summaries and non-green diagnostic counts.
+    assert sum(row["bucket"] == "pending" for row in required_rows) == (
+        0 if case == "quorum_fail" else 2 if case == "required_pending" else 1
+    )
+    assert pr["statusCheckRollup"][0]["status"] == (
+        "COMPLETED" if case == "quorum_fail" else "IN_PROGRESS"
+    )
+
+
+def test_required_check_reporting_is_truthful(reporting_case) -> None:
+    case, packet, _pr, _required_rows = reporting_case
+    surfaces = packet.check_surfaces
+    rollup, required = surfaces["pr_rollup"], surfaces["required_pr_checks"]
+    diagnosis = surfaces["diagnosis"]
+    reason = packet.machine_recommendation_reason
+    optional = case.startswith("optional_")
+    assert ("non-required PR checks are non-green" in " ".join(packet.risk_flags)) is optional
+    assert ("non-required non-green checks" in diagnosis) is optional
+    assert ("non-required PR checks are non-green" in reason) is optional
+    assert rollup["pending_count"] == int(
+        case in {"quorum_pending", "required_pending", "optional_pending"}
+    )
+    assert rollup["failing_or_cancelled_count"] == int(case.endswith("_fail"))
+    assert rollup["non_green_count"] == int(case.startswith(("quorum_", "required_", "optional_")))
+    if case == "unavailable":
+        assert required["available"] is False
+        assert required["error"] == "required surface transport unavailable"
+        assert "required PR checks surface is unavailable" in required["gate_blocked_reason"]
+        assert "required PR checks surface is unavailable" in diagnosis
+        assert "unavailable" in reason
+        assert "rollup is non-green" not in diagnosis
+        assert "required checks green" not in reason
+        assert "non_required_non_green_count" not in rollup
+    else:
+        assert required["available"] is True
+        assert rollup["non_required_non_green_count"] == int(optional)
+        assert rollup["non_required_non_green_sample"] == (["optional-audit"] if optional else [])
+    if case in {"green", "low_risk", "optional_fail", "optional_pending"}:
+        assert required["summary"] == "5/5 required green"
+        assert required["gate_blocked_reason"] == ""
+        assert required["failing_or_cancelled"] == required["pending"] == []
+        assert "required check" in diagnosis and "green" in diagnosis
+        assert "branch-protection required checks green" in reason
+    elif case.startswith(("required_", "quorum_")):
+        pending = case.endswith("_pending")
+        name = "lint" if case.startswith("required_") else "aragora-merge-quorum"
+        count = 5 if name == "lint" else 6
+        assert required["summary"] == f"1 {'pending' if pending else 'failing'} / {count} required"
+        assert required["pending"] == ([name] if pending else [])
+        assert required["failing_or_cancelled"] == ([] if pending else [name])
+        assert any(name in sample for sample in rollup["non_green_sample"])
+        if case == "quorum_fail":
+            assert required["gate_blocked_reason"] == ""
+            assert "aragora-merge-quorum" in diagnosis
+        else:
+            assert ("pending" if pending else "failing") in required["gate_blocked_reason"]
+            assert required["gate_blocked_reason"] in diagnosis
+    if case in {"green", "low_risk", "unavailable"}:
+        assert rollup["summary"] == "6/6 green"
+
+
 def _make_reviewer_output(
     *,
     slot_id: str,

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -119,6 +119,116 @@ def _make_pr(
     }
 
 
+@pytest.fixture
+def in_job_advisory_inputs(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, Any], list]:
+    """Mock GitHub inputs, not a live CI execution, for packet-level reachability."""
+    from aragora.cli.commands import review_queue as rq
+
+    head = "a" * 40
+    for flag in (
+        "TIERED_MERGE_GATE",
+        "SEVERITY_GATED_DISSENT",
+        "ADVISORY_DISSENT_SETTLE",
+        "OPERATOR_ADVISORY_SETTLEMENT",
+    ):
+        monkeypatch.setenv(f"ARAGORA_ENABLE_{flag}", "1")
+    monkeypatch.setenv("ARAGORA_SETTLEMENT_CREATOR", "scarmani")
+    monkeypatch.setenv("ARAGORA_TRUSTED_EVIDENCE_POSTERS", "scarmani")
+    monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+    monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+    monkeypatch.setenv("GITHUB_RUN_ID", "26288586838")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+    quorum_row = {
+        "name": "aragora-merge-quorum",
+        "workflowName": "Aragora Merge Quorum",
+        "status": "IN_PROGRESS",
+        "conclusion": "",
+        "detailsUrl": "https://github.com/synaptent/aragora/actions/runs/26288586838/job/1",
+    }
+    green_rows = [
+        {"name": name, "status": "COMPLETED", "conclusion": "SUCCESS"}
+        for name in (
+            "lint",
+            "typecheck",
+            "sdk-parity",
+            "Generate & Validate",
+            "TypeScript SDK Type Check",
+        )
+    ]
+    pr = _make_pr(
+        number=6283,
+        files=["aragora/server/handlers/x.py"],
+        checks=[
+            quorum_row,
+            *green_rows,
+            {"context": "aragora/human-settlement", "state": "SUCCESS"},
+        ],
+    )
+    pr["headRefOid"] = head
+    pr["commits"] = [{"commit": {"committedDate": "2026-07-10T23:00:00Z"}}]
+    pr["comments"] = [
+        {
+            "author": {"login": "scarmani"},
+            "createdAt": "2026-07-11T00:00:00Z",
+            "body": (
+                f"## {family} independent model review\n**Model family:** {family}\n"
+                f"Current head: {head}\nVerdict: CHANGES-REQUESTED\n"
+                "- [P2] A non-blocking advisory."
+            ),
+        }
+        for family in ("claude", "openai")
+    ] + [
+        {
+            "author": {"login": "scarmani"},
+            "body": f"Tier-4 Human Settlement Authorization\n{head}\n"
+            "admin_squash_merge\nhuman-risk settlement",
+        }
+    ]
+    required = [
+        {**row, "bucket": "pending" if row is quorum_row else "pass"}
+        for row in [quorum_row, *green_rows]
+    ]
+    monkeypatch.setattr(rq, "_gh_json", lambda args: pr)
+    monkeypatch.setattr(
+        rq,
+        "_fetch_required_pr_check_surface",
+        lambda *_args: {"available": True, "checks": required},
+    )
+    monkeypatch.setattr(rq, "_human_settlement_status_creator_verified", lambda **_kw: (True, "ok"))
+    monkeypatch.setattr(rq, "_has_successful_status_context", lambda *_args, **_kw: True)
+    return pr, required
+
+
+def test_build_packet_in_job_all_green_rollup_populates_required_surface_and_fires_valve(
+    in_job_advisory_inputs, tmp_path: Path
+) -> None:
+    packet = _build_packet("6283", repo_override="synaptent/aragora", review_queue_root=tmp_path)
+    assert packet.check_surfaces["required_pr_checks"]["advisory_settle_surface_clear"] is True
+    assert packet.model_review_quorum["status"] == "satisfied"
+    assert packet.model_review_quorum["verdict"] == "operator_advisory_settlement"
+
+
+def test_build_packet_same_pending_quorum_without_job_keeps_valve_blocked(
+    in_job_advisory_inputs, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("GITHUB_JOB")
+    packet = _build_packet("6283", repo_override="synaptent/aragora", review_queue_root=tmp_path)
+    assert packet.check_surfaces["required_pr_checks"]["advisory_settle_surface_clear"] is False
+    assert packet.model_review_quorum["verdict"] == "not_ready_for_settlement"
+
+
+def test_build_packet_in_job_non_quorum_required_failure_keeps_valve_blocked(
+    in_job_advisory_inputs, tmp_path: Path
+) -> None:
+    pr, required = in_job_advisory_inputs
+    pr["statusCheckRollup"][1]["conclusion"] = "FAILURE"
+    required[1].update(bucket="fail", conclusion="FAILURE")
+    packet = _build_packet("6283", repo_override="synaptent/aragora", review_queue_root=tmp_path)
+    assert packet.check_surfaces["required_pr_checks"]["advisory_settle_surface_clear"] is False
+    assert packet.model_review_quorum["verdict"] == "not_ready_for_settlement"
+
+
 def _make_reviewer_output(
     *,
     slot_id: str,


### PR DESCRIPTION
## Bug

The enforcing `aragora-merge-quorum` job removes its current IN_PROGRESS row from the rollup summary. When all other checks are green, `_build_packet` never fetches the branch-protection required-check surface, so the operator-advisory-settlement valve cannot see `advisory_settle_surface_clear`.

Observed on #10000 at historical H3: the ordinary local packet returned `satisfied` / `operator_advisory_settlement`, but run **34067217933 attempt 4**, executing default-branch code `684127e42d`, returned `needs_model_review_quorum` / `collect_model_quorum_before_merge`, with `model quorum incomplete: 0/2 signal(s)`.

## Fix and scope

- Widen only the required-surface fetch guard when the existing actual run/env-bound detector identifies an excluded self row.
- Preserve the detectors, required-check summarizer, settlement predicates, and diagnostic semantics. No workflow changes.
- Add three controlled packet tests: all-green in-job positive, identical pending-row no-job negative twin, and failing non-quorum required-check guard.
- Add one reachability sentence to the spec.

Measured three-dot diff: **3 files, +122/-1 = 123 LOC** (expected approximately 120, below the 800 cap).

## Authority

Tier-4 implementation and in-session settlement authorized by **P4B HANDLERS DECOMPOSITION, AMENDMENT 5**, `library/decision-ledger.md L1013 == library/operator-approvals.md L880`, SHA-256 without newline:
`254774a3da6482f4215d2c73e3183c592d086e6796c37ef61cb606859b63f514`.

AMENDMENT 7 L1015/A884 clarifies that controlled tests are **unit evidence, mocked in-job env, not live CI proof**. The local `--ignore-own-quorum-check` diagnostic is informational, not the actual CI self-row detector. No diagnostic verdict change is promised or required.

This PR does not mutate #10000. Actual post-fix H4 enforcing CI proof remains pending and owned by batch 1.

## Validation

All commands run with the managed worktree on `PYTHONPATH`.

Red-first at tests-only commit `a8b102ff93ad3187d2c4488acfb1b3cff8708ff5`, with production source identical to origin/main `955183a97c21365e4ace129fbf3d55d8c1220bae`:

`python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:randomly --color=no -k 'all_green_rollup_populates_required_surface or same_pending_quorum_without_job or in_job_non_quorum_required_failure'`

```text
FAILED tests/cli/commands/test_review_queue.py::test_build_packet_in_job_all_green_rollup_populates_required_surface_and_fires_valve - KeyError: 'required_pr_checks'
1 failed, 2 passed, 360 deselected, 7 warnings in 0.52s
```

After fix:

`python3 -m pytest tests/cli/commands/test_review_queue.py tests/cli/commands/test_review_queue_merge_packet_fields.py tests/cli/commands/test_review_queue_settlement_status.py tests/governance/test_operator_advisory_settlement.py -q -p no:randomly --color=no`

```text
397 passed, 7 warnings in 7.35s
```

- `make lint`: All checks passed!
- `ruff format --check aragora/ tests/ scripts/`: 10905 files already formatted.
- `mypy --ignore-missing-imports --follow-imports=skip aragora/cli/commands/review_queue.py`: no issues in 1 source file, both before and after.
- `bash scripts/preflight_mypy.sh --diff-base origin/main`, after committing, fresh cache: no issues in 2 source files.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: preflight: ok.
- AWS-neutralized `make test-smoke`: Core/Server/Memory imports OK; Smoke tests passed!
