### PR TITLE
feat(atlas): pairwise agreement summary, totals rows, regenerate block

### DIFF
--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -139,6 +139,8 @@ still enumerates the index). An identical collect leaves the cache files untouch
 `--refresh` refetches per-PR responses and `--refresh-index` discovers new PRs.
 `build` and `summary` need no network. Keep the cache outside the checkout.
 
+A from-scratch collect costs about three API calls per indexed PR plus the index pages (thousands of calls and tens of minutes for the full window); use `--prs 8802 8811 8824` for a bounded smoke run.
+
 ## Verify
 
 ```bash

--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -138,6 +138,9 @@ on PASS records from labelled rounds. Its manifest and sample remain unchanged.
 still enumerates the index). An identical collect leaves the cache files untouched;
 `--refresh` refetches per-PR responses and `--refresh-index` discovers new PRs.
 `build` and `summary` need no network. Keep the cache outside the checkout.
+Inaccessible PRs are warned about and skipped while other PRs continue; the final
+line counts skipped PRs and collect exits 1 if any were skipped, so automation
+must stop before building or publishing an incomplete collection.
 
 A from-scratch collect costs about three API calls per indexed PR plus the index pages (thousands of calls and tens of minutes for the full window); use `--prs 8802 8811 8824` for a bounded smoke run.
 

--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -24,7 +24,7 @@ Successor to [#8860](https://github.com/synaptent/aragora/issues/8860).
 
 | File | Purpose |
 |---|---|
-| `atlas-v1.jsonl` | The dataset: one JSON object per line, sorted by PR, round, head, family. Committed when ≤ 5 MB; otherwise only `atlas-v1.sample.jsonl` (200 records) is committed and the full file ships as a release asset (see *Release asset*). |
+| `atlas-v1.jsonl` | The dataset: one JSON object per line, sorted by PR, round, head, family. Always gitignored and published as a release asset; `atlas-v1.sample.jsonl` is the committed sample (see *Release asset*). |
 | `schema.json` | JSON Schema (draft 2020-12) for a record, including the controlled vocabularies. |
 | `manifest.json` | JCS-canonical manifest: SHA-256 and byte length of the dataset, record and PR counts, source window, vocabularies, `content_digest`, and a `signatures[]` array in the ODR detached-signature shape. |
 | `summary.md` | Headline tables — regenerated, never hand-edited. |
@@ -86,7 +86,7 @@ See `schema.json` for the full contract. The load-bearing fields:
   merge), `re_gate_flip` (same head, same family, later PASS with no recorded
   refutation), `none_required` (PASS), `closed_unmerged`, `unresolved` (blocking
   dissent at the merged head with no recorded adjudication), `not_applicable`.
-- `adjudication.source` — `labeled` when the (PR, head) is in the eval fixture
+- `adjudication.source` — `labeled` for a dissent when the (PR, head) is in the eval fixture
   (hand labels win; the inferred mechanism is kept as a secondary), else
   `inferred` from thread facts: PASS → `none_required`; PR closed →
   `closed_unmerged`; same-head later PASS → `evidence_post` / `premise_self_expiry`
@@ -129,21 +129,33 @@ added or edited; the manifest's `receipt_inputs.files` pins the SHA-256 of every
 receipt file the records cite so `verify` reports that case as a receipt-input
 mismatch rather than a dataset mismatch.
 
+The same generator revision is also required: parser or adjudication fixes can
+change a rebuild. In particular, new builds attach `ground_truth` only to
+CHANGES-REQUESTED records; the frozen `atlas-v1` asset still includes those labels
+on PASS records from labelled rounds. Its manifest and sample remain unchanged.
+
+`collect --prs 8802 8811 8824` limits per-PR fetches for a smoke run (the first run
+still enumerates the index). An identical collect leaves the cache files untouched;
+`--refresh` refetches per-PR responses and `--refresh-index` discovers new PRs.
+`build` and `summary` need no network. Keep the cache outside the checkout.
+
 ## Verify
 
 ```bash
 # The full dataset is a release asset, not a tracked file (see *Release asset*).
 gh release download atlas-v1 -R synaptent/aragora -p atlas-v1.jsonl -D docs/atlas
-python3 scripts/build_disagreement_atlas.py verify --manifest docs/atlas/manifest.json
+python3 scripts/build_disagreement_atlas.py verify --manifest docs/atlas/manifest.json --require-dataset
 ```
 
 recomputes the dataset SHA-256, byte length and record count, the `schema.json`
 hash, and `content_digest = SHA-256(JCS(manifest minus content_digest and
 signatures))` using the ODR reference canonicaliser
 (`aragora.gauntlet.odr_export.jcs_canonicalize`). Exit code 0 and the word
-`VERIFIED` mean every check passed. Without the download, `verify` still checks
-the sample, the schema hash and the content digest, and reports the dataset line
-as `SKIPPED` (with the expected SHA-256) rather than failing.
+`VERIFIED` with `--require-dataset` mean every check passed, including the full
+dataset. Without the download, that command fails. Omit `--require-dataset` only
+for a sample-only checkout check: it reports the dataset line as `SKIPPED` (with
+the expected SHA-256), and exit 0 does not verify the missing full dataset.
+Release and weekly-regeneration checks must use `--require-dataset`.
 
 The manifest carries the same detached-signature shape as an ODR receipt. To
 sign, pass `--sign-key <ed25519.pem>` to `build` (this calls
@@ -156,12 +168,14 @@ equivalent and shares its digest algorithm.
 
 ## Release asset
 
-If `atlas-v1.jsonl` exceeds 5 MB it is **not** committed. `build` then also
-writes `atlas-v1.sample.jsonl` (all hand-labelled records plus an evenly spaced
-selection, 200 records) which is committed with `manifest.json` (whose
-`dataset.sha256` still covers the full file) and `summary.md`. The full file is
-attached to the GitHub release tagged `atlas-v1` as `atlas-v1.jsonl`; download
-it next to `manifest.json` and run `verify`.
+The full `atlas-v1.jsonl` is **never** committed, regardless of size.
+Above 5 MB (or with `--force-sample`), `build` also writes
+`atlas-v1.sample.jsonl` (up to 200 records, prioritising hand-labelled records).
+An existing sample is regenerated even if the dataset shrinks below 5 MB.
+The sample is committed with `manifest.json` (whose `dataset.sha256` covers the
+full file) and `summary.md`. The full file is attached to the GitHub release
+tagged `atlas-v1` as `atlas-v1.jsonl`; download it next to `manifest.json` and run
+`verify --require-dataset`.
 
 ## Limitations — read before citing
 

--- a/docs/atlas/summary.md
+++ b/docs/atlas/summary.md
@@ -136,6 +136,8 @@ python3 scripts/build_disagreement_atlas.py build --cache-dir /tmp/atlas-cache -
 python3 scripts/build_disagreement_atlas.py summary --dataset /tmp/atlas-build/atlas-v1.jsonl --out /tmp/atlas-build/summary.md
 ```
 
+A from-scratch collect costs about three API calls per indexed PR plus the index pages (thousands of calls and tens of minutes for the full window); use `--prs 8802 8811 8824` for a bounded smoke run.
+
 An identical collect reuses cached files without rewriting them. Use `--refresh-index` to discover new PRs and `--refresh` to refetch per-PR responses; `--prs 8802 8811 8824` restricts collection for a smoke run. Build and summary run offline; identical cache and checkout inputs produce byte-identical JSONL. Cache files stay outside the tree.
 
 These commands build from the current cache and checkout, not the frozen release. To reproduce this page's tables, download `atlas-v1.jsonl` and `manifest.json` from the `atlas-v1` release and run summary with that dataset. See [README.md](README.md) for download and `verify --require-dataset` commands.

--- a/docs/atlas/summary.md
+++ b/docs/atlas/summary.md
@@ -37,7 +37,7 @@ Posted verdicts skew to PASS: Tier 3-4 PRs run the collector prepare-only, so th
 
 ## 1. Split verdicts: was the minority later vindicated?
 
-| Family | Split rounds as minority |   as lone dissenter | Vindicated | Share | Dissents vindicated | Share |
+| Family | Split rounds as minority |   on dissenting minority side | Vindicated | Share | Dissents vindicated | Share |
 |---|---|---|---|---|---|---|
 | claude | 4 | 4 | 3 | 75.0% | 3 | 75.0% |
 | gemini | 0 | 0 | 0 | n/a | 0 | n/a |
@@ -46,7 +46,22 @@ Posted verdicts skew to PASS: Tier 3-4 PRs run the collector prepare-only, so th
 | openai | 25 | 25 | 19 | 76.0% | 19 | 76.0% |
 | **all** | 29 | 29 | 22 | 75.9% | 22 | 75.9% |
 
+A minority side can contain multiple families; **all** counts distinct split rounds, not family appearances.
+
 Rounds with ≥2 counting families: **635**; of those, split: **29** (4.6%). Agreement is therefore 95.4%.
+
+## Pairwise agreement by family pair
+
+Each pair is compared once per (PR, head) with a known counting verdict from both families, using the latest PASS/CHANGES-REQUESTED per family. Agreements include pairs on the same side of a split round; unknown and advisory-only verdicts are excluded. The total is weighted by pair-round comparisons, not unique rounds.
+
+| Family A | Family B | Rounds compared | Agreements | Agreement rate (%) |
+|---|---|---|---|---|
+| claude | grok | 20 | 20 | 100.0% |
+| claude | mistral | 2 | 2 | 100.0% |
+| claude | openai | 578 | 551 | 95.3% |
+| grok | mistral | 2 | 2 | 100.0% |
+| grok | openai | 39 | 37 | 94.9% |
+| **all pairs** |  | 641 | 612 | 95.5% |
 
 ## 2. False negatives by taxonomy class and family
 
@@ -62,6 +77,9 @@ A *false negative* is a CHANGES-REQUESTED verdict whose finding was not valid (h
 | cross_family_contradiction | 0 | 0 | 0 | 0 | 0 | 0 |
 | control | 0 | 0 | 0 | 0 | 0 | 0 |
 | *(unlabelled) dissent merged over at same head* | 1 | 0 | 0 | 0 | 6 | 7 |
+| **all** | 7 | 0 | 0 | 0 | 13 | 20 |
+
+Totals count class memberships; a multi-labelled dissent can contribute more than once.
 
 Hand-labelled dissents: **9** invalid (false negatives), **5** valid (true positives). Labels come from `tests/governance/fixtures/adjudicator_eval_cases.json`; everything else is inferred.
 
@@ -82,6 +100,7 @@ Hand-labelled dissents: **9** invalid (false negatives), **5** valid (true posit
 | 2 | 15 |
 | 3 | 2 |
 | 4 | 1 |
+| **all** | 682 |
 
 ## Adjudication mechanisms (dissent records only)
 
@@ -106,3 +125,17 @@ Dissents with a follow-up issue reference: **10**; dissents at a head that merge
 - **Vindicated**: a dissenting minority is vindicated when the PR's head advanced before merge (the demand for change was followed by change) or the PR closed unmerged; a passing minority is vindicated when the PR merged at that exact head. This is a mechanical proxy — heads also advance for main-merges — so read it as an upper bound on dissent validity.
 - **Clean pass**: the first round where every counting verdict is PASS and at least one is from a western-frontier family (claude/openai) — the Tier 1-2 settlement bar.
 - **Mechanism** (controlled vocabulary, see `schema.json`): hand labels win where present; otherwise inferred from thread facts — PASS→`none_required`; closed PR→`closed_unmerged`; same-head later PASS→`evidence_post`/`premise_self_expiry`/`re_gate_flip`; head advanced→`revision`; merged at this head with a settlement signal→`operator_adjudication`; merged at this head on [P2]/[P3]-only dissent→`severity_gating`; otherwise `unresolved`.
+
+## How to regenerate
+
+From the repository root (Python 3.11 and authenticated `gh` for collect):
+
+```bash
+python3 scripts/build_disagreement_atlas.py collect --cache-dir /tmp/atlas-cache --since 2026-06-26T21:04:36Z
+python3 scripts/build_disagreement_atlas.py build --cache-dir /tmp/atlas-cache --out /tmp/atlas-build/atlas-v1.jsonl --manifest /tmp/atlas-build/manifest.json --schema docs/atlas/schema.json
+python3 scripts/build_disagreement_atlas.py summary --dataset /tmp/atlas-build/atlas-v1.jsonl --out /tmp/atlas-build/summary.md
+```
+
+An identical collect reuses cached files without rewriting them. Use `--refresh-index` to discover new PRs and `--refresh` to refetch per-PR responses; `--prs 8802 8811 8824` restricts collection for a smoke run. Build and summary run offline; identical cache and checkout inputs produce byte-identical JSONL. Cache files stay outside the tree.
+
+These commands build from the current cache and checkout, not the frozen release. To reproduce this page's tables, download `atlas-v1.jsonl` and `manifest.json` from the `atlas-v1` release and run summary with that dataset. See [README.md](README.md) for download and `verify --require-dataset` commands.

--- a/scripts/build_disagreement_atlas.py
+++ b/scripts/build_disagreement_atlas.py
@@ -48,6 +48,7 @@ import subprocess
 import sys
 import time
 from collections import Counter, defaultdict
+from itertools import combinations
 from pathlib import Path
 from typing import Any
 
@@ -269,10 +270,17 @@ class GitHubClient:
                 self._maybe_throttle(headers)
                 return json.loads(body or "null")
             err = (proc.stderr or "").strip() or body.strip()
-            lowered = err.lower()
-            if "404" in lowered and "not found" in lowered:
+            lowered = f"{err} {body}".lower()
+            status_match = re.match(r"HTTP/\S+\s+(\d{3})", proc.stdout or "")
+            status = int(status_match[1]) if status_match else None
+            if status == 404 or ("404" in lowered and "not found" in lowered):
                 raise LookupError(f"{path}: {err[:200]}")
-            if "rate limit" in lowered or "403" in lowered or "429" in lowered:
+            if (
+                status == 429
+                or "rate limit" in lowered
+                or _int_header(headers, "x-ratelimit-remaining") == 0
+                or "retry-after" in headers
+            ):
                 # Rate-limit waits never consume the retry budget: the cache makes
                 # a long pause strictly cheaper than a crash-and-rerun.
                 rate_limit_waits += 1
@@ -281,6 +289,8 @@ class GitHubClient:
                     raise RuntimeError(f"gh api {path}: still rate-limited after 12 waits")
                 self._sleep_until_reset(reason=err[:120], headers=headers)
                 continue
+            if status == 403 or "HTTP 403" in err:
+                raise PermissionError(f"{path}: {err[:200]}")
             if attempt >= attempts:
                 raise RuntimeError(f"gh api {path} failed after {attempts} attempts: {err[:300]}")
             time.sleep(min(60, 5 * attempt))
@@ -469,27 +479,32 @@ def cmd_collect(args: argparse.Namespace) -> int:
     for position, number in enumerate(numbers, start=1):
         base = f"prs/{number}"
         pr_path = args.cache_dir / base / "pr.json"
-        if not pr_path.exists():
-            client.cached(f"{base}/pr.json", f"repos/{repo}/pulls/{number}")
-        comments = client.cached(
-            f"{base}/comments.json", f"repos/{repo}/issues/{number}/comments", paginate=True
-        )
-        # Model verdicts may be mirrored only as GitHub review objects, so the
-        # review list is fetched before deciding whether the PR is a thread.
-        reviews = client.cached(
-            f"{base}/reviews.json", f"repos/{repo}/pulls/{number}/reviews", paginate=True
-        )
-        if not _looks_like_review_thread(comments, reviews):
+        try:
+            if not pr_path.exists() or args.refresh:
+                client.cached(f"{base}/pr.json", f"repos/{repo}/pulls/{number}")
+            comments = client.cached(
+                f"{base}/comments.json", f"repos/{repo}/issues/{number}/comments", paginate=True
+            )
+            # A model verdict can exist only as a review object.
+            reviews = client.cached(
+                f"{base}/reviews.json", f"repos/{repo}/pulls/{number}/reviews", paginate=True
+            )
+            if not _looks_like_review_thread(comments, reviews):
+                continue
+            pr = json.loads(pr_path.read_text(encoding="utf-8"))
+            client.cached(
+                f"{base}/commits.json", f"repos/{repo}/pulls/{number}/commits", paginate=True
+            )
+            head_sha = str((pr.get("head") or {}).get("sha") or "")
+            if head_sha:
+                client.cached(
+                    f"statuses/{head_sha}.json",
+                    f"repos/{repo}/commits/{head_sha}/statuses?per_page=100",
+                )
+        except (LookupError, PermissionError) as exc:
+            _log(f"[collect] warning: skipping PR #{number}: {exc}")
             continue
         with_verdicts += 1
-        pr = json.loads(pr_path.read_text(encoding="utf-8"))
-        client.cached(f"{base}/commits.json", f"repos/{repo}/pulls/{number}/commits", paginate=True)
-        head_sha = str((pr.get("head") or {}).get("sha") or "")
-        if head_sha:
-            client.cached(
-                f"statuses/{head_sha}.json",
-                f"repos/{repo}/commits/{head_sha}/statuses?per_page=100",
-            )
         if position % 50 == 0:
             _log(
                 f"[collect] {position}/{len(numbers)} PRs, {with_verdicts} review threads, "
@@ -1115,12 +1130,12 @@ def _assemble_pr(
         taxonomy_classes: list[str] = []
         if labeled_case is not None:
             truth = _ground_truth(labeled_case)
-            adjudication["source"] = "labeled"
-            adjudication["ground_truth"] = truth
             # The failure classes describe the dissent at this head; a PASS at
             # the same head did not exhibit them. ``control`` labels the whole
             # round as correctly handled, so every verdict in it keeps it.
             if record["verdict"] == "changes_requested":
+                adjudication["source"] = "labeled"
+                adjudication["ground_truth"] = truth
                 taxonomy_classes = truth["taxonomy_classes"]
             else:
                 taxonomy_classes = [c for c in truth["taxonomy_classes"] if c == "control"]
@@ -1393,9 +1408,9 @@ def cmd_build(args: argparse.Namespace) -> int:
     base = args.repo_root
 
     sample_info: tuple[str, bytes, int] | None = None
-    if len(payload) > FULL_COMMIT_LIMIT_BYTES or args.force_sample:
+    sample_path = out_dir / out.name.replace(".jsonl", ".sample.jsonl")
+    if len(payload) > FULL_COMMIT_LIMIT_BYTES or args.force_sample or sample_path.exists():
         sample = select_sample(records, SAMPLE_SIZE)
-        sample_path = out_dir / out.name.replace(".jsonl", ".sample.jsonl")
         sample_bytes = write_jsonl(sample, sample_path)
         sample_info = (_rel_to(sample_path, base), sample_bytes, len(sample))
         _log(f"[build] dataset is {len(payload)} bytes; wrote {len(sample)}-record sample")
@@ -1684,7 +1699,7 @@ def render_summary(records: list[dict[str, Any]], manifest: dict[str, Any] | Non
             [
                 "Family",
                 "Split rounds as minority",
-                "  as lone dissenter",
+                "  on dissenting minority side",
                 "Vindicated",
                 "Share",
                 "Dissents vindicated",
@@ -1692,6 +1707,11 @@ def render_summary(records: list[dict[str, Any]], manifest: dict[str, Any] | Non
             ],
             rows,
         )
+    )
+    lines.append("")
+    lines.append(
+        "A minority side can contain multiple families; **all** counts distinct split rounds, "
+        "not family appearances."
     )
     lines.append("")
     heads_multi = defaultdict(set)
@@ -1702,6 +1722,39 @@ def render_summary(records: list[dict[str, Any]], manifest: dict[str, Any] | Non
     lines.append(
         f"Rounds with ≥2 counting families: **{multi}**; of those, split: **{len(splits)}** "
         f"({_pct(len(splits), multi)}). Agreement is therefore {_pct(multi - len(splits), multi)}."
+    )
+    lines.append("")
+
+    lines.append("## Pairwise agreement by family pair")
+    lines.append("")
+    lines.append(
+        "Each pair is compared once per (PR, head) with a known counting verdict from both "
+        "families, using the latest PASS/CHANGES-REQUESTED per family. Agreements include "
+        "pairs on the same side of a split round; unknown and advisory-only verdicts are excluded. "
+        "The total is weighted by pair-round comparisons, not unique rounds."
+    )
+    lines.append("")
+    compared: Counter = Counter()
+    disagreed: Counter = Counter()
+    for fams in heads_multi.values():
+        compared.update(combinations(sorted(fams), 2))
+    for split in splits:
+        for minority in split["minority_families"]:
+            for majority in split["majority_families"]:
+                disagreed[tuple(sorted((minority, majority)))] += 1
+    rows = [
+        [a, b, n, n - disagreed[(a, b)], _pct(n - disagreed[(a, b)], n)]
+        for (a, b), n in sorted(compared.items())
+    ]
+    total_compared = sum(compared.values())
+    total_agreed = total_compared - sum(disagreed.values())
+    rows.append(
+        ["**all pairs**", "", total_compared, total_agreed, _pct(total_agreed, total_compared)]
+    )
+    lines.append(
+        _md_table(
+            ["Family A", "Family B", "Rounds compared", "Agreements", "Agreement rate (%)"], rows
+        )
     )
     lines.append("")
 
@@ -1752,7 +1805,12 @@ def render_summary(records: list[dict[str, Any]], manifest: dict[str, Any] | Non
         overruled_row.append(n)
     overruled_row.append(total)
     rows.append(overruled_row)
+    rows.append(["**all**", *(sum(row[i] for row in rows) for i in range(1, len(families) + 2))])
     lines.append(_md_table(["Taxonomy class", *families, "Total"], rows))
+    lines.append("")
+    lines.append(
+        "Totals count class memberships; a multi-labelled dissent can contribute more than once."
+    )
     lines.append("")
     valid_true = sum(
         1
@@ -1783,9 +1841,12 @@ def render_summary(records: list[dict[str, Any]], manifest: dict[str, Any] | Non
     lines.append(_md_table(["Measure", "Value"], rows))
     lines.append("")
     dist = Counter(reached)
-    if dist:
-        lines.append(_md_table(["Rounds", "PRs"], [[n, dist[n]] for n in sorted(dist)]))
-        lines.append("")
+    lines.append(
+        _md_table(
+            ["Rounds", "PRs"], [[n, dist[n]] for n in sorted(dist)] + [["**all**", len(reached)]]
+        )
+    )
+    lines.append("")
 
     # -- adjudication mechanisms --------------------------------------------
     lines.append("## Adjudication mechanisms (dissent records only)")
@@ -1851,6 +1912,34 @@ def render_summary(records: list[dict[str, Any]], manifest: dict[str, Any] | Non
         "this head on [P2]/[P3]-only dissent→`severity_gating`; otherwise `unresolved`."
     )
     lines.append("")
+    lines.extend(
+        [
+            "## How to regenerate",
+            "",
+            "From the repository root (Python 3.11 and authenticated `gh` for collect):",
+            "",
+            "```bash",
+            "python3 scripts/build_disagreement_atlas.py collect --cache-dir /tmp/atlas-cache "
+            "--since 2026-06-26T21:04:36Z",
+            "python3 scripts/build_disagreement_atlas.py build --cache-dir /tmp/atlas-cache "
+            "--out /tmp/atlas-build/atlas-v1.jsonl --manifest /tmp/atlas-build/manifest.json "
+            "--schema docs/atlas/schema.json",
+            "python3 scripts/build_disagreement_atlas.py summary "
+            "--dataset /tmp/atlas-build/atlas-v1.jsonl --out /tmp/atlas-build/summary.md",
+            "```",
+            "",
+            "An identical collect reuses cached files without rewriting them. Use `--refresh-index` "
+            "to discover new PRs and `--refresh` to refetch per-PR responses; `--prs 8802 8811 8824` "
+            "restricts collection for a smoke run. Build and summary run offline; identical cache "
+            "and checkout inputs produce byte-identical JSONL. Cache files stay outside the tree.",
+            "",
+            "These commands build from the current cache and checkout, not the frozen release. "
+            "To reproduce this page's tables, download `atlas-v1.jsonl` and `manifest.json` from "
+            "the `atlas-v1` release and run summary with that dataset. See [README.md](README.md) "
+            "for download and `verify --require-dataset` commands.",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -1873,7 +1962,11 @@ def cmd_summary(args: argparse.Namespace) -> int:
 
 
 def verify_manifest(
-    manifest_path: Path, *, base: Path, public_key_path: Path | None = None
+    manifest_path: Path,
+    *,
+    base: Path,
+    public_key_path: Path | None = None,
+    require_dataset: bool = False,
 ) -> tuple[bool, list[str]]:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     problems: list[str] = []
@@ -1882,9 +1975,8 @@ def verify_manifest(
     dataset = manifest.get("dataset") or {}
     dataset_path = base / str(dataset.get("path") or "")
     if not dataset_path.exists():
-        # The full dataset ships as a release asset when it exceeds the commit
-        # size cap, so a checkout verifies the sample and digest without it.
-        if manifest.get("sample"):
+        # A checkout can verify the sample; publishing must verify the full asset.
+        if manifest.get("sample") and not require_dataset:
             checks.append(
                 f"dataset SKIPPED (not present: {dataset_path}; download the release "
                 f"asset next to manifest.json to verify sha256 {dataset.get('sha256')})"
@@ -1994,7 +2086,12 @@ def verify_manifest(
 
 
 def cmd_verify(args: argparse.Namespace) -> int:
-    ok, lines = verify_manifest(args.manifest, base=args.repo_root, public_key_path=args.public_key)
+    ok, lines = verify_manifest(
+        args.manifest,
+        base=args.repo_root,
+        public_key_path=args.public_key,
+        require_dataset=args.require_dataset,
+    )
     for line in lines:
         print(f"  - {line}")
     print("VERIFIED" if ok else "FAILED")
@@ -2186,6 +2283,9 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("--manifest", type=Path, default=Path("docs/atlas/manifest.json"))
     verify.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     verify.add_argument("--public-key", type=Path, default=None, help="Ed25519 PEM public key")
+    verify.add_argument(
+        "--require-dataset", action="store_true", help="fail if the full dataset is absent"
+    )
     verify.set_defaults(func=cmd_verify)
 
     fixture = sub.add_parser("make-fixture", help="strip cached PRs into a test fixture")

--- a/scripts/build_disagreement_atlas.py
+++ b/scripts/build_disagreement_atlas.py
@@ -1928,6 +1928,10 @@ def render_summary(records: list[dict[str, Any]], manifest: dict[str, Any] | Non
             "--dataset /tmp/atlas-build/atlas-v1.jsonl --out /tmp/atlas-build/summary.md",
             "```",
             "",
+            "A from-scratch collect costs about three API calls per indexed PR plus the index pages "
+            "(thousands of calls and tens of minutes for the full window); use `--prs 8802 8811 8824` "
+            "for a bounded smoke run.",
+            "",
             "An identical collect reuses cached files without rewriting them. Use `--refresh-index` "
             "to discover new PRs and `--refresh` to refetch per-PR responses; `--prs 8802 8811 8824` "
             "restricts collection for a smoke run. Build and summary run offline; identical cache "

--- a/scripts/build_disagreement_atlas.py
+++ b/scripts/build_disagreement_atlas.py
@@ -476,6 +476,7 @@ def cmd_collect(args: argparse.Namespace) -> int:
         numbers = numbers[: args.max_prs]
 
     with_verdicts = 0
+    skipped = 0
     for position, number in enumerate(numbers, start=1):
         base = f"prs/{number}"
         pr_path = args.cache_dir / base / "pr.json"
@@ -502,6 +503,7 @@ def cmd_collect(args: argparse.Namespace) -> int:
                     f"repos/{repo}/commits/{head_sha}/statuses?per_page=100",
                 )
         except (LookupError, PermissionError) as exc:
+            skipped += 1
             _log(f"[collect] warning: skipping PR #{number}: {exc}")
             continue
         with_verdicts += 1
@@ -512,9 +514,10 @@ def cmd_collect(args: argparse.Namespace) -> int:
             )
     _log(
         f"[collect] done: {len(numbers)} PRs, {with_verdicts} review threads, "
-        f"{client.calls} API calls this run, {client.total_logged_calls()} logged in total"
+        f"{client.calls} API calls this run, {client.total_logged_calls()} logged in total, "
+        f"{skipped} PRs skipped"
     )
-    return 0
+    return int(skipped > 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_build_disagreement_atlas.py
+++ b/tests/scripts/test_build_disagreement_atlas.py
@@ -10,8 +10,11 @@ parsers read. Nothing here touches ``gh`` or the network.
 from __future__ import annotations
 
 import importlib.util
+import copy
 import json
+import re
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -304,6 +307,145 @@ def test_summary_numbers_regenerate_from_records(built, tmp_path: Path) -> None:
         assert heading in text
 
 
+def _table(text: str, heading: str) -> list[list[str]]:
+    section = text.split(heading, 1)[1].split("\n## ", 1)[0]
+    return [
+        [cell.strip() for cell in line.strip("|").split("|")]
+        for line in section.splitlines()
+        if line.startswith("| ")
+    ]
+
+
+def test_summary_pairwise_agreement_uses_latest_counting_verdicts(built) -> None:
+    template = built[0][0]
+    records = []
+    # A split with two agreeing PASS families, a clean pair, and a re-gate flip.
+    rounds = [
+        [("claude", "pass"), ("openai", "pass"), ("grok", "changes_requested")],
+        [("claude", "pass"), ("openai", "pass")],
+        [("claude", "pass"), ("openai", "changes_requested"), ("openai", "pass")],
+        [("claude", "pass"), ("grok", "changes_requested"), ("openai", "unknown")],
+    ]
+    for n, verdicts in enumerate(rounds, 1):
+        for i, (family, verdict) in enumerate([*verdicts, ("gemini", "changes_requested")]):
+            record = copy.deepcopy(template)
+            record.update(head_sha=f"{n:040x}", round=n, verdict=verdict, source_id=str(i))
+            record["posted_at"] = f"2026-07-01T00:00:0{i}Z"
+            record["reviewer"].update(family=family, counting_class=atlas._counting_class(family))
+            records.append(record)
+    jsonschema = pytest.importorskip("jsonschema")
+    for record in records:
+        jsonschema.validate(record, json.loads(SCHEMA.read_text()))
+    text = atlas.render_summary(records, None)
+    rows = _table(text, "## Pairwise agreement by family pair")
+    assert rows == [
+        ["Family A", "Family B", "Rounds compared", "Agreements", "Agreement rate (%)"],
+        ["claude", "grok", "2", "0", "0.0%"],
+        ["claude", "openai", "3", "3", "100.0%"],
+        ["grok", "openai", "1", "0", "0.0%"],
+        ["**all pairs**", "", "6", "3", "50.0%"],
+    ]
+    assert rows == _table(
+        atlas.render_summary(list(reversed(records)), None),
+        "## Pairwise agreement by family pair",
+    )
+
+
+@pytest.mark.parametrize("empty", [False, True])
+def test_summary_four_totals_and_regenerate_block(built, empty: bool) -> None:
+    records = [] if empty else built[0]
+    text = atlas.render_summary(records, None)
+    assert len(re.findall(r"^\| \*\*all( pairs)?\*\* \|", text, re.MULTILINE)) == 4
+    headings = [
+        "## 1. Split verdicts",
+        "## Pairwise agreement by family pair",
+        "## 2. False negatives by taxonomy class and family",
+        "## 3. Rounds to a clean pass",
+        "## Adjudication mechanisms",
+    ]
+    assert [text.index(h) for h in headings] == sorted(text.index(h) for h in headings)
+    taxonomy = _table(text, headings[2])
+    assert taxonomy[-1][0] == "**all**"
+    for col in range(1, len(taxonomy[0])):
+        assert int(taxonomy[-1][col]) == sum(int(row[col]) for row in taxonomy[1:-1])
+    distribution = _table(text, headings[3])
+    reached = int(distribution[1][1])
+    assert distribution[-1] == ["**all**", str(reached)]
+    start = distribution.index(["Rounds", "PRs"]) + 1
+    assert sum(int(row[1]) for row in distribution[start:-1]) == reached
+    block = text.split("## How to regenerate", 1)[1].split("```bash\n", 1)[1].split("```", 1)[0]
+    commands = block.replace("\\\n", "").splitlines()
+    for command, name in zip(commands, ("collect", "build", "summary"), strict=True):
+        assert command.startswith(f"python3 scripts/build_disagreement_atlas.py {name} ")
+        args = atlas.build_parser().parse_args(command.split()[2:])
+        assert args.command == name
+    assert "--since" in commands[0] and "--cache-dir" in commands[0]
+
+
+def test_build_refreshes_existing_sample_after_dataset_shrinks(tmp_path: Path) -> None:
+    records, _manifest, out = _build(tmp_path)
+    sample_path = out.with_suffix(".sample.jsonl")
+    atlas.write_jsonl(records * 2, sample_path)
+    records, manifest, _out = _build(tmp_path)
+    assert atlas.read_jsonl(sample_path) == atlas.select_sample(records, atlas.SAMPLE_SIZE)
+    assert manifest["sample"]["sha256"] == atlas._sha256(sample_path.read_bytes())
+
+
+@pytest.mark.parametrize("status,error", [(403, PermissionError), (404, LookupError)])
+def test_collect_http_access_errors_do_not_backoff(tmp_path, monkeypatch, status, error) -> None:
+    client = atlas.GitHubClient(tmp_path)
+    response = subprocess.CompletedProcess(
+        [], 1, stdout=f'HTTP/2.0 {status}\n\n{{"message":"unavailable"}}', stderr=f"HTTP {status}"
+    )
+    monkeypatch.setattr(atlas.subprocess, "run", lambda *a, **kw: response)
+    monkeypatch.setattr(atlas.time, "sleep", lambda *a: pytest.fail("must not back off"))
+    with pytest.raises(error):
+        client.api("repos/o/r/pulls/42")
+    assert client.calls == 1
+
+
+@pytest.mark.parametrize("status", [403, 429])
+def test_collect_rate_limit_still_retries(tmp_path, monkeypatch, status) -> None:
+    client = atlas.GitHubClient(tmp_path)
+    responses = iter(
+        [
+            subprocess.CompletedProcess(
+                [],
+                1,
+                stdout=f"HTTP/2.0 {status}\nx-ratelimit-remaining: 0\n\n{{}}",
+                stderr=f"HTTP {status}",
+            ),
+            subprocess.CompletedProcess([], 0, stdout="[]"),
+        ]
+    )
+    waits = []
+    monkeypatch.setattr(atlas.subprocess, "run", lambda *a, **kw: next(responses))
+    monkeypatch.setattr(client, "_sleep_until_reset", lambda **kw: waits.append(kw))
+    assert client.api("repos/o/r/pulls/42") == []
+    assert client.calls == 2 and len(waits) == 1
+
+
+@pytest.mark.parametrize("error", [LookupError, PermissionError])
+def test_collect_skips_inaccessible_pr_and_continues(tmp_path, monkeypatch, capsys, error) -> None:
+    shutil.copytree(FIXTURE, tmp_path / "cache")
+    seen = []
+    original = atlas.GitHubClient.cached
+
+    def cached(self, rel, path, **kwargs):
+        seen.append(path)
+        if "/8802/comments" in path:
+            raise error("inaccessible")
+        return original(self, rel, path, **kwargs)
+
+    monkeypatch.setattr(atlas.GitHubClient, "cached", cached)
+    assert (
+        atlas.main(["collect", "--cache-dir", str(tmp_path / "cache"), "--since", "2026-01-01"])
+        == 0
+    )
+    assert any("/8824/comments" in path for path in seen)
+    assert "[collect] warning: skipping PR #8802" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Parser reuse on a synthetic evidence comment
 # ---------------------------------------------------------------------------
@@ -458,11 +600,9 @@ def test_failure_classes_attach_only_to_the_dissenting_verdict(built) -> None:
     records, _manifest, _out = built
     claude_pass = _find(records, 8802, "21a4ac4", "claude")
     assert claude_pass["verdict"] == "pass"
-    assert claude_pass["adjudication"]["source"] == "labeled"
+    assert claude_pass["adjudication"]["source"] == "inferred"
     assert claude_pass["taxonomy_classes"] == []
-    assert claude_pass["adjudication"]["ground_truth"]["taxonomy_classes"] == [
-        "out_of_scope_carousel"
-    ]
+    assert claude_pass["adjudication"]["ground_truth"] is None
     for r in records:
         if r["verdict"] == "pass":
             assert set(r["taxonomy_classes"]) <= {"control"}, r["record_id"]
@@ -522,6 +662,19 @@ def test_verify_skips_an_absent_dataset_when_the_sample_is_present(built, tmp_pa
     assert ok, lines
     assert any(line.startswith("dataset SKIPPED") for line in lines)
     assert any("sample sha256 ok" in line for line in lines)
+    assert (
+        atlas.main(
+            [
+                "verify",
+                "--manifest",
+                str(manifest_path),
+                "--repo-root",
+                str(root),
+                "--require-dataset",
+            ]
+        )
+        == 1
+    )
     (root / "docs" / "atlas" / "atlas-v1.sample.jsonl").unlink()
     ok, lines = atlas.verify_manifest(manifest_path, base=root)
     assert not ok

--- a/tests/scripts/test_build_disagreement_atlas.py
+++ b/tests/scripts/test_build_disagreement_atlas.py
@@ -426,24 +426,29 @@ def test_collect_rate_limit_still_retries(tmp_path, monkeypatch, status) -> None
 
 
 @pytest.mark.parametrize("error", [LookupError, PermissionError])
-def test_collect_skips_inaccessible_pr_and_continues(tmp_path, monkeypatch, capsys, error) -> None:
+@pytest.mark.parametrize("all_skipped", [False, True])
+def test_collect_skips_inaccessible_pr_and_continues(
+    tmp_path, monkeypatch, capsys, error, all_skipped
+) -> None:
     shutil.copytree(FIXTURE, tmp_path / "cache")
     seen = []
     original = atlas.GitHubClient.cached
 
     def cached(self, rel, path, **kwargs):
         seen.append(path)
-        if "/8802/comments" in path:
+        if "/8802/comments" in path or all_skipped:
             raise error("inaccessible")
         return original(self, rel, path, **kwargs)
 
     monkeypatch.setattr(atlas.GitHubClient, "cached", cached)
     assert (
         atlas.main(["collect", "--cache-dir", str(tmp_path / "cache"), "--since", "2026-01-01"])
-        == 0
+        == 1
     )
     assert any("/8824/comments" in path for path in seen)
-    assert "[collect] warning: skipping PR #8802" in capsys.readouterr().err
+    output = capsys.readouterr().err
+    assert "[collect] warning: skipping PR #8802" in output
+    assert f"{3 if all_skipped else 1} PRs skipped" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Receipt-First epic #9966, feature `m2-atlas-pairwise-summary`, attempt 1 resumed after ruling 13.

- Add pairwise agreement by counting-family pair and totals for all four summary tables, preserving the three numbered headings.
- Regenerate the page from the frozen `atlas-v1` release, with unchanged table reproduction and dataset SHA-256 `3ddd6249d7370a9ddf40e7c2ea238107a7c2dd96db9781a6686beac47f4995c8`.
- Preserve the full-window regeneration commands and document their cost in the summary and README.
- Address #9951 carry-overs: require-full-dataset verification, release-asset wording, stale sample regeneration, PASS adjudication, minority-column naming, and inaccessible-PR handling.

## Exit metric moved

Row 5 (Atlas summary v2): **1 totals row / no pairwise table → 4 totals rows + pairwise table**.
The weekly regeneration and docs-site navigation remain separate features.

## Test commands

All commands ran from the isolated worktree with the mission Python 3.11 environment.
Final head: `471bd6d721d026560323bc6163598f496f0227b1`.
Computed `merge-packet` tier: **2** (`tier_2_live_automation`), `head_sha` matches the final head; no human risk settlement required.

- `ruff format scripts/build_disagreement_atlas.py tests/scripts/test_build_disagreement_atlas.py`: unchanged; whole PR 427 LOC.
- `timeout 300 python3 -m pytest tests/scripts/test_build_disagreement_atlas.py -q -n 8 -p no:cacheprovider --timeout=120`: 38 passed. The original attempt recorded red-first failures before implementation; the incomplete-collection repair first produced four failing cases (`0 == 1`), then all 38 passed.
- `python3 scripts/build_disagreement_atlas.py summary --dataset /tmp/rf-atlas-pairwise-release/atlas-v1.jsonl --manifest docs/atlas/manifest.json --out docs/atlas/summary.md`: exit 0, 1661 records; every table line matches the release regeneration. Exactly four totals and one cost sentence per page; three block commands byte-identical to the parked head.
- `cd docs-site && node scripts/sync-docs.js`: exit 0, 276 synced, zero skipped; `git diff --exit-code --stat -- docs-site`: clean.
- `cd docs-site && (test -d node_modules || npm ci --no-audit --no-fund) && npm run build`: exit 0.

Bounded regeneration block (VAL-ATLAS-004.5):

```bash
mkdir -p /tmp/atlas-build
/opt/homebrew/bin/timeout 280 python3 scripts/build_disagreement_atlas.py collect --cache-dir /tmp/atlas-cache --since 2026-06-26T21:04:36Z --prs 8802 8811 8824
python3 scripts/build_disagreement_atlas.py build --cache-dir /tmp/atlas-cache --out /tmp/atlas-build/atlas-v1.jsonl --manifest /tmp/atlas-build/manifest.json --schema docs/atlas/schema.json
python3 scripts/build_disagreement_atlas.py summary --dataset /tmp/atlas-build/atlas-v1.jsonl --out /tmp/atlas-build/summary.md
```

All three exit 0. First collect:
`[collect] indexed 1165 closed PRs since 2026-06-26T21:04:36Z`
`[collect] done: 3 PRs, 3 review threads, 25 API calls this run, 25 logged in total`
Identical repeat: `0 API calls this run`, 0.099 s. Build: 27 records (the three fetched PRs plus evaluation fixtures); summary: one pairwise heading, four totals.

Incremental contract (VAL-ATLAS-009):

```bash
python3 scripts/build_disagreement_atlas.py collect --help
python3 scripts/build_disagreement_atlas.py build --help
mkdir -p /tmp/rf-atlas/cache
/opt/homebrew/bin/timeout 900 python3 scripts/build_disagreement_atlas.py collect --cache-dir /tmp/rf-atlas/cache --prs 8802 8811 8824
python3 scripts/build_disagreement_atlas.py build --cache-dir /tmp/rf-atlas/cache --out /tmp/rf-atlas/mini.jsonl --manifest /tmp/rf-atlas/mini.manifest.json --schema docs/atlas/schema.json --repo-root "$PWD"
python3 scripts/build_disagreement_atlas.py build --cache-dir /tmp/rf-atlas/cache --out /tmp/rf-atlas/mini2.jsonl --manifest /tmp/rf-atlas/mini2.manifest.json --schema docs/atlas/schema.json --repo-root "$PWD"
cmp /tmp/rf-atlas/mini.jsonl /tmp/rf-atlas/mini2.jsonl
python3 scripts/build_disagreement_atlas.py summary --dataset /tmp/rf-atlas/mini.jsonl --out /tmp/rf-atlas/mini.summary.md
```

Required flags present, all exits 0. First collect: indexed 1165; done 3 PRs / 3 review threads / 26 API calls. Repeat: zero calls in 0.118 s; `stat -f %m` of `pr.json`, `comments.json`, `commits.json`, `reviews.json` unchanged. Two builds byte-identical; mini summary includes pairwise heading.
Repeated from a fresh `/tmp/rf-atlas/cache` on the repaired final head, preserving the prior smoke cache at `/tmp/rf-atlas/cache-before-review-repair`: indexed 1165, 26 calls, 0 PRs skipped; repeat 0 calls in 0.118 s with unchanged mtimes; both builds, comparison, and summary exit 0.

Full dataset verification:
`gh release download atlas-v1 -R synaptent/aragora -p atlas-v1.jsonl -D docs/atlas --clobber && python3 scripts/build_disagreement_atlas.py verify --manifest docs/atlas/manifest.json --require-dataset`: `VERIFIED`, exit 0.
After removing only that ignored download, the same required verification: `FAILED`, `dataset missing`, exit 1; without `--require-dataset`: `dataset SKIPPED`, exit 0. Download removed before commit.

Final committed-head gates:

```bash
bash "$MISSION_DIR/bin/gate.sh" lint
bash "$MISSION_DIR/bin/gate.sh" typecheck
bash "$MISSION_DIR/bin/gate.sh" contracts
bash "$MISSION_DIR/bin/gate.sh" guardrails
bash "$MISSION_DIR/bin/gate.sh" test
bash scripts/automation_pr_preflight.sh origin/main HEAD
```

Every gate exit 0, `GATE PASSED`; preflight exit 0. Curated tests: 3955 passed / 3 skipped; CI-shadow collection passed; skip audit 93 (91 + 2 allowed); publish-shadow 104 passed / 2 skipped. Mypy remains 1744 baseline errors, baseline length 3115. Guardrails: cycles 138, handlers 187, workflows 97, docs 1120 (external #9995 tolerance), packages 145, operations 3205. No page added.

## Reviewed design tradeoffs

- Pairwise comparisons include all known counting-family pair-rounds; disagreements come from the opposite sides of `split_rounds`. Unknown and advisory-only verdicts do not inflate the denominator.
- The block stays unrestricted with a cost sentence because it documents full regeneration. Its argparse round-trip test and bounded live proof append `--prs 8802 8811 8824` to collect only; build and summary run unchanged. No unrestricted collect ran in this resumed session.
- PASS records keep inferred adjudication and no ground-truth label in new builds. The frozen release remains unchanged and the README discloses its historical PASS labels.
- `--require-dataset` is opt-in to retain explicit sample-only verification. The README uses it for full verification.

Collection 1 disposition (head `47ea975acd`; one transport-only attempt on max-01, then the allowed retry on max-11):

- Claude P2, incomplete collection exits 0: **repaired** in `471bd6d721`. Continue processing other PRs, count skipped PRs in the done line, then return 1 if any were skipped. Four offline fixture cases cover partial/all skipped for both 403 and 404 paths. README tells automation to stop before build/publish. No changes to retry/backoff semantics.
- Claude P3, fixed regeneration window: **ruled limitation**, not changed. Ruling 13 requires these three commands byte-identical. Direct check: `source.since` in the frozen release manifest is `2026-06-26T21:04:36Z`, matching the block; a page for a different window still prints that fixed example. No claim that it dynamically renders other windows.
- Claude P3, PASS labels and `ATLAS_VERSION`: **documented divergence**, not a schema change. Recount confirms six PASS/labeled records in the frozen sample; README explicitly says the frozen release retains these labels and that identical rebuilds require the same generator revision. No claim that this generator reproduces old JSONL bytes.
- Claude P3, small first-build sample: **refuted as a prose defect**, with two checks. The smoke manifest has `sample: null`; `git check-ignore docs/atlas/atlas-v1.jsonl` confirms the unconditional ignore rule. README accurately says a sample is generated only above 5 MB, with `--force-sample`, or when a prior sample exists. “Never committed” describes release-asset policy, not automatic sample generation; small first-time builds must request `--force-sample` when they need a committable sample.
- OpenAI: grounded PASS, no findings.

## Risks

- Collection 2 (`471bd6d721d026560323bc6163598f496f0227b1`, claude profile `max-05`): both families returned grounded PASS, no P0–P2 findings, no dissent or transport failures. Claude's fixed-window P3 repeats the ruled limitation in the Collection 1 disposition above; its frozen-sample P3 repeats the documented generator/release divergence there. Neither demands a repair. The new `Retry-After` P3 is accepted as a performance advisory, not a correctness defect (the reviewer explicitly says “Not wrong”): responses carrying that header take the bounded rate-limit wait path, including transient 5xx responses, rather than the shorter generic retry ladder. Source inspection confirms both the header check and the 12-wait bound. No claim here promises the generic ladder for such responses; changing that policy is unnecessary for this clean head. No third collection or source change.
- Carry-over (a): the weekly job's `--require-dataset` invocation belongs to `m2-atlas-weekly-job`, not this Tier-2 PR. No workflow is changed.
- Carry-over (b) canonicalization was already fixed by `979f83d85e`. Carry-overs (c)-(g) are addressed here; the historical release and manifest are deliberately not rewritten.
- The full-window regeneration is the weekly job's run, never reproduced locally.
- Smoke caches are not complete caches. Builds also inject evaluation fixtures and report coverage against the full cached index.
- The regeneration example is fixed to the atlas-v1 window. Small first-time builds need `--force-sample` to produce a committable sample. Parser/adjudication fixes can change build bytes without changing schema version; use the dataset digest and generator revision.
- Existing `metrics-drift.yml` advisory failure reports stale `docs/METRICS.md`; regeneration of that unrelated page is out of scope.

