### PR TITLE
fix(review): distinguish Claude profile failures [Tier 4]

### DIFF
--- a/aragora/agents/claude_pool_health.py
+++ b/aragora/agents/claude_pool_health.py
@@ -18,15 +18,19 @@ Snapshot shape (matches the format both consumers parse)::
 
 from __future__ import annotations
 
+import json
+import re
+
 # States consumers treat as unusable (mirror review_routing._UNHEALTHY_PROFILE_STATES).
 UNHEALTHY_STATES = {"expired", "not_configured", "unauthenticated", "logged_out"}
 
 _AUTH_FAILURE_MARKERS = (
-    "401",
+    r"\b401\b",
     "invalid authentication",
+    r"invalid (?:x-api-key|api key)",
     "failed to authenticate",
     "unauthorized",
-    "oauth token has expired",
+    r"(?:oauth .*)?token.*expir",
 )
 _NOT_CONFIGURED_MARKERS = (
     "no such file",
@@ -34,6 +38,94 @@ _NOT_CONFIGURED_MARKERS = (
     "no credentials",
     "claude_profile.sh not found",
 )
+
+
+_REASON_PATTERNS = (
+    ("auth_missing", "|".join(_NOT_CONFIGURED_MARKERS)),
+    ("auth_revoked", r"(?:oauth .*)?(?:token|credential).*revoked"),
+    ("auth_expired", "|".join(_AUTH_FAILURE_MARKERS)),
+    (
+        "quota_exhausted",
+        r"you['’]re out of usage credits|\b429\b|rate[ _-]?limit|"
+        r"quota (?:exceeded|exhausted)|insufficient credits|"
+        r"(?:you(?: have|['’]ve)? )?hit your (?:usage|session) limit|credit balance is too low",
+    ),
+    ("transport_timeout", r"(?:request |connection )?(?:timed? out|timeout)"),
+    ("service_unavailable", r"\b50[0234]\b|service unavailable|overloaded|internal server error"),
+    (
+        "invalid_response",
+        r"(?:(?:i['’]m )?sorry[, .]*(?:but )?)?(?:i (?:cannot|can['’]t|am unable)|refus(?:al|ed))",
+    ),
+)
+REASON_CODES = frozenset({"ok", "unknown_failure", *(reason for reason, _ in _REASON_PATTERNS)})
+
+
+def _plain_probe_reason(text: str, failed: bool = False) -> str:
+    text = text.strip().lower()
+    if not text:
+        return "invalid_response"
+    any_failure = failed
+    for line in text.splitlines():
+        line = line.strip()
+        line_failed = failed or bool(re.match(r"(?:api error|error\b|failed\b|http\b)", line))
+        match = re.search if line_failed else re.match
+        for reason, pattern in _REASON_PATTERNS:
+            if match(pattern, line):
+                return reason
+        any_failure = any_failure or line_failed
+    return "unknown_failure" if any_failure else "ok"
+
+
+def classify_probe_reason(
+    stdout: str, returncode: int | None = None, timed_out: bool = False
+) -> str:
+    if timed_out:
+        return "transport_timeout"
+    text = (stdout or "").strip()
+    failed = returncode not in (None, 0)
+    lines = text.splitlines()
+    json_start = next(
+        (index for index, line in enumerate(lines) if line.lstrip().startswith(("{", "["))),
+        None,
+    )
+    if json_start is not None:
+        if json_start:
+            preamble_reason = _plain_probe_reason("\n".join(lines[:json_start]))
+            if preamble_reason not in ("ok", "unknown_failure"):
+                return preamble_reason
+            failed = failed or preamble_reason == "unknown_failure"
+        try:
+            payload = json.loads("\n".join(lines[json_start:]))
+        except (ValueError, RecursionError):
+            return "invalid_response"
+        if not isinstance(payload, dict):
+            return "invalid_response"
+        if "is_error" in payload and not isinstance(payload["is_error"], bool):
+            return "invalid_response"
+        structured_error = (
+            payload.get("is_error") is True
+            or "error" in payload
+            or bool(payload.get("errors"))
+            or payload.get("type") == "error"
+            or str(payload.get("subtype", "")).startswith("error")
+        )
+        if structured_error:
+            failed = True
+            text = json.dumps(
+                [payload.get(key) for key in ("result", "error", "errors")], ensure_ascii=False
+            )
+        else:
+            if (
+                payload.get("type") != "result"
+                or payload.get("is_error") is not False
+                or payload.get("subtype") not in (None, "success")
+            ):
+                return "invalid_response"
+            result = payload.get("result")
+            if not isinstance(result, str):
+                return "invalid_response"
+            text = result
+    return _plain_probe_reason(text, failed)
 
 
 def classify_probe(stdout: str, *, returncode: int | None = None, timed_out: bool = False) -> str:
@@ -45,24 +137,23 @@ def classify_probe(stdout: str, *, returncode: int | None = None, timed_out: boo
     - ``not_configured``: the profile has no usable credentials at all.
     - ``unauthenticated``: timed out or produced no output (treated as unusable).
     """
-    text = (stdout or "").strip()
-    lowered = text.lower()
-    if timed_out:
+    reason = classify_probe_reason(stdout, returncode=returncode, timed_out=timed_out)
+    if reason == "transport_timeout":
         return "unauthenticated"
-    if any(marker in lowered for marker in _NOT_CONFIGURED_MARKERS):
+    if reason == "auth_missing":
         return "not_configured"
-    if any(marker in lowered for marker in _AUTH_FAILURE_MARKERS):
+    if reason in ("auth_expired", "auth_revoked"):
         return "expired"
-    if not text:
+    if not (stdout or "").strip():
         # No output and not a recognized error: cannot confirm liveness.
         return "unauthenticated"
     if returncode not in (None, 0):
         return "expired"
-    return "ok"
+    return "ok" if reason == "ok" else "unauthenticated"
 
 
 def is_healthy(state: str) -> bool:
-    return state not in UNHEALTHY_STATES
+    return state == "ok"
 
 
 def build_snapshot(records: list[dict], *, generated_at: str) -> dict:
@@ -75,6 +166,18 @@ def build_snapshot(records: list[dict], *, generated_at: str) -> dict:
         }
         for r in records
     ]
+    for profile, record in zip(profiles, records):
+        if profile["state"] not in UNHEALTHY_STATES | {"ok"}:
+            profile["state"] = "unauthenticated"
+        if "reason_code" in record:
+            reason = record["reason_code"]
+            profile["reason_code"] = (
+                reason if isinstance(reason, str) and reason in REASON_CODES else "unknown_failure"
+            )
+            if profile["reason_code"] != "ok" and is_healthy(profile["state"]):
+                profile["state"] = "unauthenticated"
+            elif profile["reason_code"] == "ok" and not is_healthy(profile["state"]):
+                profile["reason_code"] = "unknown_failure"
     healthy = sum(1 for p in profiles if is_healthy(p["state"]))
     return {
         "generated_at": generated_at,

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](https://g
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.10.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,330 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,327 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 2,001,754 | `docs/METRICS.md` |
-| Automated tests | 226,584 test functions | `docs/METRICS.md` |
-| Test files | 5,592 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 2,001,881 | `docs/METRICS.md` |
+| Automated tests | 226,622 test functions | `docs/METRICS.md` |
+| Test files | 5,596 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,330 tracked Python files | 145 top-level modules | 226,584 test functions across 5,592 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
+**Scale:** 4,327 tracked Python files | 145 top-level modules | 226,622 test functions across 5,596 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,330 Python files | 226,584 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,327 Python files | 226,622 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,330
-- **Tests**: 226,584 across 5,592 test files
+- **Python files (`aragora/`)**: 4,327
+- **Tests**: 226,622 across 5,596 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,584 tests across 5,592 test files
-- **Source files**: 4,330 Python files under `aragora/`
+- **Test coverage**: 226,622 tests across 5,596 test files
+- **Source files**: 4,327 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.10.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,330 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,327 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 2,001,754 | `docs/METRICS.md` |
-| Automated tests | 226,584 test functions | `docs/METRICS.md` |
-| Test files | 5,592 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 2,001,881 | `docs/METRICS.md` |
+| Automated tests | 226,622 test functions | `docs/METRICS.md` |
+| Test files | 5,596 | `docs/METRICS.md` |
 | API operations | 3,205 across 2,912 paths | `docs/METRICS.md` |
 | API paths | 2,912 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,330 tracked Python files | 145 top-level modules | 226,584 test functions across 5,592 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,327 tracked Python files | 145 top-level modules | 226,622 test functions across 5,596 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4330` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `2001754` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4327` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `2001881` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5592` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `226584` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `1130` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5596` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `226622` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `1149` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2912` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3205` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,330
-- **Tests**: 226,584 across 5,592 test files
+- **Python files (`aragora/`)**: 4,327
+- **Tests**: 226,622 across 5,596 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,205 across 2,912 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 226,584 tests across 5,592 test files
-- **Source files**: 4,330 Python files under `aragora/`
+- **Test coverage**: 226,622 tests across 5,596 test files
+- **Source files**: 4,327 Python files under `aragora/`
 - **API surface**: 3,205 API operations across 2,912 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/guides/CLAUDE_MAX_POOL.md
+++ b/docs/guides/CLAUDE_MAX_POOL.md
@@ -64,9 +64,22 @@ pool.
 }
 ```
 
-States: `ok`, `expired`, `logged_out`, `not_configured`, `unknown`. The review router skips
-profiles whose state is unhealthy (`expired` / `logged_out` / `not_configured` /
-`unauthenticated`) and only counts the snapshot when it is fresh (see TTL below).
+The `state` field retains the legacy values `ok`, `expired`, `logged_out`,
+`not_configured`, and `unauthenticated` so existing readers keep excluding
+unavailable profiles. It is an availability signal, not a precise diagnosis:
+`expired` can also represent a nonzero exit caused by exhausted quota.
+
+New verifier records additionally include a sanitized `reason_code`: `ok`,
+`quota_exhausted`, `auth_revoked`, `auth_expired`, `auth_missing`,
+`transport_timeout`, `service_unavailable`, `invalid_response`, or
+`unknown_failure`. Raw provider errors are not stored in this field. The CLI
+reports quota exhaustion separately from profiles requiring reauthentication.
+
+Unknown states and contradictory state/reason pairs are normalized to an existing
+unhealthy state rather than being advertised as healthy to older readers. Records
+without a reason remain compatible. The review router still requires a fresh
+snapshot (see TTL below); these changes do not add live transport failover or
+change which model evidence can count toward quorum.
 
 Override the snapshot location with `ARAGORA_CLAUDE_POOL_HEALTH_FILE`.
 

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,330 Python files | 226,584 tests | 3,205 API operations across 2,912 paths
+**Total**: 230+ features | 4,327 Python files | 226,622 tests | 3,205 API operations across 2,912 paths
 <!-- metrics:end -->
 
 ---

--- a/ide/vscode-aragora/package-lock.json
+++ b/ide/vscode-aragora/package-lock.json
@@ -3911,9 +3911,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/scripts/claude_pool_verify.py
+++ b/scripts/claude_pool_verify.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from aragora.agents.claude_pool_health import (  # noqa: E402
     build_snapshot,
     classify_probe,
+    classify_probe_reason,
     is_healthy,
 )
 
@@ -80,6 +81,12 @@ def _profile_email(profile_tool: Path, profile: str) -> str:
 
 
 def _probe(profile_tool: Path, profile: str, prompt: str, timeout: int) -> str:
+    return _probe_with_reason(profile_tool, profile, prompt, timeout)[0]
+
+
+def _probe_with_reason(
+    profile_tool: Path, profile: str, prompt: str, timeout: int
+) -> tuple[str, str]:
     try:
         proc = subprocess.run(
             [str(profile_tool), "exec", profile, "--", "claude", "--print", "-p", "-"],
@@ -90,9 +97,11 @@ def _probe(profile_tool: Path, profile: str, prompt: str, timeout: int) -> str:
             check=False,
         )
     except subprocess.TimeoutExpired:
-        return "unauthenticated"
-    except OSError as exc:
-        return classify_probe(str(exc))
+        return "unauthenticated", "transport_timeout"
+    except FileNotFoundError:
+        return "not_configured", "auth_missing"
+    except OSError:
+        return "expired", "unknown_failure"
     # Strip the claude_profile.sh wrapper preamble before classifying.
     lines = [
         ln
@@ -100,9 +109,14 @@ def _probe(profile_tool: Path, profile: str, prompt: str, timeout: int) -> str:
         if not (ln.startswith("Using profile home:") or ln.startswith("Command:"))
     ]
     combined = "\n".join(lines)
-    if not combined.strip():
+    if not combined.strip() or (
+        (proc.stderr or "").strip() and classify_probe_reason(proc.stderr) != "ok"
+    ):
         combined = proc.stderr or ""
-    return classify_probe(combined, returncode=proc.returncode)
+    return (
+        classify_probe(combined, returncode=proc.returncode),
+        classify_probe_reason(combined, returncode=proc.returncode),
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -123,12 +137,13 @@ def main(argv: list[str] | None = None) -> int:
 
     records: list[dict] = []
     for profile in profiles:
-        state = _probe(profile_tool, profile, args.prompt, args.timeout)
+        state, reason = _probe_with_reason(profile_tool, profile, args.prompt, args.timeout)
         records.append(
             {
                 "name": profile,
                 "email": _profile_email(profile_tool, profile),
                 "state": state,
+                "reason_code": reason,
             }
         )
 
@@ -145,11 +160,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Claude pool verify — {snapshot['healthy']}/{snapshot['total']} healthy")
         for p in snapshot["profiles"]:
             flag = "ok " if is_healthy(p["state"]) else "DEAD"
-            print(f"  [{flag}] {p['name']:9} {p['state']:15} {p['email']}")
+            print(f"  [{flag}] {p['name']:9} {p['state']:15} {p['email']} {p['reason_code']}")
         print(f"\nSnapshot: {snapshot_path}")
-        dead = [p["name"] for p in snapshot["profiles"] if not is_healthy(p["state"])]
-        if dead:
-            print(f"Re-auth needed: {', '.join(dead)}")
+        for label, reasons in (
+            ("Re-auth needed", {"auth_revoked", "auth_expired", "auth_missing"}),
+            ("Quota exhausted", {"quota_exhausted"}),
+        ):
+            names = [p["name"] for p in snapshot["profiles"] if p["reason_code"] in reasons]
+            if names:
+                print(f"{label}: {', '.join(names)}")
 
     # Non-zero when any configured profile is unusable, for cron alerting.
     return 0 if snapshot["healthy"] == snapshot["total"] else 1

--- a/tests/agents/test_claude_pool_health.py
+++ b/tests/agents/test_claude_pool_health.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import json
+
+import pytest
+
+from aragora.agents import claude_pool_health as health
 from aragora.agents.claude_pool_health import build_snapshot, classify_probe, is_healthy
 
 
@@ -58,3 +63,171 @@ def test_build_snapshot_defaults_missing_state():
     snap = build_snapshot([{"name": "max-09"}], generated_at="x")
     assert snap["profiles"][0]["state"] == "unauthenticated"
     assert snap["healthy"] == 0
+
+
+@pytest.mark.parametrize(
+    ("text", "code", "timeout", "reason"),
+    [
+        ("You're out of usage credits", 0, False, "quota_exhausted"),
+        ("API Error: 429 rate_limit_error", 0, False, "quota_exhausted"),
+        ("Rate limit exceeded", 0, False, "quota_exhausted"),
+        ("Insufficient credits", 0, False, "quota_exhausted"),
+        (
+            "Failed to authenticate. API Error: 401 OAuth access token has been revoked",
+            0,
+            False,
+            "auth_revoked",
+        ),
+        ("OAuth token has expired", 0, False, "auth_expired"),
+        ("API Error: 401 Invalid authentication credentials", 0, False, "auth_expired"),
+        ("No such file or directory: .credentials.json", 0, False, "auth_missing"),
+        ("not logged in", 0, False, "auth_missing"),
+        ("OK", 0, True, "transport_timeout"),
+        ("Request timed out", 0, False, "transport_timeout"),
+        ("API Error: 503 Service unavailable", 0, False, "service_unavailable"),
+        ("Overloaded", 0, False, "service_unavailable"),
+        ("I cannot fulfill this request.", 0, False, "invalid_response"),
+        ("I'm sorry, but I can't assist with that.", 0, False, "invalid_response"),
+        ("Sorry, but I can’t comply.", 0, False, "invalid_response"),
+        ("Internal server error", 0, False, "service_unavailable"),
+        ('{"type":"result","is_error":', 0, False, "invalid_response"),
+        ("", 0, False, "invalid_response"),
+        ("weird failure", 2, False, "unknown_failure"),
+        ("API Error: unrecognized provider failure", 0, False, "unknown_failure"),
+        ("OK", 0, False, "ok"),
+        ("The docs discuss 401 and quota exhaustion.", 0, False, "ok"),
+    ],
+)
+def test_probe_reason_and_legacy_availability(text, code, timeout, reason):
+    assert health.classify_probe_reason(text, returncode=code, timed_out=timeout) == reason
+    assert is_healthy(classify_probe(text, returncode=code, timed_out=timeout)) == (reason == "ok")
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        (
+            {"type": "result", "is_error": True, "result": "You're out of usage credits"},
+            "quota_exhausted",
+        ),
+        (
+            {"type": "result", "is_error": True, "errors": ["OAuth access token has been revoked"]},
+            "auth_revoked",
+        ),
+        ({"type": "result", "is_error": True, "result": "OK"}, "unknown_failure"),
+        (
+            {"type": "result", "is_error": False, "result": "OK", "errors": ["private failure"]},
+            "unknown_failure",
+        ),
+        (
+            {"type": "result", "is_error": False, "subtype": "error_during_execution"},
+            "unknown_failure",
+        ),
+        ({"type": "result", "is_error": "false", "result": "OK"}, "invalid_response"),
+        ({"type": "result", "is_error": False, "result": {}}, "invalid_response"),
+        ({"type": "result", "is_error": False, "result": ""}, "invalid_response"),
+        (
+            {"type": "result", "is_error": False, "result": "API Error: 503 overloaded"},
+            "service_unavailable",
+        ),
+        (
+            {
+                "type": "result",
+                "is_error": False,
+                "result": "The docs discuss 401 and quota exhaustion.",
+            },
+            "ok",
+        ),
+        ({"type": "error", "error": {"type": "rate_limit_error"}}, "quota_exhausted"),
+        ({"error": "private failure"}, "unknown_failure"),
+        ({"unexpected": "OK"}, "invalid_response"),
+        ([], "invalid_response"),
+    ],
+)
+def test_structured_probe_reason(payload, reason):
+    text = json.dumps(payload)
+    assert health.classify_probe_reason(text, returncode=0) == reason
+    assert is_healthy(classify_probe(text, returncode=0)) == (reason == "ok")
+
+
+@pytest.mark.parametrize(
+    "reason", ["quota_exhausted", "auth_revoked", "unknown_failure", "SENSITIVE", None]
+)
+def test_conflicting_health_reason_cannot_advertise_success(reason):
+    snap = build_snapshot(
+        [{"name": "max-01", "state": "ok", "reason_code": reason}], generated_at="x"
+    )
+    assert snap["profiles"][0]["state"] in health.UNHEALTHY_STATES
+    assert snap["healthy"] == 0
+    assert "SENSITIVE" not in json.dumps(snap)
+
+
+def test_failed_state_cannot_advertise_ok_reason():
+    snap = build_snapshot(
+        [{"name": "max-01", "state": "expired", "reason_code": "ok"}], generated_at="x"
+    )
+    assert snap["profiles"][0]["reason_code"] == "unknown_failure"
+    assert snap["healthy"] == 0
+
+
+@pytest.mark.parametrize(
+    ("text", "reason"),
+    [
+        (
+            "Warning: update available\nAPI Error: 401 Invalid authentication credentials",
+            "auth_expired",
+        ),
+        ("Warning: update available\nYou're out of usage credits", "quota_exhausted"),
+        ("You have hit your usage limit", "quota_exhausted"),
+        ("Invalid API key · Please run /login", "auth_expired"),
+    ],
+)
+def test_provider_failure_after_preamble_is_unhealthy(text, reason):
+    assert health.classify_probe_reason(text, returncode=0) == reason
+    assert not is_healthy(classify_probe(text, returncode=0))
+
+
+@pytest.mark.parametrize("ensure_ascii", [False, True])
+@pytest.mark.parametrize("preamble", ["", "Warning: update available\n"])
+def test_structured_unicode_quota_message(ensure_ascii, preamble):
+    text = preamble + json.dumps(
+        {"type": "result", "is_error": True, "result": "You’re out of usage credits"},
+        ensure_ascii=ensure_ascii,
+    )
+    assert health.classify_probe_reason(text, returncode=0) == "quota_exhausted"
+    assert not is_healthy(classify_probe(text, returncode=0))
+
+
+@pytest.mark.parametrize(
+    ("preamble", "payload", "reason"),
+    [
+        ("Warning: update available", '{"type":"result","is_error":false,"result":"OK"}', "ok"),
+        (
+            "API Error: 401 Invalid authentication credentials",
+            '{"type":"result","is_error":false,"result":"OK"}',
+            "auth_expired",
+        ),
+        ("Warning: update available", '{"type":"result","is_error":', "invalid_response"),
+        (
+            "Warning: update available",
+            '{\n  "type": "result",\n  "is_error": true,\n  "result": "Insufficient credits"\n}',
+            "quota_exhausted",
+        ),
+    ],
+)
+def test_preamble_and_structured_probe(preamble, payload, reason):
+    text = preamble + "\n" + payload
+    assert health.classify_probe_reason(text, returncode=0) == reason
+    assert is_healthy(classify_probe(text, returncode=0)) == (reason == "ok")
+
+
+def test_unknown_states_and_reason_metadata_fail_closed():
+    for state in ("new_state", "quota_exhausted", "", None):
+        assert not is_healthy(state)
+        snap = build_snapshot([{"name": "max-01", "state": state}], generated_at="x")
+        assert snap["profiles"][0]["state"] in health.UNHEALTHY_STATES
+        assert snap["healthy"] == 0
+    for reason in ("quota_exhausted", "auth_revoked", "secret-token-material", None, {}):
+        snap = build_snapshot([{"state": "expired", "reason_code": reason}], generated_at="x")
+        expected = reason if reason in ("quota_exhausted", "auth_revoked") else "unknown_failure"
+        assert snap["profiles"][0]["reason_code"] == expected

--- a/tests/scripts/test_claude_pool_verify.py
+++ b/tests/scripts/test_claude_pool_verify.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from scripts import claude_pool_verify as verify
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected"),
+    [
+        (
+            subprocess.CompletedProcess(
+                [],
+                0,
+                "Using profile home: private\nCommand: private\nYou're out of usage credits",
+                "",
+            ),
+            ("unauthenticated", "quota_exhausted"),
+        ),
+        (
+            subprocess.CompletedProcess(
+                [],
+                0,
+                "",
+                "Failed to authenticate. API Error: 401 OAuth access token has been revoked",
+            ),
+            ("expired", "auth_revoked"),
+        ),
+        (
+            subprocess.CompletedProcess(
+                [], 0, '{"type":"result","is_error":true,"result":"private failure"}', ""
+            ),
+            ("unauthenticated", "unknown_failure"),
+        ),
+        (subprocess.CompletedProcess([], 2, "private failure", ""), ("expired", "unknown_failure")),
+        (
+            subprocess.TimeoutExpired("private command", 1, output=b"private output"),
+            ("unauthenticated", "transport_timeout"),
+        ),
+        (OSError("private error"), ("expired", "unknown_failure")),
+        (FileNotFoundError("private path"), ("not_configured", "auth_missing")),
+        (subprocess.CompletedProcess([], 0, "OK", ""), ("ok", "ok")),
+        (
+            subprocess.CompletedProcess([], 0, "OK", "API Error: 429 rate limit"),
+            ("unauthenticated", "quota_exhausted"),
+        ),
+        (subprocess.CompletedProcess([], 0, "OK", "Warning: update available"), ("ok", "ok")),
+        (
+            subprocess.CompletedProcess([], 2, "Starting...", "API Error: 401 token revoked"),
+            ("expired", "auth_revoked"),
+        ),
+        (
+            subprocess.CompletedProcess([], 0, "OK", '{"is_error":'),
+            ("unauthenticated", "invalid_response"),
+        ),
+    ],
+)
+def test_single_probe_reason_and_legacy_helper(monkeypatch, outcome, expected):
+    run = Mock(
+        side_effect=[outcome] if isinstance(outcome, Exception) else None, return_value=outcome
+    )
+    monkeypatch.setattr(verify.subprocess, "run", run)
+    assert verify._probe_with_reason(Path("unused"), "max-01", "hi", 1) == expected
+    assert run.call_count == 1
+    run.reset_mock(side_effect=True)
+    if isinstance(outcome, Exception):
+        run.side_effect = [outcome]
+    assert verify._probe(Path("unused"), "max-01", "hi", 1) == expected[0]
+    assert run.call_count == 1
+
+
+@pytest.mark.parametrize("stream", ["stdout", "stderr"])
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("You have hit your usage limit", ("unauthenticated", "quota_exhausted")),
+        ("API Error: 401 Invalid authentication credentials", ("expired", "auth_expired")),
+        (
+            '{"type":"result","is_error":true,"result":"You’re out of usage credits"}',
+            ("unauthenticated", "quota_exhausted"),
+        ),
+    ],
+)
+def test_probe_failure_after_warning_and_wrapper_preamble(monkeypatch, stream, text, expected):
+    preamble = "Using profile home: private\nCommand: private\n"
+    failure = f"Warning: update available\n{text}"
+    stdout = preamble + (failure if stream == "stdout" else "OK")
+    stderr = failure if stream == "stderr" else ""
+    run = Mock(return_value=subprocess.CompletedProcess([], 0, stdout, stderr))
+    monkeypatch.setattr(verify.subprocess, "run", run)
+    assert verify._probe_with_reason(Path("unused"), "max-01", "hi", 1) == expected
+    assert run.call_count == 1
+
+
+@pytest.mark.parametrize("as_json", [False, True])
+@pytest.mark.parametrize(
+    ("text", "reason", "label"),
+    [
+        ("You're out of usage credits: private-token", "quota_exhausted", "Quota exhausted:"),
+        (
+            "Failed to authenticate. API Error: 401 OAuth access token has been revoked: private-token",
+            "auth_revoked",
+            "Re-auth needed:",
+        ),
+    ],
+)
+def test_main_reason_metadata_without_raw_output(
+    monkeypatch, tmp_path, capsys, as_json, text, reason, label
+):
+    run = Mock(return_value=subprocess.CompletedProcess([], 0, text, ""))
+    monkeypatch.setattr(verify.subprocess, "run", run)
+    monkeypatch.setattr(verify, "_profile_email", lambda *args: "")
+    path = tmp_path / "snapshot.json"
+    argv = ["--snapshot-path", str(path), "max-01"] + (["--json"] if as_json else [])
+    assert verify.main(argv) == 1
+    output = capsys.readouterr().out
+    snapshot = json.loads(path.read_text())
+    assert snapshot["profiles"][0]["reason_code"] == reason
+    assert "private-token" not in output + path.read_text()
+    assert run.call_count == 1
+    if as_json:
+        assert json.loads(output) == snapshot
+    else:
+        assert label in output
+        if reason == "quota_exhausted":
+            assert "Re-auth needed:" not in output


### PR DESCRIPTION
## Summary
- Add sanitized reason codes that distinguish quota exhaustion, revoked/missing auth, timeouts, service failures, and invalid probe responses.
- Preserve legacy availability states and old snapshot shapes; normalize unknown or contradictory records fail-closed so older readers do not treat unavailable profiles as healthy.
- Report quota separately from reauthentication advice, using the same existing completion probe.
- Cover exit-zero provider errors, warning preambles, structured JSON, Unicode errors, stderr signals, and metadata redaction.

## Scope and risk
This is the first bounded unit of the approved reviewer-transport plan, treated as Tier 4 because it touches reviewer authentication/availability. It does not add live failover, modify the collector, change family eligibility or quorum rules, copy credentials, or alter workflows. The five non-generated source/test/documentation files are under the 800-line scope limit; generated metrics and mirrors are refreshed separately.

The dry-run planner is preserved in the separate local foundation worktree for a follow-up, not included here. PR #9846 and its downstream stack remain untouched. No merge or settlement is authorized by this PR.

## Test plan
- [x] 530 focused health, verifier, profile-routing, collector, and quorum-contract tests passed on the reconciled tree.
- [x] Reviewer-found warning/JSON/Unicode cases reproduced red before repair; existing tests and comments preserved.
- [x] Ruff check and format check, mypy, code-quality ratchet, metrics drift, automation preflight, and applicable commit/push hooks passed.
- [ ] Fresh exact-head CI.
- [ ] Independent heterogeneous evidence and Tier-4 human settlement before merge.

Generated with [Devin](https://devin.ai)