### PR TITLE
[DIC-17] Add --emit-followup flag to aragora coherence-scan CLI

### DIFF
--- a/aragora/cli/commands/dic26_coherence.py
+++ b/aragora/cli/commands/dic26_coherence.py
@@ -1,14 +1,21 @@
 """CLI command: ``aragora coherence-scan``.
 
 DIC-26 operator surface for the belief coherence monitor (issue #6220).
+DIC-17 bridge: ``--emit-followup`` flag forwards error-severity coherence
+issues to the follow-up proposal bridge (issue #6027).
 
 Reads a JSON file where each element is a BeliefEntry dict:
     {"belief_id": "...", "subject": "...", "confidence": 0.8,
      "status": "pass", "evidence_paths": ["docs/status/foo.md"]}
 
-Flag: ``ARAGORA_COHERENCE_MONITOR_ENABLED`` (default OFF).
-Live queue effect: none — read-only operator report.
-Advances: issue #6220 (DIC-26).
+Flags:
+  ``ARAGORA_COHERENCE_MONITOR_ENABLED`` (default OFF) — gate for scanning.
+  ``ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED`` (default OFF) — gate for proposals;
+  also required when ``--emit-followup`` is passed.
+
+Live queue effect: none — read-only operator report; proposals are printed
+but never filed.
+Advances: issues #6220 (DIC-26) and #6027 (DIC-17).
 """
 
 from __future__ import annotations
@@ -22,6 +29,7 @@ from typing import Any
 
 from aragora.epistemic.coherence import (
     BeliefEntry,
+    CoherenceReport,
     coherence_monitor_enabled,
     scan_coherence,
 )
@@ -59,6 +67,24 @@ def _load_entries(path: Path) -> list[BeliefEntry]:
     return entries
 
 
+def _render_proposals(report: CoherenceReport) -> None:
+    """Print DIC-17 follow-up proposals to stdout (text mode only)."""
+    if not report.proposals:
+        return
+    print()
+    print(f"  follow-up proposals ({len(report.proposals)}):")
+    for p in report.proposals:
+        prov = p.provenance
+        kind = prov.get("kind", "?")
+        ids_list = prov.get("belief_ids", [])
+        ids_str = ", ".join(str(i) for i in ids_list)
+        print(f"    [{kind}] {p.title[:100]}")
+        print(f"      beliefs: {ids_str}")
+        print(f"      labels : {', '.join(p.labels)}")
+    print()
+    print("  (proposals printed, not filed — no live queue effect)")
+
+
 def cmd_coherence_scan(args: argparse.Namespace) -> int:
     """Handle the ``aragora coherence-scan`` subcommand."""
     if not coherence_monitor_enabled():
@@ -79,11 +105,13 @@ def cmd_coherence_scan(args: argparse.Namespace) -> int:
         print(f"error: failed to load {input_path}: {exc}", file=sys.stderr)
         return 1
 
+    emit_followup: bool = getattr(args, "emit_followup", False)
     report = scan_coherence(
         entries,
         contradiction_gap=float(getattr(args, "contradiction_gap", _DEFAULT_GAP)),
         min_confidence=float(getattr(args, "min_confidence", _DEFAULT_MIN_CONFIDENCE)),
         enabled=True,
+        emit_followup_proposals=emit_followup,
     )
 
     as_json: bool = getattr(args, "json", False)
@@ -103,4 +131,6 @@ def cmd_coherence_scan(args: argparse.Namespace) -> int:
             ids = ", ".join(issue.belief_ids)
             print(f"  [{issue.severity}] {issue.kind.value}: {ids}")
             print(f"    {issue.detail}")
+    if emit_followup:
+        _render_proposals(report)
     return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -728,6 +728,17 @@ def _add_coherence_scan_parser(subparsers) -> None:
         help="Minimum confidence threshold for rot detection (default: 0.3)",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    p.add_argument(
+        "--emit-followup",
+        dest="emit_followup",
+        action="store_true",
+        default=False,
+        help=(
+            "DIC-17: forward error-severity issues to the follow-up proposal bridge. "
+            "Requires ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED=1. "
+            "Proposals are printed but never filed (no live queue effect)."
+        ),
+    )
     p.set_defaults(func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan"))
 
 

--- a/tests/cli/test_dic26_coherence.py
+++ b/tests/cli/test_dic26_coherence.py
@@ -141,10 +141,20 @@ _CONTRADICTING = [
     {"belief_id": "bL", "subject": "auth.gateway", "confidence": 0.04, "status": "fail"},
 ]
 _WARNING_ONLY = [
-    {"belief_id": "w1", "subject": "cache.hit", "confidence": 0.40, "status": "pass",
-     "evidence_paths": ["docs/cache.md"]},
-    {"belief_id": "w2", "subject": "cache.miss", "confidence": 0.60, "status": "fail",
-     "evidence_paths": ["docs/cache.md"]},
+    {
+        "belief_id": "w1",
+        "subject": "cache.hit",
+        "confidence": 0.40,
+        "status": "pass",
+        "evidence_paths": ["docs/cache.md"],
+    },
+    {
+        "belief_id": "w2",
+        "subject": "cache.miss",
+        "confidence": 0.60,
+        "status": "fail",
+        "evidence_paths": ["docs/cache.md"],
+    },
 ]
 
 
@@ -166,9 +176,7 @@ class TestEmitFollowupFlag:
         """--emit-followup is set but ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED is off."""
         monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
         monkeypatch.delenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", raising=False)
-        rc = cmd_coherence_scan(
-            _args(str(_write(tmp_path, _CONTRADICTING)), emit_followup=True)
-        )
+        rc = cmd_coherence_scan(_args(str(_write(tmp_path, _CONTRADICTING)), emit_followup=True))
         assert rc == 0
         out = capsys.readouterr().out
         # The --emit-followup section is printed but proposals list is empty
@@ -181,9 +189,7 @@ class TestEmitFollowupFlag:
         """Both flags set: text output shows follow-up proposals section."""
         monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
         monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
-        rc = cmd_coherence_scan(
-            _args(str(_write(tmp_path, _CONTRADICTING)), emit_followup=True)
-        )
+        rc = cmd_coherence_scan(_args(str(_write(tmp_path, _CONTRADICTING)), emit_followup=True))
         assert rc == 0
         out = capsys.readouterr().out
         assert "follow-up proposals" in out
@@ -209,9 +215,7 @@ class TestEmitFollowupFlag:
         """Warning-severity evidence conflicts must never produce proposals."""
         monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
         monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
-        rc = cmd_coherence_scan(
-            _args(str(_write(tmp_path, _WARNING_ONLY)), emit_followup=True)
-        )
+        rc = cmd_coherence_scan(_args(str(_write(tmp_path, _WARNING_ONLY)), emit_followup=True))
         assert rc == 0
         out = capsys.readouterr().out
         assert "follow-up proposals" not in out

--- a/tests/cli/test_dic26_coherence.py
+++ b/tests/cli/test_dic26_coherence.py
@@ -1,8 +1,9 @@
 """DIC-26 coherence-scan CLI tests.
 
-Flag: ARAGORA_COHERENCE_MONITOR_ENABLED (default OFF)
+Flags: ARAGORA_COHERENCE_MONITOR_ENABLED (default OFF),
+       ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED (default OFF, required for proposals)
 Live queue effect: none
-Advances: issue #6220 (DIC-26)
+Advances: issues #6220 (DIC-26) and #6027 (DIC-17 --emit-followup flag)
 """
 
 from __future__ import annotations
@@ -13,7 +14,11 @@ from pathlib import Path
 
 import pytest
 
-from aragora.cli.commands.dic26_coherence import _load_entries, cmd_coherence_scan
+from aragora.cli.commands.dic26_coherence import (
+    _load_entries,
+    _render_proposals,
+    cmd_coherence_scan,
+)
 
 
 def _args(
@@ -22,12 +27,14 @@ def _args(
     json_output: bool = False,
     gap: float = 0.5,
     min_conf: float = 0.3,
+    emit_followup: bool = False,
 ) -> argparse.Namespace:
     ns = argparse.Namespace()
     ns.input = input_path
     ns.json = json_output
     ns.contradiction_gap = gap
     ns.min_confidence = min_conf
+    ns.emit_followup = emit_followup
     return ns
 
 
@@ -123,3 +130,113 @@ def test_load_entries_accepts_single_object(tmp_path: Path) -> None:
     p.write_text(json.dumps(raw), encoding="utf-8")
     entries = _load_entries(p)
     assert len(entries) == 1 and entries[0].belief_id == "singleton"
+
+
+# ---------------------------------------------------------------------------
+# DIC-17 --emit-followup flag tests
+# ---------------------------------------------------------------------------
+
+_CONTRADICTING = [
+    {"belief_id": "bH", "subject": "auth.gateway", "confidence": 0.95, "status": "pass"},
+    {"belief_id": "bL", "subject": "auth.gateway", "confidence": 0.04, "status": "fail"},
+]
+_WARNING_ONLY = [
+    {"belief_id": "w1", "subject": "cache.hit", "confidence": 0.40, "status": "pass",
+     "evidence_paths": ["docs/cache.md"]},
+    {"belief_id": "w2", "subject": "cache.miss", "confidence": 0.60, "status": "fail",
+     "evidence_paths": ["docs/cache.md"]},
+]
+
+
+class TestEmitFollowupFlag:
+    def test_emit_followup_absent_by_default_no_proposals(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Without --emit-followup, proposals must never appear in text output."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        rc = cmd_coherence_scan(_args(str(_write(tmp_path, _CONTRADICTING))))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "follow-up proposals" not in out
+
+    def test_emit_followup_requires_env_flag_for_proposals(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--emit-followup is set but ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED is off."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.delenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", raising=False)
+        rc = cmd_coherence_scan(
+            _args(str(_write(tmp_path, _CONTRADICTING)), emit_followup=True)
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # The --emit-followup section is printed but proposals list is empty
+        # (env gate not set), so the "follow-up proposals (N)" line must not appear
+        assert "follow-up proposals" not in out
+
+    def test_emit_followup_populates_proposals_in_text(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Both flags set: text output shows follow-up proposals section."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        rc = cmd_coherence_scan(
+            _args(str(_write(tmp_path, _CONTRADICTING)), emit_followup=True)
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "follow-up proposals" in out
+        assert "printed, not filed" in out
+
+    def test_emit_followup_proposals_in_json_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Both flags set in JSON mode: JSON output includes 'proposals' key."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        rc = cmd_coherence_scan(
+            _args(str(_write(tmp_path, _CONTRADICTING)), json_output=True, emit_followup=True)
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "proposals" in data
+        assert isinstance(data["proposals"], list) and len(data["proposals"]) >= 1
+
+    def test_emit_followup_no_proposals_for_warning_only_issues(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Warning-severity evidence conflicts must never produce proposals."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        rc = cmd_coherence_scan(
+            _args(str(_write(tmp_path, _WARNING_ONLY)), emit_followup=True)
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "follow-up proposals" not in out
+
+    def test_emit_followup_no_boss_ready_label_in_json(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Queue-governance invariant: boss-ready must never appear in proposals."""
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+        monkeypatch.setenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", "1")
+        rc = cmd_coherence_scan(
+            _args(str(_write(tmp_path, _CONTRADICTING)), json_output=True, emit_followup=True)
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        for proposal_prov in data.get("proposals", []):
+            labels = proposal_prov.get("labels", [])
+            assert "boss-ready" not in labels, f"boss-ready found in {labels}"
+
+    def test_render_proposals_noop_when_empty(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """_render_proposals prints nothing when report.proposals is empty."""
+        from aragora.epistemic.coherence import CoherenceReport
+
+        report = CoherenceReport(scanned=0)
+        _render_proposals(report)
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

Wires the DIC-17 follow-up proposal bridge into the `aragora coherence-scan` CLI (DIC-26). The library (`scan_coherence`) already supported `emit_followup_proposals=True`; this PR adds the CLI surface that was missing.

**Changes (3 files, ~164 LOC net):**
- `aragora/cli/parser.py` — adds `--emit-followup` argument to `_add_coherence_scan_parser()`
- `aragora/cli/commands/dic26_coherence.py` — adds `_render_proposals()` helper and wires `emit_followup_proposals` into `scan_coherence()` call; text and JSON paths both handled
- `tests/cli/test_dic26_coherence.py` — 7 new tests in `TestEmitFollowupFlag` covering all gate combinations and the queue-governance invariant

## Behaviour

| Condition | Result |
|---|---|
| `--emit-followup` absent | no proposals ever printed (no change to existing output) |
| `--emit-followup` set, `ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED` unset | scan runs; proposals section silent |
| Both flags set, text mode | prints `follow-up proposals (N):` block; ends with `(proposals printed, not filed — no live queue effect)` |
| Both flags set, `--json` mode | JSON output includes `"proposals": [...]` key |
| Warning-severity issues only | no proposals regardless of flags |
| Any path | `boss-ready` label never appears in proposals |

## Feature flags

- `ARAGORA_COHERENCE_MONITOR_ENABLED` (existing) — scan gate, default OFF
- `ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED` (existing) — proposal gate, default OFF
- `--emit-followup` CLI flag — new, default OFF

**Live queue effect: none.** Proposals are printed only, never filed.

## Tests

```
16 passed, 7 warnings in 0.91s
```
(9 pre-existing + 7 new)

Advances: closes #6027 (DIC-17 CLI surface), advances #6220 (DIC-26).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaxbJ5p7karMU9saGSQQU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaxbJ5p7karMU9saGSQQU9)_