### PR TITLE
fix(sdk): prevent replay after successful HTTP responses

### DIFF
--- a/sdk/typescript/REQUEST_LIFECYCLE.md
+++ b/sdk/typescript/REQUEST_LIFECYCLE.md
@@ -1,0 +1,32 @@
+# HTTP request lifecycle
+
+## Successful responses are not replayed on a decoding failure
+
+Once the TypeScript client's HTTP request receives a successful response
+(`Response.ok`), reading or decoding that response cannot trigger another network
+attempt. This applies to `request`, the HTTP helpers, and namespaces using them,
+even when retries are enabled. A failed body read propagates its original error;
+invalid JSON propagates `SyntaxError`. Neither is reclassified as a connection,
+timeout, or server error by the request retry loop.
+
+This intentionally changes older SDK behavior that could repeat an operation
+after its successful response failed to decode. The server may already have
+performed the operation: do not blindly retry a creation or other side effect
+from a catch handler. Inspect its state through an existing lookup interface
+before deciding whether another operation is appropriate. This is not a guarantee
+of exactly-once execution or an idempotency mechanism.
+
+```typescript
+try {
+  const result = await client.post('/api/v1/debates', { task: 'Compare approaches' });
+  console.log(result);
+} catch (error) {
+  // Handle the interruption; this catch intentionally sends no second request.
+  console.error('Request failed; inspect operation state before retrying.', error);
+}
+```
+
+JSON, text, and empty-response return values are unchanged. Failed HTTP responses
+and failures before a response keep their existing retry rules, attempt counts,
+backoff, and error classification. This change does not extend timeout coverage,
+alter timer cleanup, add automatic reconnection, or change WebSocket behavior.

--- a/sdk/typescript/src/__tests__/request-lifecycle.test.ts
+++ b/sdk/typescript/src/__tests__/request-lifecycle.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AragoraClient } from '../client';
+import { AragoraError, ConnectionError, TimeoutError } from '../errors';
+
+describe('HTTP successful-response lifecycle', () => {
+  let client: AragoraClient;
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    client = new AragoraClient({
+      baseUrl: 'https://api.example.test',
+      maxRetries: 3,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // Attach rejection handling before advancing timers, including on broken base.
+  async function outcome<T>(request: Promise<T>) {
+    const settled = request.then(
+      value => ({ value, error: undefined }),
+      (error: unknown) => ({ value: undefined, error }),
+    );
+    await vi.runAllTimersAsync();
+    return settled;
+  }
+
+  it.each(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'post'])(
+    '%s does not replay a successful response containing invalid JSON',
+    async method => {
+      fetchMock.mockImplementation(async () => new Response('{invalid', { status: 200 }));
+      const started = Date.now();
+      const result = await outcome(client.request(method, '/api/v1/debates', {
+        body: { task: 'deterministic test' },
+      }));
+      expect(result.error).toBeInstanceOf(SyntaxError);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(Date.now()).toBe(started); // No retry backoff either.
+      expect(fetchMock.mock.calls[0][1]?.method).toBe(method);
+    },
+  );
+
+  it.each([false, true])('preserves decoding errors with retryEnabled=%s', async retryEnabled => {
+    client = new AragoraClient({ baseUrl: 'https://api.example.test', retryEnabled });
+    const decodingError = new SyntaxError('invalid JSON body');
+    fetchMock.mockResolvedValue(new Response('not JSON'));
+    vi.spyOn(JSON, 'parse').mockImplementation(() => { throw decodingError; });
+    const result = await outcome(client.post('/api/v1/debates', { task: 'example' }));
+    expect(result.error).toBe(decodingError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  const bodyFailures: Array<[string, unknown]> = [
+    ['ordinary error', new Error('body stream interrupted')],
+    ['network-named TypeError', new TypeError('network body failure')],
+    ['abort', new DOMException('body aborted', 'AbortError')],
+    ['SDK server error', new AragoraError('body failed', 503, 'SERVICE_UNAVAILABLE')],
+    ['string', 'body failed'],
+    ['null', null],
+  ];
+
+  describe.each(['json', 'text'] as const)('%s response consumption', responseType => {
+    it.each(bodyFailures)('preserves %s without reclassification or replay', async (_name, failure) => {
+      fetchMock.mockImplementation(async () => {
+        const response = new Response('unread');
+        vi.spyOn(response, 'text').mockRejectedValue(failure);
+        return response;
+      });
+      const result = await outcome(client.request('POST', '/api/v1/debates', { responseType }));
+      expect(result.error).toBe(failure);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  it.each([
+    ['object JSON', 'json', '{"ok":true}', 200, { ok: true }],
+    ['array JSON', 'json', '[1,2]', 200, [1, 2]],
+    ['null JSON', 'json', 'null', 200, null],
+    ['empty JSON', 'json', '', 200, {}],
+    ['no-content JSON', 'json', null, 204, {}],
+    ['plain text', 'text', '{invalid', 200, '{invalid'],
+    ['empty text', 'text', '', 200, ''],
+    ['no-content text', 'text', null, 204, ''],
+  ] as const)('preserves %s success', async (_label, responseType, body, status, expected) => {
+    fetchMock.mockResolvedValue(new Response(body, { status }));
+    const result = await outcome(client.request('GET', '/api/v1/debates', { responseType }));
+    expect(result.error).toBeUndefined();
+    expect(result.value).toEqual(expected);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each(['invalid JSON', 'body failure'])('stops after a retried request succeeds with %s', async kind => {
+    const bodyError = new Error('read failed after retry');
+    fetchMock.mockResolvedValueOnce(new Response('{"error":"busy"}', { status: 503 }));
+    fetchMock.mockImplementation(async () => {
+      const response = new Response('{invalid');
+      if (kind === 'body failure') vi.spyOn(response, 'text').mockRejectedValue(bodyError);
+      return response;
+    });
+    const started = Date.now();
+    const result = await outcome(client.post('/api/v1/debates', {}));
+    if (kind === 'body failure') expect(result.error).toBe(bodyError);
+    else expect(result.error).toBeInstanceOf(SyntaxError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(Date.now() - started).toBe(1000);
+  });
+
+  it('retains server-error attempts and exponential backoff', async () => {
+    fetchMock.mockImplementation(async () => new Response('{"error":"busy"}', { status: 503 }));
+    const started = Date.now();
+    const result = await outcome(client.post('/api/v1/debates', {}));
+    expect(result.error).toBeInstanceOf(AragoraError);
+    expect((result.error as AragoraError).statusCode).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(Date.now() - started).toBe(3000);
+  });
+
+  it.each([false, true])('retains server-error recovery (malformed error body=%s)', async malformed => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(malformed ? 'bad JSON' : '{"error":"busy"}', { status: 500 }))
+      .mockResolvedValueOnce(new Response('{"id":"created-once"}', { status: 201 }));
+    const started = Date.now();
+    const result = await outcome(client.post('/api/v1/debates', {}));
+    expect(result).toEqual({ value: { id: 'created-once' }, error: undefined });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(Date.now() - started).toBe(1000);
+  });
+
+  it.each([400, 401, 429])('retains immediate HTTP %s rejection', async status => {
+    fetchMock.mockImplementation(async () => new Response('bad JSON', { status }));
+    const result = await outcome(client.post('/api/v1/debates', {}));
+    expect(result.error).toBeInstanceOf(AragoraError);
+    expect((result.error as AragoraError).statusCode).toBe(status);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['network', new TypeError('Failed to fetch'), ConnectionError],
+    ['timeout', new DOMException('aborted', 'AbortError'), TimeoutError],
+  ] as const)('retains existing immediate %s classification before a response', async (_label, error, expected) => {
+    fetchMock.mockRejectedValue(error);
+    const result = await outcome(client.post('/api/v1/debates', {}));
+    expect(result.error).toBeInstanceOf(expected);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains existing retries for other pre-response errors', async () => {
+    const error = new Error('transport unavailable');
+    fetchMock.mockRejectedValue(error);
+    const result = await outcome(client.post('/api/v1/debates', {}));
+    expect(result.error).toBe(error);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1275,12 +1275,13 @@ export class AragoraClient {
     const maxAttempts = this.config.retryEnabled ? this.config.maxRetries : 1;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      let response: Response;
       try {
         const controller = new AbortController();
         const timeout = options.timeout ?? this.config.timeout;
         const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-        const response = await fetch(url.toString(), {
+        response = await fetch(url.toString(), {
           method,
           headers,
           body: options.body ? JSON.stringify(options.body) : undefined,
@@ -1293,21 +1294,6 @@ export class AragoraClient {
           const body = await response.json().catch(() => ({ error: response.statusText }));
           throw AragoraError.fromResponse(response.status, body);
         }
-
-        const text = await response.text();
-
-        // Text responses keep their contract even when the body is empty:
-        // '' is a valid string result, never coerced to {}.
-        if (options.responseType === 'text') {
-          return text as T;
-        }
-
-        // Handle empty JSON responses
-        if (!text) {
-          return {} as T;
-        }
-
-        return JSON.parse(text) as T;
       } catch (error) {
         lastError = error as Error;
 
@@ -1328,7 +1314,25 @@ export class AragoraClient {
         if (attempt < maxAttempts) {
           await this.sleep(Math.pow(2, attempt - 1) * 1000);
         }
+        continue;
       }
+
+      // A successful response may represent an operation already performed.
+      // Body/decoding errors must propagate unchanged, outside retry handling.
+      const text = await response.text();
+
+      // Text responses keep their contract even when the body is empty:
+      // '' is a valid string result, never coerced to {}.
+      if (options.responseType === 'text') {
+        return text as T;
+      }
+
+      // Handle empty JSON responses
+      if (!text) {
+        return {} as T;
+      }
+
+      return JSON.parse(text) as T;
     }
 
     // Check if lastError is a connection-type error


### PR DESCRIPTION
## Summary

Prevent response-body/JSON failures after a successful HTTP response from replaying a TypeScript SDK request. Successful-response processing now sits outside the existing request retry catch. Original body/decoding errors propagate unchanged; JSON/text/empty return values and failed-response retry policy remain intact.

HTTP Consumer Reliability campaign unit3, following merged #10056 and #10063. Three files only; no models, dependencies, timer policy, server, workflow, receipt format or shared Quickstart changes. The preserved model-refresh JSDoc hunk and parked #10014/#10015 are untouched.

## Risk — Tier 3, operator review required

This intentionally changes observable SDK semantics: decoding/consumption failure after success is no longer retried or reclassified by the transport loop. The server may already have performed an operation; callers must not blindly replay it from their own catch handlers. It is not an exactly-once guarantee. Existing server-error retry policy, max attempt counts, backoff, and pre-response exception mapping are unchanged. Body deadline/timer cleanup remains a separate next unit.

Keep draft pending independent non-countable review and a new exact-head Tier-3 human checkpoint. No countable evidence, ready, settlement or merge authorization is claimed by this PR.

## Validation

- New deterministic suite:23 failures on unchanged base;41 passes after fix, Node20.20.2 and25.9.0.
- Full TypeScript SDK:1728 passed /1 unchanged stats-route failure (base1687 passed /same1 failure), no skipped tests.
- SDK ESLint0errors/78 unchanged warnings; implementation and strict new-test typechecks pass.
- CJS/ESM/declaration builds pass on Node20 and25; installed artifact byte provenance checked.
- Six meaningful mutants killed; healthy retry/error behavior retained by negative controls.
- Fresh npm tarball consumers:30 cases each on Node20 and25 across CJS/ESM, representative debate/review/receipt interfaces, executable docs, and real loopback single-POST verification. No live provider calls.
- Repository SDK integration403 passed/421 unchanged warnings, fresh base identical.
- Quality ratchet passes. Eleven ci-required constituent commands pass; broad mypy fails with exactly the same1735 errors/460files as freshly archived base. No gate weakened or baseline failure suppressed.

Base09617840f9afe3e7dea429fc42d1d97db46f4fcd; five required code checks green at admission. Broader main contract-drift failure remains outside this scope. Operational logs, fixtures and ownership records are ignored/uncommitted, not part of this diff.
