### PR TITLE
test: recover cache and reputation regression signals

### DIFF
--- a/tests/debate/cache/test_embeddings_lru.py
+++ b/tests/debate/cache/test_embeddings_lru.py
@@ -534,18 +534,21 @@ class TestThreadSafety:
         assert len(results) == 20
 
     def test_concurrent_gets(self, embedding_cache):
-        """Test concurrent get operations are thread-safe."""
-        # Prepopulate cache
-        for i in range(5):
-            embedding_cache.put(f"text_{i}", np.array([float(i)], dtype=np.float32))
+        """Concurrent readers receive the exact vector for their requested key."""
+        expected = [np.array([i, i + 0.5, -i], dtype=np.float32) for i in range(5)]
+        # All keys fit: a missing result cannot be explained by eviction.
+        for i, embedding in enumerate(expected):
+            embedding_cache.put(f"text_{i}", embedding.copy())
 
         errors = []
         results = []
+        start = threading.Barrier(50)
 
         def get_item(i: int):
             try:
+                start.wait(timeout=10)
                 result = embedding_cache.get(f"text_{i % 5}")
-                results.append(result)
+                results.append((i, result))
             except Exception as e:
                 errors.append(e)
 
@@ -558,8 +561,12 @@ class TestThreadSafety:
         for t in threads:
             t.join()
 
-        assert len(errors) == 0
+        assert not errors, f"Worker errors: {errors}"
         assert len(results) == 50
+        assert {i for i, _ in results} == set(range(50))
+        for i, result in results:
+            assert result is not None, f"Missing cached vector for text_{i % 5}"
+            np.testing.assert_array_equal(result, expected[i % 5])
 
     def test_concurrent_put_get(self, embedding_cache):
         """Test concurrent put and get operations."""

--- a/tests/debate/cache/test_embeddings_lru.py
+++ b/tests/debate/cache/test_embeddings_lru.py
@@ -509,29 +509,41 @@ class TestPersistence:
 class TestThreadSafety:
     """Tests for thread safety."""
 
-    def test_concurrent_puts(self, embedding_cache):
-        """Test concurrent put operations are thread-safe."""
+    def test_concurrent_puts(self):
+        """Every concurrent write survives when all keys fit in the cache."""
+        from aragora.debate.cache.embeddings_lru import EmbeddingCache
+
+        expected = [np.array([i, i + 0.5, -i], dtype=np.float32) for i in range(20)]
+        cache = EmbeddingCache(max_size=len(expected), persist=False)
+        start = threading.Barrier(len(expected))
         errors = []
         results = []
 
         def put_item(i: int):
             try:
-                embedding_cache.put(f"text_{i}", np.array([float(i)], dtype=np.float32))
+                start.wait(timeout=10)
+                cache.put(f"text_{i}", expected[i].copy())
                 results.append(i)
             except Exception as e:
                 errors.append(e)
 
         threads = []
-        for i in range(20):
-            t = threading.Thread(target=put_item, args=(i,))
+        for i in range(len(expected)):
+            t = threading.Thread(target=put_item, args=(i,), daemon=True)
             threads.append(t)
             t.start()
 
+        deadline = time.monotonic() + 10
         for t in threads:
-            t.join()
+            t.join(timeout=max(0, deadline - time.monotonic()))
 
-        assert len(errors) == 0
-        assert len(results) == 20
+        assert not any(t.is_alive() for t in threads), "Writers did not finish"
+        assert not errors, f"Worker errors: {errors}"
+        assert sorted(results) == list(range(len(expected)))
+        for i, embedding in enumerate(expected):
+            result = cache.get(f"text_{i}")
+            assert result is not None, f"Missing cached vector for text_{i}"
+            np.testing.assert_array_equal(result, embedding)
 
     def test_concurrent_gets(self, embedding_cache):
         """Concurrent readers receive the exact vector for their requested key."""
@@ -568,35 +580,63 @@ class TestThreadSafety:
             assert result is not None, f"Missing cached vector for text_{i % 5}"
             np.testing.assert_array_equal(result, expected[i % 5])
 
-    def test_concurrent_put_get(self, embedding_cache):
-        """Test concurrent put and get operations."""
-        errors = []
+    def test_concurrent_put_get(self):
+        """Readers see written versions, and every writer's final value survives."""
+        from aragora.debate.cache.embeddings_lru import EmbeddingCache
 
-        def writer():
+        cache = EmbeddingCache(max_size=10, persist=False)
+        expected = [
+            [np.array([i, version, -i], dtype=np.float32) for version in range(-1, 100)]
+            for i in range(5)
+        ]
+        # One writer per key; all keys remain resident throughout the race.
+        for i, versions in enumerate(expected):
+            cache.put(f"text_{i}", versions[0].copy())
+        start = threading.Barrier(10)
+        errors = []
+        writers_done = []
+        results = [[] for _ in expected]
+
+        def writer(i: int):
             try:
-                for i in range(100):
-                    embedding_cache.put(f"text_{i}", np.array([float(i)], dtype=np.float32))
+                start.wait(timeout=10)
+                for embedding in expected[i][1:]:
+                    cache.put(f"text_{i}", embedding.copy())
+                writers_done.append(i)
             except Exception as e:
                 errors.append(e)
 
-        def reader():
+        def reader(i: int):
             try:
-                for i in range(100):
-                    embedding_cache.get(f"text_{i}")
+                start.wait(timeout=10)
+                for _ in range(100):
+                    result = cache.get(f"text_{i}")
+                    results[i].append(result.copy() if result is not None else None)
             except Exception as e:
                 errors.append(e)
 
         threads = []
-        for _ in range(5):
-            threads.append(threading.Thread(target=writer))
-            threads.append(threading.Thread(target=reader))
+        for i in range(len(expected)):
+            threads.append(threading.Thread(target=writer, args=(i,), daemon=True))
+            threads.append(threading.Thread(target=reader, args=(i,), daemon=True))
 
         for t in threads:
             t.start()
+        deadline = time.monotonic() + 10
         for t in threads:
-            t.join()
+            t.join(timeout=max(0, deadline - time.monotonic()))
 
-        assert len(errors) == 0
+        assert not any(t.is_alive() for t in threads), "Readers/writers did not finish"
+        assert not errors, f"Worker errors: {errors}"
+        assert sorted(writers_done) == list(range(len(expected)))
+        for i, reads in enumerate(results):
+            assert len(reads) == 100
+            for result in reads:
+                assert result is not None, f"Missing cached vector for text_{i}"
+                assert any(np.array_equal(result, value) for value in expected[i]), (
+                    f"Unexpected vector for text_{i}: {result}"
+                )
+            np.testing.assert_array_equal(cache.get(f"text_{i}"), expected[i][-1])
 
     def test_concurrent_eviction(self, small_cache):
         """Test that concurrent evictions don't cause errors."""

--- a/tests/debate/test_consensus_stress.py
+++ b/tests/debate/test_consensus_stress.py
@@ -921,23 +921,36 @@ class TestThreadSafety:
 class TestCacheIsolation:
     """Tests for cache isolation between debates."""
 
-    def test_debate_cache_isolation(self):
-        """Test that debate caches are isolated."""
-        debate_id_1 = f"isolated-1-{uuid.uuid4().hex[:8]}"
-        debate_id_2 = f"isolated-2-{uuid.uuid4().hex[:8]}"
+    @pytest.mark.parametrize("cleanup_first", [0, 1])
+    def test_debate_cache_isolation(self, cleanup_first):
+        """Cleaning one debate must preserve the other debate's cached values."""
+        debate_ids = [f"isolated-{i}-{uuid.uuid4().hex}" for i in range(2)]
+        scores = [0.9, 0.2]
+        try:
+            caches = [get_pairwise_similarity_cache(debate_id) for debate_id in debate_ids]
+            caches[0].put("text_a", "text_b", scores[0])
+            assert caches[0].get("text_a", "text_b") == scores[0]
+            assert caches[1].get("text_a", "text_b") is None
 
-        cache1 = get_pairwise_similarity_cache(debate_id_1)
-        cache2 = get_pairwise_similarity_cache(debate_id_2)
+            caches[1].put("text_a", "text_b", scores[1])
+            for cache, score in zip(caches, scores):
+                assert cache.get("text_a", "text_b") == score
 
-        # Add to cache1
-        cache1.put("text_a", "text_b", 0.9)
+            cleanup_similarity_cache(debate_ids[cleanup_first])
+            assert caches[cleanup_first].get("text_a", "text_b") is None
 
-        # Should not be in cache2
-        assert cache2.get("text_a", "text_b") is None
+            survivor = 1 - cleanup_first
+            assert caches[survivor].get("text_a", "text_b") == scores[survivor]
+            surviving_cache = get_pairwise_similarity_cache(debate_ids[survivor])
+            assert surviving_cache.get("text_a", "text_b") == scores[survivor]
 
-        # Cleanup
-        cleanup_similarity_cache(debate_id_1)
-        cleanup_similarity_cache(debate_id_2)
+            replacement = get_pairwise_similarity_cache(debate_ids[cleanup_first])
+            assert replacement.get("text_a", "text_b") is None
+            replacement.put("text_a", "text_b", 0.5)
+            assert surviving_cache.get("text_a", "text_b") == scores[survivor]
+        finally:
+            for debate_id in debate_ids:
+                cleanup_similarity_cache(debate_id)
 
     def test_convergence_detector_isolation(self):
         """Test ConvergenceDetector instances are isolated."""

--- a/tests/memory/test_sqlite_concurrency.py
+++ b/tests/memory/test_sqlite_concurrency.py
@@ -222,15 +222,17 @@ class TestCritiqueStoreConcurrency:
             assert mode.lower() == "wal", f"CritiqueStore not using WAL: {mode}"
 
     def test_concurrent_reputation_updates(self, temp_db):
-        """Test concurrent reputation updates don't cause deadlocks."""
+        """Successful concurrent updates must match the persisted reputation totals."""
         store = CritiqueStore(temp_db)
 
         errors = []
         success_count = [0]
         lock = threading.Lock()
+        start = threading.Barrier(10)
 
         def update_reputation(agent_name):
             try:
+                start.wait(timeout=5)
                 store.update_reputation(
                     agent_name=agent_name,
                     proposal_accepted=True,
@@ -249,11 +251,27 @@ class TestCritiqueStoreConcurrency:
 
         for t in threads:
             t.start()
+        deadline = time.monotonic() + 30
         for t in threads:
-            t.join(timeout=30)
+            t.join(timeout=max(0, deadline - time.monotonic()))
 
+        assert not any(t.is_alive() for t in threads), "Reputation workers did not finish"
+        assert success_count[0] + len(errors) == len(threads)
         # Most updates should succeed with WAL mode
         assert success_count[0] >= 5, f"Too many failures: {len(errors)} errors"
+
+        # Read committed state on a fresh connection, not the cached reputation getter.
+        conn = sqlite3.connect(temp_db)
+        try:
+            row = conn.execute(
+                "SELECT proposals_made, proposals_accepted, critiques_given, critiques_valuable "
+                "FROM agent_reputation WHERE agent_name = ?",
+                ("test-agent",),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None, "Successful calls did not persist a reputation row"
+        assert row == (0, success_count[0], 0, success_count[0])
 
 
 class TestContinuumMemoryConcurrency:


### PR DESCRIPTION
## Summary

Recover missing regression signals in existing cache and reputation tests. This
is the Regression-Signal Recovery mission's only implementation PR. Runtime
behavior, persistence schema, contention policy and public interfaces are unchanged.

- R3: verify exact per-key vectors for all 50 concurrent reads, using independent
  expected arrays; reject missing values and worker errors.
- R4: verify 20 resident concurrent writes, 500 mixed reads, final overwrites,
  worker completion and errors. Do not assume scheduler order. Both R4 tests use
  a shared 10-second join deadline.
- R5: compare persisted reputation counters on a fresh SQLite connection against
  successful worker calls. Retain the existing minimum five successes out of ten.
- R6: exercise both cleanup orders, preserving another session's values through
  held and re-fetched references; recreate the removed session independently.

Only three test files changed, +125/-47. R6 adds one parametrized case. No runtime,
workflow, global fixture, runner, baseline, dependency, API, SDK, governance,
review/settlement-tooling, credential or deployment changes.

## Exact-head controlled-fault proof

All six contracts were replayed at
`69cbc356ed0635ae2f3e2ba54eb843655576ad10` on 2026-09-11.

| Contract | Proof at this head |
| --- | --- |
| R1 capacity | Existing siblings reject unbounded growth at limits 3, 5 and 256; no new test needed |
| R2 LRU/clear | Existing siblings reject missing hit promotion, MRU eviction and ineffective clear |
| R3 reads | Reject None, wrong-key vectors, corrupted arrays and worker exceptions |
| R4 writes/readback | Reject dropped writes, wrong keys/vectors, ignored overwrites, missing reads, exceptions, incomplete workers and blocked workers |
| R5 persisted totals | Reject no-op updates, missing/halved/doubled rewards, wrong-agent writes and complete database failure |
| R6 isolation/cleanup | Reject global cleanup, survivor clearing/unregistration, no-op/uncleared cleanup, shared caches and always-missing reads |

**29 negative variants**, all failing in the intended test body, with no
collection/setup errors. Healthy counterparts pass. R5 also passes the policy
witness with five explicit database failures and five persisted updates, yielding
`(0, 5, 0, 5)`; ten healthy calls yield `(0, 10, 0, 10)`.

Before the respective repairs, selected tests passed with missing/wrong embedding
values, lost writes/overwrites, no-op or incorrectly accumulated reputation
updates, and destructive cross-session cleanup. Before/after artifacts are
preserved privately under `/private/tmp/aragora-regression-proof-20260911`.
The consolidated artifacts use `head69-r1-*` through `head69-r6-*`.

Faults are private process-local injections, restored after each test. R3-R5
faults target worker operations only; R6 changes actual function code so existing
import aliases also observe the fault. Normal repository fixtures/plugins remain
enabled. Deliberately blocked R4 workers are released and joined after the test;
the harness reports zero surviving workers. No mutation harness is committed.

These are targeted witnesses, not exhaustive scheduling, deadlock,
linearizability, crash-durability or reputation-calibration claims.

## Validation

- Expanded combined suite: **309 passed** independently with seeds **11, 29, 71**.
  This includes all three Jaccard sibling classes, the complete changed files,
  pairwise/convergence-cache files and relevant reputation/manager neighbors.
- Ruff on all three touched files passed.
- `git diff --check origin/main...HEAD` passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` passed.
- Normal commit and pre-push hooks passed on the published head without bypass.
- All six required checks are green while draft; draft quorum success is not
  model-review evidence. No new commit or push during consolidation.

```sh
ARAGORA_USE_SECRETS_MANAGER=false python3 -m pytest -q \
  tests/debate/test_consensus_stress.py \
  tests/debate/convergence/test_cache.py \
  tests/debate/test_convergence_cache.py \
  tests/debate/test_convergence_comprehensive.py::TestGlobalCacheManager \
  tests/debate/test_convergence_comprehensive.py::TestCacheManagerEdgeCases \
  tests/memory/test_sqlite_concurrency.py \
  tests/storage/test_store_extended.py::TestAgentReputationExtended \
  tests/memory/test_memory_store.py::TestAgentReputationTracking \
  tests/debate/cache/test_embeddings_lru.py \
  tests/debate/test_similarity_backends.py::TestJaccardBackend \
  tests/debate/similarity/test_backends.py::TestJaccardBackend \
  tests/debate/test_debate_convergence_comprehensive.py::TestJaccardBackend \
  --randomly-seed=11
```

## Risk and status

Live current-main merge-packet classifies this PR as **Tier 3** because the
covered behavior includes reputation/persistence. That classification is retained;
test-only placement does not waive the human risk gate.

Draft, technical proof complete at this branch head, not landed. The next step is
one bounded independent exact-head dry-run, not evidence publication or merge.
Any substantive findings consume the mission's single consolidated review-driven
repair opportunity; a second dissent round parks the PR. Human risk acceptance,
separate merge authority and final resulting-main positive/negative verification
remain required. This PR does not complete the mission by itself.
