### PR TITLE
feat(scripts): scoreboard row 6 marker count, row 8 target-commit threshold, guardrail tolerance

### DIFF
--- a/scripts/receipt_first_scoreboard.py
+++ b/scripts/receipt_first_scoreboard.py
@@ -141,10 +141,10 @@ def release_assets(tag: str) -> list[str]:
     return [a["name"] for a in release_view(tag).get("assets", [])]
 
 
-def commit_date(sha: Any, fallback: str) -> str:
-    if not sha:
+def commit_date(ref: Any, fallback: str) -> str:
+    if not ref:
         return fallback
-    c = run_cmd(["gh", "api", f"repos/{REPO}/commits/{sha}", "--jq", ".commit.committer.date"])
+    c = run_cmd(["gh", "api", f"repos/{REPO}/commits/{ref}", "--jq", ".commit.committer.date"])
     return c.out.strip() if c.ok and c.out.strip() else fallback
 
 
@@ -270,7 +270,8 @@ def metric_6(ctx: Any) -> Row:
     r.update(atlas_upper_bound(ctx))
     live = False
     if ctx.offline or not ctx.network_ok:
-        r["reason"] = "offline" if ctx.offline else "pypi.org pre-probe failed"
+        why = "offline" if ctx.offline else "pypi.org pre-probe failed"
+        r["reason"] = "; ".join(filter(None, (r.get("reason"), why)))
     else:
         try:
             r["marker_comments"], live = marker_comments(), True
@@ -296,17 +297,20 @@ def metric_7(ctx: Any) -> Row:
 
 def metric_8(ctx: Any) -> Row:
     rel = [x for x in releases() if x["tagName"].startswith("receipts-")]
-    newest = max(rel, key=lambda x: x.get("publishedAt", ""), default=None)
+    newest = max(rel, key=lambda x: x.get("publishedAt") or "", default=None)
     views = {x["tagName"]: release_view(x["tagName"], "assets,targetCommitish") for x in rel}
     odr = lambda v: sum(a["name"].endswith(".odr.json") for a in v.get("assets", []))
     per_tag = {t: odr(v) for t, v in views.items()}
     total, run_url = sum(per_tag.values()), None
     # A run dispatched after the M4 merge but before the release exists must still count, so the
     # threshold is the release's target commit date, not the moment the release was published.
+    # target_commitish may be a branch name (a release created without --target records "main"),
+    # which the commits API would resolve to that branch's CURRENT tip; the tag names the commit.
+    # An empty threshold (draft release, lookups failed) admits every successful run.
     since = ""
     if newest is not None:
-        published = newest.get("publishedAt", "")
-        since = commit_date(views[newest["tagName"]].get("targetCommitish"), published)
+        tag, target = newest["tagName"], str(views[newest["tagName"]].get("targetCommitish") or "")
+        since = commit_date(target if HEX40.match(target) else tag, newest.get("publishedAt") or "")
     argv = f"gh run list -R {REPO} --workflow metrics-drift.yml --status success".split()
     argv += ["--limit", "10", "--json", "databaseId,createdAt,url"]
     c = run_cmd(argv) if total >= 3 else None
@@ -548,9 +552,10 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, ValueError):
         cache = {}
     args.network_ok, args.atlas_v1_assets, args.generated_at = True, None, utc_stamp()
-    # Guardrails (worktree and origin/main) run alongside the rows to keep --offline under 10 s.
+    # Guardrails (worktree and origin/main) run alongside the rows to keep --offline under 10 s;
+    # the origin/main measurement is local (archive of the local ref) and only fetches online.
     with ThreadPoolExecutor(max_workers=2) as pool:
-        main_future = pool.submit(measure_main, root, False)
+        main_future = pool.submit(measure_main, root, not args.offline)
         local_future = pool.submit(measure_guardrails, root)
         rows, new_cache = build_rows(args, cache, pending)
     if new_cache:

--- a/scripts/receipt_first_scoreboard.py
+++ b/scripts/receipt_first_scoreboard.py
@@ -26,6 +26,10 @@ ATLAS_DIR = Path.home() / ".aragora" / "receipt-first-atlas"
 API_PROBE = "https://api.aragora.ai/readyz"
 CANARY_PROBE = "https://api-canary.aragora.ai/readyz"
 CODE_SEARCH_QUERY = "synaptent/aragora@ -repo:synaptent/aragora"
+MARKER = "<!-- aragora-advisory-summary head="
+PR_LIST = (
+    f"gh pr list -R {REPO} --label receipt-first --state all --limit 500 --json number".split()
+)
 VECTORS = "tests/verify/test_odr_vectors.py"
 MANIFEST = "docs/atlas/manifest.json"
 PIN_RE = re.compile(r"synaptent/aragora@([0-9a-f]{7,40})")
@@ -53,9 +57,11 @@ MEASUREMENTS = {
     3: "sed -n 3p docs/specs/OPEN_DECISION_RECEIPT.md; test -f tests/verify/test_odr_vectors.py",
     4: "curl https://pypi.org/pypi/aragora-verify/json; ^version in aragora-verify/pyproject.toml",
     5: "docs/atlas/manifest.json .dataset.record_count; gh release view atlas-v1; gh pr view 9951",
-    6: "Atlas JSONL: verdict==changes_requested, posted_to_thread, distinct (pr, head_sha) rounds",
+    6: "gh: comments starting with <!-- aragora-advisory-summary head= over receipt-first PRs; "
+    "Atlas JSONL: changes_requested, posted_to_thread, distinct (pr.number, head_sha) rounds",
     7: f"curl -s -o /dev/null -w %{{http_code}} --max-time 15 {API_PROBE} (one probe per run)",
-    8: "receipts-* releases → *.odr.json assets; receipt-first-hour job (metrics-drift.yml, M4)",
+    8: "receipts-* releases → *.odr.json assets; receipt-first-hour job (metrics-drift.yml) run "
+    "since the newest release's target commit (committer date; fallback publishedAt)",
     9: "gh api search/code (paths under .github/workflows/); gh repo view aragora-receipt-demo",
     10: "check_contract_drift_ratchet.py --mode program --ref <40-hex> --json .current.total_items",
 }
@@ -87,8 +93,8 @@ def run_cmd(argv: list[str], *, timeout: float = 60, cwd: Any = None, env: Any =
     return Cmd(p.returncode, p.stdout, p.stderr)
 
 
-def json_cmd(argv: list[str], *, timeout: float = 60, cwd: Path | None = None) -> Any:
-    c = run_cmd(argv, timeout=timeout, cwd=cwd)
+def json_cmd(argv: list[str], *, timeout: float = 60, cwd: Any = None, env: Any = None) -> Any:
+    c = run_cmd(argv, timeout=timeout, cwd=cwd, env=env)
     if not c.ok or not c.out.strip():
         raise RuntimeError(c.err.strip() or f"empty output from {argv[0]}")
     return json.loads(c.out)
@@ -102,6 +108,7 @@ age_days = lambda s: (datetime.now(timezone.utc).date() - utc_dt(s).date()).days
 read_text = lambda p: p.read_text(errors="replace") if p.is_file() else ""
 is_number = lambda v: isinstance(v, (int, float)) and not isinstance(v, bool)
 semver = lambda text: tuple(int(x) for x in re.findall(r"\d+", text)[:3])
+guardrail_limit = lambda ceiling, main: max(ceiling, main) if is_number(main) else ceiling
 RELEASE_LIST = f"gh release list -R {REPO} --limit 100 --json tagName,publishedAt".split()
 releases = lambda: json_cmd(RELEASE_LIST)
 
@@ -123,11 +130,22 @@ def pypi_newest(package: str) -> tuple[str, str]:
     return d["info"]["version"], newest
 
 
-def release_assets(tag: str) -> list[str]:
-    c = run_cmd(["gh", "release", "view", tag, "-R", REPO, "--json", "assets"])
+def release_view(tag: str, fields: str = "assets") -> Row:
+    c = run_cmd(["gh", "release", "view", tag, "-R", REPO, "--json", fields])
     if not c.ok and "not found" not in c.err.lower():
         raise RuntimeError(c.err.strip())
-    return [a["name"] for a in json.loads(c.out or "{}").get("assets", [])]
+    return json.loads(c.out or "{}")
+
+
+def release_assets(tag: str) -> list[str]:
+    return [a["name"] for a in release_view(tag).get("assets", [])]
+
+
+def commit_date(sha: Any, fallback: str) -> str:
+    if not sha:
+        return fallback
+    c = run_cmd(["gh", "api", f"repos/{REPO}/commits/{sha}", "--jq", ".commit.committer.date"])
+    return c.out.strip() if c.ok and c.out.strip() else fallback
 
 
 def metric_1(ctx: Any) -> Row:
@@ -207,23 +225,63 @@ def atlas_pr_number(rec: dict[str, Any]) -> Any:
     return pr.get("number") if isinstance(pr, dict) else pr
 
 
-def metric_6(ctx: Any) -> Row:
-    r: Row = {"now": None, "upper_bound": True, "quorum_runs": ctx.quorum_runs}
-    r["note"] = "upper bound from the Atlas JSONL; ok needs the post-M2 advisory-summary count"
-    r["status"] = "unavailable"
+def marker_comments() -> int:
+    """Advisory-summary marker comments over every receipt-first PR (REST, one call per PR)."""
+
+    def count(number: int) -> int:
+        url = f"repos/{REPO}/issues/{number}/comments?per_page=100"
+        pages = json_cmd(["gh", "api", url, "--paginate", "--slurp"], timeout=120)
+        return sum(str(c.get("body", "")).startswith(MARKER) for page in pages for c in page)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        return sum(pool.map(count, [pr["number"] for pr in json_cmd(PR_LIST)]))
+
+
+def atlas_upper_bound(ctx: Any) -> Row:
     if not ctx.offline and ctx.atlas_v1_assets and not list(ATLAS_DIR.glob("*.jsonl")):
         ATLAS_DIR.mkdir(parents=True, exist_ok=True)
         run_cmd(f"gh release download atlas-v1 -R {REPO} -p *.jsonl".split(), cwd=ATLAS_DIR)
     candidates = [ctx.root / "docs/atlas/atlas-v1.jsonl", *sorted(ATLAS_DIR.glob("*.jsonl"))]
     jsonl = next((p for p in candidates if p.is_file()), None)
     if jsonl is None:
-        return r | {"reason": "no Atlas JSONL (docs/atlas/atlas-v1.jsonl or atlas-v1 asset)"}
+        return {"reason": "no Atlas JSONL (docs/atlas/atlas-v1.jsonl or atlas-v1 asset)"}
     recs = [json.loads(line) for line in jsonl.read_text().splitlines() if line.strip()]
     cr = sum(x.get("verdict") == "changes_requested" for x in recs)
     posted = sum(bool(x.get("posted_to_thread")) for x in recs)
     rounds = len({(atlas_pr_number(x), x.get("head_sha")) for x in recs})
-    r.update(now=cr, posted=posted, rounds=rounds, records=len(recs), source=str(jsonl))
-    return r | {"ratio": round(posted / rounds, 3) if rounds else None, "status": "fail"}
+    r: Row = {"changes_requested": cr, "posted": posted, "rounds": rounds, "records": len(recs)}
+    return r | {"upper_bound": f"{cr} / {posted} / {rounds}", "source": str(jsonl)}
+
+
+def metric_6(ctx: Any) -> Row:
+    """Post-M2 rule: the marker count is the measurement; the Atlas figures stay an upper bound."""
+    n: Any = ctx.quorum_runs
+    r: Row = {"quorum_runs": n, "marker_comments": None}
+    r["note"] = (
+        "now = PR comments starting with <!-- aragora-advisory-summary head= over receipt-first "
+        "PRs; changes_requested / posted / rounds from the Atlas JSONL is an upper bound; "
+        "ratio = marker_comments / --quorum-runs is informational"
+    )
+    r.update(atlas_upper_bound(ctx))
+    live = False
+    if ctx.offline or not ctx.network_ok:
+        r["reason"] = "offline" if ctx.offline else "pypi.org pre-probe failed"
+    else:
+        try:
+            r["marker_comments"], live = marker_comments(), True
+        except (RuntimeError, ValueError, KeyError, TypeError) as exc:
+            r["reason"] = f"{type(exc).__name__}: {exc}"
+    old = ctx.cached.get("6") or {}
+    if not live and old.get("marker_comments") is not None:
+        r.update(marker_comments=old["marker_comments"], cached_at=old.get("cached_at"))
+    count, bound = r["marker_comments"], r.get("upper_bound")
+    if is_number(count) and is_number(n) and n > 0:
+        r["ratio"] = round(count / n, 3)
+    shown = "?" if count is None else count
+    r["now"] = f"{shown} aragora-advisory-summary comments; upper bound {bound or '?'}"
+    if not live or bound is None:
+        return r | {"status": "unavailable"}
+    return r | {"status": "ok" if "ratio" in r and count >= n else "fail"}
 
 
 def metric_7(ctx: Any) -> Row:
@@ -233,20 +291,31 @@ def metric_7(ctx: Any) -> Row:
 
 def metric_8(ctx: Any) -> Row:
     rel = [x for x in releases() if x["tagName"].startswith("receipts-")]
-    tags = [x["tagName"] for x in rel]
-    per_tag = {t: sum(n.endswith(".odr.json") for n in release_assets(t)) for t in tags}
-    total, run_ok = sum(per_tag.values()), False
-    newest = max((x.get("publishedAt", "") for x in rel), default="")
+    newest = max(rel, key=lambda x: x.get("publishedAt", ""), default=None)
+    views = {x["tagName"]: release_view(x["tagName"], "assets,targetCommitish") for x in rel}
+    odr = lambda v: sum(a["name"].endswith(".odr.json") for a in v.get("assets", []))
+    per_tag = {t: odr(v) for t, v in views.items()}
+    total, run_url = sum(per_tag.values()), None
+    # A run dispatched after the M4 merge but before the release exists must still count, so the
+    # threshold is the release's target commit date, not the moment the release was published.
+    since = ""
+    if newest is not None:
+        published = newest.get("publishedAt", "")
+        since = commit_date(views[newest["tagName"]].get("targetCommitish"), published)
     argv = f"gh run list -R {REPO} --workflow metrics-drift.yml --status success".split()
-    c = run_cmd(argv + ["--limit", "10", "--json", "databaseId,createdAt"]) if total >= 3 else None
-    runs = [x for x in json.loads(c.out or "[]") if x.get("createdAt", "") >= newest] if c else []
+    argv += ["--limit", "10", "--json", "databaseId,createdAt,url"]
+    c = run_cmd(argv) if total >= 3 else None
+    runs = [x for x in json.loads(c.out or "[]") if x.get("createdAt", "") >= since] if c else []
     jq = '[.jobs[]|select(.name=="receipt-first-hour" and .conclusion=="success")]|length'
     for run in runs[:3]:
         url = f"repos/{REPO}/actions/runs/{run['databaseId']}/jobs"
         j = run_cmd(["gh", "api", url, "--jq", jq])
-        run_ok = run_ok or (j.ok and j.out.strip().isdigit() and int(j.out) > 0)
-    r: Row = {"now": total, "receipts_releases": per_tag, "first_hour_run_ok": run_ok}
-    return r | {"status": "ok" if total >= 3 and run_ok else "fail"}
+        if j.ok and j.out.strip().isdigit() and int(j.out) > 0:
+            run_url = run.get("url")
+            break
+    r: Row = {"now": total, "receipts_releases": per_tag, "first_hour_run_ok": run_url is not None}
+    r.update(first_hour_run_url=run_url, first_hour_since=since or None)
+    return r | {"status": "ok" if total >= 3 and run_url else "fail"}
 
 
 def metric_9(ctx: Any) -> Row:
@@ -280,21 +349,55 @@ def metric_10(ctx: Any) -> Row:
     return r | {"status": "ok" if ok else "fail"}
 
 
-def measure_guardrails(root: Path) -> Row:
-    graph = [sys.executable, "scripts/ci/measure_import_graph.py", "--json"]
-    regen = [sys.executable, "scripts/regenerate_metrics.py", "--json"]
-    g, m = json_cmd(graph, cwd=root, timeout=180), json_cmd(regen, cwd=root, timeout=180)
+GRAPH_CMD = [sys.executable, "scripts/ci/measure_import_graph.py", "--json"]
+REGEN_CMD = [sys.executable, "scripts/regenerate_metrics.py", "--json"]
+
+
+def guardrail_values(g: Row, m: Row) -> Row:
     vals = {x["key"]: x["value"] for x in m["metrics"]} if "metrics" in m else m
     r: Row = {"import_cycles": g.get("mutual_import_cycles")}
     r["handlers_flat_root"] = g.get("handlers_flat_root")
     return r | {gid: vals.get(gid) for gid, _, _, _ in GUARDRAILS[2:]}
 
 
-def guardrail_rows(values: Row) -> list[Row]:
+def measure_guardrails(root: Path, env: Any = None) -> Row:
+    g = json_cmd(GRAPH_CMD, cwd=root, timeout=180, env=env)
+    return guardrail_values(g, json_cmd(REGEN_CMD, cwd=root, timeout=180, env=env))
+
+
+def measure_main(root: Path, fetch: bool) -> tuple[str, Row]:
+    """Guardrail counts on origin/main, measured in an archived copy of the local ref."""
+    if fetch:
+        run_cmd(["git", "fetch", "origin", "main", "--quiet"], cwd=root, timeout=120)
+    sha = run_cmd(["git", "rev-parse", "origin/main"], cwd=root).out.strip()
+    gitdir = run_cmd(["git", "rev-parse", "--absolute-git-dir"], cwd=root).out.strip()
+    g: Row = {}
+    m: Row = {}
+    with tempfile.TemporaryDirectory(prefix="rf-scoreboard-main-") as tmp:
+        unpack = ["sh", "-c", f"git archive origin/main | tar -x -C '{tmp}'"]
+        if not run_cmd(unpack, cwd=root).ok:
+            return sha, {}
+        # regenerate_metrics.py counts tracked files with `git ls-files`, so the archive borrows an
+        # index of the same tree from the repo (a fresh `git init` would apply .gitignore instead).
+        env = {**os.environ, "PYTHONPATH": tmp, "GIT_DIR": gitdir, "GIT_WORK_TREE": tmp}
+        env["GIT_INDEX_FILE"] = f"{tmp}/.rf-index"
+        run_cmd(["git", "read-tree", sha], cwd=tmp, env=env)
+        try:
+            g = json_cmd(GRAPH_CMD, cwd=tmp, timeout=180, env=env)
+            m = json_cmd(REGEN_CMD, cwd=tmp, timeout=180, env=env)
+        except (RuntimeError, ValueError, KeyError, TypeError):
+            pass
+    return sha, guardrail_values(g, m)
+
+
+def guardrail_rows(values: Row, main: Row) -> list[Row]:
+    """Status is ``ok`` iff now ≤ max(ceiling, origin/main's own value), as bin/gate.sh does."""
     keys = ("id", "name", "ceiling", "baseline")
     rows: list[Row] = [dict(zip(keys, g), now=values.get(g[0])) for g in GUARDRAILS]
     for r in rows:
-        r["status"] = "ok" if is_number(r["now"]) and r["now"] <= r["ceiling"] else "over"
+        r["main"] = main.get(r["id"]) if is_number(main.get(r["id"])) else None
+        limit = guardrail_limit(r["ceiling"], r["main"])
+        r["status"] = "ok" if is_number(r["now"]) and r["now"] <= limit else "over"
     return rows
 
 
@@ -313,15 +416,8 @@ def read_parked(path: Path | None) -> tuple[dict[int, str], str]:
 
 
 def check_guardrails(root: Path, offline: bool) -> int:
-    if not offline:
-        run_cmd(["git", "fetch", "origin", "main", "--quiet"], cwd=root, timeout=120)
-    sha = run_cmd(["git", "rev-parse", "origin/main"], cwd=root).out.strip()
-    with tempfile.TemporaryDirectory(prefix="rf-scoreboard-main-") as tmp:
-        unpack = ["sh", "-c", f"git archive origin/main | tar -x -C '{tmp}'"]
-        argv = [sys.executable, "scripts/ci/measure_import_graph.py", "--json"]
-        env = {**os.environ, "PYTHONPATH": tmp}
-        g = run_cmd(argv, cwd=tmp, timeout=180, env=env) if run_cmd(unpack, cwd=root).ok else None
-    main_cycles = json.loads(g.out).get("mutual_import_cycles") if g and g.ok and g.out else None
+    sha, main = measure_main(root, fetch=not offline)
+    main_cycles = main.get("import_cycles")
     print(f"origin/main mutual_import_cycles: {main_cycles or 'unknown'} ({sha[:10]})")
     values = measure_guardrails(root)
     mypy = ["sh", "-c", "mypy aragora/ --ignore-missing-imports | tail -1"]
@@ -330,9 +426,10 @@ def check_guardrails(root: Path, offline: bool) -> int:
     errors = int(m.group(1)) if m else (0 if tail.startswith("Success") else None)
     wc = int(run_cmd(["sh", "-c", "wc -l < .mypy-baseline"], cwd=root).out.strip() or -1)
     print(f"mypy: {tail or 'no output'}")
-    limit = max(140, main_cycles) if isinstance(main_cycles, int) else 140
-    checks = [("mutual_import_cycles", values["import_cycles"], limit)]
-    checks += [(gid, values[gid], ceiling) for gid, _, ceiling, _ in GUARDRAILS[1:]]
+    # Count limits mirror bin/gate.sh (max of the fixed ceiling and origin/main); mypy stays fixed.
+    checks = [("mutual_import_cycles", values["import_cycles"], guardrail_limit(140, main_cycles))]
+    for gid, _, ceiling, _ in GUARDRAILS[1:]:
+        checks.append((gid, values[gid], guardrail_limit(ceiling, main.get(gid))))
     checks += [("mypy_errors", errors, 1744), ("mypy_baseline_lines", wc, 3115)]
     bad = [name for name, value, cap in checks if not (is_number(value) and 0 <= value <= cap)]
     for name, value, cap in checks:
@@ -343,6 +440,7 @@ def check_guardrails(root: Path, offline: bool) -> int:
 
 def build_rows(ctx: Any, cache: Row, pending: dict[int, str]) -> tuple[list[Row], Row]:
     cached, stamp = cache.get("metrics", {}), ctx.generated_at
+    ctx.cached = cached
     measured, failed = {}, {}
 
     def attempt(i: int) -> None:
@@ -367,6 +465,9 @@ def build_rows(ctx: Any, cache: Row, pending: dict[int, str]) -> tuple[list[Row]
             row.update(measured[mid])
             if mid in NETWORK_ROWS:
                 new_cache[str(mid)] = measured[mid] | {"cached_at": stamp}
+            elif mid == 6 and row.get("marker_comments") is not None and not row.get("cached_at"):
+                keep = {k: row.get(k) for k in ("marker_comments", "now", "upper_bound")}
+                new_cache["6"] = keep | {"cached_at": stamp}
         else:
             row.update(old or {"now": None}, status="unavailable", reason=failed[mid])
             row["cached_at"] = old.get("cached_at", cache.get("cached_at")) if old else None
@@ -377,7 +478,7 @@ def build_rows(ctx: Any, cache: Row, pending: dict[int, str]) -> tuple[list[Row]
             row["local_version"] = local
             row["local_ahead_of_pypi"] = bool(local and now and semver(local) > semver(str(now)))
         row.update(measurement=MEASUREMENTS[mid], delta=compute_delta(baseline, row.get("now")))
-        if row["status"] == "fail" and mid in pending:
+        if row["status"] == "fail" and mid in pending and mid != 6:
             row.update(status="pending-operator", pending_ref=pending[mid])
         rows.append(row)
     fresh = any(i in measured for i in NETWORK_ROWS)
@@ -393,12 +494,17 @@ def render_markdown(doc: Row, parked_given: bool) -> str:
         cached = r["status"] == "unavailable" and r.get("cached_at")
         parts = (r["status"], r.get("pending_ref"), cached and f"(cached {cached})")
         unit = {1: " d", 2: " d", 7: f" (canary {r.get('canary_code')})"}.get(r["id"], "")
+        if r["id"] == 6 and "ratio" in r:
+            unit = f" (informational {r['marker_comments']}/{r['quorum_runs']})"
+        elif r["id"] == 8 and r.get("first_hour_run_url"):
+            unit = f" ({r['first_hour_run_url']})"
         now = "null" if r.get("now") is None else f"{r['now']}{unit}"
         status = " ".join(filter(None, parts))
         out.append(line((r["id"], r["name"], r["baseline_cell"], now, r["delta"], status)))
-    keys = ("name", "ceiling", "baseline", "now", "status")
+    keys = ("name", "ceiling", "baseline", "now")
+    cell = lambda g: [*(g[k] for k in keys), f"{g['status']} (main {g.get('main')})"]
     out += ["", "## Guardrails", "", line(("Guardrail", "Ceiling", "Baseline", "Now", "Status"))]
-    out += ["|---" * 5 + "|"] + [line([g[k] for k in keys]) for g in doc["guardrails"]]
+    out += ["|---" * 5 + "|"] + [line(cell(g)) for g in doc["guardrails"]]
     if parked_given:
         out += ["", "## Parked", doc["parked"] or "(none yet)"]
     return "\n".join(out) + "\n"
@@ -437,15 +543,19 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, ValueError):
         cache = {}
     args.network_ok, args.atlas_v1_assets, args.generated_at = True, None, utc_stamp()
-    rows, new_cache = build_rows(args, cache, pending)
+    # Guardrails (worktree and origin/main) run alongside the rows to keep --offline under 10 s.
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        main_future = pool.submit(measure_main, root, False)
+        local_future = pool.submit(measure_guardrails, root)
+        rows, new_cache = build_rows(args, cache, pending)
     if new_cache:
         args.cache.parent.mkdir(parents=True, exist_ok=True)
         args.cache.write_text(json.dumps(new_cache, indent=2, sort_keys=True) + "\n")
     try:
-        guardrails = guardrail_rows(measure_guardrails(root))
+        guardrails = guardrail_rows(local_future.result(), main_future.result()[1])
     except Exception as exc:
         print(f"warning: guardrail measurement failed: {exc}", file=sys.stderr)
-        guardrails = guardrail_rows({})
+        guardrails = guardrail_rows({}, {})
     doc: Row = {"baseline_ref": BASELINE_REF, "baseline_date": BASELINE_DATE, "ref": args.ref}
     doc.update(generated_at=args.generated_at, network_ok=args.network_ok, parked=parked_text)
     doc.update(cached_at=(new_cache or cache).get("cached_at"), metrics=rows, guardrails=guardrails)

--- a/scripts/receipt_first_scoreboard.py
+++ b/scripts/receipt_first_scoreboard.py
@@ -254,7 +254,12 @@ def atlas_upper_bound(ctx: Any) -> Row:
 
 
 def metric_6(ctx: Any) -> Row:
-    """Post-M2 rule: the marker count is the measurement; the Atlas figures stay an upper bound."""
+    """Post-M2 rule: the live marker count decides ok/fail against --quorum-runs.
+
+    The Atlas figures are the row's upper bound, and the metric definition leaves the row
+    ``unavailable`` (never decided) when that bound is missing, exactly as for an offline or
+    failed count: a decided status always carries both numbers.
+    """
     n: Any = ctx.quorum_runs
     r: Row = {"quorum_runs": n, "marker_comments": None}
     r["note"] = (

--- a/tests/scripts/test_receipt_first_scoreboard.py
+++ b/tests/scripts/test_receipt_first_scoreboard.py
@@ -431,6 +431,8 @@ def test_row6_unavailable_without_atlas_even_when_count_is_live(fake, capsys, ro
     assert r[6]["status"] == "unavailable" and "no Atlas JSONL" in r[6]["reason"]
     assert r[6]["marker_comments"] == 3 and r[6]["ratio"] == 1.5 and "upper_bound" not in r[6]
     assert r[6]["now"] == "3 aragora-advisory-summary comments; upper bound ?"
+    _, r = rows(capsys, "--offline", "--cache", "/nonexistent/c.json")
+    assert r[6]["reason"].startswith("no Atlas JSONL") and r[6]["reason"].endswith("; offline")
 
 
 def test_markdown_row6_baseline_cell_unchanged_and_informational_ratio(fake, capsys, root):
@@ -467,6 +469,23 @@ def test_row8_first_hour_threshold_uses_target_commit_date(fake, capsys):
     _, r = rows(capsys)
     assert r[8]["first_hour_since"] == "2026-10-01T12:00:00Z" and r[8]["first_hour_run_ok"] is False
     assert r[8]["first_hour_run_url"] is None and r[8]["status"] == "fail"
+
+
+def test_row8_branch_target_commitish_resolves_through_the_tag(fake, capsys):
+    tag = "receipts-2026-10-01"
+    fake.on("gh release list", out=json.dumps([{"tagName": tag, "publishedAt": "2026-10-01"}]))
+    view = {"assets": [{"name": f"pr{i}.odr.json"} for i in range(3)], "targetCommitish": "main"}
+    fake.on(f"gh release view {tag}", out=json.dumps(view))
+    fake.on(f"gh api repos/synaptent/aragora/commits/{tag}", out="2026-09-30T00:00:00Z\n")
+    fake.on("gh api repos/synaptent/aragora/commits/main", out="2026-12-31T00:00:00Z\n")
+    fake.on("gh run list", out="[]")
+    _, r = rows(capsys)
+    assert r[8]["first_hour_since"] == "2026-09-30T00:00:00Z"
+    assert fake.matching("gh api repos/synaptent/aragora/commits/main") == []
+    fake.on("gh release list", out=json.dumps([{"tagName": tag, "publishedAt": None}]))
+    fake.on(f"gh api repos/synaptent/aragora/commits/{tag}", rc=1, err="HTTP 404")
+    _, r = rows(capsys)
+    assert r[8]["first_hour_since"] is None and r[8]["status"] == "fail" and "reason" not in r[8]
 
 
 def regen(**over: int) -> str:

--- a/tests/scripts/test_receipt_first_scoreboard.py
+++ b/tests/scripts/test_receipt_first_scoreboard.py
@@ -28,20 +28,24 @@ LEDGER += "- [metric 2] bump #79 head n/a\n\n## Parked\n(none yet)\n"
 GUARD = ["--check-guardrails", "--offline"]
 
 
+MAIN_TREE = "rf-scoreboard-main-"  # tempdir prefix of the archived origin/main tree
+
+
 class FakeCmds:
-    """Routes run_cmd argv to canned results; records every call."""
+    """Routes run_cmd argv (optionally keyed on cwd) to canned results; records every call."""
 
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
-        self.routes: list[tuple[tuple[str, ...], sb.Cmd]] = []
+        self.routes: list[tuple[tuple[str, ...], str | None, sb.Cmd]] = []
 
-    def on(self, *needles: str, out: str = "", rc: int = 0, err: str = "") -> None:
-        self.routes.insert(0, (needles, sb.Cmd(rc, out, err)))
+    def on(self, *needles: str, out: str = "", rc: int = 0, err: str = "", cwd=None) -> None:
+        self.routes.insert(0, (needles, cwd, sb.Cmd(rc, out, err)))
 
     def __call__(self, argv, **kwargs) -> sb.Cmd:
         self.calls.append(list(argv))
-        joined = " ".join(argv)
-        hit = next((r for n, r in self.routes if all(x in joined for x in n)), None)
+        joined, where = " ".join(argv), str(kwargs.get("cwd") or "")
+        match = lambda n, c: all(x in joined for x in n) and (c is None or c in where)
+        hit = next((r for n, c, r in self.routes if match(n, c)), None)
         return hit or sb.Cmd(1, "", f"unhandled: {joined}")
 
     def matching(self, *needles: str) -> list[list[str]]:
@@ -77,6 +81,7 @@ def fake(monkeypatch: pytest.MonkeyPatch, root: Path, tmp_path: Path) -> FakeCmd
     f.on("gh release list", out='[{"tagName": "v2.9.0", "publishedAt": "2026-07-06T00:00:00Z"}]')
     f.on("gh release view atlas-v1", rc=1, err="release not found")
     f.on("gh pr view 9951", out='{"state": "OPEN"}')
+    f.on("gh pr list", "--label receipt-first", out="[]")
     f.on("gh api search/code", out='{"total_count": 0, "items": []}')
     f.on("gh repo view synaptent/aragora-receipt-demo", rc=1, err="Could not resolve")
     f.on("check_contract_drift_ratchet.py", out=json.dumps(RATCHET), rc=1)
@@ -131,8 +136,9 @@ def test_json_shape_and_baseline_constants(fake, capsys):
         assert m["status"] in sb.STATUSES and m["delta"] is not None
     assert [g["ceiling"] for g in doc["guardrails"]] == [140, 187, 97, 1119, 145, 3205]
     for g in doc["guardrails"]:
-        assert {"id", "name", "ceiling", "baseline", "now", "status"} <= set(g)
-    assert doc["guardrails"][0]["now"] == 144 and doc["guardrails"][0]["status"] != "ok"
+        assert {"id", "name", "ceiling", "baseline", "now", "status", "main"} <= set(g)
+    cycles = doc["guardrails"][0]
+    assert cycles["now"] == 144 and cycles["main"] == 144 and cycles["status"] == "ok"
 
 
 def test_row_details_match_definitions(fake, capsys):
@@ -315,15 +321,13 @@ def test_row6_counts_atlas_jsonl(fake, capsys, root, limit):
     if limit is None:
         assert (cr, posted, rounds, len(recs)) == (18, 187, 189, 200)
     _, r = rows(capsys, "--offline", "--quorum-runs", "4")
-    assert "reason" not in r[6] and r[6]["status"] == "fail"
-    assert (r[6]["now"], r[6]["posted"], r[6]["rounds"], r[6]["records"]) == (
-        cr,
-        posted,
-        rounds,
-        len(recs),
-    )
-    assert r[6]["ratio"] == round(posted / rounds, 3) and r[6]["delta"] == cr - 53
-    assert r[6]["quorum_runs"] == 4 and r[6]["upper_bound"] is True
+    assert r[6]["status"] == "unavailable" and r[6]["reason"] == "offline"
+    got = (r[6]["changes_requested"], r[6]["posted"], r[6]["rounds"], r[6]["records"])
+    assert got == (cr, posted, rounds, len(recs))
+    assert r[6]["upper_bound"] == f"{cr} / {posted} / {rounds}" and r[6]["quorum_runs"] == 4
+    assert r[6]["marker_comments"] is None and "ratio" not in r[6]
+    assert r[6]["now"] == f"? aragora-advisory-summary comments; upper bound {r[6]['upper_bound']}"
+    assert r[6]["delta"] == f"53 → {r[6]['now']}"
 
 
 def test_row6_accepts_legacy_scalar_pr(fake, capsys, root):
@@ -335,7 +339,176 @@ def test_row6_accepts_legacy_scalar_pr(fake, capsys, root):
     ]
     write_atlas(root, recs)
     _, r = rows(capsys, "--offline")
-    assert (r[6]["now"], r[6]["posted"], r[6]["rounds"], r[6]["records"]) == (1, 3, 2, 4)
+    got = (r[6]["changes_requested"], r[6]["posted"], r[6]["rounds"], r[6]["records"])
+    assert got == (1, 3, 2, 4) and r[6]["upper_bound"] == "1 / 3 / 2"
+
+
+MARK = sb.MARKER + "%s -->\n**Advisory summary**"
+NOT_MARK = "quoting <!-- aragora-advisory-summary head=zzz --> mid-body does not count"
+PR_COMMENTS = {
+    1: [[]],
+    2: [[{"body": MARK % "a1"}, {"body": "LGTM"}]],
+    3: [[{"body": MARK % "b1"}, {"body": NOT_MARK}], [{"body": MARK % "b2"}]],
+}
+
+
+def markers(fake: FakeCmds, root: Path) -> None:
+    """Fake three receipt-first PRs whose paginated comment pages hold 0/1/2 marker comments."""
+    write_atlas(root, [{"pr": 1, "head_sha": "x", "verdict": "changes_requested"}] * 2)
+    fake.on(
+        "gh pr list", "--label receipt-first", out=json.dumps([{"number": n} for n in PR_COMMENTS])
+    )
+    for n, pages in PR_COMMENTS.items():
+        fake.on(f"gh api repos/synaptent/aragora/issues/{n}/comments", out=json.dumps(pages))
+
+
+def test_row6_counts_marker_comments_over_labelled_prs(fake, capsys, root):
+    markers(fake, root)
+    _, r = rows(capsys, "--quorum-runs", "2")
+    assert r[6]["marker_comments"] == 3 and r[6]["ratio"] == 1.5 and r[6]["status"] == "ok"
+    assert r[6]["upper_bound"] == "2 / 0 / 1" and r[6]["quorum_runs"] == 2
+    assert r[6]["now"] == "3 aragora-advisory-summary comments; upper bound 2 / 0 / 1"
+    assert r[6]["delta"] == f"53 → {r[6]['now']}" and "reason" not in r[6]
+    calls = [fake.matching(f"issues/{n}/comments?per_page=100", "--paginate") for n in (1, 2, 3)]
+    assert [len(c) for c in calls] == [1, 1, 1]
+    assert fake.matching("gh pr list", "--state all", "--limit 500")
+
+
+def test_row6_status_ok_iff_count_reaches_quorum_runs(fake, capsys, root):
+    markers(fake, root)
+    for n, status in ((1, "ok"), (3, "ok"), (4, "fail")):
+        _, r = rows(capsys, "--quorum-runs", str(n))
+        assert (r[6]["status"], r[6]["ratio"]) == (status, round(3 / n, 3))
+    _, r = rows(capsys)
+    assert r[6]["status"] == "fail" and "ratio" not in r[6] and r[6]["quorum_runs"] is None
+    _, r = rows(capsys, "--quorum-runs", "0")
+    assert r[6]["status"] == "fail" and "ratio" not in r[6]
+
+
+def test_row6_note_and_measurement_literals(fake, capsys, root):
+    markers(fake, root)
+    _, r = rows(capsys)
+    words = ("aragora-advisory-summary", "upper bound", "informational")
+    assert all(w in r[6]["note"] for w in words) and "posted/rounds" not in r[6]["note"]
+    assert (
+        r[6]["measurement"] == sb.MEASUREMENTS[6] and "(pr.number, head_sha)" in sb.MEASUREMENTS[6]
+    )
+
+
+def test_row6_offline_keeps_cached_count_and_upper_bound_without_ratio(
+    fake, capsys, tmp_path, root
+):
+    markers(fake, root)
+    rows(capsys)
+    data = json.loads((tmp_path / "c.json").read_text())["metrics"]
+    assert {"1", "4", "5", "6", "7", "8", "9"} <= set(data) and data["6"]["marker_comments"] == 3
+    fake.calls.clear()
+    _, r = rows(capsys, "--offline")
+    assert r[6]["status"] == "unavailable" and r[6]["marker_comments"] == 3 and "ratio" not in r[6]
+    assert r[6]["cached_at"] == data["6"]["cached_at"] and r[6]["upper_bound"] == "2 / 0 / 1"
+    assert r[6]["now"] == "3 aragora-advisory-summary comments; upper bound 2 / 0 / 1"
+    assert fake.matching("gh ") == []
+    _, r = rows(capsys, "--offline", "--quorum-runs", "2")
+    assert r[6]["status"] == "unavailable" and r[6]["ratio"] == 1.5
+
+
+def test_row6_network_failure_and_ledger_line_never_pending_operator(fake, capsys, root, tmp_path):
+    markers(fake, root)
+    parked = tmp_path / "parked.md"
+    parked.write_text(LEDGER.replace("## Parked", "- [metric 6] x #80 head n/a\n\n## Parked"))
+    _, r = rows(capsys, "--parked-file", str(parked))
+    assert r[6]["status"] == "fail" and "pending_ref" not in r[6]
+    fake.on("gh api repos/synaptent/aragora/issues/2/comments", rc=7, err="Failed to connect")
+    _, r = rows(capsys, "--parked-file", str(parked), "--quorum-runs", "1")
+    assert r[6]["status"] == "unavailable" and "Failed to connect" in r[6]["reason"]
+    assert r[6]["marker_comments"] == 3 and r[6]["cached_at"] and "pending_ref" not in r[6]
+
+
+def test_markdown_row6_baseline_cell_unchanged_and_informational_ratio(fake, capsys, root):
+    markers(fake, root)
+    row6 = lambda md: next(line for line in md.splitlines() if line.startswith("| 6 |"))
+    _, md, _ = run(capsys, "--markdown", "--offline")
+    cell = (
+        "| 53 CHANGES-REQUESTED / 1659 records | ? aragora-advisory-summary comments; upper bound"
+    )
+    assert cell in row6(md) and "informational" not in row6(md) and "unavailable" in row6(md)
+    _, md, _ = run(capsys, "--markdown", "--quorum-runs", "2")
+    assert cell.replace("| ?", "| 3") in row6(md) and "(informational 3/2)" in row6(md)
+    assert row6(md).endswith("| ok |")
+
+
+def test_row8_first_hour_threshold_uses_target_commit_date(fake, capsys):
+    tag, sha, url = "receipts-2026-10-01", "d" * 40, "https://github.com/synaptent/aragora/runs/7"
+    fake.on(
+        "gh release list", out=json.dumps([{"tagName": tag, "publishedAt": "2026-10-01T12:00:00Z"}])
+    )
+    assets = [{"name": f"pr{i}.odr.json"} for i in range(3)]
+    fake.on(f"gh release view {tag}", out=json.dumps({"assets": assets, "targetCommitish": sha}))
+    fake.on(f"gh api repos/synaptent/aragora/commits/{sha}", out="2026-10-01T10:00:00Z\n")
+    run_row = {"databaseId": 7, "createdAt": "2026-10-01T11:00:00Z", "url": url}
+    fake.on("gh run list", out=json.dumps([run_row]))
+    fake.on("gh api repos/synaptent/aragora/actions/runs/7/jobs", out="1\n")
+    _, r = rows(capsys)
+    assert r[8]["first_hour_since"] == "2026-10-01T10:00:00Z" and r[8]["first_hour_run_ok"] is True
+    assert r[8]["first_hour_run_url"] == url and r[8]["status"] == "ok" and r[8]["now"] == 3
+    assert fake.matching("gh run list", "--json databaseId,createdAt,url")
+    _, md, _ = run(capsys, "--markdown")
+    assert f"| 3 ({url}) |" in md
+    fake.on(f"gh api repos/synaptent/aragora/commits/{sha}", rc=1, err="HTTP 404")
+    _, r = rows(capsys)
+    assert r[8]["first_hour_since"] == "2026-10-01T12:00:00Z" and r[8]["first_hour_run_ok"] is False
+    assert r[8]["first_hour_run_url"] is None and r[8]["status"] == "fail"
+
+
+def regen(**over: int) -> str:
+    return json.dumps({"metrics": [{"key": k, "value": v} for k, v in (KEYS | over).items()]})
+
+
+def test_check_guardrails_limit_is_max_of_ceiling_and_origin_main(fake, capsys):
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1120))
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1120), cwd=MAIN_TREE)
+    assert sb.main(GUARD) == 0
+    out = capsys.readouterr().out
+    assert "doc_files: 1120 (limit 1120) ok" in out and "guardrails ok" in out
+    assert "origin/main mutual_import_cycles: 144 (aaaaaaa" in out and "(limit 144) ok" in out
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1121))
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1120), cwd=MAIN_TREE)
+    assert sb.main(GUARD) == 1
+    out = capsys.readouterr().out
+    assert (
+        "doc_files: 1121 (limit 1120) OVER" in out
+        and "FAIL: guardrail regression: doc_files" in out
+    )
+
+
+def test_check_guardrails_falls_back_to_ceiling_when_main_unmeasurable(fake, capsys):
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1120))
+    fake.on("regenerate_metrics.py", rc=1, err="boom", cwd=MAIN_TREE)
+    fake.on("measure_import_graph.py", rc=1, err="boom", cwd=MAIN_TREE)
+    assert sb.main(GUARD) == 1
+    out = capsys.readouterr().out
+    assert "origin/main mutual_import_cycles: unknown (aaaaaaa" in out
+    assert "mutual_import_cycles: 144 (limit 140) OVER" in out
+    assert "doc_files: 1120 (limit 1119) OVER" in out and "mypy_errors: 1744 (limit 1744) ok" in out
+
+
+def test_json_guardrails_carry_main_and_tolerant_status(fake, capsys):
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1120))
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1120), cwd=MAIN_TREE)
+    doc, _ = rows(capsys, "--offline")
+    docs = next(g for g in doc["guardrails"] if g["id"] == "doc_files")
+    assert (docs["ceiling"], docs["now"], docs["main"], docs["status"]) == (1119, 1120, 1120, "ok")
+    _, md, _ = run(capsys, "--markdown", "--offline")
+    assert "| Docs pages | 1119 | 1119 | 1120 | ok (main 1120) |" in md
+    fake.on("regenerate_metrics.py", out=regen(doc_files=1119), cwd=MAIN_TREE)
+    doc, _ = rows(capsys, "--offline")
+    docs = next(g for g in doc["guardrails"] if g["id"] == "doc_files")
+    assert (docs["main"], docs["status"]) == (1119, "over")
+    fake.on("regenerate_metrics.py", rc=1, err="boom", cwd=MAIN_TREE)
+    doc, _ = rows(capsys, "--offline")
+    docs = next(g for g in doc["guardrails"] if g["id"] == "doc_files")
+    assert (docs["main"], docs["status"]) == (None, "over")
+    assert [g["ceiling"] for g in doc["guardrails"]] == [140, 187, 97, 1119, 145, 3205]
 
 
 def test_post_creates_new_comment_with_refs(fake, capsys):

--- a/tests/scripts/test_receipt_first_scoreboard.py
+++ b/tests/scripts/test_receipt_first_scoreboard.py
@@ -424,6 +424,15 @@ def test_row6_network_failure_and_ledger_line_never_pending_operator(fake, capsy
     assert r[6]["marker_comments"] == 3 and r[6]["cached_at"] and "pending_ref" not in r[6]
 
 
+def test_row6_unavailable_without_atlas_even_when_count_is_live(fake, capsys, root):
+    markers(fake, root)
+    (root / "docs/atlas/atlas-v1.jsonl").unlink()
+    _, r = rows(capsys, "--quorum-runs", "2")
+    assert r[6]["status"] == "unavailable" and "no Atlas JSONL" in r[6]["reason"]
+    assert r[6]["marker_comments"] == 3 and r[6]["ratio"] == 1.5 and "upper_bound" not in r[6]
+    assert r[6]["now"] == "3 aragora-advisory-summary comments; upper bound ?"
+
+
 def test_markdown_row6_baseline_cell_unchanged_and_informational_ratio(fake, capsys, root):
     markers(fake, root)
     row6 = lambda md: next(line for line in md.splitlines() if line.startswith("| 6 |"))


### PR DESCRIPTION
## Summary

Post-M2 measurement rules for `scripts/receipt_first_scoreboard.py`, in one Tier-2 PR touching only the script and its hermetic test file (451 LOC delta after `ruff format`).

- **Row 6 (Dissent visibility, VAL-DISSENT-007).** Online, the row counts PR comments whose body starts with `<!-- aragora-advisory-summary head=` over every `receipt-first`-labelled PR (`gh pr list … --label receipt-first --state all --limit 500`, then one REST `gh api "repos/…/issues/<n>/comments?per_page=100" --paginate --slurp` per PR, four in parallel). New keys: `marker_comments` (cached like the other network rows), `changes_requested` / `posted` / `rounds` / `records` from the Atlas JSONL, `upper_bound` = `"<cr> / <posted> / <rounds>"`, `quorum_runs`, `ratio` (= marker_comments / N, present only when `--quorum-runs N` is given and the count is known; the old Atlas `posted/rounds` ratio is gone), `note`, and `now` = `"<count> aragora-advisory-summary comments; upper bound <upper_bound>"` (`?` for an unknown offline count). Status: `ok` iff N ≥ 1 and marker_comments ≥ N, `fail` online otherwise, `unavailable` offline / on network failure / without an Atlas JSONL; never `pending-operator`. Markdown: the Now cell prints the `now` string plus ` (informational <c>/<N>)` when a ratio exists; the baseline cell `53 CHANGES-REQUESTED / 1659 records` is byte-identical.
- **Row 8 (VAL-PROOF-009.1).** Asset count unchanged. The `receipt-first-hour` success threshold is now the committer date of the newest `receipts-*` release's `target_commitish` (`gh api repos/…/commits/<sha> --jq .commit.committer.date`, falling back to `publishedAt`), so a run dispatched after the M4 merge but before the release exists still counts. Adds `first_hour_run_url` (URL of the first successful run, else `null`) and `first_hour_since`; the markdown Now cell prints the URL when present.
- **Guardrail tolerance (VAL-SCORE-017).** `--check-guardrails` and `.guardrails[]` now mirror `bin/gate.sh guardrails`: every count guardrail's limit is `max(fixed ceiling, origin/main's own value)`; mypy limits stay fixed at 1744 / 3115. The origin/main values come from the same archived `origin/main` tree the cycles code already used, now also running `scripts/regenerate_metrics.py --json` there (the archive borrows the repo's index via `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` + `git read-tree`, because `regenerate_metrics.py` counts tracked files with `git ls-files` and a fresh `git init` would apply `.gitignore` and undercount `doc_files`). `.guardrails[]` objects gain `main` (`null` when unmeasurable → status falls back to the fixed ceiling); `ceiling` values unchanged; the `origin/main mutual_import_cycles: <M> (<short sha>)` line and the `<name>: <value> (limit <L>) ok|OVER` format are unchanged. The origin/main measurement runs in a thread alongside the metric rows so `--offline` stays under 10 s.
- Cosmetic M0 carry-over: `MEASUREMENTS[6]` reads `distinct (pr.number, head_sha) rounds`.

## Exit metric moved

- Row 6: measurement rule (baseline `53 CHANGES-REQUESTED / 1659 records` → online today `2 aragora-advisory-summary comments; upper bound 55 / 1648 / 917`, status `ok` at `--quorum-runs 2`).
- Row 8: status rule (still `0`, `fail`, `first_hour_run_url: null` until M4).
- VAL-SCORE-017: reporting fidelity only (`doc_files: 1120 (limit 1120) ok`).

## Test commands

- `timeout 300 python3 -m pytest tests/scripts/test_receipt_first_scoreboard.py -q -p no:cacheprovider` → `35 passed` (23 existing + 12 new: 9 row-6/row-8 cases incl. the 3-PR marker fixture with 0/1/2 markers and a non-marker body containing the string, `ratio` only with `--quorum-runs`, offline cached count without `ratio`, status ok/fail around N, `note`/`now` literals, row-8 target-commit threshold + fallback + `first_hour_run_url`, markdown baseline cell; 3 VAL-SCORE-017 cases keyed on the archived-main `cwd`).
- Single online run: `time /opt/homebrew/bin/timeout 120 python3 scripts/receipt_first_scoreboard.py --json --parked-file … --quorum-runs 2` → `real 0m21.069s`, exit 0; row 6 `marker_comments: 2` = REST sum over the 17 labelled PRs (#10016 comment 5574932508, #10036 comment 5575252624), `ratio 1.0`, `status ok`.
- `--json --offline` → `real 0m5.198s` (head 1), `real 0m5.669s` (head 3), exit 0, row 6 has no `ratio`, `marker_comments 2` cached, `status unavailable`; `--markdown --offline` → `real 0m5.355s`, exit 0.
- `--check-guardrails --offline` → `real 1m3.953s`, exit 0, `doc_files: 1120 (limit 1120) ok`; negative scratch tree with three extra `docs/zz_<i>.md` pages → exit 1, `doc_files: 1121 (limit 1120) OVER`, `FAIL: guardrail regression: doc_files`.
- `bin/gate.sh lint | typecheck | contracts | guardrails | test` → all `GATE PASSED` (test: 3941 passed, 3 skipped; CI-shadow collection and skip audit green).

## Reviewed design tradeoffs

- REST per PR (4 workers) instead of one GraphQL query: the online run measured 21 s (budget 60 s), and the REST sum is the validator's own cross-check, so the two numbers cannot drift apart.
- Row 6 is cached under its own cache key (`"6"`) rather than joining `NETWORK_ROWS`, because its Atlas part must still be computed offline from the local JSONL; a cached count never produces `ok`/`fail` (only a live count decides).
- `git read-tree` into a borrowed index rather than `git init && git add -A` in the archive: 2.3 s instead of 7 s and the correct tracked-file count (1120, not 1118).
- Round-1 finding (OpenAI P2, head b4f5c6e): "a missing Atlas file should not suppress a valid live marker count". The feature's rule (VAL-DISSENT-007 / feature spec) is that row 6 is `unavailable` under `--offline`, on network failure, OR when no Atlas JSONL exists: a decided `ok`/`fail` always carries both the count and the upper bound. The docstring that implied otherwise was the real inaccuracy; commit 2 restates the rule there and pins it with `test_row6_unavailable_without_atlas_even_when_count_is_live` (live count 3, ratio 1.5 still reported, status `unavailable`, `reason` names the missing JSONL).
- Round-2 findings (head 08686bc). Claude P2 "`target_commitish` may be a branch name, so `commits/<branch>` resolves to the current tip": real (verified: `gh release view v2.9.0` → `targetCommitish: "main"`; `gh api repos/…/commits/main` → today's tip, `commits/v2.9.0` → the tagged commit). Commit 3 uses the value only when it is a 40-hex SHA and otherwise resolves the tag itself (`repos/…/commits/<tag>`), pinned by `test_row8_branch_target_commitish_resolves_through_the_tag`. OpenAI P2 "`main()` always submits `measure_main(root, False)` even under `--offline`; expensive": the measurement is local (archive of the local `origin/main` ref, no network), takes ≈2.3 s in a thread parallel to the rows, and the `--offline` run measures `real 0m5.669s` (budget 10 s); the "even when offline" observation is by design (VAL-SCORE-017 requires `.guardrails[].main` under `--offline`), but the non-fetching-when-online half of the same line was a real gap: commit 3 passes `fetch=not args.offline` so the scoreboard fetches `origin/main` online exactly as `--check-guardrails` does (`git fetch origin main` ≈0.4 s). Claude P3s: draft releases (`publishedAt: null`) no longer break `max(...)`; the offline "no Atlas JSONL" reason is now kept in front of "offline"; `gh --slurp` is available (gh 2.96.0 here; governance §3 prescribes `--paginate --slurp`); the 500-PR cap is stated under Risks (17 labelled PRs today).
- Guardrail `status` tolerance is data-driven from the measured `main` value; when origin/main cannot be measured the row reports `main: null` and judges against the fixed ceiling (fail-closed).

## Risks

- `gh pr list --label receipt-first --limit 500` caps at 500 PRs; the label has 17 today.
- `Metrics Drift` (non-required) fails on `origin/main` itself (`docs/METRICS.md` stale on main; AGENTS.md Known Issues); this PR does not regenerate `docs/METRICS.md`.
- The marker count depends on gh read access; any per-PR read failure marks row 6 `unavailable` with the error in `reason` and falls back to the cached count.
