### PR TITLE
fix(migrations): dialect-aware DDL and psycopg2 error handling [Tier 3]

### DIFF
--- a/aragora/migrations/__main__.py
+++ b/aragora/migrations/__main__.py
@@ -48,17 +48,16 @@ def cmd_upgrade(args: argparse.Namespace) -> int:
 
 def cmd_downgrade(args: argparse.Namespace) -> int:
     """Rollback migrations."""
-    runner = get_migration_runner(
-        db_path=args.db_path,
-        database_url=args.database_url,
-    )
-
     dry_run = getattr(args, "dry_run", False)
     steps = getattr(args, "steps", None)
     reason = getattr(args, "reason", None)
     use_stored = getattr(args, "use_stored_rollback", False)
 
     try:
+        runner = get_migration_runner(
+            db_path=args.db_path,
+            database_url=args.database_url,
+        )
         # Determine rollback mode
         if steps is not None:
             # Validate first
@@ -107,7 +106,7 @@ def cmd_downgrade(args: argparse.Namespace) -> int:
         else:
             print("No migrations to rollback.")
         return 0
-    except (RuntimeError, OSError, ValueError) as e:
+    except DATABASE_ERRORS + (RuntimeError, OSError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:
@@ -116,12 +115,11 @@ def cmd_downgrade(args: argparse.Namespace) -> int:
 
 def cmd_rollback_history(args: argparse.Namespace) -> int:
     """Show rollback history."""
-    runner = get_migration_runner(
-        db_path=args.db_path,
-        database_url=args.database_url,
-    )
-
     try:
+        runner = get_migration_runner(
+            db_path=args.db_path,
+            database_url=args.database_url,
+        )
         history = runner.get_rollback_history()
         if not history:
             print("No rollback history found.")
@@ -135,7 +133,7 @@ def cmd_rollback_history(args: argparse.Namespace) -> int:
             print(f"    by: {record.rolled_back_by}{reason_text}")
             print()
         return 0
-    except (RuntimeError, OSError, ValueError) as e:
+    except DATABASE_ERRORS + (RuntimeError, OSError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:

--- a/aragora/migrations/__main__.py
+++ b/aragora/migrations/__main__.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from pathlib import Path
 
 from aragora.migrations.runner import (
+    DATABASE_ERRORS,
     get_migration_runner,
     reset_runner,
 )
@@ -25,12 +26,11 @@ from aragora.migrations.runner import (
 
 def cmd_upgrade(args: argparse.Namespace) -> int:
     """Apply pending migrations."""
-    runner = get_migration_runner(
-        db_path=args.db_path,
-        database_url=args.database_url,
-    )
-
     try:
+        runner = get_migration_runner(
+            db_path=args.db_path,
+            database_url=args.database_url,
+        )
         applied = runner.upgrade(target_version=args.target)
         if applied:
             print(f"Applied {len(applied)} migration(s):")
@@ -39,7 +39,7 @@ def cmd_upgrade(args: argparse.Namespace) -> int:
         else:
             print("No pending migrations.")
         return 0
-    except (RuntimeError, OSError, ValueError) as e:
+    except (*DATABASE_ERRORS, RuntimeError, OSError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:
@@ -144,12 +144,11 @@ def cmd_rollback_history(args: argparse.Namespace) -> int:
 
 def cmd_status(args: argparse.Namespace) -> int:
     """Show migration status."""
-    runner = get_migration_runner(
-        db_path=args.db_path,
-        database_url=args.database_url,
-    )
-
     try:
+        runner = get_migration_runner(
+            db_path=args.db_path,
+            database_url=args.database_url,
+        )
         status = runner.status()
         print("Migration Status:")
         print(f"  Backend: {runner._backend.backend_type}")
@@ -164,7 +163,7 @@ def cmd_status(args: argparse.Namespace) -> int:
                 print(f"  - {v}")
 
         return 0
-    except (RuntimeError, OSError, ValueError, KeyError) as e:
+    except (*DATABASE_ERRORS, RuntimeError, OSError, ValueError, KeyError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:

--- a/aragora/migrations/__main__.py
+++ b/aragora/migrations/__main__.py
@@ -39,7 +39,7 @@ def cmd_upgrade(args: argparse.Namespace) -> int:
         else:
             print("No pending migrations.")
         return 0
-    except (*DATABASE_ERRORS, RuntimeError, OSError, ValueError) as e:
+    except DATABASE_ERRORS + (RuntimeError, OSError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:
@@ -163,7 +163,7 @@ def cmd_status(args: argparse.Namespace) -> int:
                 print(f"  - {v}")
 
         return 0
-    except (*DATABASE_ERRORS, RuntimeError, OSError, ValueError, KeyError) as e:
+    except DATABASE_ERRORS + (RuntimeError, OSError, ValueError, KeyError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:

--- a/aragora/migrations/patterns.py
+++ b/aragora/migrations/patterns.py
@@ -461,7 +461,8 @@ def _execute_concurrent_index(backend: DatabaseBackend, statement: str) -> None:
             with connection.cursor() as cursor:
                 cursor.execute(statement)
         finally:
-            connection.autocommit = autocommit
+            if not connection.closed:
+                connection.autocommit = autocommit
 
 
 def safe_create_index(

--- a/aragora/migrations/patterns.py
+++ b/aragora/migrations/patterns.py
@@ -452,6 +452,18 @@ def safe_set_not_null(
     logger.info("Set %s.%s to NOT NULL", table, column)
 
 
+def _execute_concurrent_index(backend: DatabaseBackend, statement: str) -> None:
+    """Run PostgreSQL concurrent DDL outside a transaction, then restore pool state."""
+    with backend.connection() as connection:
+        autocommit = connection.autocommit
+        try:
+            connection.autocommit = True
+            with connection.cursor() as cursor:
+                cursor.execute(statement)
+        finally:
+            connection.autocommit = autocommit
+
+
 def safe_create_index(
     backend: DatabaseBackend,
     index_name: str,
@@ -481,8 +493,9 @@ def safe_create_index(
     if is_postgresql(backend) and concurrently:
         # PostgreSQL: CREATE INDEX CONCURRENTLY doesn't block writes
         # Note: Cannot be run inside a transaction
-        backend.execute_write(
-            f"CREATE {unique_str}INDEX CONCURRENTLY IF NOT EXISTS {qi} ON {qt} ({columns_str})"
+        _execute_concurrent_index(
+            backend,
+            f"CREATE {unique_str}INDEX CONCURRENTLY IF NOT EXISTS {qi} ON {qt} ({columns_str})",
         )
     else:
         backend.execute_write(
@@ -507,7 +520,7 @@ def safe_drop_index(
     qi = quote_identifier(index_name, "index_name")
 
     if is_postgresql(backend) and concurrently:
-        backend.execute_write(f"DROP INDEX CONCURRENTLY IF EXISTS {qi}")
+        _execute_concurrent_index(backend, f"DROP INDEX CONCURRENTLY IF EXISTS {qi}")
     else:
         backend.execute_write(f"DROP INDEX IF EXISTS {qi}")
 

--- a/aragora/migrations/runner.py
+++ b/aragora/migrations/runner.py
@@ -534,7 +534,7 @@ class MigrationRunner:
                     applied.append(migration)
                     logger.info("Applied migration %s", migration.version)
 
-                except (RuntimeError, OSError, ValueError) as e:
+                except DATABASE_ERRORS + (RuntimeError, OSError, ValueError) as e:
                     logger.error("Failed to apply migration %s: %s", migration.version, e)
                     raise
         finally:
@@ -655,7 +655,7 @@ class MigrationRunner:
                     rolled_back.append(migration)
                     logger.info("Rolled back migration %s", migration.version)
 
-                except (RuntimeError, OSError, ValueError) as e:
+                except DATABASE_ERRORS + (RuntimeError, OSError, ValueError) as e:
                     logger.error("Failed to rollback migration %s: %s", migration.version, e)
                     raise
         finally:

--- a/aragora/migrations/runner.py
+++ b/aragora/migrations/runner.py
@@ -282,7 +282,7 @@ class MigrationRunner:
         """
         try:
             self._backend.execute_write(sql)
-        except (*DATABASE_ERRORS, OSError, RuntimeError, ValueError) as e:
+        except DATABASE_ERRORS + (OSError, RuntimeError, ValueError) as e:
             # Non-fatal: rollback history is optional audit functionality
             logger.debug("Could not create rollback history table: %s", e)
 

--- a/aragora/migrations/runner.py
+++ b/aragora/migrations/runner.py
@@ -41,6 +41,14 @@ from aragora.storage.backends import (
 
 logger = logging.getLogger(__name__)
 
+DATABASE_ERRORS: tuple[type[Exception], ...] = (sqlite3.Error,)
+try:
+    from psycopg2 import Error as PostgreSQLError
+except ImportError:
+    pass
+else:
+    DATABASE_ERRORS += (PostgreSQLError,)
+
 # Advisory lock ID for migration coordination (hash of 'aragora_migration')
 MIGRATION_LOCK_ID = 2089872453
 
@@ -257,9 +265,14 @@ class MigrationRunner:
     def _init_rollback_history_table(self) -> None:
         """Create the rollback history table if it doesn't exist."""
         version_type = "BIGINT" if isinstance(self._backend, PostgreSQLBackend) else "INTEGER"
+        id_type = (
+            "SERIAL PRIMARY KEY"
+            if isinstance(self._backend, PostgreSQLBackend)
+            else "INTEGER PRIMARY KEY AUTOINCREMENT"
+        )
         sql = f"""
             CREATE TABLE IF NOT EXISTS {self.ROLLBACK_HISTORY_TABLE} (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                id {id_type},
                 version {version_type} NOT NULL,
                 name TEXT NOT NULL,
                 rolled_back_at TIMESTAMP NOT NULL,
@@ -269,7 +282,7 @@ class MigrationRunner:
         """
         try:
             self._backend.execute_write(sql)
-        except (sqlite3.Error, OSError, RuntimeError, ValueError) as e:
+        except (*DATABASE_ERRORS, OSError, RuntimeError, ValueError) as e:
             # Non-fatal: rollback history is optional audit functionality
             logger.debug("Could not create rollback history table: %s", e)
 

--- a/aragora/migrations/runner.py
+++ b/aragora/migrations/runner.py
@@ -311,7 +311,7 @@ class MigrationRunner:
                     reason,
                 ),
             )
-        except (sqlite3.Error, OSError, RuntimeError, ValueError) as e:
+        except DATABASE_ERRORS + (OSError, RuntimeError, ValueError) as e:
             # Non-fatal: don't let history tracking failures block rollback
             logger.warning("Failed to record rollback history for v%s: %s", migration.version, e)
 

--- a/tests/migrations/test_patterns.py
+++ b/tests/migrations/test_patterns.py
@@ -787,8 +787,11 @@ class TestPostgreSQLSpecificBehavior:
 
         safe_create_index(mock_backend, "idx_test", "users", ["email"], concurrently=True)
 
-        call_args = mock_backend.execute_write.call_args[0][0]
+        connection = mock_backend.connection.return_value.__enter__.return_value
+        cursor = connection.cursor.return_value.__enter__.return_value
+        call_args = cursor.execute.call_args[0][0]
         assert "CONCURRENTLY" in call_args
+        mock_backend.execute_write.assert_not_called()
 
     def test_drop_index_concurrently_pg(self):
         from aragora.migrations.patterns import safe_drop_index
@@ -798,8 +801,11 @@ class TestPostgreSQLSpecificBehavior:
 
         safe_drop_index(mock_backend, "idx_test", concurrently=True)
 
-        call_args = mock_backend.execute_write.call_args[0][0]
+        connection = mock_backend.connection.return_value.__enter__.return_value
+        cursor = connection.cursor.return_value.__enter__.return_value
+        call_args = cursor.execute.call_args[0][0]
         assert "CONCURRENTLY" in call_args
+        mock_backend.execute_write.assert_not_called()
 
     def test_drop_column_verifies_unused_pg(self):
         from aragora.migrations.patterns import safe_drop_column

--- a/tests/migrations/test_runner_dialects.py
+++ b/tests/migrations/test_runner_dialects.py
@@ -123,6 +123,15 @@ def test_database_failure_logs_migration_version(operation, caplog):
     assert f"Failed to {action} migration 123: migration failure" in caplog.text
 
 
+def test_postgres_rollback_history_insert_failure_is_nonfatal(caplog):
+    psycopg2 = pytest.importorskip("psycopg2")
+    backend = MagicMock(spec=PostgreSQLBackend)
+    runner = MigrationRunner(backend=backend)
+    backend.execute_write.side_effect = psycopg2.Error("audit table unavailable")
+    runner._record_rollback(Migration(version=123, name="rolled_back", up_sql="SELECT 1"))
+    assert "Failed to record rollback history for v123: audit table unavailable" in caplog.text
+
+
 def test_concurrent_index_does_not_restore_closed_connection():
     psycopg2 = pytest.importorskip("psycopg2")
     from aragora.migrations.patterns import safe_drop_index

--- a/tests/migrations/test_runner_dialects.py
+++ b/tests/migrations/test_runner_dialects.py
@@ -1,0 +1,130 @@
+"""Regression tests for dialect-specific bookkeeping and CLI database errors."""
+
+import argparse
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.migrations import __main__ as cli
+from aragora.migrations.runner import MigrationRunner
+from aragora.storage.backends import PostgreSQLBackend, SQLiteBackend
+
+
+def test_postgres_rollback_history_uses_serial():
+    backend = MagicMock(spec=PostgreSQLBackend)
+    MigrationRunner(backend=backend)
+    ddl = backend.execute_write.call_args_list[-1].args[0]
+    assert "id SERIAL PRIMARY KEY" in ddl
+    assert "AUTOINCREMENT" not in ddl
+    assert "version BIGINT NOT NULL" in ddl
+
+
+def test_sqlite_rollback_history_keeps_autoincrement():
+    backend = MagicMock(spec=SQLiteBackend)
+    MigrationRunner(backend=backend)
+    ddl = backend.execute_write.call_args_list[-1].args[0]
+    assert "id INTEGER PRIMARY KEY AUTOINCREMENT" in ddl
+    assert "version INTEGER NOT NULL" in ddl
+
+
+def test_postgres_rollback_history_error_is_logged(caplog):
+    psycopg2 = pytest.importorskip("psycopg2")
+    backend = MagicMock(spec=PostgreSQLBackend)
+    backend.execute_write.side_effect = [None, psycopg2.Error("cannot create audit table")]
+    with caplog.at_level(logging.DEBUG, logger="aragora.migrations.runner"):
+        MigrationRunner(backend=backend)
+    assert "Could not create rollback history table: cannot create audit table" in caplog.text
+
+
+def test_sqlite_rollback_history_error_is_still_logged(caplog):
+    backend = MagicMock(spec=SQLiteBackend)
+    backend.execute_write.side_effect = [None, sqlite3.OperationalError("read only")]
+    with caplog.at_level(logging.DEBUG, logger="aragora.migrations.runner"):
+        MigrationRunner(backend=backend)
+    assert "Could not create rollback history table: read only" in caplog.text
+
+
+@pytest.mark.parametrize("command", ["upgrade", "status"])
+@pytest.mark.parametrize("phase", ["connect", "execute"])
+def test_cli_reports_postgres_errors_and_resets_runner(command, phase, capsys):
+    psycopg2 = pytest.importorskip("psycopg2")
+    error = psycopg2.OperationalError("password authentication failed")
+    args = argparse.Namespace(db_path="unused.db", database_url=None, target=None)
+    with (
+        patch.object(cli, "get_migration_runner") as get_runner,
+        patch.object(cli, "reset_runner") as reset,
+    ):
+        if phase == "connect":
+            get_runner.side_effect = error
+        else:
+            getattr(get_runner.return_value, command).side_effect = error
+        assert getattr(cli, f"cmd_{command}")(args) == 1
+        reset.assert_called_once_with()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "Error: password authentication failed\n"
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize("operation", ["create", "drop"])
+@pytest.mark.parametrize("fails", [False, True])
+def test_concurrent_indexes_restore_connection_autocommit(operation, fails):
+    psycopg2 = pytest.importorskip("psycopg2")
+    from aragora.migrations.patterns import safe_create_index, safe_drop_index
+
+    backend = MagicMock(spec=PostgreSQLBackend)
+    backend.backend_type = "postgresql"
+    connection = backend.connection.return_value.__enter__.return_value
+    connection.autocommit = False
+    cursor = connection.cursor.return_value.__enter__.return_value
+
+    def execute(statement):
+        assert connection.autocommit is True
+        assert "INDEX CONCURRENTLY" in statement
+        if fails:
+            raise psycopg2.Error("index failure")
+
+    cursor.execute.side_effect = execute
+
+    def run():
+        if operation == "create":
+            safe_create_index(backend, "test_idx", "test_table", ["id"])
+        else:
+            safe_drop_index(backend, "test_idx")
+
+    if fails:
+        with pytest.raises(psycopg2.Error, match="index failure"):
+            run()
+    else:
+        run()
+    cursor.execute.assert_called_once()
+    backend.execute_write.assert_not_called()
+    assert connection.autocommit is False
+
+
+def test_sqlite_cli_works_without_psycopg2(tmp_path):
+    env = os.environ.copy()
+    for key in ("DATABASE_URL", "ARAGORA_DATABASE_URL"):
+        env.pop(key, None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import runpy, sys; sys.modules['psycopg2'] = None; "
+            "runpy.run_module('aragora.migrations', run_name='__main__')",
+            "status",
+            "--db-path",
+            str(tmp_path / "sqlite-only.db"),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "  Backend: sqlite\n" in result.stdout

--- a/tests/migrations/test_runner_dialects.py
+++ b/tests/migrations/test_runner_dialects.py
@@ -6,12 +6,12 @@ import os
 import sqlite3
 import subprocess
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
 from aragora.migrations import __main__ as cli
-from aragora.migrations.runner import MigrationRunner
+from aragora.migrations.runner import Migration, MigrationRunner
 from aragora.storage.backends import PostgreSQLBackend, SQLiteBackend
 
 
@@ -49,7 +49,7 @@ def test_sqlite_rollback_history_error_is_still_logged(caplog):
     assert "Could not create rollback history table: read only" in caplog.text
 
 
-@pytest.mark.parametrize("command", ["upgrade", "status"])
+@pytest.mark.parametrize("command", ["upgrade", "status", "downgrade", "rollback_history"])
 @pytest.mark.parametrize("phase", ["connect", "execute"])
 def test_cli_reports_postgres_errors_and_resets_runner(command, phase, capsys):
     psycopg2 = pytest.importorskip("psycopg2")
@@ -62,7 +62,8 @@ def test_cli_reports_postgres_errors_and_resets_runner(command, phase, capsys):
         if phase == "connect":
             get_runner.side_effect = error
         else:
-            getattr(get_runner.return_value, command).side_effect = error
+            method = "get_rollback_history" if command == "rollback_history" else command
+            getattr(get_runner.return_value, method).side_effect = error
         assert getattr(cli, f"cmd_{command}")(args) == 1
         reset.assert_called_once_with()
     captured = capsys.readouterr()
@@ -81,6 +82,7 @@ def test_concurrent_indexes_restore_connection_autocommit(operation, fails):
     backend.backend_type = "postgresql"
     connection = backend.connection.return_value.__enter__.return_value
     connection.autocommit = False
+    connection.closed = False
     cursor = connection.cursor.return_value.__enter__.return_value
 
     def execute(statement):
@@ -105,6 +107,42 @@ def test_concurrent_indexes_restore_connection_autocommit(operation, fails):
     cursor.execute.assert_called_once()
     backend.execute_write.assert_not_called()
     assert connection.autocommit is False
+
+
+@pytest.mark.parametrize("operation", ["upgrade", "downgrade"])
+def test_database_failure_logs_migration_version(operation, caplog):
+    psycopg2 = pytest.importorskip("psycopg2")
+    runner = MigrationRunner(backend=MagicMock(spec=SQLiteBackend))
+    fail = MagicMock(side_effect=psycopg2.Error("migration failure"))
+    runner.register(Migration(version=123, name="failing", up_fn=fail, down_fn=fail))
+    applied = [123] if operation == "downgrade" else []
+    with patch.object(runner, "get_applied_versions", return_value=applied):
+        with pytest.raises(psycopg2.Error, match="migration failure"):
+            getattr(runner, operation)()
+    action = "apply" if operation == "upgrade" else "rollback"
+    assert f"Failed to {action} migration 123: migration failure" in caplog.text
+
+
+def test_concurrent_index_does_not_restore_closed_connection():
+    psycopg2 = pytest.importorskip("psycopg2")
+    from aragora.migrations.patterns import safe_drop_index
+
+    backend = MagicMock(spec=PostgreSQLBackend)
+    connection = backend.connection.return_value.__enter__.return_value
+    autocommit = PropertyMock(
+        side_effect=[False, None, psycopg2.InterfaceError("connection already closed")]
+    )
+    type(connection).autocommit = autocommit
+    connection.closed = False
+
+    def disconnect(statement):
+        connection.closed = True
+        raise psycopg2.OperationalError("server closed during index operation")
+
+    connection.cursor.return_value.__enter__.return_value.execute.side_effect = disconnect
+    with pytest.raises(psycopg2.OperationalError, match="server closed during index operation"):
+        safe_drop_index(backend, "test_idx")
+    assert autocommit.call_count == 2
 
 
 def test_sqlite_cli_works_without_psycopg2(tmp_path):

--- a/tests/migrations/test_runner_postgres_live.py
+++ b/tests/migrations/test_runner_postgres_live.py
@@ -10,14 +10,16 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("ARAGORA_TEST_DATABASE_URL"),
+    reason="set ARAGORA_TEST_DATABASE_URL to run live PostgreSQL tests",
+)
+
 
 @pytest.fixture
 def postgres_dsn():
-    dsn = os.environ.get("ARAGORA_TEST_DATABASE_URL")
-    if not dsn:
-        pytest.skip("set ARAGORA_TEST_DATABASE_URL to run live PostgreSQL tests")
     pytest.importorskip("psycopg2")
-    return dsn
+    return os.environ["ARAGORA_TEST_DATABASE_URL"]
 
 
 @pytest.fixture

--- a/tests/migrations/test_runner_postgres_live.py
+++ b/tests/migrations/test_runner_postgres_live.py
@@ -1,4 +1,4 @@
-"""Opt-in PostgreSQL CLI tests; the test role must have CREATEDB permission."""
+"""Opt-in PostgreSQL 13+ CLI tests; the test role must have CREATEDB permission."""
 
 import importlib
 import os
@@ -36,7 +36,9 @@ def isolated_database(postgres_dsn):
             try:
                 yield make_dsn(postgres_dsn, dbname=database)
             finally:
-                cursor.execute(sql.SQL("DROP DATABASE {}").format(sql.Identifier(database)))
+                cursor.execute(
+                    sql.SQL("DROP DATABASE {} WITH (FORCE)").format(sql.Identifier(database))
+                )
 
 
 def run_cli(command, dsn):
@@ -105,8 +107,22 @@ def test_wrong_password_reports_authentication_without_traceback(postgres_dsn):
     from psycopg2.extensions import make_dsn
 
     wrong_dsn = make_dsn(postgres_dsn, password="wrong-" + uuid.uuid4().hex)
-    for command in ("upgrade", "status"):
+    for command in ("upgrade", "status", "downgrade", "rollback-history"):
         result = run_cli(command, wrong_dsn)
         assert result.returncode != 0
         assert "authentication" in result.stderr.lower()
         assert "Traceback" not in result.stdout + result.stderr
+
+
+def test_database_cleanup_terminates_lingering_connection(postgres_dsn):
+    import psycopg2
+
+    database = isolated_database.__wrapped__(postgres_dsn)
+    with closing(psycopg2.connect(next(database))) as lingering:
+        name = lingering.info.dbname
+        with pytest.raises(StopIteration):
+            next(database)
+    with closing(psycopg2.connect(postgres_dsn)) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT 1 FROM pg_database WHERE datname = %s", (name,))
+            assert cursor.fetchone() is None

--- a/tests/migrations/test_runner_postgres_live.py
+++ b/tests/migrations/test_runner_postgres_live.py
@@ -126,3 +126,24 @@ def test_database_cleanup_terminates_lingering_connection(postgres_dsn):
         with conn.cursor() as cursor:
             cursor.execute("SELECT 1 FROM pg_database WHERE datname = %s", (name,))
             assert cursor.fetchone() is None
+
+
+def test_rollback_succeeds_without_optional_history_table(isolated_database, caplog):
+    from aragora.migrations.runner import Migration, MigrationRunner
+    from aragora.storage.backends import PostgreSQLBackend
+
+    with closing(PostgreSQLBackend(isolated_database, pool_size=1, pool_max_overflow=0)) as backend:
+        runner = MigrationRunner(backend=backend)
+        migration = Migration(
+            version=123,
+            name="rollback_test",
+            up_sql="CREATE TABLE rollback_test (id INTEGER)",
+            down_sql="DROP TABLE rollback_test",
+        )
+        runner.register(migration)
+        assert runner.upgrade() == [migration]
+        backend.execute_write("DROP TABLE _aragora_rollback_history")
+        assert runner.downgrade() == [migration]
+        assert runner.get_applied_versions() == set()
+        assert backend.fetch_one("SELECT to_regclass('rollback_test')")[0] is None
+        assert "Failed to record rollback history for v123:" in caplog.text

--- a/tests/migrations/test_runner_postgres_live.py
+++ b/tests/migrations/test_runner_postgres_live.py
@@ -1,0 +1,110 @@
+"""Opt-in PostgreSQL CLI tests; the test role must have CREATEDB permission."""
+
+import importlib
+import os
+import subprocess
+import sys
+import uuid
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def postgres_dsn():
+    dsn = os.environ.get("ARAGORA_TEST_DATABASE_URL")
+    if not dsn:
+        pytest.skip("set ARAGORA_TEST_DATABASE_URL to run live PostgreSQL tests")
+    pytest.importorskip("psycopg2")
+    return dsn
+
+
+@pytest.fixture
+def isolated_database(postgres_dsn):
+    import psycopg2
+    from psycopg2 import sql
+    from psycopg2.extensions import make_dsn
+
+    database = "migration_test_" + uuid.uuid4().hex
+    with closing(psycopg2.connect(postgres_dsn)) as conn:
+        conn.autocommit = True
+        with conn.cursor() as cursor:
+            cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database)))
+            try:
+                yield make_dsn(postgres_dsn, dbname=database)
+            finally:
+                cursor.execute(sql.SQL("DROP DATABASE {}").format(sql.Identifier(database)))
+
+
+def run_cli(command, dsn):
+    return subprocess.run(
+        [sys.executable, "-m", "aragora.migrations", command, "--database-url", dsn],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_upgrade_and_status_against_real_postgres(isolated_database):
+    import psycopg2
+    from aragora.migrations import versions
+
+    dsn = isolated_database
+    upgraded = run_cli("upgrade", dsn)
+    assert upgraded.returncode == 0, upgraded.stderr
+    assert "AUTOINCREMENT" not in upgraded.stderr
+    expected = []
+    for path in Path(versions.__file__).parent.glob("v*.py"):
+        migration = importlib.import_module(f"aragora.migrations.versions.{path.stem}").migration
+        assert path.stem.startswith(f"v{migration.version}_")
+        expected.append((migration.version, migration.name))
+    assert expected
+    status = run_cli("status", dsn)
+    assert status.returncode == 0, status.stderr
+    assert "  Backend: postgresql\n" in status.stdout
+    assert "  Pending: 0\n" in status.stdout
+    assert f"  Applied: {len(expected)}\n" in status.stdout
+    with closing(psycopg2.connect(dsn)) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT version, name FROM _aragora_migrations ORDER BY version")
+            assert cursor.fetchall() == sorted(expected)
+            cursor.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
+            )
+            assert {"_aragora_migrations", "_aragora_rollback_history"} <= {
+                row[0] for row in cursor.fetchall()
+            }
+    repeated = run_cli("upgrade", dsn)
+    assert repeated.returncode == 0, repeated.stderr
+    assert repeated.stdout == "No pending migrations.\n"
+
+
+def test_concurrent_index_failure_leaves_pool_usable(isolated_database):
+    import psycopg2
+    from aragora.migrations.patterns import safe_create_index, safe_drop_index
+    from aragora.storage.backends import PostgreSQLBackend
+
+    with closing(PostgreSQLBackend(isolated_database, pool_size=1, pool_max_overflow=0)) as backend:
+        backend.execute_write("CREATE TABLE index_test (id INTEGER)")
+        safe_create_index(backend, "test_idx", "index_test", ["id"])
+        assert backend.fetch_one("SELECT to_regclass('test_idx')")[0] == "test_idx"
+        safe_drop_index(backend, "test_idx")
+        assert backend.fetch_one("SELECT to_regclass('test_idx')")[0] is None
+        with pytest.raises(psycopg2.errors.UndefinedTable):
+            safe_create_index(backend, "missing_idx", "missing_table", ["id"])
+        with backend.connection() as connection:
+            assert connection.autocommit is False
+        backend.execute_write("INSERT INTO index_test VALUES (1)")
+        assert backend.fetch_one("SELECT COUNT(*) FROM index_test") == (1,)
+
+
+def test_wrong_password_reports_authentication_without_traceback(postgres_dsn):
+    from psycopg2.extensions import make_dsn
+
+    wrong_dsn = make_dsn(postgres_dsn, password="wrong-" + uuid.uuid4().hex)
+    for command in ("upgrade", "status"):
+        result = run_cli(command, wrong_dsn)
+        assert result.returncode != 0
+        assert "authentication" in result.stderr.lower()
+        assert "Traceback" not in result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- PostgreSQL prerequisite tracked under #9391 and #9955: use `SERIAL PRIMARY KEY` for PostgreSQL rollback history and preserve SQLite's `INTEGER PRIMARY KEY AUTOINCREMENT`.
- Catch optional psycopg2 errors during runner initialization and execution in all four database CLI commands, returning an error without a traceback.
- The live reproduction exposed a second blocker: concurrent index helpers used transactional `execute_write`. Run those statements on a checked-out autocommit connection and restore its mode, including on failure.
- Add dialect, driver-absent SQLite, authentication, and opt-in live PostgreSQL regressions. Only `aragora/migrations/` and `tests/migrations/` change.

## Exit metric moved
Row 7, hosted API prerequisite: a fresh PostgreSQL 16 database now upgrades all 11 migrations. This is local database readiness, not a claim that the hosted API is restored.

## Test commands
Run from the feature worktree using the mission's Python 3.11 environment and `$RF_ISOLATE` prefix:
- Before: `python3 -m aragora.migrations upgrade --database-url "$RF_DSN"` failed with `psycopg2.errors.SyntaxError` at `AUTOINCREMENT`. New regressions: 8 failed, 2 passed. Subsequent live run exposed `CREATE INDEX CONCURRENTLY cannot run inside a transaction block`; four index regressions also failed before their fix.
- `ARAGORA_TEST_DATABASE_URL="$RF_DSN" python3 -m pytest tests/migrations -q -p no:cacheprovider -n 4`: 530 passed after the review repairs, including all five live tests.
- `python3 -m pytest tests/migrations/test_runner_postgres_live.py -q -p no:cacheprovider` without the opt-in DSN: 5 skipped, no failures.
- Dialect regressions now cover 21 cases. Collection 1's seven new error-path cases failed before their fixes; collection 2's audit-insert regression also failed before its fix. All passed with the full suite.
- Fresh-container `upgrade --database-url "$RF_DSN"` then `status --database-url "$RF_DSN"`: exit 0, `Backend: postgresql`, `Applied: 11`, `Pending: 0`. psycopg2 confirmed both bookkeeping tables and all 11 `(version, name)` rows matching the committed migration objects. Second upgrade stdout: exactly `No pending migrations.`.
- Wrong-password `upgrade`, `status`, `downgrade`, and `rollback-history`: nonzero exit, `password authentication failed`, no `Traceback`.
- SQLite `upgrade --db-path /tmp/rf-mig.db` and `status --db-path /tmp/rf-mig.db`: exit 0, `Backend: sqlite`, 11 applied. Help retains both `--db-path` occurrences and `default: aragora.db`.
- `python3 -m aragora.cli.main quickstart --demo --no-browser --output /tmp/rf-migrations-quickstart.json`: exit 0, demo receipt produced.
- Mission gates `lint`, `typecheck`, `contracts`, `test`, `guardrails`: all `GATE PASSED` on repaired head `80dcb6161dd75e6ede8fd395a18560d576b7f017`. Curated tests: 3976 passed, 8 skipped; publish-shadow: 104 passed, 2 skipped. Whole-tree mypy remains at its pre-existing 1744 errors; diff-scoped mypy is clean.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed. Mission Postgres removed with `docker compose down -v`.

## Reviewed design tradeoffs
- Keep psycopg2 optional rather than adding a runtime dependency. SQLite import/execution works when the driver is absent.
- Reuse the runner's existing backend classification. Preserve version `BIGINT`, CLI flags, human-readable migration names, historical migration files, and checksums.
- Preserve nonblocking `CONCURRENTLY` semantics rather than disabling concurrent index creation or changing historical migrations. Only the concurrent index helpers use a temporary autocommit mode; regular writes keep the backend's commit/rollback behavior. Live tests prove the single-connection pool remains usable after an index error.
- Live tests create/drop uniquely named test databases so pre-existing tables in other schemas cannot affect migration introspection. They require PostgreSQL 13+, an explicitly configured test DSN and a role with `CREATEDB`; the supplied database is not migrated or dropped. Forced cleanup is limited to each newly generated database.

### Collection 1 dispositions
- Claude P2: repaired `downgrade` and `rollback-history` construction/catches, with both mock phases and real wrong-password commands covered.
- Claude P3 migration context: repaired per-migration upgrade/downgrade logging to include database exceptions; tests require the failing version in each log.
- Claude P3 closed connection: the new concurrent-index helper no longer restores autocommit on a closed connection, preventing its own cleanup from replacing the original error. This does not change the storage backend's pre-existing commit/rollback-on-exit implementation, which is outside the migrations-only scope.
- Claude P3 lingering clients: disposable database cleanup now uses `WITH (FORCE)`; a real test leaves a client connected and confirms the database is removed.
- OpenAI: PASS, no findings. Collection 2 binds the repaired head, not the superseded review.

### Collection 2 dispositions
- OpenAI P2: repaired `_record_rollback()` to catch PostgreSQL errors just like SQLite errors. A unit regression failed with `psycopg2.Error: audit table unavailable` before the fix. The live regression drops only the disposable database's history table and proves rollback succeeds, removes its migration row and table, and logs the nonfatal audit failure.
- Claude: PASS. Its P3 backend closed-connection cleanup and session-scoped advisory-lock observations are pre-existing outside the changed behavior; neither is claimed fixed. A backend/locking follow-up needs its own scope and tests.
- Claude could not run live tests without a DSN. Worker verification used PostgreSQL 16 on 15432 with a CREATEDB-capable role: 530 passed, including all five live tests; the container was removed afterwards.

### Collection 3 result
Both Claude and OpenAI returned grounded, counted PASS on `80dcb6161dd75e6ede8fd395a18560d576b7f017`; no P0/P1/P2 findings, no dissenting families or transport failures. Claude's remaining P3 notes concern pre-existing lock-release error masking/session affinity, constructor-failure pool cleanup, and the documented PostgreSQL 13+/opt-in live-test requirements. These are not claimed fixed here; the CLI exits and releases process resources, and worker-run live coverage is recorded above.

## Risks
- Persistence change, Tier 3: operator settlement required. No worker merge.
- Concurrent DDL is not transactionally rolled back, as PostgreSQL requires; an interrupted build can still need operator index cleanup.
- Rollback-history creation and recording retain SQLite's existing nonfatal logging behavior on PostgreSQL too. An unavailable audit table therefore produces a warning rather than undoing a completed rollback.
- The CI migration step in `test.yml` belongs to the separate deploy-pack PR, not this change. Existing metrics-doc drift and the externally introduced 1120-page docs count remain outside this scope.

## Operator settlement
Prepare-only. The exact-head packet follows independent review and settled required checks. The enforcing `aragora-merge-quorum` check is expected to fail until human settlement.

Computed tier: 3, `requires_human_risk_settlement=true`; final head `80dcb6161dd75e6ede8fd395a18560d576b7f017`. PR delta: 390 additions, 34 deletions; no workflow changes.

Post-merge operator note: after merge, re-run test.yml migration-test.
