### PR TITLE
fix(cli): validate receipt inspection before rendering

### DIFF
--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -478,6 +478,13 @@ def _cmd_view(args: argparse.Namespace) -> None:
         print(f"Receipt opened in browser. Saved to {tmp_path}")
 
 
+def _escape_receipt_text(value: Any) -> str:
+    """Escape display text without truncating or changing verification inputs."""
+    encoding = sys.stdout.encoding or "utf-8"
+    text = str(value).encode(encoding, errors="backslashreplace").decode(encoding)
+    return "".join(char if char.isprintable() else json.dumps(char)[1:-1] for char in text)
+
+
 def cmd_receipt_verify(args: argparse.Namespace) -> None:
     """Verify a receipt's artifact hash and signature integrity."""
     receipt_path = getattr(args, "receipt", None)
@@ -495,7 +502,7 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
     receipt_id = data.get("receipt_id", "unknown")
     stored_hash = data.get("artifact_hash", "")
 
-    print(f"\nReceipt Verification: {receipt_id}")
+    print(f"\nReceipt Verification: {_escape_receipt_text(receipt_id)}")
     print("=" * 60)
 
     checks_passed = 0
@@ -504,7 +511,7 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
     # Check 1: artifact_hash present
     checks_total += 1
     if stored_hash:
-        print(f"  [PASS] artifact_hash present: {stored_hash[:16]}...")
+        print(f"  [PASS] artifact_hash present: {_escape_receipt_text(stored_hash[:16])}...")
         checks_passed += 1
     else:
         print("  [FAIL] artifact_hash is missing")
@@ -519,12 +526,14 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
             detail = "integrity verified"
             if verbose:
                 detail += f" (stored={stored_hash[:16]}..., recomputed={receipt._calculate_hash()[:16]}...)"
-            print(f"  [PASS] {detail}")
+            print(f"  [PASS] {_escape_receipt_text(detail)}")
             checks_passed += 1
         else:
             expected = receipt._calculate_hash()
             print(
-                f"  [FAIL] hash mismatch: stored={stored_hash[:16]}..., expected={expected[:16]}..."
+                _escape_receipt_text(
+                    f"  [FAIL] hash mismatch: stored={stored_hash[:16]}..., expected={expected[:16]}..."
+                )
             )
     except ImportError:
         # Fallback: manual hash check
@@ -547,7 +556,9 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
             checks_passed += 1
         else:
             print(
-                f"  [FAIL] hash mismatch: stored={stored_hash[:16]}..., expected={expected[:16]}..."
+                _escape_receipt_text(
+                    f"  [FAIL] hash mismatch: stored={stored_hash[:16]}..., expected={expected[:16]}..."
+                )
             )
 
     # Check 3: Required fields present
@@ -573,7 +584,7 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
             else:
                 print("  [FAIL] cryptographic signature invalid")
         except (OSError, RuntimeError, ValueError) as e:
-            print(f"  [FAIL] signature verification error: {e}")
+            print(f"  [FAIL] signature verification error: {_escape_receipt_text(e)}")
 
     print("")
     if checks_passed == checks_total:
@@ -599,14 +610,13 @@ def _inspection_cosmetic(value: Any, field: str) -> str:
     try:
         if isinstance(value, str):
             value.encode(sys.stdout.encoding or "utf-8")
-            summary = "".join(
-                char if char.isprintable() else json.dumps(char)[1:-1] for char in value[:121]
-            )
+            summary = _escape_receipt_text(value[:121])
             return summary[:117] + "..." if len(summary) > 120 else summary
         if not isinstance(value, bool) and (
             isinstance(value, int) or isinstance(value, float) and math.isfinite(value)
         ):
-            return str(value)
+            summary = str(value)
+            return summary[:117] + "..." if len(summary) > 120 else summary
         if isinstance(value, (dict, list)):
             summary = json.dumps(value, separators=(",", ":"), allow_nan=False)
             return summary[:117] + "..." if len(summary) > 120 else summary

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -599,7 +599,10 @@ def _inspection_cosmetic(value: Any, field: str) -> str:
     try:
         if isinstance(value, str):
             value.encode(sys.stdout.encoding or "utf-8")
-            return value
+            summary = "".join(
+                char if char.isprintable() else json.dumps(char)[1:-1] for char in value[:121]
+            )
+            return summary[:117] + "..." if len(summary) > 120 else summary
         if not isinstance(value, bool) and (
             isinstance(value, int) or isinstance(value, float) and math.isfinite(value)
         ):

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -586,18 +586,31 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
 
 
 def _inspection_consensus_reached(value: Any) -> bool:
-    """Decode explicit legacy flags, never arbitrary truthiness, for display."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, int) and value in (0, 1):
-        return bool(value)
-    if isinstance(value, str):
-        flag = value.strip().lower()
-        if flag in {"true", "1", "yes", "on"}:
-            return True
-        if flag in {"false", "0", "no", "off", ""}:
-            return False
-    raise ValueError("consensus_proof.reached must be a boolean or an explicit 0/1/true/false flag")
+    from aragora.gauntlet.receipt_models import _normalize_receipt_boolean
+
+    try:
+        return _normalize_receipt_boolean(value, strict=True)
+    except ValueError:
+        raise ValueError("consensus_proof.reached is not a recognized boolean") from None
+
+
+def _inspection_cosmetic(value: Any, field: str) -> str:
+    """Display only: never interpret these fields as decisions or verification."""
+    try:
+        if isinstance(value, str):
+            value.encode(sys.stdout.encoding or "utf-8")
+            return value
+        if not isinstance(value, bool) and (
+            isinstance(value, int) or isinstance(value, float) and math.isfinite(value)
+        ):
+            return str(value)
+        if isinstance(value, (dict, list)):
+            summary = json.dumps(value, separators=(",", ":"), allow_nan=False)
+            return summary[:117] + "..." if len(summary) > 120 else summary
+    except (TypeError, ValueError, OverflowError, RecursionError):
+        pass
+    print(f"Warning: Cannot render receipt field {field}", file=sys.stderr)
+    return "(unrenderable)"
 
 
 def _validate_inspection_fields(data: dict[str, Any]) -> None:
@@ -625,15 +638,12 @@ def _validate_inspection_fields(data: dict[str, Any]) -> None:
     for field in ("confidence", "robustness_score"):
         if not math.isfinite(number(data.get(field, 0), field) * 100):
             raise ValueError(f"{field} cannot be displayed as a finite percentage")
-    for field in ("signature", "artifact_hash", "input_hash", "verdict_reasoning"):
-        require(data.get(field), str, field, nullable=True)
-
     risk = data.get("risk_summary")
     require(risk, dict, "risk_summary", nullable=True)
     if risk:
         for field in ("critical", "high", "medium", "low", "total"):
             if field in risk:
-                number(risk[field], f"risk_summary.{field}")
+                number(risk[field], f"risk_summary.{field}", allow_string=True)
 
     consensus = data.get("consensus_proof")
     require(consensus, dict, "consensus_proof", nullable=True)
@@ -655,12 +665,6 @@ def _validate_inspection_fields(data: dict[str, Any]) -> None:
 
     cost = data.get("cost_summary")
     require(cost, dict, "cost_summary", nullable=True)
-    if cost:
-        field = "total_cost" if "total_cost" in cost else "total"
-        total = cost.get(field, 0)
-        # Older receipts can omit a cost or serialize it as a decimal string.
-        if total is not None and total != "":
-            number(total, f"cost_summary.{field}", allow_string=True)
 
     config = data.get("config_used", {})
     require(config, dict, "config_used")
@@ -669,7 +673,6 @@ def _validate_inspection_fields(data: dict[str, Any]) -> None:
     for i, critique in enumerate(critiques or []):
         prefix = f"config_used.critique_summaries[{i}]"
         require(critique, dict, prefix)
-        number(critique.get("severity", 0), f"{prefix}.severity")
         require(critique.get("issues", []), list, f"{prefix}.issues")
     require(data.get("dissenting_views"), list, "dissenting_views", nullable=True)
 
@@ -747,17 +750,18 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     else:
         print("Signed:        No")
 
-    if data.get("artifact_hash"):
-        print(f"Artifact Hash: {data['artifact_hash'][:40]}...")
+    if "signature" in data:
+        print(f"Signature:     {_inspection_cosmetic(data['signature'], 'signature')}")
 
-    if data.get("input_hash"):
-        print(f"Input Hash:    {data['input_hash'][:40]}...")
+    for field, label in (("artifact_hash", "Artifact Hash"), ("input_hash", "Input Hash")):
+        if field in data:
+            print(f"{label + ':':15}{_inspection_cosmetic(data[field], field)}")
 
     # Verdict reasoning
     reasoning = data.get("verdict_reasoning", "")
-    if reasoning:
+    if "verdict_reasoning" in data:
         print("\n--- Verdict Reasoning ---")
-        print(f"  {reasoning[:500]}")
+        print(f"  {_inspection_cosmetic(reasoning, 'verdict_reasoning')}")
 
     # Agent responses
     agent_responses = data.get("agent_responses", [])
@@ -780,9 +784,9 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     cost = data.get("cost_summary")
     if cost and isinstance(cost, dict):
         total = cost.get("total_cost", cost.get("total", 0))
-        if total:
+        if "total_cost" in cost or "total" in cost:
             print("\n--- Cost ---")
-            print(f"  Total: ${float(total):.4f}")
+            print(f"  Total: ${_inspection_cosmetic(total, 'cost_summary total')}")
 
     # Critique summaries (from config_used)
     config = data.get("config_used", {})
@@ -794,7 +798,7 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
             target = c.get("target", "")
             severity = c.get("severity", 0.0)
             issues = c.get("issues", [])
-            print(f"  {critic} → {target} (severity: {severity:.1f})")
+            print(f"  {critic} → {target} (severity: {_inspection_cosmetic(severity, 'severity')})")
             for issue in issues[:3]:
                 print(f"    - {str(issue)[:100]}")
 

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -585,6 +585,21 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
     sys.exit(0 if checks_passed == checks_total else 1)
 
 
+def _inspection_consensus_reached(value: Any) -> bool:
+    """Decode explicit legacy flags, never arbitrary truthiness, for display."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        flag = value.strip().lower()
+        if flag in {"true", "1", "yes", "on"}:
+            return True
+        if flag in {"false", "0", "no", "off", ""}:
+            return False
+    raise ValueError("consensus_proof.reached must be a boolean or an explicit 0/1/true/false flag")
+
+
 def _validate_inspection_fields(data: dict[str, Any]) -> None:
     """Check display inputs without normalizing decisions or verifying signatures."""
 
@@ -624,7 +639,7 @@ def _validate_inspection_fields(data: dict[str, Any]) -> None:
     require(consensus, dict, "consensus_proof", nullable=True)
     if consensus:
         if "reached" in consensus:
-            require(consensus["reached"], bool, "consensus_proof.reached")
+            _inspection_consensus_reached(consensus["reached"])
         for field in ("supporting_agents", "dissenting_agents"):
             agents = consensus.get(field)
             require(agents, list, f"consensus_proof.{field}", nullable=True)
@@ -715,7 +730,8 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     consensus = data.get("consensus_proof", {})
     if consensus:
         print("\n--- Consensus ---")
-        print(f"Reached:       {'Yes' if consensus.get('reached') else 'No'}")
+        reached = _inspection_consensus_reached(consensus.get("reached", False))
+        print(f"Reached:       {'Yes' if reached else 'No'}")
         print(f"Method:        {consensus.get('method', 'N/A')}")
         supporting = consensus.get("supporting_agents", [])
         dissenting = consensus.get("dissenting_agents", [])

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -14,6 +14,7 @@ import argparse
 from datetime import datetime
 import json
 import logging
+import math
 import os
 import sys
 import tempfile
@@ -584,6 +585,80 @@ def cmd_receipt_verify(args: argparse.Namespace) -> None:
     sys.exit(0 if checks_passed == checks_total else 1)
 
 
+def _validate_inspection_fields(data: dict[str, Any]) -> None:
+    """Check display inputs without normalizing decisions or verifying signatures."""
+
+    def require(value: Any, kind: type, field: str, *, nullable: bool = False) -> None:
+        if value is None and nullable:
+            return
+        if not isinstance(value, kind):
+            raise ValueError(f"{field} must be {kind.__name__}")
+
+    def number(value: Any, field: str, *, allow_string: bool = False) -> float:
+        kinds = (int, float, str) if allow_string else (int, float)
+        if isinstance(value, bool) or not isinstance(value, kinds):
+            raise ValueError(f"{field} must be a finite number")
+        try:
+            numeric = float(value)
+        except (ValueError, OverflowError):
+            raise ValueError(f"{field} must be a finite number") from None
+        if not math.isfinite(numeric):
+            raise ValueError(f"{field} must be a finite number")
+        return numeric
+
+    require(data.get("verdict", "UNKNOWN"), str, "verdict")
+    for field in ("confidence", "robustness_score"):
+        if not math.isfinite(number(data.get(field, 0), field) * 100):
+            raise ValueError(f"{field} cannot be displayed as a finite percentage")
+    for field in ("signature", "artifact_hash", "input_hash", "verdict_reasoning"):
+        require(data.get(field), str, field, nullable=True)
+
+    risk = data.get("risk_summary")
+    require(risk, dict, "risk_summary", nullable=True)
+    if risk:
+        for field in ("critical", "high", "medium", "low", "total"):
+            if field in risk:
+                number(risk[field], f"risk_summary.{field}")
+
+    consensus = data.get("consensus_proof")
+    require(consensus, dict, "consensus_proof", nullable=True)
+    if consensus:
+        if "reached" in consensus:
+            require(consensus["reached"], bool, "consensus_proof.reached")
+        for field in ("supporting_agents", "dissenting_agents"):
+            agents = consensus.get(field)
+            require(agents, list, f"consensus_proof.{field}", nullable=True)
+            for i, agent in enumerate(agents or []):
+                require(agent, str, f"consensus_proof.{field}[{i}]")
+
+    responses = data.get("agent_responses")
+    require(responses, list, "agent_responses", nullable=True)
+    for i, response in enumerate(responses or []):
+        prefix = f"agent_responses[{i}]"
+        require(response, dict, prefix)
+        require(response.get("content", ""), str, f"{prefix}.content")
+
+    cost = data.get("cost_summary")
+    require(cost, dict, "cost_summary", nullable=True)
+    if cost:
+        field = "total_cost" if "total_cost" in cost else "total"
+        total = cost.get(field, 0)
+        # Older receipts can omit a cost or serialize it as a decimal string.
+        if total is not None and total != "":
+            number(total, f"cost_summary.{field}", allow_string=True)
+
+    config = data.get("config_used", {})
+    require(config, dict, "config_used")
+    critiques = config.get("critique_summaries")
+    require(critiques, list, "config_used.critique_summaries", nullable=True)
+    for i, critique in enumerate(critiques or []):
+        prefix = f"config_used.critique_summaries[{i}]"
+        require(critique, dict, prefix)
+        number(critique.get("severity", 0), f"{prefix}.severity")
+        require(critique.get("issues", []), list, f"{prefix}.issues")
+    require(data.get("dissenting_views"), list, "dissenting_views", nullable=True)
+
+
 def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     """Display detailed receipt information."""
     receipt_path = getattr(args, "receipt", None)
@@ -595,6 +670,12 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     path = Path(receipt_path)
     data = _load_receipt_json(path)
     if data is None:
+        sys.exit(1)
+
+    try:
+        _validate_inspection_fields(data)
+    except ValueError as e:
+        print(f"Error: Invalid receipt inspection field: {e}", file=sys.stderr)
         sys.exit(1)
 
     print("\nDecision Receipt")

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -704,10 +704,13 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
 
     # Basic info
     print("\n--- Basic Information ---")
-    print(f"Receipt ID:    {data.get('receipt_id', 'N/A')}")
-    print(f"Gauntlet ID:   {data.get('gauntlet_id', 'N/A')}")
-    print(f"Debate ID:     {data.get('debate_id', 'N/A')}")
-    print(f"Timestamp:     {data.get('timestamp', 'N/A')}")
+    for field, label in (
+        ("receipt_id", "Receipt ID"),
+        ("gauntlet_id", "Gauntlet ID"),
+        ("debate_id", "Debate ID"),
+        ("timestamp", "Timestamp"),
+    ):
+        print(f"{label + ':':15}{_inspection_cosmetic(data.get(field, 'N/A'), field)}")
 
     # Verdict
     print("\n--- Verdict ---")
@@ -718,7 +721,7 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     verdict_icon = {"PASS": "\u2713", "FAIL": "\u2717", "CONDITIONAL": "\u26a0"}.get(
         verdict.upper(), "?"
     )
-    print(f"Verdict:       {verdict_icon} {verdict}")
+    print(f"Verdict:       {verdict_icon} {_inspection_cosmetic(verdict, 'verdict')}")
     print(f"Confidence:    {confidence:.1%}")
     print(f"Robustness:    {robustness:.1%}")
 
@@ -726,11 +729,9 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     risk_summary = data.get("risk_summary", {})
     if risk_summary:
         print("\n--- Risk Summary ---")
-        print(f"Critical:      {risk_summary.get('critical', 0)}")
-        print(f"High:          {risk_summary.get('high', 0)}")
-        print(f"Medium:        {risk_summary.get('medium', 0)}")
-        print(f"Low:           {risk_summary.get('low', 0)}")
-        print(f"Total:         {risk_summary.get('total', 0)}")
+        for field in ("critical", "high", "medium", "low", "total"):
+            value = _inspection_cosmetic(risk_summary.get(field, 0), f"risk_summary.{field}")
+            print(f"{field.title() + ':':15}{value}")
 
     # Consensus
     consensus = data.get("consensus_proof", {})
@@ -738,18 +739,24 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
         print("\n--- Consensus ---")
         reached = _inspection_consensus_reached(consensus.get("reached", False))
         print(f"Reached:       {'Yes' if reached else 'No'}")
-        print(f"Method:        {consensus.get('method', 'N/A')}")
-        supporting = consensus.get("supporting_agents", [])
-        dissenting = consensus.get("dissenting_agents", [])
-        print(f"Supporting:    {', '.join(supporting) if supporting else 'None'}")
-        print(f"Dissenting:    {', '.join(dissenting) if dissenting else 'None'}")
+        print(f"Method:        {_inspection_cosmetic(consensus.get('method', 'N/A'), 'method')}")
+        for field, label in (
+            ("supporting_agents", "Supporting"),
+            ("dissenting_agents", "Dissenting"),
+        ):
+            agents = consensus.get(field) or []
+            rendered = [_inspection_cosmetic(agent, field) for agent in agents]
+            print(f"{label + ':':15}{', '.join(rendered) if agents else 'None'}")
 
     # Signature
     print("\n--- Cryptographic ---")
     if data.get("signature"):
         print("Signed:        Yes")
-        print(f"Algorithm:     {data.get('signature_algorithm', 'unknown')}")
-        print(f"Key ID:        {data.get('signature_key_id', 'N/A')}")
+        for field, label, default in (
+            ("signature_algorithm", "Algorithm", "unknown"),
+            ("signature_key_id", "Key ID", "N/A"),
+        ):
+            print(f"{label + ':':15}{_inspection_cosmetic(data.get(field, default), field)}")
     else:
         print("Signed:        No")
 
@@ -776,11 +783,11 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
             model = resp.get("llm_label", "")
             content = resp.get("content", "")
             length = len(content)
-            label = f"{name}"
+            label = _inspection_cosmetic(name, "agent_name")
             if model:
-                label += f" ({model})"
+                label += f" ({_inspection_cosmetic(model, 'llm_label')})"
             if role:
-                label += f" [{role}]"
+                label += f" [{_inspection_cosmetic(role, 'role')}]"
             print(f"  {label}: {length} chars")
 
     # Cost summary
@@ -797,20 +804,20 @@ def cmd_receipt_inspect(args: argparse.Namespace) -> None:
     if critiques:
         print(f"\n--- Critique Summaries ({len(critiques)}) ---")
         for c in critiques[:5]:
-            critic = c.get("critic", "unknown")
-            target = c.get("target", "")
+            critic = _inspection_cosmetic(c.get("critic", "unknown"), "critic")
+            target = _inspection_cosmetic(c.get("target", ""), "target")
             severity = c.get("severity", 0.0)
             issues = c.get("issues", [])
             print(f"  {critic} → {target} (severity: {_inspection_cosmetic(severity, 'severity')})")
             for issue in issues[:3]:
-                print(f"    - {str(issue)[:100]}")
+                print(f"    - {_inspection_cosmetic(issue, 'critique issue')}")
 
     # Dissenting views
     dissent = data.get("dissenting_views", [])
     if dissent:
         print(f"\n--- Dissenting Views ({len(dissent)}) ---")
         for view in dissent[:3]:
-            print(f"  - {str(view)[:200]}")
+            print(f"  - {_inspection_cosmetic(view, 'dissenting view')}")
 
     print("\n" + "=" * 60)
 

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -120,11 +120,12 @@ def _clamp_receipt_confidence(value: Any, *, default: float = 0.0) -> float:
     return numeric
 
 
-def _normalize_receipt_boolean(value: Any, *, default: bool = False) -> bool:
+def _normalize_receipt_boolean(value: Any, *, default: bool = False, strict: bool = False) -> bool:
+    """Decode legacy flags; strict consumers reject unknowns instead of defaulting."""
     if isinstance(value, bool):
         return value
     if value is None:
-        return default
+        return False if strict else default
     if isinstance(value, int | float):
         return value != 0
     if isinstance(value, str):
@@ -133,7 +134,8 @@ def _normalize_receipt_boolean(value: Any, *, default: bool = False) -> bool:
             return True
         if normalized in {"false", "0", "no", "n", "off", ""}:
             return False
-        return default
+    if strict:
+        raise ValueError("unrecognized receipt boolean")
     return default
 
 

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import math
 import uuid
 
 from aragora.agents.failure_semantics import all_responses_are_failures
@@ -127,6 +128,8 @@ def _normalize_receipt_boolean(value: Any, *, default: bool = False, strict: boo
     if value is None:
         return False if strict else default
     if isinstance(value, int | float):
+        if strict and isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("receipt boolean must be finite")
         return value != 0
     if isinstance(value, str):
         normalized = value.strip().lower()

--- a/tests/cli/test_receipt_inspect_validation.py
+++ b/tests/cli/test_receipt_inspect_validation.py
@@ -17,6 +17,71 @@ from aragora.cli.commands.receipt import cmd_receipt_inspect
 ROOT = Path(__file__).resolve().parents[2]
 
 
+@pytest.mark.parametrize("value", ["label\nSigned: Yes\u001b[2J\u009b\u202e", "x" * 121, "\ud800"])
+@pytest.mark.parametrize(
+    "field",
+    [
+        "receipt_id",
+        "gauntlet_id",
+        "debate_id",
+        "timestamp",
+        "verdict",
+        "consensus_proof.method",
+        "consensus_proof.supporting_agents.0",
+        "consensus_proof.dissenting_agents.0",
+        "signature_algorithm",
+        "signature_key_id",
+        "agent_responses.0.agent_name",
+        "agent_responses.0.role",
+        "agent_responses.0.llm_label",
+        "config_used.critique_summaries.0.critic",
+        "config_used.critique_summaries.0.target",
+        "config_used.critique_summaries.0.issues.0",
+        "dissenting_views.0",
+    ],
+)
+def test_all_display_text_uses_escaped_capped_rendering(
+    field: str, value: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    data: dict[str, Any] = {"signature": "present"}
+    cursor: Any = data
+    parts = field.split(".")
+    for index, part in enumerate(parts[:-1]):
+        child: Any = [] if parts[index + 1].isdigit() else {}
+        if isinstance(cursor, list):
+            cursor.append(child)
+        else:
+            cursor[part] = child
+        cursor = child
+    if isinstance(cursor, list):
+        cursor.append(value)
+    else:
+        cursor[parts[-1]] = value
+    source = tmp_path / "receipt.json"
+    source.write_text(json.dumps(data), encoding="utf-8")
+    cmd_receipt_inspect(argparse.Namespace(receipt=str(source)))
+    captured = capsys.readouterr()
+    assert value not in captured.out
+    if value == "\ud800":
+        assert "(unrenderable)" in captured.out
+        assert captured.err.count("Warning:") == 1
+    else:
+        expected = (
+            "x" * 117 + "..."
+            if value.startswith("x")
+            else r"label\nSigned: Yes\u001b[2J\u009b\u202e"
+        )
+        assert expected in captured.out
+        assert captured.err == ""
+
+
+def test_numeric_risk_strings_escape_whitespace_in_real_cli(tmp_path: Path) -> None:
+    result = inspect_process({"risk_summary": {"high": "\n\t2\r"}}, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert r"High:          \n\t2\r" in result.stdout
+    assert "\n\t2\n" not in result.stdout
+
+
 def inspect_process(data: dict[str, Any], tmp_path: Path) -> subprocess.CompletedProcess[str]:
     source = tmp_path / "receipt.json"
     source.write_text(json.dumps(data), encoding="utf-8")

--- a/tests/cli/test_receipt_inspect_validation.py
+++ b/tests/cli/test_receipt_inspect_validation.py
@@ -340,6 +340,8 @@ def test_numeric_risk_count_contract(value: Any, tmp_path: Path) -> None:
         "a\nb\r\t\x1b[31m\x07\x7f\x85\u202e",
         0,
         42.5,
+        pytest.param(10**2000, id="large-positive-int"),
+        pytest.param(-(10**3000), id="large-negative-int"),
         {},
         [],
         {"key": "x" * 140},
@@ -404,6 +406,15 @@ def test_cosmetic_cap_applies_after_escaping(length: int) -> None:
     assert _inspection_cosmetic(value, "signature") == (r"\n" * length)[:117] + "..."
     expected = "x" * length if length <= 120 else "x" * 117 + "..."
     assert _inspection_cosmetic("x" * length, "signature") == expected
+
+
+@pytest.mark.parametrize("length", [119, 120, 121, 3000])
+def test_numeric_display_cap_boundaries(length: int) -> None:
+    from aragora.cli.commands.receipt import _inspection_cosmetic
+
+    value = int("1" * length)
+    expected = str(value) if length <= 120 else "1" * 117 + "..."
+    assert _inspection_cosmetic(value, "numeric") == expected
 
 
 def test_escaped_cosmetics_through_cli(tmp_path: Path) -> None:

--- a/tests/cli/test_receipt_inspect_validation.py
+++ b/tests/cli/test_receipt_inspect_validation.py
@@ -166,8 +166,7 @@ def test_missing_and_nullable_optional_fields_preserve_defaults(tmp_path: Path) 
         (-0.0, "No"),
         (0.5, "Yes"),
         (-0.5, "Yes"),
-        (float("inf"), "Yes"),
-        (float("nan"), "Yes"),
+        (10**400, "Yes"),
         (" Y ", "Yes"),
         (" N ", "No"),
     ],
@@ -214,7 +213,21 @@ def test_strict_model_boolean_strings(flag: str) -> None:
     assert _normalize_receipt_boolean(None, default=True) is True
 
 
-@pytest.mark.parametrize("value", ["unknown", "2", "none", "false-ish", [], {}, [True]])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "unknown",
+        "2",
+        "none",
+        "false-ish",
+        [],
+        {},
+        [True],
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+    ],
+)
 def test_unknown_boolean_never_defaults(value: Any, tmp_path: Path) -> None:
     from aragora.gauntlet.receipt_models import _normalize_receipt_boolean
 
@@ -257,6 +270,9 @@ def test_numeric_risk_count_contract(value: Any, tmp_path: Path) -> None:
     "value",
     [
         "legacy",
+        "caf\u00e9",
+        "x" * 1000,
+        "a\nb\r\t\x1b[31m\x07\x7f\x85\u202e",
         0,
         42.5,
         {},
@@ -298,11 +314,9 @@ def test_cosmetic_values_are_display_only(
             if isinstance(value, (dict, list))
             else str(value)
         )
-        expected = (
-            expected[:117] + "..."
-            if isinstance(value, (dict, list)) and len(expected) > 120
-            else expected
-        )
+        if value == "a\nb\r\t\x1b[31m\x07\x7f\x85\u202e":
+            expected = r"a\nb\r\t\u001b[31m\u0007\u007f\u0085\u202e"
+        expected = expected[:117] + "..." if len(expected) > 120 else expected
         labels = {
             "signature": "Signature:     ",
             "artifact_hash": "Artifact Hash: ",
@@ -315,6 +329,25 @@ def test_cosmetic_values_are_display_only(
         assert labels[field] + expected in captured.out
         assert captured.err == ""
     assert "Traceback" not in captured.err and "[PASS]" not in captured.out
+
+
+@pytest.mark.parametrize("length", [119, 120, 121, 1000])
+def test_cosmetic_cap_applies_after_escaping(length: int) -> None:
+    from aragora.cli.commands.receipt import _inspection_cosmetic
+
+    value = "\n" * length
+    assert _inspection_cosmetic(value, "signature") == (r"\n" * length)[:117] + "..."
+    expected = "x" * length if length <= 120 else "x" * 117 + "..."
+    assert _inspection_cosmetic("x" * length, "signature") == expected
+
+
+def test_escaped_cosmetics_through_cli(tmp_path: Path) -> None:
+    result = inspect_process({"signature": "\x1b[31m\nForged", "input_hash": "h" * 1000}, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "Cannot render receipt field" not in result.stderr and "Traceback" not in result.stderr
+    assert r"Signature:     \u001b[31m\nForged" in result.stdout
+    assert "Input Hash:    " + "h" * 117 + "..." in result.stdout
+    assert "\x1b" not in result.stdout and "\nForged" not in result.stdout
 
 
 def test_pre_validator_legacy_fixture(tmp_path: Path) -> None:

--- a/tests/cli/test_receipt_inspect_validation.py
+++ b/tests/cli/test_receipt_inspect_validation.py
@@ -1,0 +1,179 @@
+"""Inspection validates display fields before emitting any receipt output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from aragora.cli.commands.receipt import cmd_receipt_inspect
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def inspect_process(data: dict[str, Any], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    source = tmp_path / "receipt.json"
+    source.write_text(json.dumps(data), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, "-m", "aragora.cli.main", "receipt", "inspect", str(source)],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "data,field",
+    [
+        ({"confidence": "oops"}, "confidence"),
+        ({"confidence": float("nan")}, "confidence"),
+        ({"verdict": None}, "verdict"),
+        ({"risk_summary": ["oops"]}, "risk_summary"),
+        ({"agent_responses": ["oops"]}, "agent_responses[0]"),
+        ({"config_used": None}, "config_used"),
+    ],
+)
+def test_malformed_inspection_through_cli(data: dict[str, Any], field: str, tmp_path: Path) -> None:
+    result = inspect_process(data, tmp_path)
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "Error:" in result.stderr
+    assert field in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "data,field",
+    [
+        ({"confidence": True}, "confidence"),
+        ({"confidence": None}, "confidence"),
+        ({"confidence": 10**400}, "confidence"),
+        ({"confidence": 1e308}, "confidence"),
+        ({"robustness_score": float("inf")}, "robustness_score"),
+        ({"verdict": []}, "verdict"),
+        ({"risk_summary": {"total": "many"}}, "risk_summary.total"),
+        ({"consensus_proof": []}, "consensus_proof"),
+        ({"consensus_proof": {"reached": "false"}}, "consensus_proof.reached"),
+        ({"consensus_proof": {"supporting_agents": "alice"}}, "supporting_agents"),
+        ({"consensus_proof": {"dissenting_agents": [1]}}, "dissenting_agents[0]"),
+        ({"signature": {}}, "signature"),
+        ({"artifact_hash": 42}, "artifact_hash"),
+        ({"input_hash": []}, "input_hash"),
+        ({"verdict_reasoning": {}}, "verdict_reasoning"),
+        ({"agent_responses": {}}, "agent_responses"),
+        ({"agent_responses": [{"content": None}]}, "agent_responses[0].content"),
+        ({"agent_responses": [{"content": []}]}, "agent_responses[0].content"),
+        ({"agent_responses": [{}] * 10 + [False]}, "agent_responses[10]"),
+        ({"cost_summary": []}, "cost_summary"),
+        ({"cost_summary": {"total_cost": "oops"}}, "cost_summary.total_cost"),
+        ({"cost_summary": {"total": "NaN"}}, "cost_summary.total"),
+        ({"cost_summary": {"total_cost": True}}, "cost_summary.total_cost"),
+        ({"config_used": {"critique_summaries": {}}}, "critique_summaries"),
+        ({"config_used": {"critique_summaries": [None]}}, "critique_summaries[0]"),
+        (
+            {"config_used": {"critique_summaries": [{"severity": "high"}]}},
+            "critique_summaries[0].severity",
+        ),
+        (
+            {"config_used": {"critique_summaries": [{"issues": None}]}},
+            "critique_summaries[0].issues",
+        ),
+        ({"dissenting_views": "one view"}, "dissenting_views"),
+    ],
+)
+def test_invalid_fields_never_emit_partial_receipt(
+    data: dict[str, Any], field: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "receipt.json"
+    source.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        cmd_receipt_inspect(argparse.Namespace(receipt=str(source)))
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Error:" in captured.err
+    assert field in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize("verdict", ["PASS", "pass", "CONDITIONAL", "FAIL", "legacy-verdict"])
+def test_supported_receipt_inspection(verdict: str, tmp_path: Path) -> None:
+    data = {
+        "receipt_id": "legacy-1",
+        "verdict": verdict,
+        "confidence": 0.75,
+        "robustness_score": 1,
+        "risk_summary": {"total": 2, "high": 1},
+        "consensus_proof": {"reached": False, "supporting_agents": ["alice", "bob"]},
+        "signature": "present-but-not-verified",
+        "artifact_hash": "a" * 64,
+        "agent_responses": [{"agent_name": "alice", "content": "hello"}],
+        "cost_summary": {"total": "0.0123"},
+        "config_used": {
+            "critique_summaries": [{"critic": "bob", "severity": 0.5, "issues": ["risk"]}]
+        },
+        "dissenting_views": ["wait"],
+    }
+    result = inspect_process(data, tmp_path)
+    assert result.returncode == 0, result.stderr
+    for expected in (
+        "Receipt ID:    legacy-1",
+        verdict,
+        "Confidence:    75.0%",
+        "Robustness:    100.0%",
+        "Reached:       No",
+        "Supporting:    alice, bob",
+        "Signed:        Yes",
+        "alice: 5 chars",
+        "Total: $0.0123",
+        "severity: 0.5",
+        "- risk",
+        "- wait",
+    ):
+        assert expected in result.stdout
+    assert "VALID" not in result.stdout
+    assert "verified" not in result.stdout.lower()
+
+
+def test_missing_and_nullable_optional_fields_preserve_defaults(tmp_path: Path) -> None:
+    empty = inspect_process({}, tmp_path)
+    nullable = inspect_process(
+        {"consensus_proof": None, "cost_summary": None, "signature": None}, tmp_path
+    )
+    assert empty.returncode == nullable.returncode == 0
+    assert empty.stdout == nullable.stdout
+    assert "? UNKNOWN" in empty.stdout
+    assert "Confidence:    0.0%" in empty.stdout
+
+
+def test_model_generated_receipt_remains_inspectable(tmp_path: Path) -> None:
+    from aragora.gauntlet.receipt_models import AgentResponseRecord, DecisionReceipt
+
+    receipt = DecisionReceipt(
+        receipt_id="native-1",
+        gauntlet_id="g1",
+        timestamp="2026-09-12T00:00:00Z",
+        input_summary="example",
+        input_hash="a" * 64,
+        risk_summary={},
+        attacks_attempted=0,
+        attacks_successful=0,
+        probes_run=0,
+        vulnerabilities_found=0,
+        verdict="PASS",
+        confidence=0.8,
+        robustness_score=0.9,
+        agent_responses=[AgentResponseRecord(agent="alice", response="hello")],
+    )
+    result = inspect_process(receipt.to_dict(), tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "native-1" in result.stdout

--- a/tests/cli/test_receipt_inspect_validation.py
+++ b/tests/cli/test_receipt_inspect_validation.py
@@ -63,27 +63,16 @@ def test_malformed_inspection_through_cli(data: dict[str, Any], field: str, tmp_
         ({"risk_summary": {"total": "many"}}, "risk_summary.total"),
         ({"consensus_proof": []}, "consensus_proof"),
         ({"consensus_proof": {"reached": "undetermined"}}, "consensus_proof.reached"),
-        ({"consensus_proof": {"reached": 2}}, "consensus_proof.reached"),
+        ({"consensus_proof": {"reached": []}}, "consensus_proof.reached"),
         ({"consensus_proof": {"supporting_agents": "alice"}}, "supporting_agents"),
         ({"consensus_proof": {"dissenting_agents": [1]}}, "dissenting_agents[0]"),
-        ({"signature": {}}, "signature"),
-        ({"artifact_hash": 42}, "artifact_hash"),
-        ({"input_hash": []}, "input_hash"),
-        ({"verdict_reasoning": {}}, "verdict_reasoning"),
         ({"agent_responses": {}}, "agent_responses"),
         ({"agent_responses": [{"content": None}]}, "agent_responses[0].content"),
         ({"agent_responses": [{"content": []}]}, "agent_responses[0].content"),
         ({"agent_responses": [{}] * 10 + [False]}, "agent_responses[10]"),
         ({"cost_summary": []}, "cost_summary"),
-        ({"cost_summary": {"total_cost": "oops"}}, "cost_summary.total_cost"),
-        ({"cost_summary": {"total": "NaN"}}, "cost_summary.total"),
-        ({"cost_summary": {"total_cost": True}}, "cost_summary.total_cost"),
         ({"config_used": {"critique_summaries": {}}}, "critique_summaries"),
         ({"config_used": {"critique_summaries": [None]}}, "critique_summaries[0]"),
-        (
-            {"config_used": {"critique_summaries": [{"severity": "high"}]}},
-            "critique_summaries[0].severity",
-        ),
         (
             {"config_used": {"critique_summaries": [{"issues": None}]}},
             "critique_summaries[0].issues",
@@ -142,14 +131,12 @@ def test_supported_receipt_inspection(verdict: str, tmp_path: Path) -> None:
     ):
         assert expected in result.stdout
     assert "VALID" not in result.stdout
-    assert "verified" not in result.stdout.lower()
+    assert "cryptographic signature verified" not in result.stdout.lower()
 
 
 def test_missing_and_nullable_optional_fields_preserve_defaults(tmp_path: Path) -> None:
     empty = inspect_process({}, tmp_path)
-    nullable = inspect_process(
-        {"consensus_proof": None, "cost_summary": None, "signature": None}, tmp_path
-    )
+    nullable = inspect_process({"consensus_proof": None, "cost_summary": None}, tmp_path)
     assert empty.returncode == nullable.returncode == 0
     assert empty.stdout == nullable.stdout
     assert "? UNKNOWN" in empty.stdout
@@ -172,6 +159,17 @@ def test_missing_and_nullable_optional_fields_preserve_defaults(tmp_path: Path) 
         ("off", "No"),
         (" ON ", "Yes"),
         ("", "No"),
+        (None, "No"),
+        (2, "Yes"),
+        (-1, "Yes"),
+        (0.0, "No"),
+        (-0.0, "No"),
+        (0.5, "Yes"),
+        (-0.5, "Yes"),
+        (float("inf"), "Yes"),
+        (float("nan"), "Yes"),
+        (" Y ", "Yes"),
+        (" N ", "No"),
     ],
 )
 def test_legacy_consensus_boolean_forms(value: Any, expected: str, tmp_path: Path) -> None:
@@ -202,3 +200,126 @@ def test_model_generated_receipt_remains_inspectable(tmp_path: Path) -> None:
     result = inspect_process(receipt.to_dict(), tmp_path)
     assert result.returncode == 0, result.stderr
     assert "native-1" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "flag", ["true", "1", "yes", "y", "on", "false", "0", "no", "n", "off", ""]
+)
+def test_strict_model_boolean_strings(flag: str) -> None:
+    from aragora.gauntlet.receipt_models import _normalize_receipt_boolean
+
+    for value in (flag, flag.upper(), f"  {flag.upper()}  "):
+        assert _normalize_receipt_boolean(value, strict=True) == _normalize_receipt_boolean(value)
+    assert _normalize_receipt_boolean(None, strict=True, default=True) is False
+    assert _normalize_receipt_boolean(None, default=True) is True
+
+
+@pytest.mark.parametrize("value", ["unknown", "2", "none", "false-ish", [], {}, [True]])
+def test_unknown_boolean_never_defaults(value: Any, tmp_path: Path) -> None:
+    from aragora.gauntlet.receipt_models import _normalize_receipt_boolean
+
+    with pytest.raises(ValueError):
+        _normalize_receipt_boolean(value, strict=True)
+    assert _normalize_receipt_boolean(value, default=True) is True
+    result = inspect_process({"consensus_proof": {"reached": value}}, tmp_path)
+    assert result.returncode == 1 and result.stdout == ""
+    assert "consensus_proof.reached" in result.stderr and "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "value", [0, 2.5, "0", " 2.5 ", "1e2", "NaN", "Infinity", "many", float("nan"), float("inf")]
+)
+def test_numeric_risk_count_contract(value: Any, tmp_path: Path) -> None:
+    import math
+
+    result = inspect_process({"risk_summary": {"total": value}}, tmp_path)
+    valid = value != "many" and math.isfinite(float(value))
+    assert result.returncode == (0 if valid else 1), result.stderr
+    if valid:
+        assert f"Total:         {value}" in result.stdout
+    else:
+        assert result.stdout == "" and "risk_summary.total" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "signature",
+        "artifact_hash",
+        "input_hash",
+        "verdict_reasoning",
+        "total_cost",
+        "total",
+        "severity",
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        "legacy",
+        0,
+        42.5,
+        {},
+        [],
+        {"key": "x" * 140},
+        ["a\nb"],
+        float("inf"),
+        True,
+        None,
+        {"bad": float("nan")},
+        "\ud800",
+    ],
+)
+def test_cosmetic_values_are_display_only(
+    field: str, value: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    data = {field: value}
+    if field in ("total_cost", "total"):
+        data = {"cost_summary": {field: value}}
+    elif field == "severity":
+        data = {"config_used": {"critique_summaries": [{field: value}]}}
+    source = tmp_path / "cosmetic.json"
+    source.write_text(json.dumps(data), encoding="utf-8")
+    cmd_receipt_inspect(argparse.Namespace(receipt=str(source)))
+    captured = capsys.readouterr()
+    if (
+        value == "\ud800"
+        or value is None
+        or value is True
+        or value == float("inf")
+        or isinstance(value, dict)
+        and "bad" in value
+    ):
+        assert "(unrenderable)" in captured.out
+        assert captured.err.count("Warning:") == 1
+    else:
+        expected = (
+            json.dumps(value, separators=(",", ":"))
+            if isinstance(value, (dict, list))
+            else str(value)
+        )
+        expected = (
+            expected[:117] + "..."
+            if isinstance(value, (dict, list)) and len(expected) > 120
+            else expected
+        )
+        labels = {
+            "signature": "Signature:     ",
+            "artifact_hash": "Artifact Hash: ",
+            "input_hash": "Input Hash:    ",
+            "verdict_reasoning": "  ",
+            "total_cost": "  Total: $",
+            "total": "  Total: $",
+            "severity": "severity: ",
+        }
+        assert labels[field] + expected in captured.out
+        assert captured.err == ""
+    assert "Traceback" not in captured.err and "[PASS]" not in captured.out
+
+
+def test_pre_validator_legacy_fixture(tmp_path: Path) -> None:
+    # Checked in on 2026-02-12, before this campaign's inspection validator.
+    data = json.loads((ROOT / "examples/sample_receipt.json").read_text())
+    result = inspect_process(data, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert data["receipt_id"] in result.stdout

--- a/tests/cli/test_receipt_inspect_validation.py
+++ b/tests/cli/test_receipt_inspect_validation.py
@@ -62,7 +62,8 @@ def test_malformed_inspection_through_cli(data: dict[str, Any], field: str, tmp_
         ({"verdict": []}, "verdict"),
         ({"risk_summary": {"total": "many"}}, "risk_summary.total"),
         ({"consensus_proof": []}, "consensus_proof"),
-        ({"consensus_proof": {"reached": "false"}}, "consensus_proof.reached"),
+        ({"consensus_proof": {"reached": "undetermined"}}, "consensus_proof.reached"),
+        ({"consensus_proof": {"reached": 2}}, "consensus_proof.reached"),
         ({"consensus_proof": {"supporting_agents": "alice"}}, "supporting_agents"),
         ({"consensus_proof": {"dissenting_agents": [1]}}, "dissenting_agents[0]"),
         ({"signature": {}}, "signature"),
@@ -153,6 +154,30 @@ def test_missing_and_nullable_optional_fields_preserve_defaults(tmp_path: Path) 
     assert empty.stdout == nullable.stdout
     assert "? UNKNOWN" in empty.stdout
     assert "Confidence:    0.0%" in empty.stdout
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0, "No"),
+        (1, "Yes"),
+        (False, "No"),
+        (True, "Yes"),
+        ("false", "No"),
+        ("true", "Yes"),
+        ("0", "No"),
+        ("1", "Yes"),
+        ("no", "No"),
+        ("yes", "Yes"),
+        ("off", "No"),
+        (" ON ", "Yes"),
+        ("", "No"),
+    ],
+)
+def test_legacy_consensus_boolean_forms(value: Any, expected: str, tmp_path: Path) -> None:
+    result = inspect_process({"consensus_proof": {"reached": value}}, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert f"Reached:       {expected}" in result.stdout
 
 
 def test_model_generated_receipt_remains_inspectable(tmp_path: Path) -> None:

--- a/tests/cli/test_receipt_verify_display.py
+++ b/tests/cli/test_receipt_verify_display.py
@@ -1,0 +1,129 @@
+"""Verification escapes display text without changing the values it verifies."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from aragora.cli.commands.receipt import cmd_receipt_verify
+from aragora.gauntlet.receipt_models import DecisionReceipt
+
+SPOOF = "id\n  [PASS] FORGED\x1b[2J\u202e" + "x" * 121
+
+
+@pytest.mark.parametrize("tampered", [False, True])
+def test_verify_cli_outside_checkout(tampered: bool, tmp_path: Path) -> None:
+    data = DecisionReceipt.from_dict(
+        dict(
+            receipt_id=SPOOF,
+            verdict="PASS",
+            confidence=0.8,
+            timestamp="2026-09-12",
+        )
+    ).to_dict()
+    if tampered:
+        data["artifact_hash"] = "\n[PASS] FORGED\x1bxx" + "0" * 48
+    source = tmp_path / "receipt.json"
+    source.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "-m", "aragora.cli.main", "receipt", "verify", str(source), "--verbose"],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+            "ARAGORA_USE_SECRETS_MANAGER": "0",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == int(tampered), result.stderr
+    assert json.dumps(SPOOF)[1:-1] in result.stdout
+    assert "\n[PASS] FORGED" not in result.stdout and "\x1b" not in result.stdout
+    assert "Traceback" not in result.stderr
+    expected = "INVALID (2/3" if tampered else "VALID (3/3"
+    assert f"Result: {expected} checks passed)" in result.stdout
+
+
+@pytest.mark.parametrize("fallback", [False, True])
+@pytest.mark.parametrize("tampered", [False, True])
+@pytest.mark.parametrize("verbose", [False, True])
+def test_verification_preserves_hash_inputs_and_exit_codes(
+    fallback: bool,
+    tampered: bool,
+    verbose: bool,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data = dict(
+        receipt_id=SPOOF,
+        gauntlet_id="g1",
+        input_hash="input",
+        risk_summary={},
+        verdict="PASS",
+        confidence=0.8,
+    )
+    legacy_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
+    data.update(timestamp="2026-09-12T00:00:00Z")
+    data = DecisionReceipt.from_dict(data).to_dict()
+    if fallback:
+        data["artifact_hash"] = legacy_hash
+    if tampered:
+        data["artifact_hash"] = "\n[PASS] FORGED\x1bxx" + "0" * 48
+    source = tmp_path / "receipt.json"
+    source.write_text(json.dumps(data), encoding="utf-8")
+    original = DecisionReceipt.from_dict
+    with patch.object(
+        DecisionReceipt, "from_dict", side_effect=ImportError if fallback else original
+    ) as load:
+        with pytest.raises(SystemExit) as exc:
+            cmd_receipt_verify(argparse.Namespace(receipt=str(source), verbose=verbose))
+    assert exc.value.code == int(tampered)
+    assert all(call.args[0] == data for call in load.call_args_list)
+    captured = capsys.readouterr()
+    assert json.dumps(SPOOF)[1:-1] in captured.out
+    assert "\n[PASS] FORGED" not in captured.out and "\n  [PASS] FORGED" not in captured.out
+    assert "\x1b" not in captured.out and "\u202e" not in captured.out
+    expected = "INVALID (2/3" if tampered else "VALID (3/3"
+    assert f"Result: {expected} checks passed)" in captured.out
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize("signature_result", [True, False, RuntimeError(SPOOF)])
+def test_signature_result_and_exception_display_are_independent(
+    signature_result: bool | RuntimeError, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    data = DecisionReceipt.from_dict(
+        dict(
+            receipt_id="signed",
+            timestamp="2026-09-12",
+            verdict="PASS",
+            confidence=0.8,
+        )
+    ).to_dict()
+    data["signature"] = "present"
+    source = tmp_path / "receipt.json"
+    source.write_text(json.dumps(data), encoding="utf-8")
+    with patch.object(DecisionReceipt, "verify_signature", return_value=signature_result) as verify:
+        if isinstance(signature_result, RuntimeError):
+            verify.side_effect = signature_result
+        with pytest.raises(SystemExit) as exc:
+            cmd_receipt_verify(argparse.Namespace(receipt=str(source), verbose=False))
+    assert exc.value.code == (0 if signature_result is True else 1)
+    verify.assert_called_once_with()
+    captured = capsys.readouterr()
+    if isinstance(signature_result, RuntimeError):
+        assert json.dumps(SPOOF)[1:-1] in captured.out
+        assert "\n  [PASS] FORGED" not in captured.out and "\x1b" not in captured.out
+    assert (
+        f"Result: {'VALID (4/4' if signature_result is True else 'INVALID (3/4'} checks passed)"
+        in captured.out
+    )
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

Receipt Consumer Reliability contract 3: validate native `receipt inspect` inputs before output, render display values safely, and escape untrusted `receipt verify` display text without changing verification. Remain draft until a clean fresh two-family review.

## Operator-Approved Contract (2026-09-12)

The operator approved legacy-compatible strict decision validation, then escaped/capped strings and finite-only numeric booleans, then escaping every inspection display string. The latest explicit amendment extends the **120-character cap to numeric inspection displays** and authorizes **escape-only protection in receipt verify**. Pair 3 of the authorized ceiling of thirty additional bounded repair/review pairs implements those two findings. No replacement PR or reset of historical attempts.

1. Inspection decision fields fail before partial receipt output with stderr and exit 1: malformed verdict types, confidence, robustness, consensus reached/agent lists, risk counts and dissenting_views. Legacy verdict strings and optional defaults remain accepted.
2. Inspection uses the shared model boolean helper in strict mode: bool, integers, finite floats (nonzero true), recognized true/false strings ignoring case/whitespace, and None as false. Unknown strings/types and nonfinite floats raise. Non-strict callers and receipt_gate's separate parser remain unchanged.
3. Risk counts accept finite int/float/numeric strings; bool, NaN, infinity and nonnumeric strings remain invalid. Rendering does not change validation inputs.
4. Every inspection display string escapes nonprinting characters and is capped at 120 displayed characters including ellipsis. Finite numeric cosmetics now use that same cap. Structured cosmetics use compact one-line JSON capped at 120. Unrenderable cosmetics yield a placeholder and one warning, not a fatal inspection result. The 120-character reasoning cap is explicitly approved. Signature presence is not verification.
5. Verification changes are display-only: escape receipt IDs, stored-hash previews, verbose/mismatch text and signature-error messages. Preserve full identifier text rather than introducing an inspection-style truncation policy into verify; preserve its existing 16-character hash previews. Hash comparisons, canonicalization inputs, signature calls, check counts, fallback algorithm and exit-code decisions remain untouched. Both commands share the character escaper so terminal-control handling cannot drift.

## Validation

Before pair 3 implementation: **25 failed / 255 passed** in the numeric/verification regression set. Failures reproduce uncapped numeric inspection values and spoofable verification output. After the repair:

- **484 passed**: inspection, verification display, receipt commands/input/export/round-trip, receipt models/export and receipt-gate suites.
- **135 passed**: existing demo, debate-receipt and quickstart suites.
- **145 passed**: standalone aragora-verify suite.
- Real CLI positive/tampered witnesses run outside the checkout; both preserve expected exit codes and real check counts, and no forged line or raw ESC appears. Unit regressions additionally cover native/fallback hashing, verbose mode, valid/invalid signatures and signature errors, asserting verification receives original input values.
- Numeric tests include 119/120/121-character boundaries, 2,000/3,000-digit values, signs, and existing malformed/nonfinite cases.
- Ruff, mypy four files with follow-imports=silent, quality ratchet, automation preflight, git diff --check and normal commit/push hooks: pass. Existing deprecation warnings and one demo-test AsyncMock warning are preserved, not hidden.

## Scope And Review

Head: `ed7762039599d882c933310b18707fe169fe5b8a`. This repair changes three files, 160 insertions/10 deletions; cumulative PR has four files, 732 insertions/43 deletions (775 changed lines), above the original campaign line target after explicitly approved scope extensions. No dependency/workflow/policy/signing-algorithm/schema/exporter-internal or #9903 changes. Shared root and Factory scratch untouched.

Pair 2 at aaaaa3cd returned OpenAI countable PASS and Claude two P2s. Those findings and the original artifact remain preserved; nothing was posted or reinterpreted as support. All six draft required checks now pass at ed7762039; fresh packet is Tier2, draft/model-quorum/dogfood blocked only. Pair 3's fresh review is pending D/F reviewer release and fresh exact-head gates; no collector or review attempt was started at this head. No evidence, readiness, settlement, merge, cleanup or manual CI rerun in this unit.

Rollback is a normal revert of ed7762039, with no migration. Automated acceptance is not the human outsider proof for #8858. The campaign is incomplete until all required contracts land and final installed/offline acceptance passes.
