### PR TITLE
fix(sdk): restore typed Python transport failures

### DIFF
--- a/sdk/python/BREAKING_CHANGES.md
+++ b/sdk/python/BREAKING_CHANGES.md
@@ -10,6 +10,16 @@ This document tracks breaking changes specific to the Aragora Python SDK. For co
 
 #### Breaking Changes
 
+##### Typed HTTP transport failures
+
+Exhausted HTTP timeouts and connection-establishment failures now raise the
+existing `aragora_sdk.TimeoutError` and `aragora_sdk.ConnectionError`, respectively,
+instead of the generic `AragoraError`. Existing `except AragoraError` handlers,
+messages and chained transport causes remain compatible. Code checking exact
+exception types should accept the exported subclasses; Python's built-in
+exceptions with the same names are not these SDK classes. Attempt counts and
+backoff are unchanged. See [Python HTTP request lifecycle](REQUEST_LIFECYCLE.md#transport-failures-and-cancellation).
+
 ##### Python rate-limit automatic waits
 
 `AragoraClient` and `AragoraAsyncClient` now automatically wait only for valid

--- a/sdk/python/REQUEST_LIFECYCLE.md
+++ b/sdk/python/REQUEST_LIFECYCLE.md
@@ -48,3 +48,36 @@ with AragoraClient(base_url="http://localhost:8080", max_retries=1) as client:
 The same diagnostics are available with `async with AragoraAsyncClient(...)`
 and `await client.request(...)`. This contract does not add a global deadline,
 cancellation API, or new exception type.
+
+## Transport failures and cancellation
+
+After the existing attempt budget is exhausted, both clients raise the existing
+SDK `TimeoutError` for `httpx.TimeoutException` (including connect, read, write
+and pool timeouts), or SDK `ConnectionError` for `httpx.ConnectError`.
+Import these from `aragora_sdk`, not Python's built-in exception classes.
+Both remain subclasses of `AragoraError`, keep the messages `Request timed out`
+and `Connection failed`, and chain the final transport exception as `__cause__`.
+No HTTP status, error code, trace ID or response body is fabricated.
+
+The existing `max_retries` value is the maximum number of attempts, including
+the first request. Retry counts and exponential backoff are unchanged, as is
+successful recovery before exhaustion. This change does not newly wrap or retry
+other transport errors, response-decoding failures or arbitrary exceptions.
+
+```python
+from aragora_sdk import AragoraClient, ConnectionError, TimeoutError
+
+with AragoraClient(base_url="http://localhost:8080", max_retries=1) as client:
+    try:
+        result = client.request("GET", "/api/v1/debates")
+    except (TimeoutError, ConnectionError) as error:
+        # The configured attempt budget has already been consumed; do not retry blindly.
+        print(type(error).__name__, error.message)
+```
+
+Use `with AragoraClient(...)` or `async with AragoraAsyncClient(...)` to close
+the owned HTTP client after success or request failure. In asynchronous HTTP
+usage, caller cancellation during a request or retry backoff propagates as
+`asyncio.CancelledError` without another request attempt; context exit still
+closes the HTTP client. Cleanup is not shielded from further cancellation.
+This adds no cancellation API or total deadline and changes no WebSocket policy.

--- a/sdk/python/aragora_sdk/client.py
+++ b/sdk/python/aragora_sdk/client.py
@@ -24,9 +24,11 @@ from .exceptions import (
     AragoraError,
     AuthenticationError,
     AuthorizationError,
+    ConnectionError,
     NotFoundError,
     RateLimitError,
     ServerError,
+    TimeoutError,
     ValidationError,
 )
 
@@ -717,14 +719,14 @@ class AragoraClient:
                 if attempt < self.max_retries - 1:
                     time.sleep(self.retry_delay * (2**attempt))
                     continue
-                raise AragoraError("Request timed out") from e
+                raise TimeoutError("Request timed out") from e
 
             except httpx.ConnectError as e:
                 last_error = e
                 if attempt < self.max_retries - 1:
                     time.sleep(self.retry_delay * (2**attempt))
                     continue
-                raise AragoraError("Connection failed") from e
+                raise ConnectionError("Connection failed") from e
 
             except RateLimitError as e:
                 last_error = e
@@ -1395,14 +1397,14 @@ class AragoraAsyncClient:
                 if attempt < self.max_retries - 1:
                     await asyncio.sleep(self.retry_delay * (2**attempt))
                     continue
-                raise AragoraError("Request timed out") from e
+                raise TimeoutError("Request timed out") from e
 
             except httpx.ConnectError as e:
                 last_error = e
                 if attempt < self.max_retries - 1:
                     await asyncio.sleep(self.retry_delay * (2**attempt))
                     continue
-                raise AragoraError("Connection failed") from e
+                raise ConnectionError("Connection failed") from e
 
             except RateLimitError as e:
                 last_error = e

--- a/sdk/python/tests/test_transport_lifecycle.py
+++ b/sdk/python/tests/test_transport_lifecycle.py
@@ -1,0 +1,252 @@
+"""Public SDK transport classification, cancellation and ownership contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from aragora_sdk import AragoraAsyncClient, AragoraClient, AragoraError
+from aragora_sdk import ConnectionError as SDKConnectionError
+from aragora_sdk import TimeoutError as SDKTimeoutError
+
+FAILURES = [
+    (httpx.TimeoutException, SDKTimeoutError, "Request timed out"),
+    (httpx.ConnectTimeout, SDKTimeoutError, "Request timed out"),
+    (httpx.ReadTimeout, SDKTimeoutError, "Request timed out"),
+    (httpx.WriteTimeout, SDKTimeoutError, "Request timed out"),
+    (httpx.PoolTimeout, SDKTimeoutError, "Request timed out"),
+    (httpx.ConnectError, SDKConnectionError, "Connection failed"),
+]
+REQUESTS = [
+    ("POST", "/api/v1/debates"),
+    ("POST", "/api/v1/code-review/review"),
+    ("GET", "/api/v2/receipts/example"),
+]
+
+
+def assert_error(
+    error: AragoraError, expected: type[AragoraError], message: str, cause: Exception
+) -> None:
+    assert type(error) is expected
+    assert isinstance(error, AragoraError)
+    assert error.message == message
+    assert str(error) == f"AragoraError: {message}"
+    assert error.__cause__ is cause
+    assert error.status_code is None
+    assert error.error_code is None
+    assert error.trace_id is None
+    assert error.response_body is None
+
+
+@pytest.mark.parametrize("failure,expected,message", FAILURES)
+@pytest.mark.parametrize("attempts", [1, 3])
+def test_sync_exhaustion_preserves_type_cause_budget_and_cleanup(
+    failure: type[httpx.TransportError], expected: type[AragoraError], message: str, attempts: int
+) -> None:
+    causes: list[httpx.TransportError] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        cause = failure("private transport detail", request=request)
+        causes.append(cause)
+        raise cause
+
+    http = httpx.Client(transport=httpx.MockTransport(handle))
+    with (
+        patch("aragora_sdk.client.httpx.Client", return_value=http),
+        patch("aragora_sdk.client.time.sleep") as sleep,
+        pytest.raises(expected) as raised,
+    ):
+        with AragoraClient(max_retries=attempts, retry_delay=0.125) as client:
+            client.request("POST", REQUESTS[0][1], json={"task": "local only"})
+    assert_error(raised.value, expected, message, causes[-1])
+    assert len(causes) == attempts
+    assert [call.args[0] for call in sleep.call_args_list] == [
+        0.125 * 2**i for i in range(attempts - 1)
+    ]
+    assert http.is_closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure,expected,message", FAILURES)
+@pytest.mark.parametrize("attempts", [1, 3])
+async def test_async_exhaustion_preserves_type_cause_budget_and_cleanup(
+    failure: type[httpx.TransportError], expected: type[AragoraError], message: str, attempts: int
+) -> None:
+    causes: list[httpx.TransportError] = []
+
+    async def handle(request: httpx.Request) -> httpx.Response:
+        cause = failure("private transport detail", request=request)
+        causes.append(cause)
+        raise cause
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    with (
+        patch("aragora_sdk.client.httpx.AsyncClient", return_value=http),
+        patch("asyncio.sleep", new_callable=AsyncMock) as sleep,
+        pytest.raises(expected) as raised,
+    ):
+        async with AragoraAsyncClient(max_retries=attempts, retry_delay=0.125) as client:
+            await client.request("POST", REQUESTS[0][1], json={"task": "local only"})
+    assert_error(raised.value, expected, message, causes[-1])
+    assert len(causes) == attempts
+    assert [call.args[0] for call in sleep.call_args_list] == [
+        0.125 * 2**i for i in range(attempts - 1)
+    ]
+    assert http.is_closed
+
+
+@pytest.mark.parametrize("failure", [None, httpx.ReadTimeout, httpx.ConnectError])
+@pytest.mark.parametrize("method,path", REQUESTS)
+def test_sync_success_and_recovery_keep_budget_and_cleanup(
+    failure: type[httpx.TransportError] | None, method: str, path: str
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if failure and len(requests) < 3:
+            raise failure("transient", request=request)
+        return httpx.Response(200, json={"ok": True})
+
+    http = httpx.Client(transport=httpx.MockTransport(handle))
+    with (
+        patch("aragora_sdk.client.httpx.Client", return_value=http),
+        patch("aragora_sdk.client.time.sleep") as sleep,
+    ):
+        with AragoraClient(max_retries=3, retry_delay=0.125) as client:
+            assert client.request(method, path) == {"ok": True}
+    assert len(requests) == (3 if failure else 1)
+    assert [call.args[0] for call in sleep.call_args_list] == ([0.125, 0.25] if failure else [])
+    assert all((request.method, request.url.path) == (method, path) for request in requests)
+    assert http.is_closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [None, httpx.ReadTimeout, httpx.ConnectError])
+@pytest.mark.parametrize("method,path", REQUESTS)
+async def test_async_success_and_recovery_keep_budget_and_cleanup(
+    failure: type[httpx.TransportError] | None, method: str, path: str
+) -> None:
+    requests: list[httpx.Request] = []
+
+    async def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if failure and len(requests) < 3:
+            raise failure("transient", request=request)
+        return httpx.Response(200, json={"ok": True})
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    with (
+        patch("aragora_sdk.client.httpx.AsyncClient", return_value=http),
+        patch("asyncio.sleep", new_callable=AsyncMock) as sleep,
+    ):
+        async with AragoraAsyncClient(max_retries=3, retry_delay=0.125) as client:
+            assert await client.request(method, path) == {"ok": True}
+    assert len(requests) == (3 if failure else 1)
+    assert [call.args[0] for call in sleep.call_args_list] == ([0.125, 0.25] if failure else [])
+    assert all((request.method, request.url.path) == (method, path) for request in requests)
+    assert http.is_closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["request", "timeout", "connection", "rate_limit"])
+async def test_cancellation_propagates_without_retry_and_closes_owned_http(phase: str) -> None:
+    entered = asyncio.Event()
+    never = asyncio.Event()
+    requests: list[httpx.Request] = []
+    delays: list[float] = []
+
+    async def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if phase == "request":
+            entered.set()
+            await never.wait()
+        if phase == "timeout":
+            raise httpx.ReadTimeout("transient", request=request)
+        if phase == "connection":
+            raise httpx.ConnectError("transient", request=request)
+        return httpx.Response(429, headers={"Retry-After": "1"}, json={"error": "slow down"})
+
+    async def backoff(delay: float) -> None:
+        delays.append(delay)
+        entered.set()
+        await never.wait()
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+
+    async def operation() -> object:
+        async with AragoraAsyncClient(max_retries=3, retry_delay=0.125) as client:
+            return await client.request("POST", REQUESTS[0][1], json={"task": "local only"})
+
+    with (
+        patch("aragora_sdk.client.httpx.AsyncClient", return_value=http),
+        patch("asyncio.sleep", side_effect=backoff),
+    ):
+        task = asyncio.create_task(operation())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=2)
+            assert task.cancel("caller stopped")
+            with pytest.raises(asyncio.CancelledError, match="caller stopped"):
+                await asyncio.wait_for(task, timeout=2)
+        finally:
+            # Keep a broken implementation from leaking an in-flight fixture task.
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+    assert task.cancelled()
+    assert len(requests) == 1
+    expected_delays = [] if phase == "request" else [1 if phase == "rate_limit" else 0.125]
+    assert delays == expected_delays
+    assert http.is_closed
+
+
+@pytest.mark.parametrize("failure", [httpx.ReadError, httpx.RemoteProtocolError, ValueError])
+def test_other_sync_failures_are_not_newly_wrapped_or_retried(failure: type[Exception]) -> None:
+    cause = failure("unchanged")
+    calls: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        raise cause
+
+    http = httpx.Client(transport=httpx.MockTransport(handle))
+    with (
+        patch("aragora_sdk.client.httpx.Client", return_value=http),
+        patch("aragora_sdk.client.time.sleep") as sleep,
+        pytest.raises(failure) as raised,
+    ):
+        with AragoraClient() as client:
+            client.request("GET", REQUESTS[2][1])
+    assert raised.value is cause
+    assert len(calls) == 1
+    sleep.assert_not_called()
+    assert http.is_closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [httpx.ReadError, httpx.RemoteProtocolError, ValueError])
+async def test_other_async_failures_are_not_newly_wrapped_or_retried(
+    failure: type[Exception],
+) -> None:
+    cause = failure("unchanged")
+    calls: list[httpx.Request] = []
+
+    async def handle(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        raise cause
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    with (
+        patch("aragora_sdk.client.httpx.AsyncClient", return_value=http),
+        patch("asyncio.sleep", new_callable=AsyncMock) as sleep,
+        pytest.raises(failure) as raised,
+    ):
+        async with AragoraAsyncClient() as client:
+            await client.request("GET", REQUESTS[2][1])
+    assert raised.value is cause
+    assert len(calls) == 1
+    sleep.assert_not_called()
+    assert http.is_closed

--- a/sdk/python/tests/test_transport_lifecycle.py
+++ b/sdk/python/tests/test_transport_lifecycle.py
@@ -158,6 +158,7 @@ async def test_cancellation_propagates_without_retry_and_closes_owned_http(phase
     never = asyncio.Event()
     requests: list[httpx.Request] = []
     delays: list[float] = []
+    cancellations: list[tuple[object, ...]] = []
 
     async def handle(request: httpx.Request) -> httpx.Response:
         requests.append(request)
@@ -178,8 +179,13 @@ async def test_cancellation_propagates_without_retry_and_closes_owned_http(phase
     http = httpx.AsyncClient(transport=httpx.MockTransport(handle))
 
     async def operation() -> object:
-        async with AragoraAsyncClient(max_retries=3, retry_delay=0.125) as client:
-            return await client.request("POST", REQUESTS[0][1], json={"task": "local only"})
+        try:
+            async with AragoraAsyncClient(max_retries=3, retry_delay=0.125) as client:
+                return await client.request("POST", REQUESTS[0][1], json={"task": "local only"})
+        except asyncio.CancelledError as error:
+            # Observe SDK propagation before Python 3.10 wait_for drops the message.
+            cancellations.append(error.args)
+            raise
 
     with (
         patch("aragora_sdk.client.httpx.AsyncClient", return_value=http),
@@ -189,7 +195,7 @@ async def test_cancellation_propagates_without_retry_and_closes_owned_http(phase
         try:
             await asyncio.wait_for(entered.wait(), timeout=2)
             assert task.cancel("caller stopped")
-            with pytest.raises(asyncio.CancelledError, match="caller stopped"):
+            with pytest.raises(asyncio.CancelledError):
                 await asyncio.wait_for(task, timeout=2)
         finally:
             # Keep a broken implementation from leaking an in-flight fixture task.
@@ -197,6 +203,7 @@ async def test_cancellation_propagates_without_retry_and_closes_owned_http(phase
                 task.cancel()
                 await asyncio.gather(task, return_exceptions=True)
     assert task.cancelled()
+    assert cancellations == [("caller stopped",)]
     assert len(requests) == 1
     expected_delays = [] if phase == "request" else [1 if phase == "rate_limit" else 0.125]
     assert delays == expected_delays


### PR DESCRIPTION
## Summary

HTTP Consumer Reliability unit2, from fresh main after #10056 landed. Restore the existing exported Python SDK `TimeoutError` and `ConnectionError` when the existing sync/async transport retry budget is exhausted. Preserve messages, final httpx causes, `AragoraError` compatibility, attempt counts, backoff and recovery. No new exception, configuration, retry category, endpoint or automatic reconnect.

Only four production raise sites plus two imports change. New deterministic tests prove that request/backoff cancellation propagates without another attempt and HTTP-only context managers close owned clients after success, failure and cancellation. Those implementations already passed; they are not changed. SDK-local lifecycle and migration documentation describe the typed behavior and existing boundaries.

Four files,308additions/4deletions. SDK semantics are **Tier3**. This draft is implementation/validation and independent non-countable review only. Separate exact-head operator risk acceptance is required before countable evidence, ready, settlement or merge. #10056's landing approval does not transfer. #10014/#10015 remain preserved; no shared/model-refresh files touched.

## Verification

- Baseline:24new typed-exception regressions failed;28other new lifecycle contracts already passed. Candidate:52new transport tests and226rate-limit tests pass.
- Full SDK:1657passed/7existingwarnings on each local Python3.10.20/3.11.11/3.12.12; pristine freshbase1605passed/7warnings. Each runtime also passes52transport and302combined transport/rate-limit/retry cases. These are macOS validations, not claims of matching hosted Linux patch versions.
- Thirteen meaningful in-memory mutants killed on both Python3.10 and3.11: sync/async generic mapping, lost causes, missing cleanup, cancellation conversion in request/backoff, extraattempt, and cancellation-message loss in request/backoff. An initial range-only mutant was equivalent because the existing inner guard still terminated; it was not counted as a kill. The corrected two-guard extraattempt mutant fails24tests.
- Fresh isolated wheel2.10.0 rebuilt byte-identically after the test-only repair (SHA256`ad9d3eeebeb882a193602c93515ddea81ceeb0ab38a4db36fbc7d510b7b2834f`); installed consumers on all three Python minors each pass278focused tests, without source-path conftest. Real loopback recheck proves two readtimeouts, two connectionrefusals, one caller cancellation and the exact new documentation example, with ownedclientsclosed. Initial bound/unlistening macOS port fixture timed out instead of refusing; a closed-port,1s-bounded fixture verified refusal. No SDK workaround added.
- FullSDK Ruffcheck/format306files passed; changed-file strict mypy has no errors in either changed file. Two imported `namespaces/settlements.py` errors reproduce unchanged on pristinebase.
- All11non-mypy `make ci-required` commands pass. Broad repository mypy1735errors/460files matches pristinebase exactly, zero new/resolved. RepositorySDKintegration402passed/1baselineTS5103failure/421warnings, reproduced on both. No baseline weakening or unrelated fix.
- Normal commit/push hooks and publication preflight pass. At exact head`83855d5c711876b5ca882bbbc1950be3217ec8f0`, all45checkruns completed (21success/24skipped); all6requiredcontexts green; hostedPython3.10.21/3.11.16/3.12.14 each1657pass, hostedSDKintegration403pass. No failed/pendingchecks. A green draft quorum check is not model evidence.

## Boundaries and remaining work

The first independent non-countable review at050884692 found exactly one P2: the cancellation test asserted message preservation after Python3.10 `asyncio.wait_for` had discarded it. Hosted3.10 failed four tests; that was a new regression, not baseline. The single permitted repair now checks original cancellationargs at the SDK boundary, while retaining outer CancelledError, cancelled task, exact one request, backoff, cleanup and bounded teardown. No runtime/docs change was made for this repair. Original review remains preserved.

Fresh independent terminal review at`83855d5c711876b5ca882bbbc1950be3217ec8f0`: **no confirmed newP0-P3findings**. The reviewer had no implementation authorship or preceding PR context; inspected the complete cumulative diff/history/client/consumers and allfeedback/checkannotations; independently reran1657source+278installed+58actualconsumer cases per Pythonminor,13mutants on3.10/3.11,loopback/docs and applicablelocalchecks. It verified all201packagedfiles against source/installed bytes. This is NON-COUNTABLE technical review only. No model-family evidence, ready action, settlement or merge occurred. Lease and reviewer capacity released; the draft remains frozen for separate exact-head Tier3 operator authorization.

Risk for operator acceptance: existing caller-owned retry decorators that catch the exported transport subclasses will now activate. The SDK's per-call budget is unchanged, but nested application retries can multiply total attempts, especially for non-idempotent operations. The new documentation warns against blind retries; no application-wide attempt guarantee is claimed.

No workflows, dependencies, shared Quickstarts, model catalogs, server behavior, receipt formats, pagination, Grok transport, governance or other agents' work. Existing non-matching transport/decoding exceptions retain their behavior. This does not add a global deadline or shield cleanup from repeated cancellation; WebSocket policy is unchanged.

Next HTTP campaign work is TypeScript successful-response replay/deadline ownership, still gated on unpublished file ownership release and this unit's separately authorized landing. No additional campaign PR will be opened while this one is active.
