### PR TITLE
test(memory): require real multiprocess promotion evidence

### DIFF
--- a/tests/memory/test_tier_ops_concurrency.py
+++ b/tests/memory/test_tier_ops_concurrency.py
@@ -20,6 +20,7 @@ import threading
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
+from queue import Empty
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -413,10 +414,59 @@ def _worker_promote(db_path: str, entry_id: str, result_queue):
 class TestMultiProcessSimulation:
     """Tests simulating multi-process/multi-pod scenarios."""
 
-    @pytest.mark.skipif(
-        multiprocessing.get_start_method() == "fork",
-        reason="Fork may not be available on all platforms",
+    @pytest.mark.parametrize(
+        ("failure", "message"),
+        [
+            ("missing_result", "Missing worker result"),
+            ("worker_error", "Worker errors"),
+            ("invalid_status", "Worker errors"),
+            ("no_promotion", "Expected exactly one promotion"),
+            ("duplicate_promotion", "Expected exactly one promotion"),
+            ("crash", "Worker exit codes"),
+            ("hang", "Workers did not finish"),
+            ("not_persisted", "Promotion was not persisted"),
+        ],
     )
+    def test_multiprocess_rejects_false_success(
+        self, temp_db_path: str, monkeypatch: pytest.MonkeyPatch, failure: str, message: str
+    ) -> None:
+        results = [("success", MemoryTier.FAST), ("success", None), ("success", None)]
+        if failure == "missing_result":
+            results[-1] = Empty()
+        elif failure == "worker_error":
+            results[-1] = ("error", "worker failed")
+        elif failure == "invalid_status":
+            results[-1] = ("unknown", None)
+        elif failure == "no_promotion":
+            results[0] = ("success", None)
+        elif failure == "duplicate_promotion":
+            results[1] = ("success", MemoryTier.FAST)
+
+        context = MagicMock()
+        result_queue = context.Queue.return_value
+        result_queue.get.side_effect = results
+        processes = [MagicMock(exitcode=0) for _ in range(3)]
+        for process in processes:
+            process.is_alive.return_value = False
+        if failure == "crash":
+            processes[0].exitcode = 1
+        elif failure == "hang":
+            processes[0].is_alive.return_value = True
+        context.Process.side_effect = processes
+        get_context = MagicMock(return_value=context)
+        monkeypatch.setattr(multiprocessing, "get_context", get_context)
+
+        with pytest.raises(AssertionError, match=message):
+            self.test_multiprocess_promote_simulation(temp_db_path)
+
+        get_context.assert_called_once_with("spawn")
+        for process in processes:
+            process.close.assert_called_once()
+        if failure == "hang":
+            processes[0].terminate.assert_called_once()
+        result_queue.close.assert_called_once()
+        result_queue.join_thread.assert_called_once()
+
     def test_multiprocess_promote_simulation(self, temp_db_path: str) -> None:
         """Test that promotion is safe across multiple processes."""
         # Initialize database in main process
@@ -432,36 +482,59 @@ class TestMultiProcessSimulation:
             )
             conn.commit()
 
-        # Spawn multiple worker processes
-        result_queue = multiprocessing.Queue()
+        # Spawn avoids inheriting the parent's database connections on fork platforms.
+        context = multiprocessing.get_context("spawn")
+        result_queue = context.Queue()
         processes = []
+        try:
+            for _ in range(3):
+                process = context.Process(
+                    target=_worker_promote,
+                    args=(temp_db_path, "mp_test", result_queue),
+                )
+                process.start()
+                processes.append(process)
 
-        for _ in range(3):
-            p = multiprocessing.Process(
-                target=_worker_promote,
-                args=(temp_db_path, "mp_test", result_queue),
+            deadline = time.monotonic() + 15
+            results = []
+            for _ in processes:
+                try:
+                    results.append(result_queue.get(timeout=max(0, deadline - time.monotonic())))
+                except Empty as exc:
+                    raise AssertionError(
+                        f"Missing worker result: received {len(results)}/3"
+                    ) from exc
+
+            for process in processes:
+                process.join(timeout=max(0, deadline - time.monotonic()))
+            assert not any(p.is_alive() for p in processes), "Workers did not finish"
+            exit_codes = [p.exitcode for p in processes]
+            assert exit_codes == [0, 0, 0], f"Worker exit codes: {exit_codes}"
+            errors = [(status, result) for status, result in results if status != "success"]
+            assert not errors, f"Worker errors: {errors}"
+            successes = [result for _, result in results if result is not None]
+            assert successes == [MemoryTier.FAST], f"Expected exactly one promotion: {results}"
+
+            with cms.connection() as conn:
+                tier = conn.execute(
+                    "SELECT tier FROM continuum_memory WHERE id = ?", ("mp_test",)
+                ).fetchone()[0]
+                transitions = conn.execute(
+                    "SELECT from_tier, to_tier FROM tier_transitions WHERE memory_id = ?",
+                    ("mp_test",),
+                ).fetchall()
+            assert tier == "fast", "Promotion was not persisted"
+            assert [tuple(row) for row in transitions] == [("medium", "fast")], (
+                f"Unexpected transitions: {transitions}"
             )
-            processes.append(p)
-
-        for p in processes:
-            p.start()
-
-        for p in processes:
-            p.join(timeout=10)
-
-        # Collect results
-        results = []
-        while not result_queue.empty():
-            results.append(result_queue.get_nowait())
-
-        # Check results
-        successes = [r for status, r in results if status == "success" and r is not None]
-        errors = [r for status, r in results if status == "error"]
-
-        assert len(errors) == 0, f"Errors occurred: {errors}"
-
-        # At most one promotion should succeed due to cooldown
-        assert len(successes) <= 1, f"Multiple promotions succeeded: {successes}"
+        finally:
+            for process in processes:
+                if process.is_alive():
+                    process.terminate()
+                process.join(timeout=5)
+                process.close()
+            result_queue.close()
+            result_queue.join_thread()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The multiprocess promotion test could pass with zero worker results, including when every worker exited with an error. That made its at-most-one-promotion assertion vacuously true. This is a test-only repair; no production memory, persistence, schema, workflow, dependency, or public API changes.

- Use an explicit spawn context instead of skipping hosts whose default is fork.
- Require all three results within a shared deadline, worker termination with exit code zero, one successful FAST promotion, and one persisted medium-to-fast transition.
- Close owned processes and queue resources on success and failure.
- Add eight deterministic negative controls: missing result, reported worker error, invalid status, no promotion, duplicate promotion, worker crash, hung worker, and a claimed but unpersisted promotion.

## Red / Green Evidence

On base c9998c0d3cc91c83e1af365d3659c3b590eb4223, replacing Process with failed workers (exitcode=1) and Queue with an empty queue still allowed the original test to pass. The eight new negative controls first failed because the original test did not raise an assertion.

After repair:

```text
tests/memory/test_tier_ops_concurrency.py: 18 passed
concurrency + continuum tier ops + tier manager + transition events: 139 passed
```

Commands:

```bash
python -m pytest -q tests/memory/test_tier_ops_concurrency.py tests/memory/continuum/test_tier_ops.py tests/memory/test_tier_manager.py tests/memory/test_tier_transition_events.py --timeout=60 -p no:cacheprovider
python -m ruff check tests/memory/test_tier_ops_concurrency.py
python -m ruff format --check tests/memory/test_tier_ops_concurrency.py
git diff --check
bash scripts/automation_pr_preflight.sh origin/main HEAD
```

Existing deprecation warnings remain. Focused green tests are regression evidence, not proof of production multi-node correctness. Independent current-head review and normal governance gates remain pending; this PR is draft only.

## Scope / Ownership

All peer lanes explicitly confirmed no ownership or unpublished work on this test. Isolated, path-scoped lease; shared-root tracked tree and scratch file untouched. SDK, receipt, Atlas, store-bootstrap, release, and queue-drain work remains with its existing owners.

## Bounded Typing Repair Handoff (2026-09-13)

Current head: `4217c46ad31be7adf08719da7c0dc19b6b553d0c`, one additive commit after `6504bb911fa3cd6340d3b6f7ee37b0ed79539812`.
Codex D explicitly released source custody to Codex A for this annotation-only
test repair. The original implementation and draft-only campaign record above
remain historical; live GitHub currently reports this PR non-draft. No ready-state
change was made by this repair cycle.

- Explicitly type the mocked results list for its existing success/error tuples
  and deliberate `queue.Empty` side effect. No runtime values, assertions, test
  cases, production code or dependencies changed. AST comparison confirms the
  entire file is unchanged after removing only this local annotation.
- All eight negative controls and the 139-test focused memory slice pass.
  Ruff check, format check, automation preflight, diff check and normal commit
  and push hooks pass. Existing test deprecation warnings remain.
- Fresh targeted mypy reproduces 9 errors before and 7 after: both errors
  introduced by the mock fixture are removed, with zero additions. The remaining
  seven errors are inherited from current main (one generator-return annotation
  and six optional-entry attribute accesses). Raw targeted mypy still exits 1;
  no baseline was suppressed or edited. Current main independently reports 8
  errors because it additionally retains the old unannotated result queue.
- The original OpenAI prepare-only artifact remains byte-identical and historical
  at `6504bb911fa3cd6340d3b6f7ee37b0ed79539812`. This new head cannot reuse it. One historical review pass remains
  consumed; this repair adds no review allowance and resets no attempt budget.
- Original D and prior validation worktrees, locks and ignored artifacts remain
  untouched. The new locked repair worktree is clean with no unpublished commits;
  its lane and scoped lease are being finalized and released.
- Fresh exact-head CI and separately applicable review authority remain. No
  reviewer invocation, model evidence posting, manual CI rerun, settlement, merge,
  label, branch deletion or worktree deletion occurred in this repair cycle.
