### PR TITLE
fix(ci): report monitor transport and step outcomes accurately

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -43,6 +43,7 @@ jobs:
           fi
 
       - name: Check Frontend Critical Routes
+        id: frontend
         run: |
           FRONTEND_URL="${LIVE_FRONTEND_BASE_URL:-https://aragora.ai}"
           # Retry once on transient failure
@@ -60,11 +61,15 @@ jobs:
           exit 1
 
       - name: Check Production API (Lightsail)
+        id: production_api
         run: |
           # Use /api/health (public, load-balancer friendly)
-          response=$(curl -sf -o /dev/null -w "%{http_code}" "https://api.aragora.ai/api/health" || echo "000")
-          if [ "$response" != "200" ]; then
-            echo "::error::Production API returned $response"
+          CURL_EXIT=0
+          response=$(curl -sf -o /dev/null -w "%{http_code}" "https://api.aragora.ai/api/health") || CURL_EXIT=$?
+          response=${response:-000}
+          echo "Production API: http_status=$response curl_exit=$CURL_EXIT"
+          if [ "$CURL_EXIT" -ne 0 ] || [ "$response" != "200" ]; then
+            echo "::error::Production API failed (http_status=$response curl_exit=$CURL_EXIT)"
             exit 1
           fi
           echo "Production API: OK ($response)"
@@ -94,13 +99,16 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          FRONTEND_OUTCOME: ${{ steps.frontend.outcome }}
+          PRODUCTION_API_OUTCOME: ${{ steps.production_api.outcome }}
         run: |
           echo "## Health Check Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Service | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend (Vercel/custom domain) | ${{ job.status == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Production API | ${{ job.status == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend (Vercel/custom domain) | ${FRONTEND_OUTCOME:-skipped} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Production API | ${PRODUCTION_API_OUTCOME:-skipped} |" >> $GITHUB_STEP_SUMMARY
           echo "| Timestamp | $(date -u) |" >> $GITHUB_STEP_SUMMARY
 
   notify-on-failure:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -16,12 +16,14 @@ jobs:
     steps:
       - name: Check backend health
         run: |
+          CURL_EXIT=0
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             --max-time 10 \
-            "${API_URL}/healthz" || echo "000")
-          echo "Health check status: $STATUS"
-          if [ "$STATUS" != "200" ]; then
-            echo "::error::Backend health check failed (status=$STATUS)"
+            "${API_URL}/healthz") || CURL_EXIT=$?
+          STATUS=${STATUS:-000}
+          echo "Health check: http_status=$STATUS curl_exit=$CURL_EXIT"
+          if [ "$CURL_EXIT" -ne 0 ] || [ "$STATUS" != "200" ]; then
+            echo "::error::Backend health check failed (http_status=$STATUS curl_exit=$CURL_EXIT)"
             exit 1
           fi
         env:
@@ -29,12 +31,14 @@ jobs:
 
       - name: Check playground status endpoint
         run: |
+          CURL_EXIT=0
           STATUS=$(curl -sS -o /tmp/playground-status.json -w "%{http_code}" \
             --max-time 10 \
-            "${API_URL}/api/v1/playground/status" || echo "000")
-          echo "Playground status endpoint: $STATUS"
-          if [ "$STATUS" != "200" ]; then
-            echo "::error::Playground status endpoint failed (status=$STATUS)"
+            "${API_URL}/api/v1/playground/status") || CURL_EXIT=$?
+          STATUS=${STATUS:-000}
+          echo "Playground status endpoint: http_status=$STATUS curl_exit=$CURL_EXIT"
+          if [ "$CURL_EXIT" -ne 0 ] || [ "$STATUS" != "200" ]; then
+            echo "::error::Playground status endpoint failed (http_status=$STATUS curl_exit=$CURL_EXIT)"
             [ -f /tmp/playground-status.json ] && cat /tmp/playground-status.json
             exit 1
           fi

--- a/tests/scripts/test_monitor_workflow_diagnostics.py
+++ b/tests/scripts/test_monitor_workflow_diagnostics.py
@@ -1,0 +1,178 @@
+"""Exercise monitor shell blocks without calling any live service."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROBES = (
+    ("production-smoke.yml", "smoke", "Check backend health"),
+    ("production-smoke.yml", "smoke", "Check playground status endpoint"),
+    ("monitor.yml", "health-check", "Check Production API (Lightsail)"),
+)
+
+
+def _workflow(filename: str) -> dict:
+    return yaml.load((ROOT / ".github/workflows" / filename).read_text(), Loader=yaml.BaseLoader)
+
+
+def _step(filename: str, job: str, name: str) -> dict:
+    return next(step for step in _workflow(filename)["jobs"][job]["steps"] if step["name"] == name)
+
+
+def _run_probe(
+    tmp_path: Path,
+    probe: tuple[str, str, str],
+    http_status: str,
+    curl_exit: int,
+    body: str = '{"status":"ok"}',
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    curl = bin_dir / "curl"
+    curl.write_text(
+        """#!/bin/bash
+printf '%s\\n' "$@" > "$CURL_ARGS_FILE"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    if [ "$1" != "/dev/null" ]; then
+      printf '%s' "$CURL_BODY" > "$1"
+    fi
+  fi
+  shift
+done
+printf '%s' "$CURL_HTTP_STATUS"
+exit "$CURL_EXIT_STATUS"
+"""
+    )
+    curl.chmod(0o700)
+    # Redirect only the fixed response file, keeping concurrent tests isolated.
+    script = _step(*probe)["run"].replace(
+        "/tmp/playground-status.json", str(tmp_path / "playground-status.json")
+    )
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", script],
+        env={
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "API_URL": "https://monitor.invalid",
+            "CURL_HTTP_STATUS": http_status,
+            "CURL_EXIT_STATUS": str(curl_exit),
+            "CURL_BODY": body,
+            "CURL_ARGS_FILE": str(tmp_path / "curl-args"),
+        },
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    args = (tmp_path / "curl-args").read_text().splitlines()
+    if probe[0] == "production-smoke.yml":
+        assert args[args.index("--max-time") + 1] == "10"
+        endpoint = "/healthz" if probe == PROBES[0] else "/api/v1/playground/status"
+        assert args[-1] == f"https://monitor.invalid{endpoint}"
+    else:
+        assert args[-1] == "https://api.aragora.ai/api/health"
+        assert "-sf" in args
+    return result
+
+
+@pytest.mark.parametrize("probe", PROBES, ids=["health", "playground", "production-api"])
+@pytest.mark.parametrize(
+    ("http_status", "curl_exit", "expected_status"),
+    [
+        ("200", 0, "200"),
+        ("500", 0, "500"),
+        ("522", 22, "522"),
+        ("000", 28, "000"),
+        ("000", 6, "000"),
+        ("", 7, "000"),
+        ("", 0, "000"),
+        ("200", 28, "200"),
+    ],
+)
+def test_probe_reports_http_and_transport_separately(
+    tmp_path: Path,
+    probe: tuple[str, str, str],
+    http_status: str,
+    curl_exit: int,
+    expected_status: str,
+) -> None:
+    result = _run_probe(tmp_path, probe, http_status, curl_exit)
+    assert (result.returncode == 0) == (http_status == "200" and curl_exit == 0)
+    assert f"http_status={expected_status} curl_exit={curl_exit}" in result.stdout
+    assert "000000" not in result.stdout
+    assert "522000" not in result.stdout
+
+
+def test_playground_still_requires_ok_payload(tmp_path: Path) -> None:
+    result = _run_probe(tmp_path, PROBES[1], "200", 0, '{"status":"unavailable"}')
+    assert result.returncode != 0
+    assert "missing expected ok marker" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("frontend", "production"),
+    [
+        ("success", "failure"),
+        ("failure", "skipped"),
+        ("success", "cancelled"),
+        ("success", "success"),
+    ],
+)
+def test_summary_uses_individual_step_outcomes(
+    tmp_path: Path, frontend: str, production: str
+) -> None:
+    frontend_step = _step("monitor.yml", "health-check", "Check Frontend Critical Routes")
+    production_step = _step(*PROBES[2])
+    summary = _step("monitor.yml", "health-check", "Summary")
+    assert frontend_step["id"] == "frontend"
+    assert production_step["id"] == "production_api"
+    assert summary["if"] == "always()"
+    assert "job.status" not in json.dumps(summary)
+    expressions = {
+        "${{ steps.frontend.outcome }}": frontend,
+        "${{ steps.production_api.outcome }}": production,
+    }
+    assert set(summary["env"].values()) == set(expressions)
+    env = {key: expressions[value] for key, value in summary["env"].items()}
+    report = tmp_path / "summary.md"
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", summary["run"]],
+        env={"PATH": os.defpath, "GITHUB_STEP_SUMMARY": str(report), **env},
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    text = report.read_text()
+    assert f"| Frontend (Vercel/custom domain) | {frontend} |" in text
+    assert f"| Production API | {production} |" in text
+
+
+@pytest.mark.parametrize(
+    "filename,job", [("production-smoke.yml", "smoke"), ("monitor.yml", "health-check")]
+)
+def test_monitor_schedule_and_failure_policy_are_unchanged(filename: str, job: str) -> None:
+    workflow = _workflow(filename)
+    assert workflow["on"]["schedule"] == [{"cron": "*/30 * * * *"}]
+    assert "workflow_dispatch" in workflow["on"]
+    assert workflow["jobs"][job]["timeout-minutes"] == "5"
+    assert "continue-on-error" not in workflow["jobs"][job]
+    for probe in PROBES:
+        if probe[0] == filename:
+            step = _step(*probe)
+            assert "continue-on-error" not in step
+            assert "if" not in step
+            assert not re.search(r"\|\|\s*(true|echo)", step["run"])


### PR DESCRIPTION
## Summary

- Separate curl exit status from HTTP status for the two production smoke probes and the uptime monitor's production API probe. A timeout now reports `http_status=000 curl_exit=28`; an HTTP error retains its actual code rather than becoming `522000`.
- Report frontend and production API step outcomes independently, including skipped/cancelled states. A backend failure no longer mislabels healthy frontend routes.
- Add 31 deterministic regression cases that execute the workflow shell blocks with stubbed curl. No real service requests or credentials are used by the tests.

## Authority and boundaries

Tier 4: GitHub Actions workflow files. The operator approved the narrow diagnostic-repair plan and its implementation in Codex D. This approval does not authorize merge or settlement; this PR stays draft for a separate exact-head review/risk decision.

Schedules, endpoints, timeouts, runners, accepted health responses, staging/WebSocket behavior, notifications, and trajectory enforcement are unchanged. No production activation, service restart, branch-protection change, or workflow rerun was performed. The production outage and trajectory deficit are not fixed by this diagnostics change.

Coordination with the existing schedule-parking draft: https://github.com/synaptent/aragora/pull/10025#issuecomment-5643015639 . This does not adopt or modify #10025/#10026. Deployment recovery remains with the #9391 owners; trajectory paydown remains with #9979/#10013 owners.

## Validation

Base: `b06b3e303b9500b53b6914ede947fc095537584f`.
Repair head: `4ab837f03eaca2931d306f38097be1d2ed77efda`.

- Red: new regression suite on unchanged workflows: **30 failed, 1 passed**; reproduced concatenated `000000`/`522000` and missing per-step summary outcomes.
- Green: **37 passed** across the new 31 cases, three existing frontend-route tests, and three existing trajectory no-masking regression tests.
- Actionlint on both touched workflows: passed.
- Ruff check/format on the touched Python test: passed.
- `git diff --check`: passed.
- `bash scripts/automation_pr_preflight.sh --json origin/main HEAD`: `status=ok`, no forbidden files, source with tests.
- Pre-commit and pre-push hooks: passed, including YAML, Ruff, changed-file mypy gate, gitleaks, and portability checks.

```bash
python -m pytest tests/scripts/test_monitor_workflow_diagnostics.py \
  tests/scripts/test_verify_frontend_routes.py \
  tests/scripts/test_contract_drift_workflow.py::test_pr_admission_is_event_bound_absolute_and_terminal \
  tests/scripts/test_contract_drift_workflow.py::test_program_trajectory_upload_is_sha_qualified_and_never_masks_the_analyzer \
  tests/scripts/test_contract_drift_workflow.py::test_program_trajectory_preserves_real_red_exit -q
actionlint .github/workflows/production-smoke.yml .github/workflows/monitor.yml
python -m ruff check tests/scripts/test_monitor_workflow_diagnostics.py
git diff --check
```

Live failure evidence used for diagnosis: [production smoke job](https://github.com/synaptent/aragora/actions/runs/34668221298/job/103484406124), [uptime monitor job](https://github.com/synaptent/aragora/actions/runs/34668263438/job/103484525185). Local stub tests validate the repair; they do not claim that the hosted production API recovered.
