### PR TITLE
[AGT-05] Three-axis stale-claim calibration policy

### DIFF
--- a/aragora/reputation/stale_policy.py
+++ b/aragora/reputation/stale_policy.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -282,8 +283,15 @@ def resolve_stale_calibration(
         A :class:`StaleCalibrationDecision` with the advisory action.
 
     Raises:
-        ValueError: If ``evidence_age_days < 0`` or ``half_life_days <= 0``.
+        ValueError: If either input is NaN or infinite, if
+            ``evidence_age_days < 0``, or if ``half_life_days <= 0``.
     """
+    # NaN compares False against every bound and infinities collapse the band
+    # arithmetic, so both would silently route to a decision; reject them first.
+    if not math.isfinite(evidence_age_days):
+        raise ValueError(f"evidence_age_days must be finite; got {evidence_age_days!r}")
+    if not math.isfinite(half_life_days):
+        raise ValueError(f"half_life_days must be finite; got {half_life_days!r}")
     if evidence_age_days < 0:
         raise ValueError(f"evidence_age_days must be >= 0; got {evidence_age_days!r}")
     if half_life_days <= 0:

--- a/aragora/reputation/stale_policy.py
+++ b/aragora/reputation/stale_policy.py
@@ -17,9 +17,25 @@ This is shadow-only:
   machine-greppable.
 - No production code path calls into this module yet.
 
-A future PR can wire this into ``settle_claim``, the calibration
-leaderboard, and the rev-4 staging scorecard. Until then, this seed
-exists only so the policy surface is reviewable in isolation.
+Three-axis calibration policy (added in AGT-05 / #6066):
+
+The :func:`resolve_stale_calibration` function implements the proposal from
+``docs/plans/2026-04-29-agt-05-stale-claim-policy.md``.  It maps evidence age
+relative to a settlement half-life to one of three :class:`PolicyDecision`
+values:
+
+- ``decay_penalty`` — evidence is fresh relative to its half-life; treat the
+  stale verdict as a calibration miss and apply the full penalty.
+- ``renewal_required`` — evidence is in the mid-band; abstain from penalty and
+  emit a deterministic ``claim_renewal_id`` so the agent can re-evidence.
+- ``abstain`` — evidence is so old that staleness is structural; abstain
+  without any renewal signal.
+
+This function is **advisory and pure** — no calibration delta or renewal
+record is written by this module.
+
+A future PR can wire :func:`resolve_stale_calibration` into ``settle_claim``,
+the calibration leaderboard, and the rev-4 staging scorecard.
 """
 
 from __future__ import annotations
@@ -28,6 +44,7 @@ import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Final
 
 # Default tuning. These mirror the half-life used in
@@ -165,6 +182,145 @@ def is_stale(
     )
 
 
+# ---------------------------------------------------------------------------
+# Three-axis calibration policy (AGT-05 / #6066)
+# ---------------------------------------------------------------------------
+
+
+class PolicyDecision(str, Enum):
+    """Calibration action for a stale claim.
+
+    See ``docs/plans/2026-04-29-agt-05-stale-claim-policy.md`` for the full
+    rationale.
+
+    - ``DECAY_PENALTY``: evidence is fresh relative to its half-life; apply
+      the full calibration penalty.
+    - ``RENEWAL_REQUIRED``: evidence is in the mid-band; abstain from penalty
+      and emit a renewal token.
+    - ``ABSTAIN``: evidence is structurally old; abstain silently.
+    """
+
+    DECAY_PENALTY = "decay_penalty"
+    RENEWAL_REQUIRED = "renewal_required"
+    ABSTAIN = "abstain"
+
+
+@dataclass(frozen=True)
+class StaleCalibrationDecision:
+    """Output of :func:`resolve_stale_calibration`.
+
+    All fields are advisory.  No calibration delta is written by this module.
+
+    Attributes:
+        policy_decision: The three-axis calibration action.
+        calibration_delta_modifier: 1.0 for full penalty, 0.0 to abstain.
+        evidence_age_days: Age of the evidence at evaluation time.
+        half_life_used_days: Settlement half-life that produced this decision.
+        claim_renewal_id: Deterministic renewal token when policy_decision is
+            ``RENEWAL_REQUIRED``; ``None`` otherwise.  Derived from
+            ``claim_id`` and ``evidence_age_days`` so callers can correlate
+            audit rows without a round-trip to a database.
+        policy_fingerprint: SHA-256–derived 12-char tag over the inputs, for
+            audit-trail tagging.  Format: ``"cp_" + 12 hex chars``.
+    """
+
+    policy_decision: PolicyDecision
+    calibration_delta_modifier: float
+    evidence_age_days: float
+    half_life_used_days: float
+    claim_renewal_id: str | None
+    policy_fingerprint: str
+
+
+def _calibration_fingerprint(evidence_age_days: float, half_life_days: float) -> str:
+    material = json.dumps(
+        {
+            "evidence_age_days": round(evidence_age_days, 6),
+            "half_life_days": round(half_life_days, 6),
+        },
+        sort_keys=True,
+    )
+    return f"cp_{hashlib.sha256(material.encode('utf-8')).hexdigest()[:12]}"
+
+
+def _renewal_id(claim_id: str, evidence_age_days: float) -> str:
+    material = f"{claim_id}:{evidence_age_days:.6f}"
+    return f"renew_{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def resolve_stale_calibration(
+    *,
+    evidence_age_days: float,
+    half_life_days: float,
+    claim_id: str = "",
+) -> StaleCalibrationDecision:
+    """Map evidence age to a three-axis calibration decision.
+
+    Implements the policy table from
+    ``docs/plans/2026-04-29-agt-05-stale-claim-policy.md``:
+
+    +-----------------------------------------------+--------------------+----------+
+    | Condition                                     | Decision           | Modifier |
+    +===============================================+====================+==========+
+    | evidence_age < 0.5 × half_life                | decay_penalty      | 1.0      |
+    +-----------------------------------------------+--------------------+----------+
+    | 0.5 × half_life ≤ evidence_age < 1.5 × half  | renewal_required   | 0.0      |
+    +-----------------------------------------------+--------------------+----------+
+    | evidence_age ≥ 1.5 × half_life                | abstain            | 0.0      |
+    +-----------------------------------------------+--------------------+----------+
+
+    This function is **pure and side-effect free**.  Shadow only; no live
+    settlement path calls this yet.
+
+    Args:
+        evidence_age_days: Age of the underlying evidence in days (>= 0).
+        half_life_days: Settlement half-life in days (> 0).
+        claim_id: Optional stable identifier for the claim; included in the
+            ``claim_renewal_id`` hash so audit rows are correlatable.
+
+    Returns:
+        A :class:`StaleCalibrationDecision` with the advisory action.
+
+    Raises:
+        ValueError: If ``evidence_age_days < 0`` or ``half_life_days <= 0``.
+    """
+    if evidence_age_days < 0:
+        raise ValueError(f"evidence_age_days must be >= 0; got {evidence_age_days!r}")
+    if half_life_days <= 0:
+        raise ValueError(f"half_life_days must be > 0; got {half_life_days!r}")
+
+    fp = _calibration_fingerprint(evidence_age_days, half_life_days)
+    lo = 0.5 * half_life_days
+    hi = 1.5 * half_life_days
+
+    if evidence_age_days < lo:
+        return StaleCalibrationDecision(
+            policy_decision=PolicyDecision.DECAY_PENALTY,
+            calibration_delta_modifier=1.0,
+            evidence_age_days=evidence_age_days,
+            half_life_used_days=half_life_days,
+            claim_renewal_id=None,
+            policy_fingerprint=fp,
+        )
+    if evidence_age_days < hi:
+        return StaleCalibrationDecision(
+            policy_decision=PolicyDecision.RENEWAL_REQUIRED,
+            calibration_delta_modifier=0.0,
+            evidence_age_days=evidence_age_days,
+            half_life_used_days=half_life_days,
+            claim_renewal_id=_renewal_id(claim_id, evidence_age_days),
+            policy_fingerprint=fp,
+        )
+    return StaleCalibrationDecision(
+        policy_decision=PolicyDecision.ABSTAIN,
+        calibration_delta_modifier=0.0,
+        evidence_age_days=evidence_age_days,
+        half_life_used_days=half_life_days,
+        claim_renewal_id=None,
+        policy_fingerprint=fp,
+    )
+
+
 __all__ = [
     "DEFAULT_FRESH_DAYS",
     "DEFAULT_STALE_DAYS",
@@ -172,4 +328,7 @@ __all__ = [
     "StalePolicy",
     "StaleDecision",
     "is_stale",
+    "PolicyDecision",
+    "StaleCalibrationDecision",
+    "resolve_stale_calibration",
 ]

--- a/tests/reputation/test_stale_calibration_policy.py
+++ b/tests/reputation/test_stale_calibration_policy.py
@@ -22,8 +22,8 @@ from aragora.reputation.stale_policy import (
 )
 
 HL = 30.0  # days — mirrors settlement default
-LO = 0.5 * HL   # 15.0 — lower band boundary
-HI = 1.5 * HL   # 45.0 — upper band boundary
+LO = 0.5 * HL  # 15.0 — lower band boundary
+HI = 1.5 * HL  # 45.0 — upper band boundary
 
 
 # ---------------------------------------------------------------------------

--- a/tests/reputation/test_stale_calibration_policy.py
+++ b/tests/reputation/test_stale_calibration_policy.py
@@ -13,6 +13,8 @@ Reference: docs/plans/2026-04-29-agt-05-stale-claim-policy.md
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from aragora.reputation.stale_policy import (
@@ -116,6 +118,16 @@ class TestInputValidation:
     def test_negative_half_life_raises(self) -> None:
         with pytest.raises(ValueError, match="half_life_days"):
             resolve_stale_calibration(evidence_age_days=10.0, half_life_days=-5.0)
+
+    @pytest.mark.parametrize("age", [math.nan, math.inf, -math.inf])
+    def test_non_finite_age_raises(self, age: float) -> None:
+        with pytest.raises(ValueError, match="evidence_age_days must be finite"):
+            resolve_stale_calibration(evidence_age_days=age, half_life_days=HL)
+
+    @pytest.mark.parametrize("half_life", [math.nan, math.inf, -math.inf])
+    def test_non_finite_half_life_raises(self, half_life: float) -> None:
+        with pytest.raises(ValueError, match="half_life_days must be finite"):
+            resolve_stale_calibration(evidence_age_days=10.0, half_life_days=half_life)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/reputation/test_stale_calibration_policy.py
+++ b/tests/reputation/test_stale_calibration_policy.py
@@ -1,0 +1,163 @@
+"""Tests for the three-axis stale-calibration policy (AGT-05 / #6066).
+
+Policy table under test
+-----------------------
+| Condition                           | Decision          | Modifier |
+|-------------------------------------|-------------------|----------|
+| evidence_age < 0.5 × half_life      | decay_penalty     | 1.0      |
+| 0.5 × hl ≤ evidence_age < 1.5 × hl | renewal_required  | 0.0      |
+| evidence_age ≥ 1.5 × half_life      | abstain           | 0.0      |
+
+Reference: docs/plans/2026-04-29-agt-05-stale-claim-policy.md
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.reputation.stale_policy import (
+    PolicyDecision,
+    StaleCalibrationDecision,
+    resolve_stale_calibration,
+)
+
+HL = 30.0  # days — mirrors settlement default
+LO = 0.5 * HL   # 15.0 — lower band boundary
+HI = 1.5 * HL   # 45.0 — upper band boundary
+
+
+# ---------------------------------------------------------------------------
+# Band routing
+# ---------------------------------------------------------------------------
+
+
+class TestBandRouting:
+    @pytest.mark.parametrize("age", [0.0, 5.0, LO - 0.001])
+    def test_penalty_band(self, age: float) -> None:
+        d = resolve_stale_calibration(evidence_age_days=age, half_life_days=HL)
+        assert d.policy_decision == PolicyDecision.DECAY_PENALTY
+        assert d.calibration_delta_modifier == 1.0
+        assert d.claim_renewal_id is None
+
+    @pytest.mark.parametrize("age", [LO, HL, HI - 0.001])
+    def test_renewal_band(self, age: float) -> None:
+        d = resolve_stale_calibration(evidence_age_days=age, half_life_days=HL)
+        assert d.policy_decision == PolicyDecision.RENEWAL_REQUIRED
+        assert d.calibration_delta_modifier == 0.0
+        assert d.claim_renewal_id is not None
+        assert d.claim_renewal_id.startswith("renew_")
+        assert len(d.claim_renewal_id) == 22  # "renew_" + 16 hex chars
+
+    @pytest.mark.parametrize("age", [HI, HI + 10.0, 365.0])
+    def test_abstain_band(self, age: float) -> None:
+        d = resolve_stale_calibration(evidence_age_days=age, half_life_days=HL)
+        assert d.policy_decision == PolicyDecision.ABSTAIN
+        assert d.calibration_delta_modifier == 0.0
+        assert d.claim_renewal_id is None
+
+
+# ---------------------------------------------------------------------------
+# Renewal-id determinism
+# ---------------------------------------------------------------------------
+
+
+class TestRenewalIdDeterminism:
+    def test_same_inputs_produce_same_id(self) -> None:
+        d1 = resolve_stale_calibration(evidence_age_days=20.0, half_life_days=HL, claim_id="c1")
+        d2 = resolve_stale_calibration(evidence_age_days=20.0, half_life_days=HL, claim_id="c1")
+        assert d1.claim_renewal_id == d2.claim_renewal_id
+
+    def test_different_claim_ids_differ(self) -> None:
+        d1 = resolve_stale_calibration(evidence_age_days=20.0, half_life_days=HL, claim_id="c1")
+        d2 = resolve_stale_calibration(evidence_age_days=20.0, half_life_days=HL, claim_id="c2")
+        assert d1.claim_renewal_id != d2.claim_renewal_id
+
+    def test_empty_claim_id_produces_id(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=20.0, half_life_days=HL)
+        assert d.claim_renewal_id is not None
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyFingerprint:
+    def test_stable_across_calls(self) -> None:
+        d1 = resolve_stale_calibration(evidence_age_days=10.0, half_life_days=HL)
+        d2 = resolve_stale_calibration(evidence_age_days=10.0, half_life_days=HL)
+        assert d1.policy_fingerprint == d2.policy_fingerprint
+
+    def test_changes_with_age(self) -> None:
+        d1 = resolve_stale_calibration(evidence_age_days=10.0, half_life_days=HL)
+        d2 = resolve_stale_calibration(evidence_age_days=20.0, half_life_days=HL)
+        assert d1.policy_fingerprint != d2.policy_fingerprint
+
+    def test_format(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=10.0, half_life_days=HL)
+        assert d.policy_fingerprint.startswith("cp_")
+        assert len(d.policy_fingerprint) == 15  # "cp_" + 12 hex chars
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_negative_age_raises(self) -> None:
+        with pytest.raises(ValueError, match="evidence_age_days"):
+            resolve_stale_calibration(evidence_age_days=-0.001, half_life_days=HL)
+
+    def test_zero_half_life_raises(self) -> None:
+        with pytest.raises(ValueError, match="half_life_days"):
+            resolve_stale_calibration(evidence_age_days=10.0, half_life_days=0.0)
+
+    def test_negative_half_life_raises(self) -> None:
+        with pytest.raises(ValueError, match="half_life_days"):
+            resolve_stale_calibration(evidence_age_days=10.0, half_life_days=-5.0)
+
+
+# ---------------------------------------------------------------------------
+# Metadata preservation and return type
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata:
+    def test_evidence_age_preserved(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=12.3, half_life_days=HL)
+        assert d.evidence_age_days == 12.3
+
+    def test_half_life_preserved(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=10.0, half_life_days=25.0)
+        assert d.half_life_used_days == 25.0
+
+    def test_return_type(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=5.0, half_life_days=HL)
+        assert isinstance(d, StaleCalibrationDecision)
+
+    def test_modifier_is_binary(self) -> None:
+        for age in [1.0, LO, HL, HI, 200.0]:
+            d = resolve_stale_calibration(evidence_age_days=age, half_life_days=HL)
+            assert d.calibration_delta_modifier in (0.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Scales correctly with custom half_life
+# ---------------------------------------------------------------------------
+
+
+class TestCustomHalfLife:
+    HL2 = 10.0
+
+    def test_penalty_below_lo(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=4.0, half_life_days=self.HL2)
+        assert d.policy_decision == PolicyDecision.DECAY_PENALTY
+
+    def test_renewal_at_lo(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=5.0, half_life_days=self.HL2)
+        assert d.policy_decision == PolicyDecision.RENEWAL_REQUIRED
+
+    def test_abstain_at_hi(self) -> None:
+        d = resolve_stale_calibration(evidence_age_days=15.0, half_life_days=self.HL2)
+        assert d.policy_decision == PolicyDecision.ABSTAIN


### PR DESCRIPTION
## Slice

Extends the existing shadow-only `aragora/reputation/stale_policy.py` with the three-axis calibration decision surface specified in `docs/plans/2026-04-29-agt-05-stale-claim-policy.md` (AGT-05 / issue #6066).

**Policy table implemented:**

| Condition | Decision | Modifier |
|---|---|---|
| `evidence_age < 0.5 × half_life` | `decay_penalty` | 1.0 |
| `0.5 × hl ≤ evidence_age < 1.5 × hl` | `renewal_required` | 0.0 |
| `evidence_age ≥ 1.5 × half_life` | `abstain` | 0.0 |

**New symbols:**
- `PolicyDecision` enum (`DECAY_PENALTY`, `RENEWAL_REQUIRED`, `ABSTAIN`)
- `StaleCalibrationDecision` frozen dataclass (advisory output)
- `resolve_stale_calibration(evidence_age_days, half_life_days, claim_id="")` — pure, side-effect free
- `_calibration_fingerprint()` — `cp_` + 12 hex SHA-256 tag over inputs
- `_renewal_id()` — deterministic `renew_` + 16 hex token derived from `claim_id` + age

## Gating

Shadow-only — the entire module is marked advisory and no live settlement path calls into it. Default OFF by design. No feature flag required beyond the existing "no live callers" state.

Advances issue **#6066**.

## Tests

`tests/reputation/test_stale_calibration_policy.py` (163 lines, new file):
- `TestBandRouting` — parametrized over penalty / renewal / abstain band edges
- `TestRenewalIdDeterminism` — same inputs → same id; different claim_ids → different ids
- `TestPolicyFingerprint` — stable across calls, changes with age, format `cp_` + 12 hex
- `TestInputValidation` — negative age raises, zero/negative half_life raises
- `TestMetadata` — evidence_age and half_life preserved in output, return type, binary modifier
- `TestCustomHalfLife` — band boundaries scale correctly with non-default half_life

## Validation

- All test assertions verified via `python3 -c "..."` direct execution (pytest unavailable in this worktree due to missing dev deps, but the module itself is import-clean)
- `ruff check aragora/reputation/stale_policy.py tests/reputation/test_stale_calibration_policy.py` → All checks passed
- `mypy --ignore-missing-imports aragora/reputation/stale_policy.py tests/reputation/test_stale_calibration_policy.py` → no issues found

Net diff: ~328 LOC (165 source + 163 test).

## Out of scope

- Wiring into `settle_claim` or calibration leaderboard
- Calibration delta writes
- Live queue, dispatch, boss loop, or swarm supervisor changes
- Any change to `scripts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPAWgYUQVJPraucSvJboHb

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPAWgYUQVJPraucSvJboHb)_