### PR TITLE
fix(sdk): enforce HTTP body deadlines and clean up attempt timers

### DIFF
--- a/sdk/typescript/REQUEST_LIFECYCLE.md
+++ b/sdk/typescript/REQUEST_LIFECYCLE.md
@@ -5,9 +5,9 @@
 Once the TypeScript client's HTTP request receives a successful response
 (`Response.ok`), reading or decoding that response cannot trigger another network
 attempt. This applies to `request`, the HTTP helpers, and namespaces using them,
-even when retries are enabled. A failed body read propagates its original error;
-invalid JSON propagates `SyntaxError`. Neither is reclassified as a connection,
-timeout, or server error by the request retry loop.
+even when retries are enabled. An unrelated failed body read propagates its
+original error; invalid JSON propagates `SyntaxError`. The client's own deadline
+abort becomes the existing SDK `TimeoutError`, without replaying the request.
 
 This intentionally changes older SDK behavior that could repeat an operation
 after its successful response failed to decode. The server may already have
@@ -28,5 +28,19 @@ try {
 
 JSON, text, and empty-response return values are unchanged. Failed HTTP responses
 and failures before a response keep their existing retry rules, attempt counts,
-backoff, and error classification. This change does not extend timeout coverage,
-alter timer cleanup, add automatic reconnection, or change WebSocket behavior.
+backoff, and error classification, except that the configured attempt deadline
+now also covers response-body consumption.
+
+## Attempt deadlines and cleanup
+
+Each attempt's existing timeout remains active from the start of `fetch` through
+reading a successful or error response body. Per-request `timeout` overrides the
+client default as before. A stalled body is interrupted with the existing SDK
+`TimeoutError`; an error-body parsing fallback cannot hide this deadline abort.
+The client clears its attempt timer on success, decoding failure, fetch failure,
+and timeout, before any retry backoff. Concurrent requests own separate timers.
+
+The deadline relies on Fetch's abort-aware body consumption. It does not preempt
+synchronous JavaScript such as JSON decoding, create an overall retry deadline,
+or change WebSocket/reconnect behavior. A timeout after successful headers still
+does not prove the server operation failed: inspect its state before retrying.

--- a/sdk/typescript/src/__tests__/request-timeout.test.ts
+++ b/sdk/typescript/src/__tests__/request-timeout.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AragoraClient } from '../client';
+import { AragoraError, ConnectionError, TimeoutError } from '../errors';
+
+describe('HTTP attempt deadline ownership', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  let client: AragoraClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    client = new AragoraClient({ baseUrl: 'https://api.example.test', timeout: 50, maxRetries: 3 });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function observe<T>(promise: Promise<T>) {
+    return promise.then(value => ({ value, error: undefined }),
+      (error: unknown) => ({ value: undefined, error }));
+  }
+
+  // No extra timeout: the test transport owns only an abort listener. Completion
+  // is controlled explicitly so a broken SDK cannot pass by waiting for the body.
+  function stalledBody(status: number) {
+    let finish!: (body: string) => void;
+    fetchMock.mockImplementation(async (_url, init) => {
+      const signal = init!.signal!;
+      const text = new Promise<string>((resolve, reject) => {
+        const abort = () => reject(signal.reason);
+        signal.addEventListener('abort', abort, { once: true });
+        finish = body => {
+          signal.removeEventListener('abort', abort);
+          resolve(body);
+        };
+      });
+      return { ok: status < 400, status, statusText: 'unavailable',
+        text: () => text, json: () => text.then(JSON.parse) } as Response;
+    });
+    return (body = '{}') => finish(body);
+  }
+
+  it.each([200, 400, 503])('keeps the deadline through a stalled HTTP %s body', async status => {
+    const finish = stalledBody(status);
+    const result = observe(client.post('/api/debate', { task: 'fixture' }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(50);
+    finish(); // Prevent a broken implementation leaving the assertion pending.
+    expect((await result).error).toBeInstanceOf(TimeoutError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('times out before headers and removes the timer', async () => {
+    fetchMock.mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+      init!.signal!.addEventListener('abort', () => reject(init!.signal!.reason), { once: true });
+    }));
+    const result = observe(client.get('/api/debate'));
+    await vi.advanceTimersByTimeAsync(50);
+    expect((await result).error).toBeInstanceOf(TimeoutError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cleans up immediately after fetch rejection without firing a late abort', async () => {
+    const aborted = vi.fn();
+    fetchMock.mockImplementation(async (_url, init) => {
+      init!.signal!.addEventListener('abort', aborted);
+      throw new TypeError('fetch failed');
+    });
+    expect((await observe(client.get('/api/debate'))).error).toBeInstanceOf(ConnectionError);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(aborted).not.toHaveBeenCalled();
+  });
+
+  it.each([new Error('offline'), new Response('{}', { status: 503 })])(
+    'clears the first attempt timer before backoff', async failure => {
+      const sleep = vi.spyOn(client as unknown as { sleep(ms: number): Promise<void> }, 'sleep');
+      sleep.mockImplementation(async () => { expect(vi.getTimerCount()).toBe(0); });
+      fetchMock.mockImplementationOnce(async () => {
+        if (failure instanceof Error) throw failure;
+        return failure.clone();
+      }).mockResolvedValue(new Response('{}'));
+      expect((await observe(client.post('/api/debate', {}))).value).toEqual({});
+      expect(sleep).toHaveBeenCalledExactlyOnceWith(1000);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it.each([
+    ['json', '{"id":"ok"}', { id: 'ok' }],
+    ['json', '', {}],
+    ['text', '', ''],
+    ['text', 'hello', 'hello'],
+  ] as const)('cleans up a completed %s body', async (responseType, body, expected) => {
+    const finish = stalledBody(200);
+    const result = observe(client.request('POST', '/api/debate', { responseType }));
+    await vi.advanceTimersByTimeAsync(49);
+    finish(body);
+    expect((await result).value).toEqual(expected);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock.mock.calls[0][1]!.signal!.aborted).toBe(false);
+  });
+
+  it.each([new DOMException('unrelated abort', 'AbortError'), new TypeError('terminated'), null])(
+    'preserves unrelated successful-body errors and cleans up', async error => {
+      fetchMock.mockImplementation(async () => {
+        const response = new Response('{}');
+        vi.spyOn(response, 'text').mockRejectedValue(error);
+        return response;
+      });
+      expect((await observe(client.post('/api/debate', {}))).error).toBe(error);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it('does not replay malformed success after a failed attempt', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 503 }))
+      .mockResolvedValueOnce(new Response('{bad'));
+    const result = observe(client.post('/api/debate', {}));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect((await result).error).toBeInstanceOf(SyntaxError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps independent per-request body deadlines and overrides', async () => {
+    const finish = stalledBody(200);
+    const fast = observe(client.request('GET', '/fast', { timeout: 10 }));
+    const slow = observe(client.request('GET', '/slow', { timeout: 80 }));
+    await vi.advanceTimersByTimeAsync(10);
+    expect(fetchMock.mock.calls[0][1]!.signal!.aborted).toBe(true);
+    expect((await fast).error).toBeInstanceOf(TimeoutError);
+    expect(fetchMock.mock.calls[1][1]!.signal!.aborted).toBe(false);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(69);
+    finish('{"ok":true}');
+    expect((await slow).value).toEqual({ ok: true });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not swallow an error-body abort or spend retry backoff', async () => {
+    const finish = stalledBody(503);
+    const result = observe(client.post('/api/debate', {}));
+    await vi.advanceTimersByTimeAsync(50);
+    finish('{"error":"busy"}');
+    expect(fetchMock.mock.calls[0][1]!.signal!.aborted).toBe(true);
+    expect((await result).error).toBeInstanceOf(TimeoutError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([true, false])('honors completion/deadline ordering (completion first=%s)', async first => {
+    const finish = stalledBody(200);
+    if (first) setTimeout(() => finish(), 50);
+    const result = observe(client.get('/api/debate'));
+    if (!first) setTimeout(() => finish(), 50);
+    await vi.advanceTimersByTimeAsync(50);
+    const settled = await result;
+    if (first) expect(settled.value).toEqual({});
+    else expect(settled.error).toBeInstanceOf(TimeoutError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not replay a body timeout after an earlier server failure', async () => {
+    const finish = stalledBody(200);
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 503 }));
+    const result = observe(client.post('/api/debate', {}));
+    await vi.advanceTimersByTimeAsync(1050);
+    finish();
+    expect((await result).error).toBeInstanceOf(TimeoutError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('retains malformed error-body fallback and attempt counts', async () => {
+    fetchMock.mockImplementation(async () => new Response('invalid', { status: 503 }));
+    const result = observe(client.post('/api/debate', {}));
+    await vi.runAllTimersAsync();
+    expect((await result).error).toBeInstanceOf(AragoraError);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1275,64 +1275,67 @@ export class AragoraClient {
     const maxAttempts = this.config.retryEnabled ? this.config.maxRetries : 1;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      let response: Response;
+      const controller = new AbortController();
+      const timeout = options.timeout ?? this.config.timeout;
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
       try {
-        const controller = new AbortController();
-        const timeout = options.timeout ?? this.config.timeout;
-        const timeoutId = setTimeout(() => controller.abort(), timeout);
+        let response: Response | undefined;
+        try {
+          response = await fetch(url.toString(), {
+            method,
+            headers,
+            body: options.body ? JSON.stringify(options.body) : undefined,
+            signal: controller.signal,
+          });
 
-        response = await fetch(url.toString(), {
-          method,
-          headers,
-          body: options.body ? JSON.stringify(options.body) : undefined,
-          signal: controller.signal,
-        });
+          if (!response.ok) {
+            const statusText = response.statusText;
+            const body = await response.json().catch(error => {
+              if (controller.signal.aborted) throw error;
+              return { error: statusText };
+            });
+            throw AragoraError.fromResponse(response.status, body);
+          }
+        } catch (error) {
+          lastError = error as Error;
 
+          // Don't retry on client errors (4xx) or abort.
+          if (error instanceof AragoraError && error.statusCode && error.statusCode < 500) {
+            throw error;
+          }
+          if ((error as Error).name === 'AbortError') {
+            throw new TimeoutError('Request timeout', 'SERVICE_UNAVAILABLE');
+          }
+
+          if (error instanceof TypeError && (error.message.includes('fetch') || error.message.includes('network'))) {
+            throw new ConnectionError('Connection failed', 'SERVICE_UNAVAILABLE');
+          }
+        }
+
+        if (response?.ok) {
+          // A successful response may represent an operation already performed.
+          // Consumption stays outside retry handling; only our deadline abort
+          // is translated. Unrelated body/decoding errors propagate unchanged.
+          try {
+            const text = await response.text();
+            if (options.responseType === 'text') return text as T;
+            if (!text) return {} as T;
+            return JSON.parse(text) as T;
+          } catch (error) {
+            if (controller.signal.aborted && (error as Error)?.name === 'AbortError') {
+              throw new TimeoutError('Request timeout', 'SERVICE_UNAVAILABLE');
+            }
+            throw error;
+          }
+        }
+      } finally {
         clearTimeout(timeoutId);
-
-        if (!response.ok) {
-          const body = await response.json().catch(() => ({ error: response.statusText }));
-          throw AragoraError.fromResponse(response.status, body);
-        }
-      } catch (error) {
-        lastError = error as Error;
-
-        // Don't retry on client errors (4xx) or abort
-        if (error instanceof AragoraError && error.statusCode && error.statusCode < 500) {
-          throw error;
-        }
-        if ((error as Error).name === 'AbortError') {
-          throw new TimeoutError('Request timeout', 'SERVICE_UNAVAILABLE');
-        }
-
-        // Check for network/connection errors
-        if (error instanceof TypeError && (error.message.includes('fetch') || error.message.includes('network'))) {
-          throw new ConnectionError('Connection failed', 'SERVICE_UNAVAILABLE');
-        }
-
-        // Retry on server errors and network failures
-        if (attempt < maxAttempts) {
-          await this.sleep(Math.pow(2, attempt - 1) * 1000);
-        }
-        continue;
       }
 
-      // A successful response may represent an operation already performed.
-      // Body/decoding errors must propagate unchanged, outside retry handling.
-      const text = await response.text();
-
-      // Text responses keep their contract even when the body is empty:
-      // '' is a valid string result, never coerced to {}.
-      if (options.responseType === 'text') {
-        return text as T;
+      // Attempt resources are released before retry backoff begins.
+      if (attempt < maxAttempts) {
+        await this.sleep(Math.pow(2, attempt - 1) * 1000);
       }
-
-      // Handle empty JSON responses
-      if (!text) {
-        return {} as T;
-      }
-
-      return JSON.parse(text) as T;
     }
 
     // Check if lastError is a connection-type error


### PR DESCRIPTION
## Summary

- Keep each existing TypeScript HTTP attempt deadline active through successful
  and error response-body consumption.
- Clear the attempt timer unconditionally before retry backoff and on every exit.
- Translate owned body deadline aborts to the existing SDK TimeoutError, without
  replaying successful requests. Preserve unrelated body errors and retry policy.

Three SDK-local files; no dependencies, public APIs, server, workflow, model or
release changes. Builds on #10066 without changing its no-replay contract.

## Risk / authorization boundary

Tier 3 SDK semantics. Slow response bodies now time out where they previously
could wait beyond the configured deadline. A timeout after successful headers
does not mean the operation failed; callers must inspect state before retrying.
No global deadline, automatic retry/reconnect, or synchronous-JS preemption.

Draft for independent non-countable review and a new exact-head human risk
checkpoint. No countable evidence, ready, settlement or merge authorized here.
Parked #10014/#10015 and unpublished model-refresh JSDoc remain untouched.

## Validation

- 62 focused tests pass; unchanged-base control has 9 failing regressions.
- Six functional mutants killed: missing body deadline, missing cleanup,
  swallowed abort, raw owned abort, successful-response replay, premature cleanup.
- Full SDK: 1,749 pass and one unchanged stats-route failure on Node20/25;
  clean base 1,728 pass and the same failure. No skipped tests.
- Typecheck, CJS/ESM/declaration builds, lint (0 errors; existing warnings),
  strict new-test typecheck and additional test lint pass.
- Installed CJS/ESM: 44 deterministic acceptance cases per Node20/25, including
  real loopback slow success/error bodies and existing debate/review/receipt paths.
- Repository SDK integration: 403 pass. Ruff, version, SDK parity, namespace,
  cross-SDK, OpenAPI/contract/route constituents pass. Broad mypy retains exactly
  the clean-base 1,735 errors / 460 files; diagnostic logs byte-identical.

Base 92c8d6bdd9989a67729eded9a0ec66a99ccbca4a; current main
0242baa6177871326a2db206e839afae4f968018 differs only in docs-site lockfile, with
five required main code checks green. Broader inherited failures are not passes.

Tested tarball SHA256:
52626ad85bcbeef80e8beb29217af7e794e2cedaa86b5421a5deda8defb4bfcd.
Operational receipts remain uncommitted in the owned worktree.
