### PR TITLE
test(cli): replace version and Runner skips with executable coverage

### DIFF
--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -8,11 +8,16 @@ import builtins
 import json
 import os
 import ssl
+import subprocess
+import sys
+import tempfile
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import aragora.cli.commands.quickstart as quickstart
 from aragora.agents.base import create_agent as create_real_agent
 from aragora.cli.commands.receipt import cmd_receipt_verify
 from aragora.cli.commands.quickstart import (
@@ -296,26 +301,6 @@ class TestRunSync:
         assert len(calls) == 1
         assert seen["loop"].is_closed()
 
-    def test_run_sync_prefers_runner_when_available(self, monkeypatch):
-        if not hasattr(asyncio, "Runner"):
-            pytest.skip("asyncio.Runner unavailable on this interpreter")
-        calls: list[object] = []
-
-        def _unexpected_fallback(coro):
-            calls.append(coro)
-            return _run_sync_without_runner(coro)
-
-        monkeypatch.setattr(
-            "aragora.cli.commands.quickstart._run_sync_without_runner",
-            _unexpected_fallback,
-        )
-
-        async def _work() -> str:
-            return "runner"
-
-        assert _run_sync(_work()) == "runner"
-        assert calls == []
-
     def test_fallback_cleans_up_pending_tasks_and_asyncgens(self):
         cancelled: list[bool] = []
         closed: list[bool] = []
@@ -388,6 +373,259 @@ class TestRunSync:
         with pytest.raises(ValueError, match="boom"):
             _run_sync_without_runner(_boom())
         assert seen["loop"].is_closed()
+
+
+@pytest.mark.parametrize(
+    ("capability", "outcome"),
+    [(state, result) for state in ("absent", "none", "injected") for result in ("return", "error")],
+    ids=[f"{s}-{r}" for s in ("absent", "none", "injected") for r in ("return", "error")],
+)
+def test_runner_capability(monkeypatch, capability, outcome):
+    """Injected capability, not native Runner support on Python 3.10."""
+    events = []
+    loops = []
+    value, error = object(), ValueError("capability error")
+    factory = MagicMock(wraps=quickstart._quickstart_loop_factory)
+    fallback = MagicMock(wraps=_run_sync_without_runner)
+    monkeypatch.setattr(quickstart, "_quickstart_loop_factory", factory)
+    monkeypatch.setattr(quickstart, "_run_sync_without_runner", fallback)
+
+    class RecordingRunner:
+        def __init__(self, *, loop_factory):
+            assert loop_factory is factory
+            events.append("init")
+            self.loop = loop_factory()
+            loops.append(self.loop)
+
+        def __enter__(self):
+            events.append("enter")
+            return self
+
+        def run(self, received):
+            assert received is coro
+            events.append("run")
+            return self.loop.run_until_complete(received)
+
+        def __exit__(self, exc_type, exc, traceback):
+            events.append(("exit", exc_type, exc))
+            self.loop.close()
+            return False
+
+    if capability == "absent":
+        monkeypatch.delattr(asyncio, "Runner", raising=False)
+    else:
+        monkeypatch.setattr(
+            asyncio, "Runner", RecordingRunner if capability == "injected" else None, raising=False
+        )
+
+    async def work():
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        loop.call_soon(future.set_result, value)
+        assert await future is value
+        loops.append(loop)
+        if outcome == "error":
+            raise error
+        return value
+
+    coro = work()
+    try:
+        if outcome == "error":
+            with pytest.raises(ValueError) as caught:
+                _run_sync(coro)
+            assert caught.value is error
+        else:
+            assert _run_sync(coro) is value
+        factory.assert_called_once_with()
+        assert loops and all(loop.is_closed() for loop in loops)
+        if capability == "injected":
+            fallback.assert_not_called()
+            assert events == [
+                "init",
+                "enter",
+                "run",
+                (
+                    "exit",
+                    ValueError if outcome == "error" else None,
+                    error if outcome == "error" else None,
+                ),
+            ]
+        else:
+            fallback.assert_called_once_with(coro)
+            assert events == []
+    finally:
+        coro.close()
+        for loop in loops:
+            if not loop.is_closed():
+                loop.close()
+
+
+@pytest.mark.parametrize("outcome", ["result", "error"])
+def test_native_sync(outcome):
+    """Unpatched native dispatch, including real cancellation and executor shutdown."""
+    policy = asyncio.get_event_loop_policy()
+    try:
+        previous = policy.get_event_loop()
+    except RuntimeError:
+        previous = None
+    caller = asyncio.new_event_loop()
+    policy.set_event_loop(caller)
+    loops, tasks, generators, reported, finalized, executor_results = [], [], [], [], [], []
+    release, executor_done = threading.Event(), threading.Event()
+    primary, shutdown_error, value = (
+        ValueError("native primary"),
+        RuntimeError("shutdown"),
+        object(),
+    )
+
+    async def generator():
+        try:
+            yield value
+        finally:
+            finalized.append("generator")
+
+    async def background(started, fail):
+        try:
+            started.set()
+            await asyncio.Future()
+        finally:
+            finalized.append("shutdown-error" if fail else "task")
+            release.set()
+            if fail:
+                raise shutdown_error
+
+    async def work():
+        loop = asyncio.get_running_loop()
+        loops.append(loop)
+        loop.set_exception_handler(lambda _loop, context: reported.append(context))
+        resumed = loop.create_future()
+        loop.call_soon(resumed.set_result, value)
+        assert await resumed is value
+        gen = generator()
+        generators.append(gen)
+        assert await gen.__anext__() is value
+        for fail in (False, True):
+            started = asyncio.Event()
+            tasks.append(loop.create_task(background(started, fail)))
+            await started.wait()
+        thread_started = asyncio.Event()
+
+        def in_executor():
+            loop.call_soon_threadsafe(thread_started.set)
+            assert release.wait(5), "pending task never finalized"
+            executor_done.set()
+            return value
+
+        executor_results.append(loop.run_in_executor(None, in_executor))
+        await thread_started.wait()
+        assert not executor_done.is_set()
+        if outcome == "error":
+            raise primary
+        return value
+
+    coro = work()
+    try:
+        if outcome == "error":
+            with pytest.raises(ValueError) as caught:
+                _run_sync(coro)
+            assert caught.value is primary
+        else:
+            assert _run_sync(coro) is value
+        assert len(loops) == 1 and loops[0] is not caller and loops[0].is_closed()
+        assert sorted(finalized) == ["generator", "shutdown-error", "task"]
+        assert tasks[0].cancelled()
+        assert tasks[1].done() and tasks[1].exception() is shutdown_error
+        assert len(reported) == 1
+        assert reported[0]["exception"] is shutdown_error
+        assert reported[0]["task"] is tasks[1] and "shutdown" in reported[0]["message"]
+        assert executor_done.is_set() and executor_results[0].result() is value
+        assert policy.get_event_loop() is caller and not caller.is_closed()
+
+        async def still_usable():
+            return asyncio.get_running_loop()
+
+        assert caller.run_until_complete(still_usable()) is caller
+    finally:
+        release.set()
+        coro.close()
+        for loop in loops:
+            if not loop.is_closed():
+                for task in asyncio.all_tasks(loop):
+                    task.cancel()
+                loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.run_until_complete(loop.shutdown_default_executor())
+                loop.close()
+        caller.close()
+        policy.set_event_loop(previous)
+
+
+def test_offline_cli():
+    """Synthetic offline artifact proof, not hosted database durability."""
+    root = Path(__file__).resolve().parents[2]
+    with tempfile.TemporaryDirectory(prefix="quickstart-cli-", dir="/tmp") as directory:
+        scratch = Path(directory)
+        cwd = scratch / "cwd"
+        cwd.mkdir()
+        assert all(not (p / ".env").exists() for p in (cwd, *cwd.parents))
+        env = {
+            "HOME": str(scratch / "home"),
+            "TMPDIR": str(scratch),
+            "PATH": "/usr/bin:/bin",
+            "PYTHONPATH": str(root),
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "XDG_CACHE_HOME": str(scratch / "cache"),
+            "ARAGORA_DATA_DIR": str(scratch / "data"),
+            "ARAGORA_LOG_DIR": str(scratch / "logs"),
+            "ARAGORA_DB_BACKEND": "sqlite",
+            "ARAGORA_SINGLE_INSTANCE": "true",
+            "ARAGORA_USE_SECRETS_MANAGER": "false",
+            "ARAGORA_SECRETS_STRICT": "false",
+            "ARAGORA_USE_DISTRIBUTED_RATE_LIMIT": "false",
+            "ARAGORA_ENV": "development",
+        }
+        Path(env["HOME"]).mkdir()
+        artifact = scratch / "receipt.json"
+        question = "Should we validate the offline runtime?"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "quickstart",
+                "--demo",
+                "--no-browser",
+                "--json",
+                "--question",
+                question,
+                "--rounds",
+                "2",
+                "--output",
+                str(artifact),
+            ],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=45,
+        )
+        assert result.returncode == 0, result.stderr
+        stdout, saved = json.loads(result.stdout), json.loads(artifact.read_text())
+        assert Path(stdout["artifact_path"]) == artifact.resolve()
+        assert stdout == {**saved, "artifact_path": str(artifact.resolve())}
+        assert saved["question"] == question and saved["rounds"] == 2
+        assert saved["mode"] == "demo" and saved["synthetic"] is True
+        assert saved["debate_status"] == "completed"
+        assert saved["debate_status_source"] == "synthetic"
+        assert any(
+            entry["event_type"] == "task" and entry["description"] == question
+            for entry in saved["provenance_chain"]
+        )
+        assert saved["verdict"] == "approved"
+        assert saved["receipt_id"] and saved["receipt_id"] == saved["receipt"]["id"]
+        assert saved["artifact_hash"] == saved["receipt"]["artifact_hash"]
+        assert all(not (p / ".env").exists() for p in (cwd, *cwd.parents))
 
 
 # =============================================================================

--- a/tests/scripts/test_check_version_alignment.py
+++ b/tests/scripts/test_check_version_alignment.py
@@ -1,10 +1,15 @@
-"""Tests for scripts/check_version_alignment.py doc-pattern helpers."""
+"""Checker helpers and real CLI behavior in independently seeded repositories.
+
+Hermetic success does not prove checkout alignment. The unchanged public
+``scripts/check_version_alignment.py --check`` and contracts gate check that.
+"""
 
 from __future__ import annotations
 
 import importlib.util
 import json
-import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -527,13 +532,262 @@ def test_readme_and_catalog_patterns_track_the_hand_aligned_spots(cva, tmp_path:
     assert 'display_value = "2.10.0"' in catalog.read_text()
 
 
-# Runs the full checker against the live repo, duplicating the CI gate (sdk-parity.yml, test.yml); opt in so unrelated doc edits cannot fail the unit lane.
-@pytest.mark.skipif(
-    os.environ.get("ARAGORA_RUN_REPO_VERSION_ALIGNMENT_TEST") != "1",
-    reason="set ARAGORA_RUN_REPO_VERSION_ALIGNMENT_TEST=1 to run the checker against the live repo",
-)
-def test_repo_docs_are_aligned(cva, monkeypatch, capsys) -> None:
-    monkeypatch.chdir(REPO_ROOT)
-    monkeypatch.setattr(sys, "argv", ["check_version_alignment.py"])
-    assert cva.main() == 0
-    assert "All versions aligned!" in capsys.readouterr().out
+@pytest.fixture
+def complete_repo(cva, tmp_path):
+    """Literal input forms, independently composed before registry coverage checks."""
+    files = {}
+
+    def add(paths, text):
+        for path in paths.split():
+            assert path not in files
+            files[path] = text
+
+    add(
+        "aragora/__version__.py",
+        "VERSION_MAJOR = 3\nVERSION_MINOR = 7\nVERSION_PATCH = 2\n"
+        "# Release date (ISO 8601 format) — set when the v3.7.2 tag is pushed\n"
+        'RELEASE_DATE = "2030-02-03"\n',
+    )
+    add(
+        "pyproject.toml sdk/python/pyproject.toml",
+        '[project]\nname = "fixture"\nversion = "3.7.2"\ndependencies = ["other==2.9.0"]\n',
+    )
+    add("sdk/python/aragora_sdk/__init__.py", '__version__ = "3.7.2"\n')
+    for directory in (
+        "aragora/live",
+        "sdk/typescript",
+        "ide/vscode-aragora",
+        "ide/vscode-aragora/webview-ui",
+    ):
+        package = {"name": "fixture", "version": "3.7.2"}
+        add(f"{directory}/package.json", json.dumps(package, indent=2) + "\n")
+        packages = {
+            "": package,
+            "../../sdk/typescript": {"name": "@aragora/sdk", "version": "3.7.2"},
+            "node_modules/other": {"version": "2.9.0"},
+        }
+        add(
+            f"{directory}/package-lock.json",
+            json.dumps({**package, "lockfileVersion": 3, "packages": packages}, indent=2) + "\n",
+        )
+    add(
+        "uv.lock",
+        '[[package]]\nname = "aragora"\nversion = "3.7.2"\n'
+        '[[package]]\nname = "other"\nversion = "2.9.0"\n',
+    )
+    add("README.md", "Python + TypeScript SDKs · v3.7.2.**\n")
+    add(
+        "CHANGELOG.md",
+        "_Post-v3.7.2 changes land here until the next stable tag._\n## [2.9.0]\nOld release.\n",
+    )
+    add(
+        "docs/status/metrics/catalog.toml",
+        'claims = [\n  { key = "project_version", display_value = "3.7.2" },\n'
+        '  { key = "other", display_value = "2.9.0" },\n]\n',
+    )
+    add(
+        "docs/STATUS.md docs/status/STATUS.md docs-site/docs/contributing/status.md",
+        "Current released version is **v3.7.2** (released 2030-02-03).\n- **Version**: v3.7.2\n",
+    )
+    add(
+        "docs/deployment/SCALING.md docs-site/docs/deployment/scaling.md",
+        '{\n  "version": "3.7.2",\n  "healthy": true\n}\n',
+    )
+    add(
+        "docs/api/API_REFERENCE.md docs-site/docs/api/reference.md",
+        "| TypeScript (npm) | 3.7.2 | stable |\n| Python (pip) | 3.7.2 | stable |\n"
+        "> **Last Updated:** 2030-02-03 (v3.7.2 alignment with repo versions)\n",
+    )
+    add(
+        "docs/CANONICAL_GOALS.md docs-site/docs/contributing/canonical-goals.md",
+        "| Version | 3.7.2 | stable |\n",
+    )
+    add(
+        "docs/DEPLOYMENT.md docs-site/docs/deployment/overview.md",
+        "`3.7.2` (version from pyproject.toml)\n`v3.7.2` (git tag)\n"
+        "image: ghcr.io/synaptent/aragora/backend:3.7.2\n",
+    )
+    add(
+        "docs/deployment/GO_LIVE_CHECKLIST.md",
+        "image: ghcr.io/synaptent/aragora/backend:3.7.2\n"
+        "image: ghcr.io/synaptent/aragora/frontend:3.7.2\n",
+    )
+    add(
+        "docs/reference/INSTALL_MATRIX.md docs-site/docs/reference/install-matrix.md",
+        "| Root platform | pip | package | **3.7.2** | stable |\n"
+        "| Python SDK | pip | package | **3.7.2** | stable |\n"
+        "| This checkout (`pip install ./sdk/python`) | 3.7.2 | stable |\n"
+        "PyPI serves 2.9.0; the 3.7.2 build ships when the operator tags `v3.7.2`\n"
+        "in-tree version has moved to 3.7.2 but PyPI serves 2.9.0\n"
+        "gives you 2.9.0, not 3.7.2\nin-tree version (3.7.2, not yet released to PyPI)\n",
+    )
+    add(
+        "docs/guides/SELF_HOSTED_QUICKSTART.md",
+        '*Updated: 2030-02-03*\n*Version: 3.7.2*\n{"status": "healthy", "version": "3.7.2"}\n',
+    )
+    add(
+        "docs/guides/SELF_HOSTED_COMPLETE_GUIDE.md",
+        "*Version: 3.7.2 | Updated: 2030-02-03*\n"
+        "**Version:** 3.7.2\n**Last Updated:** 2030-02-03\n"
+        '  "version": "3.7.2",\nimage: ghcr.io/synaptent/aragora/backend:3.7.2\n',
+    )
+    add(
+        "docs/migration/V3_MIGRATION_GUIDE.md",
+        "> **Current version:** v3.7.2\n"
+        "> **Deprecation warnings active since:** v2.0 (still emitted by v3.7)\n",
+    )
+    add(
+        "docs/SDK_GUIDE.md docs-site/docs/guides/sdk.md",
+        "(e.g. the repo can declare 3.7.2 while PyPI serves 2.9.0)\n",
+    )
+    add(
+        "docs/deployment/UPGRADE_ROADMAP.md",
+        "**Aragora v3.7.2** (released 2030-02-03)\n"
+        "| **v3.7.x** | 2030-01-01 | Active | **Current** |\n"
+        "| v3.6.x | 2029-10-01 | Active | Supported |\n"
+        "| v1.0.x | 2026-01-13 | 2026-06-01 | Deprecated |\n"
+        'print(__version__)  # "3.7.2"\n'
+        "**PyPI availability:** the `3.7.2` wheel ships when the operator pushes the "
+        "`v3.7.2` tag; PyPI serves 2.9.0.\n"
+        "### v3.6.x -> v3.7.2 (Minor Upgrade)\npip install --upgrade aragora==3.7.2\n"
+        "### v1.x -> v3.7.2 (Legacy Upgrade)\npip install --upgrade aragora==3.7.2\n"
+        "# Step 1: Historical install\npip install aragora==1.0.0\n"
+        "# Step 3: Upgrade to v3.7.2\npip install aragora==3.7.2\n"
+        'backup --label "pre-upgrade-v3.7.2"\n### v2.9.0 Behavioral Changes\nOld behavior.\n',
+    )
+    for path, text in files.items():
+        target = tmp_path / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text)
+    for name, path, kind in cva.VERSION_SOURCES:
+        text = files[str(path)]
+        actual = json.loads(text)["version"] if kind == "package" else "3.7.2"
+        assert actual == "3.7.2", name
+    for name, path in cva.PYTHON_VERSION_SOURCES:
+        assert '__version__ = "3.7.2"' in files[str(path)], name
+    for name, path, pattern in cva.DOC_SOURCES:
+        matches = list(re.finditer(pattern, files[str(path)], re.MULTILINE))
+        assert matches, name
+        for match in matches:
+            group = (
+                "series"
+                if "series" in match.re.groupindex
+                else ("version" if "version" in match.re.groupindex else 2)
+            )
+            assert match.group(group) == ("3.7" if group == "series" else "3.7.2"), name
+    return tmp_path
+
+
+def _tree(root):
+    return {
+        str(p.relative_to(root)): (p.read_bytes(), p.stat().st_mtime_ns, p.stat().st_mode)
+        for p in root.rglob("*")
+        if p.is_file()
+    }
+
+
+def _checker(root, *args, status=0):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == status, result.stdout + result.stderr
+    assert ("All versions aligned!" in result.stdout) == (status == 0)
+    return result.stdout + result.stderr
+
+
+STALE_INPUTS = {
+    "manifest": ("pyproject.toml", 'version = "3.7.2"', 'version = "2.9.0"'),
+    "sdk": ("sdk/python/aragora_sdk/__init__.py", "3.7.2", "2.9.0"),
+    "lock": ("aragora/live/package-lock.json", '"version": "3.7.2"', '"version": "2.9.0"'),
+    "doc": ("docs/DEPLOYMENT.md", "backend:3.7.2", "backend:2.9.0"),
+    "date": ("docs/deployment/UPGRADE_ROADMAP.md", "released 2030-02-03", "released 2029-01-01"),
+    "later": (
+        "docs/deployment/UPGRADE_ROADMAP.md",
+        "pip install --upgrade aragora==3.7.2",
+        "pip install --upgrade aragora==2.9.0",
+    ),
+}
+
+
+def _stale(root, scenario):
+    path, before, after = STALE_INPUTS[scenario]
+    target = root / path
+    prefix, found, suffix = target.read_text().rpartition(before)
+    assert found
+    target.write_text(prefix + after + suffix)
+    return path
+
+
+@pytest.mark.parametrize("mode", ["default", "check"])
+def test_checker_cli_aligned(complete_repo, mode):
+    before = _tree(complete_repo)
+    _checker(complete_repo, *(["--check"] if mode == "check" else []))
+    assert _tree(complete_repo) == before
+
+
+@pytest.mark.parametrize("scenario", list(STALE_INPUTS))
+def test_checker_cli_stale(complete_repo, scenario):
+    path = _stale(complete_repo, scenario)
+    before = _tree(complete_repo)
+    for args in ((), ("--check",)):
+        output = _checker(complete_repo, *args, status=1)
+        assert any(path in line and "[MISMATCH]" in line for line in output.splitlines())
+        if scenario == "later":
+            assert "[MISMATCH] (2 occurrences)" in output
+        assert _tree(complete_repo) == before
+
+
+def test_checker_cli_fix(complete_repo):
+    aligned = {p: data[0] for p, data in _tree(complete_repo).items()}
+    for scenario in STALE_INPUTS:
+        _stale(complete_repo, scenario)
+    assert "Fixed " in _checker(complete_repo, "--fix")
+    assert {p: data[0] for p, data in _tree(complete_repo).items()} == aligned
+    before = _tree(complete_repo)
+    _checker(complete_repo, "--check")
+    _checker(complete_repo, "--fix")
+    assert _tree(complete_repo) == before
+
+
+def test_checker_cli_minor(complete_repo):
+    canonical = complete_repo / "aragora/__version__.py"
+    canonical.write_text(
+        canonical.read_text()
+        .replace("VERSION_MINOR = 7", "VERSION_MINOR = 8")
+        .replace("VERSION_PATCH = 2", "VERSION_PATCH = 0")
+        .replace("2030-02-03", "2030-06-01")
+    )
+    before = {p: data[0].decode() for p, data in _tree(complete_repo).items()}
+    _checker(complete_repo, "--fix")
+    _checker(complete_repo, "--check")
+    for path, text in before.items():
+        preserved = [line for line in text.splitlines() if "2.9.0" in line or "1.0." in line]
+        for line in preserved:
+            assert line.replace("3.7.2", "3.8.0") in (complete_repo / path).read_text()
+    roadmap = (complete_repo / "docs/deployment/UPGRADE_ROADMAP.md").read_text()
+    assert "| **v3.8.x** | 2030-06-01 | Active | **Current** |" in roadmap
+    assert "| v3.7.x | 2030-01-01 | Active | Supported |" in roadmap
+    assert "| v3.6.x | 2029-10-01 | Active | Supported |" in roadmap
+    snapshot = _tree(complete_repo)
+    _checker(complete_repo, "--fix")
+    assert _tree(complete_repo) == snapshot
+
+
+@pytest.mark.parametrize("scenario", ["manifest", "pattern", "canonical", "malformed"])
+def test_checker_cli_unusable(complete_repo, scenario):
+    path = "pyproject.toml" if scenario == "manifest" else "aragora/__version__.py"
+    if scenario in ("manifest", "canonical"):
+        (complete_repo / path).unlink()
+    elif scenario == "malformed":
+        (complete_repo / path).write_text('VERSION_MAJOR = "invalid"\n')
+    else:
+        path = "README.md"
+        (complete_repo / path).write_text("No current-version declaration.\n")
+    before = _tree(complete_repo)
+    for mode in ("--check", "--fix", "--check"):
+        assert path in _checker(complete_repo, mode, status=1)
+        assert _tree(complete_repo) == before

--- a/tests/scripts/test_skip_debt_regressions.py
+++ b/tests/scripts/test_skip_debt_regressions.py
@@ -1,0 +1,106 @@
+"""Execute semantic checker/runtime scenarios, not just their collection."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER_CASES = {
+    "test_checker_cli_aligned[default]",
+    "test_checker_cli_aligned[check]",
+    "test_checker_cli_fix",
+    "test_checker_cli_minor",
+    *{
+        f"test_checker_cli_stale[{case}]"
+        for case in ("manifest", "sdk", "lock", "doc", "date", "later")
+    },
+    *{
+        f"test_checker_cli_unusable[{case}]"
+        for case in ("manifest", "pattern", "canonical", "malformed")
+    },
+}
+RUNTIME_CASES = {
+    *{
+        f"test_runner_capability[{state}-{outcome}]"
+        for state in ("absent", "none", "injected")
+        for outcome in ("return", "error")
+    },
+    "test_native_sync[result]",
+    "test_native_sync[error]",
+    "test_offline_cli",
+}
+
+
+@pytest.mark.parametrize(
+    ("suite", "required", "selection"),
+    [
+        (
+            "scripts/test_check_version_alignment.py",
+            CHECKER_CASES,
+            "test_checker_cli or test_repo_docs_are_aligned",
+        ),
+        (
+            "cli/test_quickstart.py",
+            RUNTIME_CASES,
+            "test_runner_capability or test_native_sync or test_offline_cli "
+            "or test_run_sync_prefers_runner_when_available",
+        ),
+    ],
+    ids=["checker", "runtime"],
+)
+def test_required_scenarios_execute(suite, required, selection, tmp_path):
+    report = tmp_path / "scenarios.xml"
+    env = {
+        "HOME": str(tmp_path),
+        "PATH": "/usr/bin:/bin",
+        "PYTHONPATH": f"{ROOT}:{ROOT / 'aragora-verify/src'}",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "ARAGORA_USE_SECRETS_MANAGER": "false",
+        "ARAGORA_SECRETS_STRICT": "false",
+        "ARAGORA_DB_BACKEND": "sqlite",
+        "ARAGORA_DATA_DIR": str(tmp_path / "data"),
+        "ARAGORA_LOG_DIR": str(tmp_path / "logs"),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(ROOT / "tests" / suite),
+            "-c",
+            str(ROOT / "pyproject.toml"),
+            "--rootdir",
+            str(tmp_path),
+            "-k",
+            selection,
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "--basetemp",
+            str(tmp_path / "child"),
+            "--junitxml",
+            str(report),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert report.exists(), result.stdout + result.stderr
+    cases = ET.parse(report).findall(".//testcase")
+    names = {case.attrib["name"] for case in cases}
+    assert required <= names, f"Missing semantic scenarios: {sorted(required - names)}"
+    bad = [
+        case.attrib["name"]
+        for case in cases
+        if any(case.find(tag) is not None for tag in ("skipped", "failure", "error"))
+    ]
+    assert not bad, f"Unsuccessful semantic scenarios: {bad}\n{result.stdout}"
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/scripts/test_skip_debt_regressions.py
+++ b/tests/scripts/test_skip_debt_regressions.py
@@ -80,6 +80,7 @@ def test_required_scenarios_execute(suite, required, selection, tmp_path):
             "-k",
             selection,
             "-q",
+            "-ra",
             "-p",
             "no:cacheprovider",
             "--basetemp",
@@ -103,4 +104,7 @@ def test_required_scenarios_execute(suite, required, selection, tmp_path):
         if any(case.find(tag) is not None for tag in ("skipped", "failure", "error"))
     ]
     assert not bad, f"Unsuccessful semantic scenarios: {bad}\n{result.stdout}"
+    # Non-strict XPASS has a successful JUnit testcase and exit status.
+    xpasses = [line for line in result.stdout.splitlines() if line.startswith("XPASS ")]
+    assert not xpasses, f"XPASS semantic scenarios: {xpasses}\n{result.stdout}"
     assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Receipt-First epic #9966, metric 7 gate hygiene, attempt 1 resumed after rulings 22/22A.

- Replace the opt-in version-alignment test with independently seeded complete fixtures covering all 80 registry entries across 36 files. Run the unmodified checker for aligned default/check, stale versions/dates/later occurrences, no-write failures, fix/fresh-check/idempotence, preservation, and unusable inputs.
- Replace the missing-Runner skip with absent/None/injected-Runner return/error coverage on actual Python 3.10.20 and 3.11.11. Preserve direct fallback coverage and exercise native lifecycle cleanup, private/caller loops, task cancellation, generator finalization, and executor completion.
- Exercise real isolated offline quickstart and compare stdout/artifact JSON identity. Enforce required semantic IDs through nonrecursive child pytest/JUnit checks, including explicit non-strict XPASS rejection using `-ra`.

Hermetic checker fixtures prove checker behavior, not actual-checkout alignment. The real checkout's public version check and contracts gate separately passed. Offline demo artifacts are not hosted PostgreSQL durability evidence.

## Exit metric moved

Enables metric 7's held backend-alias lane by reducing the real full-tree skip audit from 95 to 93. This does not make the hosted API healthy or complete the alias proof.

Mixed attribution: mission #9977 added one opt-in checker site; external #10010 added one missing-Runner site; external #10037 added two legitimate Darwin containment guards. This PR substantively replaces the first two sites. The complete Darwin test file, baseline 91, existing +2 allowance, analyzer, workflows and gate runner remain unchanged. No hidden marker variables or skip substitutes.

## Test commands

Current head: `4c00e7fba1f5d09de612eb14dbef640902e7bd75`. Collection 1 on `769c1ac62e9fac8bec7e6b3a3b620fa62ff8c303` returned Claude grounded PASS and OpenAI grounded CHANGES-REQUESTED (P2: the offline test unnecessarily checked shared ancestor `.env` paths). One test-only repair now checks precisely the two paths the unchanged quickstart loader searches, both owned by the test. A new regression places a harmless `.env` in an owned, unsearched ancestor and runs the same unmocked public CLI/artifact assertions; it failed at the old ancestor assertion, then passed after repair. No host `.env` file is read, written or removed by that fixture.

On this current committed head the serial focused commands below passed **149 tests, zero skips on each actual runtime** (3.10.20: 13.52s; 3.11.11: 13.78s). All five gate sections were run separately and printed GATE PASSED: test 4024 passed/8 unrelated skips, publish-shadow 143 passed/2 skips, lint, typecheck (1721 whole-tree errors below 1744), contracts, guardrails (141 cycles/1120 docs under existing main-relative tolerances). Real checkout checker exited 0; audit remained 93; automation preflight exited 0. Three-file net formatted delta is 649 additions + 32 deletions = **681 LOC** (685 summed across authored commits).

The frozen semantic contract remains byte-identical at `9d37577f191e1cd8d9c1af7f5eb8a540863422c41d572fbbe55811f3a4114141`, and both new-head focused runs execute it. The v3 mutation evidence below remains historical proof at `769c1ac62...`, not a claimed rerun at the repaired head; its harness and source pins remain unchanged. The bounded reviewer-repair procedure requires new-head focused suites and all five gates, as recorded above.

### Preserved pre-review proof at 769c1ac62

Initial reviewed head: `769c1ac62e9fac8bec7e6b3a3b620fa62ff8c303`, preserving original implementation `fa78b261408ee36b4210e776b95b1263e19ed351` and original-suite parent `92c8d6bdd9989a67729eded9a0ec66a99ccbca4a`. At that head: three files, 634 additions + 32 deletions = 666 formatted LOC.

Both-runtime focused command, serially with `PY` set to `/tmp/rf-skip-py310/bin/python` (3.10.20), then `/Users/armand/.pyenv/versions/3.11.11/bin/python3` (3.11.11), and `RUNTIME` set to `310`, then `311`:

```sh
RF_WORKTREE="$PWD" /bin/sh /tmp/rf-skip-py310/run-isolated.sh \
  /opt/homebrew/bin/timeout 300 "$PY" -m pytest \
  -c "$PWD/pyproject.toml" --rootdir=/tmp/rf-skip-py310/proof \
  -p no:cacheprovider --basetemp=/tmp/rf-skip-py310/proof/test${RUNTIME}-temp -q -ra \
  "$PWD/tests/scripts/test_check_version_alignment.py" \
  "$PWD/tests/cli/test_quickstart.py" \
  "$PWD/tests/scripts/test_skip_debt_regressions.py"
```

Results: **148 passed, zero skips on each runtime**, 12.69s and 13.45s. Native Runner absent on 3.10, present on 3.11; injected capability remains explicitly injected.

Preserved old contract SHA256 `0e5e58c04c5430031e1809d8cda5bf3927267b576f1cf1cf2c7fab22be395188` and its pre-suite-change RED/GREEN. Accepted readiness reproduced old-contract false acceptance on both runtimes: the same passing `test_checker_cli_fix`, marked `xfail(strict=False)`, produced child exit 0, `13 passed, 38 deselected, 1 xpassed`, successful JUnit and parent exit 0. That is retained **defect RED**, not enforcement success.

Corrected bytes were separately frozen once at SHA256 `9d37577f191e1cd8d9c1af7f5eb8a540863422c41d572fbbe55811f3a4114141`, matching the committed file. Ran the following at committed head `769c1ac62e9fac8bec7e6b3a3b620fa62ff8c303` on each actual interpreter, serially, without sourcing the governance environment:

```sh
RF_SKIP_CONTRACT_SHA=9d37577f191e1cd8d9c1af7f5eb8a540863422c41d572fbbe55811f3a4114141
RF_WORKTREE="$PWD" /bin/sh /tmp/rf-skip-py310/run-isolated.sh \
  /opt/homebrew/bin/timeout 300 "$PY" \
  /Users/armand/.factory/missions/b7974b8f-d2e1-4a38-81d3-8870a3ef9d6c/research/skip-debt-controls-repair-v3.py \
  --phase corrected --expected-contract-sha "$RF_SKIP_CONTRACT_SHA"
```

Both exited 0, 102.67s/113.02s, with fresh keyed parent/child JUnit and interpreter/source provenance:

- Positive before, restored original-suite replay, and positive after: parent 2, checker 14, runtime 9 passed with no unsuccessful cases.
- Identical corrected contract against original suites at the exact parent: RED for missing semantic scenarios; retained suites GREEN.
- Missing/skipped/deliberately failed required cases rejected separately. Same genuine non-strict XPASS rejected specifically for XPASS while the child still exited 0.
- Real checker restricted in memory to first-match-only: `test_checker_cli_stale[later]` failed `assert 0 == 1`.
- Runner bypass: injected-return and injected-error failed at `fallback.assert_not_called()`, not the later events assertion.
- Omitted cleanup: both native result/error cases failed private-loop `is_closed()`; retained finally reclaimed resources.

Verified v3 SHA256 `b9f1e9de3a4a524d8a574d49d081f4841af1bb1f9d2fe3793af7a1209c9b7052` and isolated wrapper remained unchanged. No setup/collection error, missing report, timeout or unexpected skip counted as negative evidence; no production/source-link mutation. Retained evidence roots: `/private/tmp/rf-skip-controls-v3-m4z2vkb8` and `/private/tmp/rf-skip-controls-v3-a2ueshui`.

Pre-review checks at `769c1ac62...` (all separately repeated at the repaired head above):

- `python3 scripts/check_version_alignment.py --check`: exit 0 on the real worktree.
- `python3 scripts/audit_test_skips.py --count-only`: 93.
- `bash "$MISSION_DIR/bin/gate.sh" test`: GATE PASSED, 4024 passed/8 unrelated skips; publish-shadow 143 passed/2 skips; CI-shadow and full skip audit passed.
- `bash "$MISSION_DIR/bin/gate.sh" lint`: GATE PASSED.
- `bash "$MISSION_DIR/bin/gate.sh" typecheck`: GATE PASSED, clean touched-file preflight; whole-tree 1721 errors below unchanged 1744 ceiling.
- `bash "$MISSION_DIR/bin/gate.sh" contracts`: GATE PASSED.
- `bash "$MISSION_DIR/bin/gate.sh" guardrails`: GATE PASSED; 141 cycles and 1120 docs within unchanged main-relative external-breach tolerances.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: exit 0.

## Reviewed design tradeoffs

Keep independent fixture data and real subprocesses instead of mocking checker success or narrowing registries. Keep both deterministic capability injection and native runtime cleanup tests, because neither replaces the other. Preserve semantic-ID subset matching rather than a brittle global total.

Pytest JUnit alone cannot distinguish non-strict XPASS from a pass. Expose the selected child's outcome summary with `-ra` and explicitly reject its XPASS lines, preserving every existing missing/skipped/failure/error check. `xfail_strict` alone is insufficient because per-test `strict=False` overrides it. No dependency or production changes.

## Risks

- **93 meets only baseline 91 + existing test allowance 2. The full-release threshold remains 91, unsolved and unwaived**, tracked by the existing 2.11.0 release work.
- No PostgreSQL persistence, API restart durability, release readiness, deployment, signing, settlement or publication claim. Alias commits remain untouched and held until the orchestrator verifies the reviewed upstream remediation merge.
- Previous failed disposable harnesses, mislabeled v2 archive, old hashes and both original parks remain immutable history. Readiness was not corrected-head evidence; the final-head proofs above are separate.
- Unrelated pre-existing whole-tree type errors and main-relative count breaches are disclosed, not repaired here. Metrics Drift may report pre-existing generated metrics staleness; no metrics regeneration belongs in this tests-only PR.
