### PR TITLE
fix(cli): report receipt input errors without tracebacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ proves. *(docs/CANONICAL_GOALS.md, docs/vision/MAXIMALIST_VISION.md)*
 
 <!-- metrics:begin readme-scale -->
 > Scale (canonical counts in [`docs/METRICS.md`](docs/METRICS.md), rounded):
-> **~4,300 Python files · ~1.9M LOC · 140+ top-level modules · 200,000+ test
+> **~4,300 Python files · ~2.0M LOC · 140+ top-level modules · 200,000+ test
 > functions across ~5,500 files · 3,205 API operations across 2,912 paths ·
 > 35+ allowlisted agent types across 12+ providers · 41 Knowledge Mound adapter specs
 > (46 files) · 360+ RBAC permissions · Python + TypeScript SDKs · v2.10.0.**

--- a/aragora-verify/src/aragora_verify/cli.py
+++ b/aragora-verify/src/aragora_verify/cli.py
@@ -85,6 +85,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     except FileNotFoundError as exc:
         print(f"error: file not found: {exc.filename}", file=sys.stderr)
         return 2
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"error: cannot read input: {exc}", file=sys.stderr)
+        return 2
     except (json.JSONDecodeError, VerificationError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/aragora-verify/tests/test_cli_input_errors.py
+++ b/aragora-verify/tests/test_cli_input_errors.py
@@ -1,0 +1,107 @@
+"""File and decode errors retain the standalone CLI's input-error exit code."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from aragora_verify.cli import main
+
+from _fixtures import valid_odr
+
+
+@pytest.mark.parametrize("json_output", [False, True])
+@pytest.mark.parametrize("target", ["receipt", "pubkey", "chain"])
+@pytest.mark.parametrize("kind", ["missing", "directory", "permission", "read_failure"])
+def test_unreadable_input_returns_two(
+    target: str, kind: str, json_output: bool, tmp_path: Path, capsys
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text(json.dumps(valid_odr()), encoding="utf-8")
+    unreadable = tmp_path / "unreadable"
+    if kind == "directory":
+        unreadable.mkdir()
+    args = (
+        [str(unreadable)] if target == "receipt" else [str(receipt), f"--{target}", str(unreadable)]
+    )
+    if json_output:
+        args.append("--json")
+    if kind in {"permission", "read_failure"}:
+        real_open = open
+
+        def failing_open(path, *open_args, **open_kwargs):
+            if str(path) == str(unreadable):
+                if kind == "permission":
+                    raise PermissionError(errno.EACCES, "Permission denied", str(path))
+                raise OSError(errno.EIO, "Input/output error", str(path))
+            return real_open(path, *open_args, **open_kwargs)
+
+        with patch("builtins.open", side_effect=failing_open):
+            rc = main(args)
+    else:
+        rc = main(args)
+
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "error:" in captured.err
+    assert str(unreadable) in captured.err
+
+
+@pytest.mark.parametrize("target", ["receipt", "chain"])
+@pytest.mark.parametrize("json_output", [False, True])
+@pytest.mark.parametrize("content", [b"\xff", b"{broken"])
+def test_invalid_text_input_returns_two(target, json_output, content, tmp_path, capsys) -> None:
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text(json.dumps(valid_odr()), encoding="utf-8")
+    invalid = tmp_path / "invalid.json"
+    invalid.write_bytes(content)
+    args = [str(invalid)] if target == "receipt" else [str(receipt), "--chain", str(invalid)]
+    if json_output:
+        args.append("--json")
+    assert main(args) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "error:" in captured.err
+
+
+@pytest.mark.parametrize("content", [[], None, True, 42, "text"])
+def test_wrong_top_level_shape_remains_verification_failure(content, tmp_path, capsys) -> None:
+    source = tmp_path / "receipt.json"
+    source.write_text(json.dumps(content), encoding="utf-8")
+    assert main([str(source), "--json"]) == 1
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    assert result["ok"] is False
+    assert result["checks"][0]["name"] == "schema_conformance"
+    assert result["checks"][0]["status"] == "fail"
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize("kind", ["directory", "invalid_encoding"])
+def test_input_errors_through_module_process(kind: str, tmp_path: Path) -> None:
+    source = tmp_path / "receipt.json"
+    if kind == "directory":
+        source.mkdir()
+    else:
+        source.write_bytes(b"\xff")
+    result = subprocess.run(
+        [sys.executable, "-m", "aragora_verify", str(source), "--json"],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src")},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "error:" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -430,14 +430,24 @@ def _cmd_view(args: argparse.Namespace) -> None:
     file_path = Path(receipt_path)
     no_browser = getattr(args, "no_browser", False)
 
-    if not file_path.exists():
+    try:
+        file_exists = file_path.exists()
+    except OSError as e:
+        print(f"Error: Cannot read file: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not file_exists:
         print(f"Error: File not found: {file_path}", file=sys.stderr)
         sys.exit(1)
 
     # If already HTML, open directly
     if file_path.suffix.lower() in (".html", ".htm"):
         if no_browser:
-            print(file_path.read_text(encoding="utf-8"))
+            try:
+                html = file_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as e:
+                print(f"Error: Cannot read file: {e}", file=sys.stderr)
+                sys.exit(1)
+            print(html)
         else:
             webbrowser.open(f"file://{file_path.resolve()}")
             print(f"Opened {file_path} in browser.")

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -194,13 +194,12 @@ def _load_receipt_json(path: Path) -> dict[str, Any] | None:
 
     Returns the parsed dict, or None on error (with message printed).
     """
-    if not path.exists():
-        print(f"Error: File not found: {path}", file=sys.stderr)
-        return None
-
     try:
+        if not path.exists():
+            print(f"Error: File not found: {path}", file=sys.stderr)
+            return None
         raw = path.read_text(encoding="utf-8")
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
         print(f"Error: Cannot read file: {e}", file=sys.stderr)
         return None
 
@@ -705,8 +704,12 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
 def _resolve_receipt_data(receipt_ref: str) -> dict[str, Any] | None:
     """Resolve a receipt argument that may be a file path or a stored receipt ID."""
     path = Path(receipt_ref)
-    if path.exists():
-        return _load_receipt_json(path)
+    try:
+        if path.exists():
+            return _load_receipt_json(path)
+    except OSError as e:
+        print(f"Error: Cannot read file: {e}", file=sys.stderr)
+        return None
 
     # Not a file on disk — try the durable store, then the legacy store.
     # Store access errors are surfaced (not silently treated as "not found")

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](https://g
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.10.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,310 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,330 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,994,979 | `docs/METRICS.md` |
-| Automated tests | 226,053 test functions | `docs/METRICS.md` |
-| Test files | 5,551 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 2,001,754 | `docs/METRICS.md` |
+| Automated tests | 226,584 test functions | `docs/METRICS.md` |
+| Test files | 5,592 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,310 tracked Python files | 145 top-level modules | 226,053 test functions across 5,551 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
+**Scale:** 4,330 tracked Python files | 145 top-level modules | 226,584 test functions across 5,592 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,310 Python files | 226,053 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,330 Python files | 226,584 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,310
-- **Tests**: 226,053 across 5,551 test files
+- **Python files (`aragora/`)**: 4,330
+- **Tests**: 226,584 across 5,592 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,053 tests across 5,551 test files
-- **Source files**: 4,310 Python files under `aragora/`
+- **Test coverage**: 226,584 tests across 5,592 test files
+- **Source files**: 4,330 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.10.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,310 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,330 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,994,979 | `docs/METRICS.md` |
-| Automated tests | 226,053 test functions | `docs/METRICS.md` |
-| Test files | 5,551 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 2,001,754 | `docs/METRICS.md` |
+| Automated tests | 226,584 test functions | `docs/METRICS.md` |
+| Test files | 5,592 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,310 tracked Python files | 145 top-level modules | 226,053 test functions across 5,551 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,330 tracked Python files | 145 top-level modules | 226,584 test functions across 5,592 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4310` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1994979` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4330` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `2001754` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5551` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `226053` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `1064` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5592` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `226584` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `1130` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2912` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3205` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1119` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1120` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `97` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,310
-- **Tests**: 226,053 across 5,551 test files
+- **Python files (`aragora/`)**: 4,330
+- **Tests**: 226,584 across 5,592 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,053 tests across 5,551 test files
-- **Source files**: 4,310 Python files under `aragora/`
+- **Test coverage**: 226,584 tests across 5,592 test files
+- **Source files**: 4,330 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,310 Python files | 226,053 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,330 Python files | 226,584 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/tests/cli/test_receipt_input_errors.py
+++ b/tests/cli/test_receipt_input_errors.py
@@ -1,0 +1,112 @@
+"""Receipt file input failures stay diagnostic, nonzero, and traceback-free."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import os
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from aragora.cli.commands.receipt import (
+    cmd_receipt_export,
+    cmd_receipt_inspect,
+    cmd_receipt_verify,
+)
+
+COMMANDS = (cmd_receipt_inspect, cmd_receipt_verify, cmd_receipt_export)
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize("command", COMMANDS)
+@pytest.mark.parametrize(
+    "content", [b"\xff", b"{broken", b"[]", b"null", b"true", b"42", b'"text"']
+)
+def test_invalid_receipt_input_has_no_success_output(
+    command, content: bytes, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "receipt.json"
+    source.write_bytes(content)
+    output = tmp_path / "export.json"
+    output.write_bytes(b"preserve existing output")
+    args = argparse.Namespace(receipt=str(source), format="json", output=str(output))
+
+    with pytest.raises(SystemExit) as exc:
+        command(args)
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Error:" in captured.err
+    assert "Traceback" not in captured.err
+    assert output.read_bytes() == b"preserve existing output"
+
+
+@pytest.mark.parametrize("command", COMMANDS)
+@pytest.mark.parametrize("kind", ["missing", "directory", "permission", "read_failure"])
+def test_unreadable_receipt_input(
+    command, kind: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "receipt.json"
+    args = argparse.Namespace(receipt=str(source), format="json", output=None)
+    if kind == "directory":
+        source.mkdir()
+    if kind in {"permission", "read_failure"}:
+        source.write_text("{}", encoding="utf-8")
+        error = (
+            PermissionError(errno.EACCES, "Permission denied", str(source))
+            if kind == "permission"
+            else OSError(errno.EIO, "Input/output error", str(source))
+        )
+        with patch.object(Path, "read_text", side_effect=error):
+            with pytest.raises(SystemExit) as exc:
+                command(args)
+    else:
+        with pytest.raises(SystemExit) as exc:
+            command(args)
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(source) in captured.err
+    assert "Error:" in captured.err
+
+
+@pytest.mark.parametrize("action", ["inspect", "verify", "export"])
+def test_invalid_encoding_through_cli_process(action: str, tmp_path: Path) -> None:
+    source = tmp_path / "invalid-utf8.json"
+    source.write_bytes(b"\xff")
+    result = subprocess.run(
+        [sys.executable, "-m", "aragora.cli.main", "receipt", action, str(source)],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "Error:" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_export_path_inspection_error_does_not_fall_back_to_storage(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "receipt.json"
+    error = PermissionError(errno.EACCES, "Permission denied", str(source))
+    with patch.object(Path, "exists", side_effect=error):
+        with patch("aragora.cli.commands.receipt._load_storage_receipt") as storage:
+            with pytest.raises(SystemExit) as exc:
+                cmd_receipt_export(
+                    argparse.Namespace(receipt=str(source), format="json", output=None)
+                )
+    assert exc.value.code == 1
+    storage.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(source) in captured.err

--- a/tests/cli/test_receipt_input_errors.py
+++ b/tests/cli/test_receipt_input_errors.py
@@ -13,12 +13,13 @@ from unittest.mock import patch
 import pytest
 
 from aragora.cli.commands.receipt import (
+    _cmd_view,
     cmd_receipt_export,
     cmd_receipt_inspect,
     cmd_receipt_verify,
 )
 
-COMMANDS = (cmd_receipt_inspect, cmd_receipt_verify, cmd_receipt_export)
+COMMANDS = (cmd_receipt_inspect, cmd_receipt_verify, cmd_receipt_export, _cmd_view)
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -33,7 +34,9 @@ def test_invalid_receipt_input_has_no_success_output(
     source.write_bytes(content)
     output = tmp_path / "export.json"
     output.write_bytes(b"preserve existing output")
-    args = argparse.Namespace(receipt=str(source), format="json", output=str(output))
+    args = argparse.Namespace(
+        receipt=str(source), format="json", output=str(output), no_browser=True
+    )
 
     with pytest.raises(SystemExit) as exc:
         command(args)
@@ -52,7 +55,7 @@ def test_unreadable_receipt_input(
     command, kind: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     source = tmp_path / "receipt.json"
-    args = argparse.Namespace(receipt=str(source), format="json", output=None)
+    args = argparse.Namespace(receipt=str(source), format="json", output=None, no_browser=True)
     if kind == "directory":
         source.mkdir()
     if kind in {"permission", "read_failure"}:
@@ -75,12 +78,25 @@ def test_unreadable_receipt_input(
     assert "Error:" in captured.err
 
 
-@pytest.mark.parametrize("action", ["inspect", "verify", "export"])
-def test_invalid_encoding_through_cli_process(action: str, tmp_path: Path) -> None:
-    source = tmp_path / "invalid-utf8.json"
+@pytest.mark.parametrize(
+    "action,suffix",
+    [
+        ("inspect", ".json"),
+        ("verify", ".json"),
+        ("export", ".json"),
+        ("view", ".json"),
+        ("view", ".html"),
+        ("view", ".htm"),
+    ],
+)
+def test_invalid_encoding_through_cli_process(action: str, suffix: str, tmp_path: Path) -> None:
+    source = tmp_path / f"invalid-utf8{suffix}"
     source.write_bytes(b"\xff")
+    argv = [sys.executable, "-m", "aragora.cli.main", "receipt", action, str(source)]
+    if action == "view":
+        argv.append("--no-browser")
     result = subprocess.run(
-        [sys.executable, "-m", "aragora.cli.main", "receipt", action, str(source)],
+        argv,
         cwd=tmp_path,
         env={**os.environ, "PYTHONPATH": str(ROOT)},
         capture_output=True,
@@ -92,6 +108,55 @@ def test_invalid_encoding_through_cli_process(action: str, tmp_path: Path) -> No
     assert result.stdout == ""
     assert "Error:" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize("suffix", [".html", ".htm"])
+@pytest.mark.parametrize("kind", ["encoding", "directory", "permission", "path_inspection"])
+def test_view_html_input_failure(
+    suffix: str, kind: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / f"receipt{suffix}"
+    args = argparse.Namespace(receipt=str(source), no_browser=True)
+    if kind == "directory":
+        source.mkdir()
+    else:
+        source.write_bytes(b"\xff" if kind == "encoding" else b"<p>Receipt</p>")
+    with patch("aragora.cli.commands.receipt.webbrowser.open") as browser:
+        if kind in {"permission", "path_inspection"}:
+            method = "read_text" if kind == "permission" else "exists"
+            error = PermissionError(errno.EACCES, "Permission denied", str(source))
+            with patch.object(Path, method, side_effect=error):
+                with pytest.raises(SystemExit) as exc:
+                    _cmd_view(args)
+        else:
+            with pytest.raises(SystemExit) as exc:
+                _cmd_view(args)
+    assert exc.value.code == 1
+    browser.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Error:" in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize("suffix", [".html", ".htm"])
+@pytest.mark.parametrize("no_browser", [True, False])
+def test_view_valid_html_preserves_output(
+    suffix: str, no_browser: bool, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / f"receipt{suffix}"
+    content = "<p>Receipt: caf\u00e9</p>"
+    source.write_text(content, encoding="utf-8")
+    with patch("aragora.cli.commands.receipt.webbrowser.open") as browser:
+        _cmd_view(argparse.Namespace(receipt=str(source), no_browser=no_browser))
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    if no_browser:
+        assert captured.out == content + "\n"
+        browser.assert_not_called()
+    else:
+        browser.assert_called_once_with(f"file://{source.resolve()}")
+        assert captured.out == f"Opened {source} in browser.\n"
 
 
 def test_export_path_inspection_error_does_not_fall_back_to_storage(


### PR DESCRIPTION
## Summary
- Continue Receipt Consumer Reliability after #10021: handle unreadable paths and invalid UTF-8 at existing CLI boundaries rather than exposing tracebacks.
- Preserve native receipt error exit 1, standalone input error exit 2, schema-verification failure exit 1, and unchecked-signature exit 3. No new JSON error schema or changes to verification/signing algorithms.
- Stop export path-inspection failures before any fallback to receipt storage; preserve normal stored-ID lookup and successful output behavior.

## Scope and Risk
Expected Tier 2: live CLI error handling. Four files, 318 changed lines. No dependency, workflow, schema, signing custody, exporter-internal, or quorum changes. This is contract 2 only; typed-field rendering, destination failures, and installed offline campaign acceptance remain later units. #9903 and peer-owned SDK/Factory/regression work are untouched.

## Baseline Witnesses
Before the implementation, the added tests produced 7 native failures and 24 standalone failures. Invalid UTF-8 and filesystem exceptions escaped; standalone subprocesses printed tracebacks and returned the wrong input-error exit status. Tests also cover existing malformed-JSON/top-level-shape handling, missing files, directories, permission failures, pubkey/chain inputs, and preservation of existing export destinations.

## Validation
- Native receipt input/export/command/roundtrip/debate tests: 146 passed.
- Standalone verifier suite with repository integration available: 145 passed.
- Standalone-only suite: 143 passed, 2 existing integration skips because aragora is not importable.
- Real subprocess witnesses execute outside the checkout and assert nonzero exits without tracebacks.
- Focused Ruff and formatting checks, mypy on all four files, quality ratchet, automation preflight, and git diff --check passed.
- Normal commit and push hooks passed, including mypy, gitleaks, portability, and receipt/verifier boundary guards; no hook bypass.

## Review and Completion
The initial exact-head review returned OpenAI PASS and one Claude P2: receipt view --no-browser still exposed input exceptions for HTML. Ten failing regressions reproduced that gap. The single permitted consolidated repair at c9ae53f3d7548b58d923eda5786b2a224e9a533c now covers view JSON/HTML input handling and preserves valid HTML stdout/browser behavior. No evidence was posted.

Fresh current-head CI and exactly one final independent review remain before normal merge gates. The repair allowance is now exhausted; further substantive dissent parks this PR without a replacement workaround. Automated acceptance does not replace the human outsider proof in #8858.